### PR TITLE
fix: prevent cursor jumping to end of textarea in NewSessionModal

### DIFF
--- a/staged/src/lib/NewSessionModal.svelte
+++ b/staged/src/lib/NewSessionModal.svelte
@@ -45,13 +45,15 @@
     }
   });
 
-  // Focus textarea on mount
+  // Focus textarea on mount (one-time)
   $effect(() => {
     if (textareaEl) {
-      textareaEl.focus();
-      if (prompt) {
-        textareaEl.selectionStart = textareaEl.selectionEnd = prompt.length;
-      }
+      const el = textareaEl;
+      // Read length from the DOM element to avoid tracking `prompt` reactively,
+      // which would re-run this effect on every keystroke and force the cursor
+      // to the end of the buffer.
+      el.focus();
+      el.selectionStart = el.selectionEnd = el.value.length;
     }
   });
 


### PR DESCRIPTION
## Problem

When typing in the textarea of the NewSessionModal, the cursor would jump to the end of the text on every keystroke. This made editing text in the middle of the prompt impossible.

## Cause

The `$effect` that focused the textarea on mount was reading `prompt` reactively, causing it to re-run on every keystroke. Each re-run would set `selectionStart` and `selectionEnd` to `prompt.length`, forcing the cursor to the end.

## Fix

Read the length from the DOM element's `.value` property instead of the reactive `prompt` variable. This avoids tracking `prompt` as a dependency, so the effect only runs once on mount (when `textareaEl` is first set) and correctly places the cursor at the end of any pre-filled text without interfering with subsequent edits.