### PR TITLE
Add @wesbillman and @matt2e as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*       @baxen
+*       @baxen @wesbillman @matt2e
 
 
 # -----------------------------------------------


### PR DESCRIPTION
This PR adds @wesbillman and @matt2e as code owners for the repository alongside the existing owner @baxen.