### PR TITLE
Move staged CI workflow to root .github/workflows

### DIFF
--- a/.github/workflows/staged-ci.yml
+++ b/.github/workflows/staged-ci.yml
@@ -27,7 +27,7 @@ jobs:
       # Install hermit (manages node, rust, just)
       - uses: cashapp/activate-hermit@v1
         with:
-          directory: staged
+          working-directory: staged
 
       # Cache Cargo dependencies
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
- Add path filters to only trigger on staged/** changes
- Set working-directory default to staged/
- Update hermit and rust-cache paths for monorepo structure
- Remove staged/.github/ directory