### PR TITLE
Import existing worktrees when adding projects

### DIFF
--- a/staged/src-tauri/src/actions/commands.rs
+++ b/staged/src-tauri/src/actions/commands.rs
@@ -32,7 +32,7 @@ pub async fn detect_project_actions(
     // Get the project
     let project = store
         .get_project(&project_id)
-        .map_err(|e| format!("Failed to get project: {}", e))?
+        .map_err(|e| format!("Failed to get project: {e}"))?
         .ok_or_else(|| "Project not found".to_string())?;
 
     // Build the working directory path
@@ -45,7 +45,7 @@ pub async fn detect_project_actions(
 
     // Create AI provider with the working directory
     let provider = AcpAiProvider::new(working_dir.clone())
-        .map_err(|e| format!("Failed to create AI provider: {}", e))?;
+        .map_err(|e| format!("Failed to create AI provider: {e}"))?;
 
     // Create detector
     let detector = ActionDetector::new(Box::new(provider));
@@ -54,7 +54,7 @@ pub async fn detect_project_actions(
     detector
         .detect_actions(&working_dir)
         .await
-        .map_err(|e| format!("Action detection failed: {}", e))
+        .map_err(|e| format!("Action detection failed: {e}"))
 }
 
 /// Run an action for a branch
@@ -71,19 +71,19 @@ pub async fn run_branch_action(
     // Get the action
     let action = store
         .get_project_action(&action_id)
-        .map_err(|e| format!("Failed to get action: {}", e))?
+        .map_err(|e| format!("Failed to get action: {e}"))?
         .ok_or_else(|| "Action not found".to_string())?;
 
     // Get the branch (unused but validates it exists)
     let _branch = store
         .get_branch(&branch_id)
-        .map_err(|e| format!("Failed to get branch: {}", e))?
+        .map_err(|e| format!("Failed to get branch: {e}"))?
         .ok_or_else(|| "Branch not found".to_string())?;
 
     // Get the worktree path for this branch
     let workdir = store
         .get_workdir_for_branch(&branch_id)
-        .map_err(|e| format!("Failed to get workdir: {}", e))?
+        .map_err(|e| format!("Failed to get workdir: {e}"))?
         .ok_or_else(|| "No worktree found for branch".to_string())?;
 
     // Create event listener
@@ -105,7 +105,7 @@ pub async fn run_branch_action(
     executor
         .execute(action.command, workdir.path, metadata, listener)
         .await
-        .map_err(|e| format!("Failed to execute action: {}", e))
+        .map_err(|e| format!("Failed to execute action: {e}"))
 }
 
 /// Stop a running action
@@ -116,7 +116,7 @@ pub fn stop_branch_action(
 ) -> Result<(), String> {
     executor
         .stop(&execution_id)
-        .map_err(|e| format!("Failed to stop action: {}", e))
+        .map_err(|e| format!("Failed to stop action: {e}"))
 }
 
 /// Get all currently running actions for a branch
@@ -161,7 +161,7 @@ pub async fn run_prerun_actions(
     // Get all actions for the project
     let actions = store
         .list_project_actions(&project_id)
-        .map_err(|e| format!("Failed to list actions: {}", e))?;
+        .map_err(|e| format!("Failed to list actions: {e}"))?;
 
     // Filter to prerun actions
     let prerun_actions: Vec<ProjectAction> = actions
@@ -172,7 +172,7 @@ pub async fn run_prerun_actions(
     // Get the worktree path for this branch
     let workdir = store
         .get_workdir_for_branch(&branch_id)
-        .map_err(|e| format!("Failed to get workdir: {}", e))?
+        .map_err(|e| format!("Failed to get workdir: {e}"))?
         .ok_or_else(|| "No worktree found for branch".to_string())?;
 
     // Execute each prerun action
@@ -194,7 +194,7 @@ pub async fn run_prerun_actions(
         let execution_id = executor
             .execute(action.command, workdir.path.clone(), metadata, listener)
             .await
-            .map_err(|e| format!("Failed to execute prerun action: {}", e))?;
+            .map_err(|e| format!("Failed to execute prerun action: {e}"))?;
 
         execution_ids.push(execution_id);
     }

--- a/staged/src-tauri/src/lib.rs
+++ b/staged/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ pub struct BranchWithWorkdir {
     pub workspace_status: Option<store::WorkspaceStatus>,
     pub agent: Option<String>,
     pub worktree_path: Option<String>,
+    pub is_main_worktree: bool,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -409,6 +410,76 @@ fn list_projects(
         .map_err(|e| e.to_string())
 }
 
+/// Import existing worktrees for a project.
+///
+/// Scans the repository for existing worktrees and creates Branch + Workdir
+/// records for each one. Skips the main worktree (the repo itself).
+///
+/// Returns the number of worktrees imported.
+fn import_existing_worktrees(
+    store: &Arc<Store>,
+    project: &store::Project,
+) -> Result<usize, String> {
+    let repo_path = Path::new(&project.repo_path);
+
+    let default_branch = git::detect_default_branch(repo_path)
+        .map_err(|e| format!("Failed to detect default branch: {e}"))?;
+
+    let worktrees =
+        git::list_worktrees(repo_path).map_err(|e| format!("Failed to list worktrees: {e}"))?;
+
+    let mut imported_count = 0;
+
+    for (worktree_path, branch_name) in worktrees {
+        let branch_name = match branch_name {
+            Some(name) => name,
+            None => {
+                log::debug!(
+                    "Skipping worktree at {} (detached HEAD)",
+                    worktree_path.display()
+                );
+                continue;
+            }
+        };
+
+        let existing_branches = store
+            .list_branches_for_project(&project.id)
+            .map_err(|e| e.to_string())?;
+
+        if existing_branches
+            .iter()
+            .any(|b| b.branch_name == branch_name)
+        {
+            log::debug!("Branch '{branch_name}' already exists, skipping import");
+            continue;
+        }
+
+        let branch = store::Branch::new(&project.id, &branch_name, &default_branch);
+        store
+            .create_branch(&branch)
+            .map_err(|e| format!("Failed to create branch '{branch_name}': {e}"))?;
+
+        let worktree_str = worktree_path
+            .to_str()
+            .ok_or_else(|| format!("Invalid worktree path: {}", worktree_path.display()))?;
+
+        let workdir = store::Workdir::new(&project.id, worktree_str).with_branch(&branch.id);
+
+        store
+            .create_workdir(&workdir)
+            .map_err(|e| format!("Failed to create workdir for '{branch_name}': {e}"))?;
+
+        log::info!(
+            "Imported worktree: {} -> {}",
+            branch_name,
+            worktree_path.display()
+        );
+        imported_count += 1;
+    }
+
+    Ok(imported_count)
+}
+
 #[tauri::command]
 fn create_project(
     store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
@@ -420,14 +491,27 @@ fn create_project(
     // Validate that the path is a git repo
     let path = Path::new(&repo_path);
     if !path.join(".git").exists() && !path.is_dir() {
-        return Err(format!("Not a git repository: {}", repo_path));
+        return Err(format!("Not a git repository: {repo_path}"));
     }
 
-    // Check for duplicate
+    // Check for duplicate — still import worktrees even for existing projects,
+    // since they may have been added before this feature existed.
     if let Some(existing) = store
         .get_project_by_repo(&repo_path)
         .map_err(|e| e.to_string())?
     {
+        match import_existing_worktrees(&store, &existing) {
+            Ok(count) if count > 0 => {
+                log::info!(
+                    "Imported {count} worktree(s) for existing project '{}'",
+                    existing.repo_path
+                );
+            }
+            Err(e) => {
+                log::warn!("Failed to import worktrees for existing project: {e}");
+            }
+            _ => {}
+        }
         return Ok(existing);
     }
 
@@ -436,6 +520,23 @@ fn create_project(
         project = project.with_subpath(sub);
     }
     store.create_project(&project).map_err(|e| e.to_string())?;
+
+    // Import any existing worktrees for this project
+    match import_existing_worktrees(&store, &project) {
+        Ok(count) => {
+            if count > 0 {
+                log::info!(
+                    "Imported {count} existing worktree(s) for project '{}'",
+                    project.repo_path
+                );
+            }
+        }
+        Err(e) => {
+            // Log the error but don't fail project creation
+            log::warn!("Failed to import existing worktrees: {e}");
+        }
+    }
+
     Ok(project)
 }
 
@@ -469,6 +570,7 @@ fn to_branch_with_workdir(
         workspace_status: branch.workspace_status,
         agent: branch.agent,
         worktree_path: workdir_path,
+        is_main_worktree: false,
         created_at: branch.created_at,
         updated_at: branch.updated_at,
     }
@@ -480,6 +582,15 @@ fn list_branches_for_project(
     project_id: String,
 ) -> Result<Vec<BranchWithWorkdir>, String> {
     let store = get_store(&store)?;
+    let project = store
+        .get_project(&project_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
+
+    let canonical_repo = Path::new(&project.repo_path)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(&project.repo_path));
+
     let branches = store
         .list_branches_for_project(&project_id)
         .map_err(|e| e.to_string())?;
@@ -490,7 +601,16 @@ fn list_branches_for_project(
             .get_workdir_for_branch(&branch.id)
             .map_err(|e| e.to_string())?;
 
-        result.push(to_branch_with_workdir(branch, workdir.map(|w| w.path)));
+        let is_main = workdir.as_ref().is_some_and(|w| {
+            Path::new(&w.path)
+                .canonicalize()
+                .unwrap_or_else(|_| PathBuf::from(&w.path))
+                == canonical_repo
+        });
+
+        let mut bw = to_branch_with_workdir(branch, workdir.map(|w| w.path));
+        bw.is_main_worktree = is_main;
+        result.push(bw);
     }
     Ok(result)
 }
@@ -508,7 +628,7 @@ fn create_branch(
     let project = store
         .get_project(&project_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Project not found: {}", project_id))?;
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
 
     let repo_path = Path::new(&project.repo_path);
 
@@ -559,7 +679,7 @@ async fn create_remote_branch(
     let project = store
         .get_project(&project_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Project not found: {}", project_id))?;
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
 
     let repo_path = Path::new(&project.repo_path);
 
@@ -618,7 +738,7 @@ async fn get_workspace_info(
     let branch = store
         .get_branch(&branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {}", branch_id))?;
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
 
     let ws_name = branch
         .workspace_name
@@ -643,7 +763,7 @@ async fn poll_workspace_status(
     let branch = store
         .get_branch(&branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {}", branch_id))?;
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
 
     let ws_name = branch
         .workspace_name
@@ -685,7 +805,7 @@ async fn delete_branch(
     let branch = store
         .get_branch(&branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {}", branch_id))?;
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
 
     match branch.branch_type {
         store::BranchType::Local => {
@@ -695,10 +815,22 @@ async fn delete_branch(
                 .map_err(|e| e.to_string())?
                 .ok_or_else(|| format!("Project not found: {}", branch.project_id))?;
 
-            // Get the workdir (if any) so we can remove the worktree
             let workdir = store
                 .get_workdir_for_branch(&branch_id)
                 .map_err(|e| e.to_string())?;
+
+            // Prevent deletion of the main worktree (the repo checkout itself)
+            if let Some(ref wd) = workdir {
+                let canonical_repo = Path::new(&project.repo_path)
+                    .canonicalize()
+                    .unwrap_or_else(|_| PathBuf::from(&project.repo_path));
+                let canonical_wd = Path::new(&wd.path)
+                    .canonicalize()
+                    .unwrap_or_else(|_| PathBuf::from(&wd.path));
+                if canonical_wd == canonical_repo {
+                    return Err("Cannot delete the main worktree".to_string());
+                }
+            }
 
             if let Some(ref wd) = workdir {
                 let repo_path = Path::new(&project.repo_path);
@@ -708,11 +840,9 @@ async fn delete_branch(
             }
         }
         store::BranchType::Remote => {
-            // Delete the Blox workspace
             if let Some(ref ws_name) = branch.workspace_name {
-                // Best-effort: log but don't fail if workspace is already gone
                 if let Err(e) = blox::ws_delete(ws_name) {
-                    log::warn!("Failed to delete workspace {}: {}", ws_name, e);
+                    log::warn!("Failed to delete workspace {ws_name}: {e}");
                 }
             }
         }
@@ -749,7 +879,7 @@ fn create_project_action(
 ) -> Result<store::models::ProjectAction, String> {
     let store = get_store(&store)?;
     let parsed_type = builderbot_actions::ActionType::parse(&action_type)
-        .ok_or_else(|| format!("Invalid action type: {}", action_type))?;
+        .ok_or_else(|| format!("Invalid action type: {action_type}"))?;
     let action =
         store::models::ProjectAction::new(project_id, name, command, parsed_type, sort_order)
             .with_auto_commit(auto_commit);
@@ -773,7 +903,7 @@ fn update_project_action(
     let action = store
         .get_project_action(&action_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Action not found: {}", action_id))?;
+        .ok_or_else(|| format!("Action not found: {action_id}"))?;
 
     let updated = store::models::ProjectAction {
         id: action.id,
@@ -781,7 +911,7 @@ fn update_project_action(
         name,
         command,
         action_type: builderbot_actions::ActionType::parse(&action_type)
-            .ok_or_else(|| format!("Invalid action type: {}", action_type))?,
+            .ok_or_else(|| format!("Invalid action type: {action_type}"))?,
         sort_order,
         auto_commit,
         created_at: action.created_at,
@@ -820,7 +950,7 @@ fn delete_note(
     let note = store
         .get_note(&note_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Note not found: {}", note_id))?;
+        .ok_or_else(|| format!("Note not found: {note_id}"))?;
 
     store.delete_note(&note_id).map_err(|e| e.to_string())?;
 
@@ -845,7 +975,7 @@ fn delete_pending_commit(
     let commit = store
         .get_commit(&commit_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Commit not found: {}", commit_id))?;
+        .ok_or_else(|| format!("Commit not found: {commit_id}"))?;
 
     // Safety check: only allow deleting commits that have no SHA (pending/failed)
     if commit.sha.is_some() {
@@ -884,7 +1014,7 @@ fn delete_commit(
     let workdir = store
         .get_workdir_for_branch(&branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("No worktree for branch: {}", branch_id))?;
+        .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
 
     let worktree = Path::new(&workdir.path);
 
@@ -934,7 +1064,7 @@ fn get_branch_timeline(
     let branch = store
         .get_branch(&branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {}", branch_id))?;
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
 
     let workdir = store
         .get_workdir_for_branch(&branch_id)
@@ -1089,12 +1219,12 @@ fn resolve_branch_context(
     let branch = store
         .get_branch(branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {}", branch_id))?;
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
 
     let workdir = store
         .get_workdir_for_branch(branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("No worktree for branch: {}", branch_id))?;
+        .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
 
     Ok(BranchDiffContext {
         worktree_path: workdir.path,
@@ -1229,7 +1359,7 @@ async fn ensure_review(
 ) -> Result<store::Review, String> {
     let store = get_store(&store)?;
     let review_scope =
-        store::ReviewScope::parse(&scope).ok_or_else(|| format!("Invalid scope: {}", scope))?;
+        store::ReviewScope::parse(&scope).ok_or_else(|| format!("Invalid scope: {scope}"))?;
 
     store
         .ensure_review(&branch_id, &commit_sha, review_scope)
@@ -1418,7 +1548,7 @@ async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
 
         for (id, bundle_id) in KNOWN_OPENERS {
             let output = Command::new("mdfind")
-                .arg(format!("kMDItemCFBundleIdentifier == '{}'", bundle_id))
+                .arg(format!("kMDItemCFBundleIdentifier == '{bundle_id}'"))
                 .output()
                 .map_err(|e| format!("Failed to run mdfind: {e}"))?;
 
@@ -1490,7 +1620,7 @@ async fn open_in_app(path: String, app_id: String) -> Result<(), String> {
             .iter()
             .find(|(id, _)| *id == app_id)
             .map(|(_, bundle)| *bundle)
-            .ok_or_else(|| format!("Unknown app ID: {}", app_id))?;
+            .ok_or_else(|| format!("Unknown app ID: {app_id}"))?;
 
         let status = Command::new("open")
             .arg("-b")
@@ -1502,7 +1632,7 @@ async fn open_in_app(path: String, app_id: String) -> Result<(), String> {
         if status.success() {
             Ok(())
         } else {
-            Err(format!("Failed to open {} in {}", path, app_id))
+            Err(format!("Failed to open {path} in {app_id}"))
         }
     }
 

--- a/staged/src-tauri/src/session_commands.rs
+++ b/staged/src-tauri/src/session_commands.rs
@@ -160,7 +160,7 @@ pub fn resume_session(
     let session = store
         .get_session(&session_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Session not found: {}", session_id))?;
+        .ok_or_else(|| format!("Session not found: {session_id}"))?;
 
     // Use the provider that originally created this session so the
     // agent's conversation history can be restored correctly.
@@ -288,7 +288,7 @@ pub fn start_branch_session(
     let branch = store
         .get_branch(&branch_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {}", branch_id))?;
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
 
     let project = store
         .get_project(&branch.project_id)
@@ -307,7 +307,7 @@ pub fn start_branch_session(
         let workdir = store
             .get_workdir_for_branch(&branch_id)
             .map_err(|e| e.to_string())?
-            .ok_or_else(|| format!("No worktree for branch: {}", branch_id))?;
+            .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
 
         let mut worktree_path = PathBuf::from(&workdir.path);
         if let Some(ref subpath) = project.subpath {

--- a/staged/src/lib/BranchCard.svelte
+++ b/staged/src/lib/BranchCard.svelte
@@ -574,6 +574,9 @@
       <div class="branch-info">
         <GitBranch size={16} class="branch-icon" />
         <span class="branch-name">{branch.branchName}</span>
+        {#if branch.isMainWorktree}
+          <span class="main-badge">main worktree</span>
+        {/if}
         <span class="branch-separator">›</span>
         <span class="base-branch-name">{formatBaseBranch(branch.baseBranch)}</span>
       </div>
@@ -689,11 +692,13 @@
               {/if}
 
               <!-- Delete last -->
-              <div class="menu-separator"></div>
-              <button class="more-menu-item danger" onclick={handleDeleteFromMenu}>
-                <Trash2 size={14} />
-                Delete
-              </button>
+              {#if !branch.isMainWorktree}
+                <div class="menu-separator"></div>
+                <button class="more-menu-item danger" onclick={handleDeleteFromMenu}>
+                  <Trash2 size={14} />
+                  Delete
+                </button>
+              {/if}
             </div>
           {/if}
         </div>
@@ -1011,6 +1016,15 @@
     font-weight: 600;
     color: var(--text-primary);
     letter-spacing: -0.01em;
+  }
+
+  .main-badge {
+    font-size: var(--size-xs);
+    font-weight: 500;
+    color: var(--text-faint);
+    background-color: var(--bg-hover);
+    padding: 1px 6px;
+    border-radius: 4px;
   }
 
   .branch-separator {

--- a/staged/src/lib/ProjectHome.svelte
+++ b/staged/src/lib/ProjectHome.svelte
@@ -112,9 +112,12 @@
     showNewProjectModal = true;
   }
 
-  function handleProjectCreated(project: Project) {
-    projects = [...projects, project];
-    branchesByProject = new Map(branchesByProject).set(project.id, []);
+  async function handleProjectCreated(project: Project) {
+    if (!projects.some((p) => p.id === project.id)) {
+      projects = [...projects, project];
+    }
+    const branches = await commands.listBranchesForProject(project.id);
+    branchesByProject = new Map(branchesByProject).set(project.id, branches);
     showNewProjectModal = false;
   }
 

--- a/staged/src/lib/types.ts
+++ b/staged/src/lib/types.ts
@@ -26,6 +26,7 @@ export interface Branch {
   workspaceStatus: WorkspaceStatus | null;
   agent: string | null;
   worktreePath: string | null;
+  isMainWorktree: boolean;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## Summary
- When a project is added (or re-added), automatically detect and import all existing git worktrees — including the main worktree (the repo checkout itself)
- Fix bug where re-adding an existing project skipped worktree import entirely
- Main worktree branches show a "main worktree" badge and cannot be deleted
<img width="848" height="735" alt="image" src="https://github.com/user-attachments/assets/b6904fa3-dc90-475f-b8c5-12c95a19185e" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)