### PR TITLE
Add multi-agent support with provider discovery and selection

### DIFF
--- a/staged/src-tauri/src/agent/acp.rs
+++ b/staged/src-tauri/src/agent/acp.rs
@@ -1,12 +1,22 @@
-//! ACP (Agent Client Protocol) driver — spawns goose and speaks ACP.
+//! ACP (Agent Client Protocol) driver — spawns an ACP-compatible agent
+//! and communicates via the ACP JSON-RPC protocol over stdio.
 //!
 //! This is the **only** file that imports `agent_client_protocol`. To
 //! switch to a different agent backend, create a new module implementing
 //! [`AgentDriver`] and leave this file untouched (or remove it).
 //!
+//! ## Supported agents
+//!
+//! | ID        | Command           | Notes                                      |
+//! |-----------|-------------------|--------------------------------------------|
+//! | `goose`   | `goose`           | Needs `acp --with-builtin developer,...`   |
+//! | `claude`  | `claude-code-acp` | Runs in ACP mode by default                |
+//! | `codex`   | `codex-acp`       | Runs in ACP mode by default                |
+//! | `pi`      | `pi-acp`          | Runs in ACP mode by default                |
+//!
 //! ## Process lifecycle
 //!
-//! The goose subprocess is spawned with `kill_on_drop(true)`. When the
+//! The agent subprocess is spawned with `kill_on_drop(true)`. When the
 //! future returned by [`AcpDriver::run`] completes — for any reason —
 //! the child is dropped and the OS process is killed. This is the
 //! primary guarantee that cancellation doesn't leave orphan processes.
@@ -23,6 +33,7 @@ use agent_client_protocol::{
     SelectedPermissionOutcome, SessionNotification, SessionUpdate, TextContent,
 };
 use async_trait::async_trait;
+use serde::Serialize;
 use tokio::process::Command;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tokio_util::sync::CancellationToken;
@@ -32,23 +43,129 @@ use super::AgentDriver;
 use crate::store::Store;
 
 // =============================================================================
+// Known agents — the registry of ACP-compatible providers
+// =============================================================================
+
+/// Static metadata for each known ACP agent.
+struct KnownAgent {
+    /// Unique identifier used in preferences and IPC.
+    id: &'static str,
+    /// Human-readable label for the UI.
+    label: &'static str,
+    /// CLI command name to search for.
+    command: &'static str,
+    /// Arguments to pass when spawning in ACP mode.
+    acp_args: &'static [&'static str],
+}
+
+/// All agents we know how to talk to, in display order.
+const KNOWN_AGENTS: &[KnownAgent] = &[
+    KnownAgent {
+        id: "goose",
+        label: "Goose",
+        command: "goose",
+        acp_args: &["acp", "--with-builtin", "developer,extensionmanager"],
+    },
+    KnownAgent {
+        id: "claude",
+        label: "Claude Code",
+        command: "claude-code-acp",
+        acp_args: &[],
+    },
+    KnownAgent {
+        id: "codex",
+        label: "Codex",
+        command: "codex-acp",
+        acp_args: &[],
+    },
+    KnownAgent {
+        id: "pi",
+        label: "Pi",
+        command: "pi-acp",
+        acp_args: &[],
+    },
+];
+
+// =============================================================================
+// Provider discovery — exposed to the frontend
+// =============================================================================
+
+/// Information about a discovered ACP provider, serialized to the frontend.
+#[derive(Debug, Clone, Serialize)]
+pub struct AcpProviderInfo {
+    pub id: String,
+    pub label: String,
+}
+
+/// Scan the system for all known ACP agents that are installed.
+///
+/// Returns only agents whose CLI binary can be found. The order matches
+/// `KNOWN_AGENTS` (display order).
+pub fn discover_providers() -> Vec<AcpProviderInfo> {
+    KNOWN_AGENTS
+        .iter()
+        .filter(|agent| find_command(agent.command).is_some())
+        .map(|agent| AcpProviderInfo {
+            id: agent.id.to_string(),
+            label: agent.label.to_string(),
+        })
+        .collect()
+}
+
+// =============================================================================
 // AcpDriver — the public driver
 // =============================================================================
 
 pub struct AcpDriver {
-    goose_path: PathBuf,
+    binary_path: PathBuf,
+    acp_args: Vec<String>,
+    agent_label: String,
 }
 
 impl AcpDriver {
-    /// Locate the `goose` binary and return a ready-to-use driver.
+    /// Create a driver for the given provider ID (e.g. "goose", "claude").
     ///
-    /// Fails immediately if goose can't be found — the caller gets a clear
-    /// error before any background work starts.
-    pub fn new() -> Result<Self, String> {
-        let goose_path = find_goose().ok_or_else(|| {
-            "Could not find `goose` binary. Install it and ensure it's on your PATH.".to_string()
+    /// Looks up the agent in `KNOWN_AGENTS`, locates the binary on disk,
+    /// and returns a ready-to-use driver. Fails immediately if the agent
+    /// is unknown or its binary can't be found.
+    pub fn new(provider_id: &str) -> Result<Self, String> {
+        let agent = KNOWN_AGENTS
+            .iter()
+            .find(|a| a.id == provider_id)
+            .ok_or_else(|| format!("Unknown agent provider: {provider_id}"))?;
+
+        let binary_path = find_command(agent.command).ok_or_else(|| {
+            format!(
+                "Could not find `{}` binary. Install it and ensure it's on your PATH.",
+                agent.command
+            )
         })?;
-        Ok(Self { goose_path })
+
+        Ok(Self {
+            binary_path,
+            acp_args: agent.acp_args.iter().map(|s| s.to_string()).collect(),
+            agent_label: agent.label.to_string(),
+        })
+    }
+
+    /// Create a driver for the first available provider.
+    ///
+    /// Tries each known agent in order and returns the first one found.
+    /// This is the fallback when no provider preference is set.
+    pub fn first_available() -> Result<Self, String> {
+        for agent in KNOWN_AGENTS {
+            if let Some(path) = find_command(agent.command) {
+                return Ok(Self {
+                    binary_path: path,
+                    acp_args: agent.acp_args.iter().map(|s| s.to_string()).collect(),
+                    agent_label: agent.label.to_string(),
+                });
+            }
+        }
+        Err(
+            "No ACP agent found. Install Goose, Claude Code, Codex, or Pi and ensure it's on your PATH."
+                .to_string(),
+        )
     }
 }
 
@@ -63,19 +180,18 @@ impl AgentDriver for AcpDriver {
         cancel_token: &CancellationToken,
         agent_session_id: Option<&str>,
     ) -> Result<(), String> {
-        // Spawn goose in ACP mode
-        let mut child = Command::new(&self.goose_path)
-            .args(["acp", "--with-builtin", "developer,extensionmanager"])
+        let mut child = Command::new(&self.binary_path)
+            .args(&self.acp_args)
             .current_dir(working_dir)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             // stderr is intentionally discarded — we don't currently need
             // anything from it, and piping without draining would block
-            // goose if the OS pipe buffer fills up.
+            // the agent if the OS pipe buffer fills up.
             .stderr(Stdio::null())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| format!("Failed to spawn goose: {e}"))?;
+            .map_err(|e| format!("Failed to spawn {}: {e}", self.agent_label))?;
 
         let stdin = child
             .stdin
@@ -350,7 +466,7 @@ fn extract_content_preview(content: &[agent_client_protocol::ToolCallContent]) -
 }
 
 // =============================================================================
-// Find goose binary
+// Binary discovery
 // =============================================================================
 
 /// Common paths where CLIs might be installed (GUI apps don't inherit shell PATH).
@@ -361,9 +477,14 @@ const COMMON_PATHS: &[&str] = &[
     "/home/linuxbrew/.linuxbrew/bin",
 ];
 
-fn find_goose() -> Option<PathBuf> {
+/// Find a CLI binary by command name.
+///
+/// Searches in order:
+/// 1. Login shell `which` (picks up user's PATH from `.zshrc` / `.bashrc`)
+/// 2. Common install locations
+fn find_command(cmd: &str) -> Option<PathBuf> {
     // Strategy 1: Login shell `which`
-    if let Some(path) = find_via_login_shell("goose") {
+    if let Some(path) = find_via_login_shell(cmd) {
         if path.exists() {
             return Some(path);
         }
@@ -371,7 +492,7 @@ fn find_goose() -> Option<PathBuf> {
 
     // Strategy 2: Common paths
     for dir in COMMON_PATHS {
-        let path = PathBuf::from(dir).join("goose");
+        let path = PathBuf::from(dir).join(cmd);
         if path.exists() {
             return Some(path);
         }

--- a/staged/src-tauri/src/agent/mod.rs
+++ b/staged/src-tauri/src/agent/mod.rs
@@ -21,6 +21,9 @@ use tokio_util::sync::CancellationToken;
 use crate::store::Store;
 use writer::MessageWriter;
 
+// Re-export provider discovery for use by Tauri commands.
+pub use acp::{discover_providers, AcpProviderInfo};
+
 /// Everything the session orchestrator needs to run one turn of an agent.
 ///
 /// Implementors own the protocol details (spawning a process, connecting,

--- a/staged/src-tauri/src/lib.rs
+++ b/staged/src-tauri/src/lib.rs
@@ -1093,6 +1093,16 @@ fn detect_default_branch_cmd(repo_path: String) -> Result<String, String> {
 }
 
 // =============================================================================
+// Utilities
+// =============================================================================
+
+/// Open a URL in the user's default browser.
+#[tauri::command]
+fn open_url(url: String) -> Result<(), String> {
+    open::that(&url).map_err(|e| format!("Failed to open URL: {e}"))
+}
+
+// =============================================================================
 // Tauri App Setup
 // =============================================================================
 
@@ -1199,6 +1209,8 @@ pub fn run() {
             delete_pending_commit,
             list_git_branches,
             detect_default_branch_cmd,
+            open_url,
+            session_commands::discover_acp_providers,
             session_commands::get_session,
             session_commands::get_session_messages,
             session_commands::get_session_messages_since,

--- a/staged/src-tauri/src/session_commands.rs
+++ b/staged/src-tauri/src/session_commands.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 use tauri::Emitter;
 
+use crate::agent::{self, AcpProviderInfo};
 use crate::git;
 use crate::session_runner::{self, SessionConfig};
 use crate::store::{self, Store};
@@ -37,6 +38,25 @@ fn get_store(store: &tauri::State<'_, Mutex<Option<Arc<Store>>>>) -> Result<Arc<
         .unwrap()
         .clone()
         .ok_or_else(|| "Database not initialized — please reset from the startup prompt".into())
+}
+
+// =============================================================================
+// Provider discovery
+// =============================================================================
+
+/// Scan the system for installed ACP-compatible agents.
+///
+/// Returns a list of available providers with their IDs and labels.
+/// The frontend uses this for the agent setup modal and selector.
+///
+/// Marked `async` so Tauri runs it on the async runtime instead of the
+/// main thread — `find_command` spawns login shells which can take tens
+/// of milliseconds per agent.
+#[tauri::command]
+pub async fn discover_acp_providers() -> Vec<AcpProviderInfo> {
+    tokio::task::spawn_blocking(agent::discover_providers)
+        .await
+        .unwrap_or_default()
 }
 
 // =============================================================================
@@ -90,10 +110,14 @@ pub fn start_session(
     app_handle: tauri::AppHandle,
     prompt: String,
     working_dir: String,
+    provider: Option<String>,
 ) -> Result<store::Session, String> {
     let store = get_store(&store)?;
     let working_dir = PathBuf::from(working_dir);
-    let session = store::Session::new_running(&prompt, &working_dir);
+    let mut session = store::Session::new_running(&prompt, &working_dir);
+    if let Some(ref p) = provider {
+        session = session.with_provider(p);
+    }
     store.create_session(&session).map_err(|e| e.to_string())?;
 
     session_runner::start_session(
@@ -103,6 +127,7 @@ pub fn start_session(
             working_dir,
             agent_session_id: None,
             pre_head_sha: None,
+            provider,
         },
         store,
         app_handle,
@@ -136,6 +161,9 @@ pub fn resume_session(
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
+    // Use the provider that originally created this session so the
+    // agent's conversation history can be restored correctly.
+    let provider = session.provider.clone();
     let agent_session_id = session.agent_id.clone();
     let working_dir = PathBuf::from(&session.working_dir);
 
@@ -162,6 +190,7 @@ pub fn resume_session(
             working_dir,
             agent_session_id,
             pre_head_sha: None,
+            provider,
         },
         store,
         app_handle,
@@ -245,6 +274,7 @@ pub fn start_branch_session(
     branch_id: String,
     prompt: String,
     session_type: BranchSessionType,
+    provider: Option<String>,
 ) -> Result<BranchSessionResponse, String> {
     let store = get_store(&store)?;
 
@@ -277,7 +307,10 @@ pub fn start_branch_session(
     let full_prompt = build_full_prompt(&prompt, &branch_context, &session_type);
 
     // Create the session
-    let session = store::Session::new_running(&full_prompt, &worktree_path);
+    let mut session = store::Session::new_running(&full_prompt, &worktree_path);
+    if let Some(ref p) = provider {
+        session = session.with_provider(p);
+    }
     store.create_session(&session).map_err(|e| e.to_string())?;
 
     // Create artifact stub and compute pre-head SHA
@@ -303,6 +336,7 @@ pub fn start_branch_session(
             working_dir: worktree_path.clone(),
             agent_session_id: None,
             pre_head_sha,
+            provider,
         },
         store,
         app_handle,

--- a/staged/src-tauri/src/session_runner.rs
+++ b/staged/src-tauri/src/session_runner.rs
@@ -131,6 +131,9 @@ pub struct SessionConfig {
     /// will check if a new commit was created and update the linked commit
     /// record in the DB.
     pub pre_head_sha: Option<String>,
+    /// ACP provider ID (e.g. "goose", "claude"). When `None`, the first
+    /// available provider is used.
+    pub provider: Option<String>,
 }
 
 /// Start a session: persist the user message, spawn the agent, stream to DB.
@@ -147,8 +150,11 @@ pub fn start_session(
     app_handle: AppHandle,
     registry: Arc<SessionRegistry>,
 ) -> Result<(), String> {
-    // Create the driver eagerly so we fail fast if goose isn't found.
-    let driver = AcpDriver::new()?;
+    // Create the driver eagerly so we fail fast if the agent isn't found.
+    let driver = match &config.provider {
+        Some(id) => AcpDriver::new(id)?,
+        None => AcpDriver::first_available()?,
+    };
 
     // Persist the user message right away so it's visible immediately.
     store

--- a/staged/src-tauri/src/store/mod.rs
+++ b/staged/src-tauri/src/store/mod.rs
@@ -59,7 +59,7 @@ impl From<rusqlite::Error> for StoreError {
 ///
 /// Bump this whenever the schema changes in an incompatible way.
 /// Many app versions may share the same schema version.
-pub const SCHEMA_VERSION: i64 = 2;
+pub const SCHEMA_VERSION: i64 = 3;
 
 /// The app version of this build, pulled from Cargo.toml at compile time.
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -262,6 +262,7 @@ impl Store {
                 prompt          TEXT NOT NULL,
                 status          TEXT NOT NULL,
                 working_dir     TEXT NOT NULL,
+                provider        TEXT,
                 agent_id        TEXT,
                 error_message   TEXT,
                 created_at      INTEGER NOT NULL,

--- a/staged/src-tauri/src/store/models.rs
+++ b/staged/src-tauri/src/store/models.rs
@@ -176,6 +176,11 @@ pub struct Session {
     pub prompt: String,
     pub status: SessionStatus,
     pub working_dir: String,
+    /// Which agent provider ran this session (e.g. "goose", "claude").
+    /// Protocol-agnostic — survives a switch from ACP to another protocol.
+    pub provider: Option<String>,
+    /// Protocol-level session ID used by the agent for conversation
+    /// resumption (e.g. the ACP session ID returned by `new_session`).
     pub agent_id: Option<String>,
     pub error_message: Option<String>,
     pub created_at: i64,
@@ -190,11 +195,17 @@ impl Session {
             prompt: prompt.to_string(),
             status: SessionStatus::Running,
             working_dir: working_dir.to_string_lossy().to_string(),
+            provider: None,
             agent_id: None,
             error_message: None,
             created_at: now,
             updated_at: now,
         }
+    }
+
+    pub fn with_provider(mut self, provider: &str) -> Self {
+        self.provider = Some(provider.to_string());
+        self
     }
 
     pub fn with_agent(mut self, agent_id: &str) -> Self {

--- a/staged/src-tauri/src/store/sessions.rs
+++ b/staged/src-tauri/src/store/sessions.rs
@@ -9,13 +9,14 @@ impl Store {
     pub fn create_session(&self, session: &Session) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO sessions (id, prompt, status, working_dir, agent_id, error_message, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO sessions (id, prompt, status, working_dir, provider, agent_id, error_message, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 session.id,
                 session.prompt,
                 session.status.as_str(),
                 session.working_dir,
+                session.provider,
                 session.agent_id,
                 session.error_message,
                 session.created_at,
@@ -28,7 +29,7 @@ impl Store {
     pub fn get_session(&self, id: &str) -> Result<Option<Session>, StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, prompt, status, working_dir, agent_id, error_message, created_at, updated_at
+            "SELECT id, prompt, status, working_dir, provider, agent_id, error_message, created_at, updated_at
              FROM sessions WHERE id = ?1",
             params![id],
             Self::row_to_session,
@@ -136,10 +137,11 @@ impl Store {
             prompt: row.get(1)?,
             status: SessionStatus::parse(&status_str).unwrap_or(SessionStatus::Error),
             working_dir: row.get(3)?,
-            agent_id: row.get(4)?,
-            error_message: row.get(5)?,
-            created_at: row.get(6)?,
-            updated_at: row.get(7)?,
+            provider: row.get(4)?,
+            agent_id: row.get(5)?,
+            error_message: row.get(6)?,
+            created_at: row.get(7)?,
+            updated_at: row.get(8)?,
         })
     }
 }

--- a/staged/src/App.svelte
+++ b/staged/src/App.svelte
@@ -10,9 +10,12 @@
   import TopBar from './lib/TopBar.svelte';
   import ProjectHome from './lib/ProjectHome.svelte';
   import SessionLauncher from './lib/SessionLauncher.svelte';
+  import AgentSetupModal from './lib/AgentSetupModal.svelte';
   import { preferences, initPreferences } from './lib/stores/preferences.svelte';
+  import { agentState, refreshProviders } from './lib/stores/agent.svelte';
 
   let showSessionLab = $state(false);
+  let showAgentSetup = $state(false);
 
   // Konami code: ↑↑↓↓←→←→BA
   const konamiSequence = [
@@ -52,6 +55,15 @@
     }
     console.debug(`[Staged] preferences ready in ${Math.round(performance.now() - t0)}ms`);
 
+    // Discover available agents. We await so we know whether to show
+    // the setup modal before revealing the window.
+    await refreshProviders();
+
+    // Show the setup modal only when no agents are installed at all.
+    if (agentState.providers.length === 0) {
+      showAgentSetup = true;
+    }
+
     // Window was created hidden — show it now that the theme is applied
     await getCurrentWindow().show();
   });
@@ -68,6 +80,10 @@
       <ProjectHome />
     </div>
   </main>
+
+  {#if showAgentSetup}
+    <AgentSetupModal onClose={() => (showAgentSetup = false)} />
+  {/if}
 
   {#if showSessionLab}
     <SessionLauncher onClose={() => (showSessionLab = false)} />

--- a/staged/src/lib/AgentDropdown.svelte
+++ b/staged/src/lib/AgentDropdown.svelte
@@ -1,0 +1,258 @@
+<!--
+  AgentDropdown.svelte — TopBar dropdown for agent status and discovery.
+
+  Shows installed agents (with a check for the selected one, clickable to
+  switch), install links for missing agents, and a refresh button.
+  Follows the same positioning/interaction pattern as ThemeSelectorModal.
+-->
+<script lang="ts">
+  import { Check, ExternalLink, RefreshCw } from 'lucide-svelte';
+  import { agentState, refreshProviders, KNOWN_AGENTS } from './stores/agent.svelte';
+  import { preferences, setAiAgent } from './stores/preferences.svelte';
+  import { openUrl } from './commands';
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  let { onClose }: Props = $props();
+
+  let dropdownRef = $state<HTMLDivElement | null>(null);
+  let refreshing = $state(false);
+
+  function isInstalled(id: string): boolean {
+    return agentState.providers.some((p) => p.id === id);
+  }
+
+  function select(id: string) {
+    setAiAgent(id);
+  }
+
+  async function refresh() {
+    refreshing = true;
+    await refreshProviders();
+    refreshing = false;
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      onClose();
+      event.preventDefault();
+    }
+  }
+
+  function handleClickOutside(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    if (dropdownRef && !dropdownRef.contains(target) && !target.closest('.agent-btn')) {
+      onClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} onclick={handleClickOutside} />
+
+<div class="agent-dropdown" bind:this={dropdownRef}>
+  <div class="dropdown-header">
+    <span class="header-label">AI Agents</span>
+    <button class="refresh-btn" onclick={refresh} disabled={refreshing} title="Re-scan for agents">
+      <span class="spin-icon" class:spinning={refreshing}><RefreshCw size={12} /></span>
+    </button>
+  </div>
+
+  <div class="agent-list">
+    {#each KNOWN_AGENTS as agent (agent.id)}
+      {@const installed = isInstalled(agent.id)}
+      {#if installed}
+        <button
+          class="agent-item"
+          class:active={preferences.aiAgent === agent.id}
+          onclick={() => select(agent.id)}
+        >
+          <div class="agent-info">
+            <span class="agent-name">{agent.label}</span>
+            <span class="agent-status installed">Installed</span>
+          </div>
+          {#if preferences.aiAgent === agent.id}
+            <Check size={14} />
+          {/if}
+        </button>
+      {:else}
+        <div class="agent-item unavailable">
+          <div class="agent-info">
+            <span class="agent-name">{agent.label}</span>
+            <span class="agent-status">Not installed</span>
+          </div>
+          {#if agent.installUrl}
+            <button
+              class="install-link"
+              onclick={() => openUrl(agent.installUrl!)}
+              title="Install {agent.label}"
+            >
+              <ExternalLink size={12} />
+            </button>
+          {/if}
+        </div>
+      {/if}
+    {/each}
+  </div>
+</div>
+
+<style>
+  .agent-dropdown {
+    position: fixed;
+    top: 40px;
+    right: 8px;
+    z-index: 1000;
+    background: var(--bg-chrome);
+    border: 1px solid var(--border-muted);
+    border-radius: 8px;
+    box-shadow: var(--shadow-elevated);
+    width: 220px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .dropdown-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .header-label {
+    font-size: var(--size-xs);
+    font-weight: 500;
+    color: var(--text-muted);
+  }
+
+  .refresh-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-faint);
+    cursor: pointer;
+    transition:
+      color 0.1s,
+      background-color 0.1s;
+  }
+
+  .refresh-btn:not(:disabled):hover {
+    color: var(--text-primary);
+    background-color: var(--bg-hover);
+  }
+
+  .refresh-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .agent-list {
+    display: flex;
+    flex-direction: column;
+    padding: 4px 0;
+  }
+
+  .agent-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    padding: 6px 12px;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: var(--size-xs);
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.1s;
+  }
+
+  .agent-item:hover {
+    background-color: var(--bg-hover);
+  }
+
+  .agent-item.active {
+    background-color: var(--bg-primary);
+  }
+
+  .agent-item.active :global(svg) {
+    color: var(--ui-accent);
+  }
+
+  .agent-item.unavailable {
+    cursor: default;
+    opacity: 0.6;
+  }
+
+  .agent-item.unavailable:hover {
+    background: none;
+  }
+
+  .agent-info {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .agent-name {
+    white-space: nowrap;
+  }
+
+  .agent-status {
+    font-size: calc(var(--size-xs) - 1px);
+    color: var(--text-faint);
+  }
+
+  .agent-status.installed {
+    color: var(--diff-added-text);
+  }
+
+  .install-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    background: none;
+    border: none;
+    color: var(--text-faint);
+    border-radius: 3px;
+    cursor: pointer;
+    transition:
+      color 0.1s,
+      background-color 0.1s;
+  }
+
+  .install-link:hover {
+    color: var(--text-primary);
+    background-color: var(--bg-hover);
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .spin-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .spin-icon.spinning {
+    animation: spin 1s linear infinite;
+  }
+</style>

--- a/staged/src/lib/AgentSelector.svelte
+++ b/staged/src/lib/AgentSelector.svelte
@@ -1,0 +1,176 @@
+<!--
+  AgentSelector.svelte — Compact dropdown for switching the AI agent.
+
+  Shows the currently selected agent with a chevron. Clicking opens a
+  dropdown with all available providers. Selection is saved to preferences.
+
+  Reads from the shared agentState cache (populated once at app startup)
+  so there's no discovery delay when opening modals.
+
+  Usage:
+    <AgentSelector />
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { ChevronDown, Check, Bot } from 'lucide-svelte';
+  import { agentState } from './stores/agent.svelte';
+  import { preferences, setAiAgent } from './stores/preferences.svelte';
+
+  interface Props {
+    disabled?: boolean;
+  }
+
+  let { disabled = false }: Props = $props();
+
+  let showDropdown = $state(false);
+
+  let currentLabel = $derived(
+    agentState.providers.find((p) => p.id === preferences.aiAgent)?.label ??
+      preferences.aiAgent ??
+      'Agent'
+  );
+
+  onMount(() => {
+    document.addEventListener('click', handleClickOutside);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('click', handleClickOutside);
+  });
+
+  function handleClickOutside(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    if (showDropdown && !target.closest('.agent-selector')) {
+      showDropdown = false;
+    }
+  }
+
+  function select(id: string) {
+    setAiAgent(id);
+    showDropdown = false;
+  }
+
+  function toggle() {
+    if (!disabled && agentState.providers.length > 1) {
+      showDropdown = !showDropdown;
+    }
+  }
+</script>
+
+{#if agentState.loaded && agentState.providers.length > 0}
+  <div class="agent-selector">
+    <button
+      type="button"
+      class="selector-btn"
+      onclick={toggle}
+      {disabled}
+      title={agentState.providers.length > 1 ? 'Select AI agent' : currentLabel}
+    >
+      <Bot size={12} />
+      <span class="selector-label">{currentLabel}</span>
+      {#if agentState.providers.length > 1}
+        <ChevronDown size={12} />
+      {/if}
+    </button>
+    {#if showDropdown}
+      <div class="selector-dropdown">
+        {#each agentState.providers as provider (provider.id)}
+          <button
+            type="button"
+            class="selector-option"
+            class:selected={preferences.aiAgent === provider.id}
+            onclick={() => select(provider.id)}
+          >
+            <span class="option-label">{provider.label}</span>
+            {#if preferences.aiAgent === provider.id}
+              <Check size={14} />
+            {/if}
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .agent-selector {
+    position: relative;
+  }
+
+  .selector-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 8px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-faint);
+    font-size: var(--size-xs);
+    font-family: inherit;
+    cursor: pointer;
+    transition:
+      background-color 0.1s,
+      color 0.1s;
+  }
+
+  .selector-btn:hover:not(:disabled) {
+    background-color: var(--bg-hover);
+    color: var(--text-muted);
+  }
+
+  .selector-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .selector-label {
+    white-space: nowrap;
+  }
+
+  .selector-dropdown {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    margin-bottom: 4px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+    z-index: 1001;
+    min-width: 140px;
+  }
+
+  .selector-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 8px 12px;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: var(--size-sm);
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.1s;
+  }
+
+  .selector-option:hover {
+    background-color: var(--bg-hover);
+  }
+
+  .selector-option.selected {
+    color: var(--ui-accent);
+  }
+
+  .selector-option.selected :global(svg) {
+    color: var(--ui-accent);
+  }
+
+  .option-label {
+    flex: 1;
+  }
+</style>

--- a/staged/src/lib/AgentSetupModal.svelte
+++ b/staged/src/lib/AgentSetupModal.svelte
@@ -1,0 +1,290 @@
+<!--
+  AgentSetupModal.svelte — Shown when no ACP agents are detected.
+
+  Informs the user that AI features require an installed agent and
+  provides install links. Has a Refresh button to re-scan and a
+  Dismiss button so the user isn't blocked from using the rest of
+  the app.
+
+  Auto-closes when an agent is detected after refresh.
+-->
+<script lang="ts">
+  import { RefreshCw, ExternalLink, Bot, X } from 'lucide-svelte';
+  import { agentState, refreshProviders, KNOWN_AGENTS } from './stores/agent.svelte';
+  import { openUrl } from './commands';
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  let { onClose }: Props = $props();
+
+  let refreshing = $state(false);
+
+  // Auto-close when agents become available after a refresh.
+  $effect(() => {
+    if (agentState.providers.length > 0) {
+      onClose();
+    }
+  });
+
+  async function refresh() {
+    refreshing = true;
+    await refreshProviders();
+    refreshing = false;
+  }
+</script>
+
+<div class="modal-backdrop" role="dialog" aria-modal="true" tabindex="-1">
+  <div class="modal">
+    <button class="close-btn" onclick={onClose} title="Dismiss">
+      <X size={16} />
+    </button>
+
+    <header class="modal-header">
+      <div class="header-icon">
+        <Bot size={24} />
+      </div>
+      <h2>No AI Agent Detected</h2>
+      <p class="subtitle">
+        Most Staged features need an AI agent to work. Install one of the following and click <strong
+          >Refresh</strong
+        >.
+      </p>
+    </header>
+
+    <div class="modal-body">
+      <div class="agents-list">
+        {#each KNOWN_AGENTS as agent (agent.id)}
+          <div class="agent-row">
+            <div class="agent-info">
+              <span class="agent-name">{agent.label}</span>
+              <p class="agent-description">{agent.description}</p>
+            </div>
+            {#if agent.installUrl}
+              <button class="install-link" onclick={() => openUrl(agent.installUrl!)}>
+                <ExternalLink size={12} />
+                Install
+              </button>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <footer class="modal-footer">
+      <button class="refresh-btn" onclick={refresh} disabled={refreshing}>
+        <span class="spin-icon" class:spinning={refreshing}><RefreshCw size={14} /></span>
+        {refreshing ? 'Checking…' : 'Refresh'}
+      </button>
+      <button class="dismiss-btn" onclick={onClose}>Dismiss</button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--shadow-overlay);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .modal {
+    position: relative;
+    background: var(--bg-chrome);
+    border-radius: 12px;
+    box-shadow: var(--shadow-elevated);
+    width: 420px;
+    max-width: 90vw;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .close-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: none;
+    border: none;
+    color: var(--text-faint);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.1s;
+  }
+
+  .close-btn:hover {
+    color: var(--text-primary);
+  }
+
+  .modal-header {
+    padding: 24px 24px 16px;
+    text-align: center;
+  }
+
+  .header-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    margin: 0 auto 12px;
+    background: var(--bg-primary);
+    border-radius: 12px;
+    color: var(--text-muted);
+  }
+
+  .modal-header h2 {
+    margin: 0 0 6px 0;
+    font-size: calc(var(--size-base) + 2px);
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .subtitle {
+    margin: 0;
+    font-size: var(--size-sm);
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+
+  .modal-body {
+    padding: 0 24px;
+  }
+
+  .agents-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .agent-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background: var(--bg-primary);
+    border-radius: 8px;
+  }
+
+  .agent-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .agent-name {
+    font-size: var(--size-sm);
+    font-weight: 500;
+    color: var(--text-primary);
+  }
+
+  .agent-description {
+    margin: 2px 0 0 0;
+    font-size: var(--size-xs);
+    color: var(--text-muted);
+  }
+
+  .install-link {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    background: none;
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: var(--size-xs);
+    font-family: inherit;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      color 0.1s,
+      border-color 0.1s;
+  }
+
+  .install-link:hover {
+    color: var(--text-primary);
+    border-color: var(--border-emphasis);
+  }
+
+  .modal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 24px;
+    margin-top: 8px;
+  }
+
+  .refresh-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    background: none;
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: var(--size-sm);
+    font-family: inherit;
+    cursor: pointer;
+    transition:
+      color 0.1s,
+      border-color 0.1s;
+  }
+
+  .refresh-btn:not(:disabled):hover {
+    color: var(--text-primary);
+    border-color: var(--border-emphasis);
+  }
+
+  .refresh-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .dismiss-btn {
+    padding: 8px 16px;
+    background: none;
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: var(--size-sm);
+    font-family: inherit;
+    cursor: pointer;
+    transition:
+      color 0.1s,
+      border-color 0.1s;
+  }
+
+  .dismiss-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--border-emphasis);
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .spin-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .spin-icon.spinning {
+    animation: spin 1s linear infinite;
+  }
+</style>

--- a/staged/src/lib/NewSessionModal.svelte
+++ b/staged/src/lib/NewSessionModal.svelte
@@ -16,6 +16,8 @@
   import { X, GitCommitHorizontal, StickyNote, GitBranch, Loader2, Send } from 'lucide-svelte';
   import type { Branch, BranchSessionType } from './types';
   import * as commands from './commands';
+  import AgentSelector from './AgentSelector.svelte';
+  import { preferences } from './stores/preferences.svelte';
 
   interface Props {
     branch: Branch;
@@ -69,7 +71,12 @@
     error = null;
 
     try {
-      const result = await commands.startBranchSession(branch.id, prompt.trim(), currentMode);
+      const result = await commands.startBranchSession(
+        branch.id,
+        prompt.trim(),
+        currentMode,
+        preferences.aiAgent ?? undefined
+      );
       onStarted({ sessionId: result.sessionId, artifactId: result.artifactId });
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
@@ -169,18 +176,21 @@
       {/if}
 
       <div class="form-actions">
-        <button type="button" class="cancel-btn" onclick={handleClose} disabled={starting}>
-          Cancel
-        </button>
-        <button type="submit" class="submit-btn" disabled={starting || !prompt.trim()}>
-          {#if starting}
-            <Loader2 size={14} class="spinning" />
-            Starting…
-          {:else}
-            <Send size={14} />
-            Start
-          {/if}
-        </button>
+        <AgentSelector disabled={starting} />
+        <div class="form-actions-right">
+          <button type="button" class="cancel-btn" onclick={handleClose} disabled={starting}>
+            Cancel
+          </button>
+          <button type="submit" class="submit-btn" disabled={starting || !prompt.trim()}>
+            {#if starting}
+              <Loader2 size={14} class="spinning" />
+              Starting…
+            {:else}
+              <Send size={14} />
+              Start
+            {/if}
+          </button>
+        </div>
       </div>
     </form>
   </div>
@@ -375,9 +385,15 @@
   /* Actions */
   .form-actions {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
+    justify-content: space-between;
     gap: 8px;
     margin-top: 4px;
+  }
+
+  .form-actions-right {
+    display: flex;
+    gap: 8px;
   }
 
   .cancel-btn,

--- a/staged/src/lib/SessionLauncher.svelte
+++ b/staged/src/lib/SessionLauncher.svelte
@@ -15,6 +15,7 @@
   import type { Session, SessionStatus } from './types';
   import { startSession, deleteSession } from './commands';
   import SessionModal from './SessionModal.svelte';
+  import { preferences } from './stores/preferences.svelte';
 
   interface Props {
     onClose: () => void;
@@ -81,7 +82,7 @@
       // We need a working directory — use the user's home dir as a default
       // for these standalone debug sessions.
       const workingDir = '/tmp';
-      const s = await startSession(text, workingDir);
+      const s = await startSession(text, workingDir, preferences.aiAgent ?? undefined);
       sessions = [...sessions, s];
       prompt = '';
     } catch (e) {

--- a/staged/src/lib/TopBar.svelte
+++ b/staged/src/lib/TopBar.svelte
@@ -5,11 +5,13 @@
   for adding new projects.
 -->
 <script lang="ts">
-  import { Palette, Plus } from 'lucide-svelte';
+  import { Palette, Plus, Bot } from 'lucide-svelte';
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import ThemeSelectorModal from './ThemeSelectorModal.svelte';
+  import AgentDropdown from './AgentDropdown.svelte';
 
   let showThemeModal = $state(false);
+  let showAgentDropdown = $state(false);
 
   function startDrag(e: PointerEvent) {
     if (e.button !== 0) return;
@@ -37,12 +39,24 @@
     </button>
 
     <button
+      class="icon-btn agent-btn"
+      onclick={() => (showAgentDropdown = !showAgentDropdown)}
+      title="AI agents"
+    >
+      <Bot size={14} />
+    </button>
+
+    <button
       class="icon-btn theme-btn"
       onclick={() => (showThemeModal = !showThemeModal)}
       title="Select theme"
     >
       <Palette size={14} />
     </button>
+
+    {#if showAgentDropdown}
+      <AgentDropdown onClose={() => (showAgentDropdown = false)} />
+    {/if}
 
     {#if showThemeModal}
       <ThemeSelectorModal onClose={() => (showThemeModal = false)} />

--- a/staged/src/lib/commands.ts
+++ b/staged/src/lib/commands.ts
@@ -81,6 +81,29 @@ export function getBranchTimeline(branchId: string): Promise<BranchTimeline> {
 }
 
 // =============================================================================
+// Utilities
+// =============================================================================
+
+/** Open a URL in the user's default browser. */
+export function openUrl(url: string): Promise<void> {
+  return invoke('open_url', { url });
+}
+
+// =============================================================================
+// Agent discovery
+// =============================================================================
+
+export interface AcpProviderInfo {
+  id: string;
+  label: string;
+}
+
+/** Scan the system for installed ACP-compatible agents. */
+export function discoverAcpProviders(): Promise<AcpProviderInfo[]> {
+  return invoke('discover_acp_providers');
+}
+
+// =============================================================================
 // Sessions
 // =============================================================================
 
@@ -99,12 +122,17 @@ export function getSessionMessagesSince(
   return invoke('get_session_messages_since', { sessionId, sinceId });
 }
 
-/** Create a session and immediately start the agent (goose). */
-export function startSession(prompt: string, workingDir: string): Promise<Session> {
-  return invoke('start_session', { prompt, workingDir });
+/** Create a session and immediately start the agent. */
+export function startSession(
+  prompt: string,
+  workingDir: string,
+  provider?: string
+): Promise<Session> {
+  return invoke('start_session', { prompt, workingDir, provider: provider ?? null });
 }
 
-/** Send a follow-up message to an existing (completed/cancelled/error) session. */
+/** Send a follow-up message to an existing session.
+ *  The backend uses the provider that originally created the session. */
 export function resumeSession(sessionId: string, prompt: string): Promise<void> {
   return invoke('resume_session', { sessionId, prompt });
 }
@@ -121,9 +149,15 @@ export function deleteSession(sessionId: string): Promise<void> {
 export function startBranchSession(
   branchId: string,
   prompt: string,
-  sessionType: BranchSessionType
+  sessionType: BranchSessionType,
+  provider?: string
 ): Promise<BranchSessionResponse> {
-  return invoke('start_branch_session', { branchId, prompt, sessionType });
+  return invoke('start_branch_session', {
+    branchId,
+    prompt,
+    sessionType,
+    provider: provider ?? null,
+  });
 }
 
 // =============================================================================

--- a/staged/src/lib/stores/agent.svelte.ts
+++ b/staged/src/lib/stores/agent.svelte.ts
@@ -1,0 +1,83 @@
+/**
+ * Agent discovery cache and known-agent metadata.
+ *
+ * Discovered providers are loaded once at app startup and cached here.
+ * Components read from this store instead of calling discoverAcpProviders()
+ * on every mount. The refresh button in various UI surfaces updates this
+ * cache so all components benefit immediately.
+ *
+ * `KNOWN_AGENTS` is the single source of truth for agent display metadata
+ * on the frontend (labels, descriptions, install URLs). The backend owns
+ * the registry of supported agent IDs and CLI commands.
+ */
+
+import { discoverAcpProviders, type AcpProviderInfo } from '../commands';
+
+// =============================================================================
+// Known agent metadata (display-only — the backend owns the real registry)
+// =============================================================================
+
+export interface KnownAgent {
+  id: string;
+  label: string;
+  description: string;
+  installUrl: string | null;
+}
+
+/** All agents the app knows about, in display order. */
+export const KNOWN_AGENTS: KnownAgent[] = [
+  {
+    id: 'goose',
+    label: 'Goose',
+    description: 'Open-source AI agent by Block',
+    installUrl: 'https://github.com/block/goose',
+  },
+  {
+    id: 'claude',
+    label: 'Claude Code',
+    description: 'AI coding assistant by Anthropic',
+    installUrl: 'https://github.com/zed-industries/claude-code-acp#installation',
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    description: 'AI coding agent by OpenAI',
+    installUrl: 'https://github.com/zed-industries/codex-acp#installation',
+  },
+  {
+    id: 'pi',
+    label: 'Pi',
+    description: 'AI coding agent by Mario Zechner',
+    installUrl: null,
+  },
+];
+
+// =============================================================================
+// Reactive discovery cache
+// =============================================================================
+
+/** Shared reactive state for discovered providers. */
+export const agentState = $state({
+  providers: [] as AcpProviderInfo[],
+  loaded: false,
+});
+
+/**
+ * Discover providers and update the cache.
+ *
+ * Safe to call multiple times — each call replaces the cached list.
+ * Called once at startup and again when the user clicks "Refresh".
+ */
+export async function refreshProviders(): Promise<AcpProviderInfo[]> {
+  try {
+    const providers = await discoverAcpProviders();
+    agentState.providers = providers;
+    agentState.loaded = true;
+    return providers;
+  } catch (e) {
+    console.error('Failed to discover ACP providers:', e);
+    agentState.providers = [];
+    agentState.loaded = true;
+    return [];
+  }
+}

--- a/staged/src/lib/stores/preferences.svelte.ts
+++ b/staged/src/lib/stores/preferences.svelte.ts
@@ -33,6 +33,7 @@ const SIZE_DEFAULT = 13;
 
 const SIZE_STORE_KEY = 'size-base';
 const SYNTAX_THEME_STORE_KEY = 'syntax-theme';
+const AI_AGENT_STORE_KEY = 'ai-agent';
 
 const DEFAULT_SYNTAX_THEME: SyntaxThemeName = 'laserwave';
 
@@ -57,6 +58,8 @@ export const preferences = $state({
   sizeBase: SIZE_DEFAULT,
   /** Current syntax theme name */
   syntaxTheme: DEFAULT_SYNTAX_THEME as string,
+  /** Selected AI agent provider ID (e.g. "goose", "claude"). Null = not yet chosen. */
+  aiAgent: null as string | null,
   /** Whether all preferences have been loaded from storage */
   loaded: false,
 });
@@ -110,6 +113,12 @@ export async function initPreferences(): Promise<void> {
   }
   await setSyntaxTheme(preferences.syntaxTheme as SyntaxThemeName);
   applyAdaptiveTheme();
+
+  // Load AI agent preference
+  const savedAgent = await getStoreValue<string>(AI_AGENT_STORE_KEY);
+  if (savedAgent) {
+    preferences.aiAgent = savedAgent;
+  }
 
   preferences.loaded = true;
 }
@@ -168,4 +177,16 @@ export function resetSize(): void {
   preferences.sizeBase = SIZE_DEFAULT;
   applySize();
   setStoreValue(SIZE_STORE_KEY, preferences.sizeBase);
+}
+
+// =============================================================================
+// AI Agent Actions
+// =============================================================================
+
+/**
+ * Set the preferred AI agent provider.
+ */
+export function setAiAgent(agentId: string): void {
+  preferences.aiAgent = agentId;
+  setStoreValue(AI_AGENT_STORE_KEY, agentId);
 }


### PR DESCRIPTION
## Summary

Generalizes the ACP integration from Goose-only to support multiple AI agents (Goose, Claude Code, Codex, Pi). Agents are discovered at startup by scanning for their CLI binaries.

## Backend

- **Agent registry**: `KNOWN_AGENTS` in `acp.rs` maps agent IDs → CLI commands + ACP args
- **Provider discovery**: `discover_acp_providers` Tauri command scans for installed agent binaries
- **Session provider tracking**: New `provider` column on sessions (schema v3) so resume uses the correct agent
- **Generic driver**: `AcpDriver::new(provider_id)` and `AcpDriver::first_available()` replace the old goose-only constructor
- **Utility**: `open_url` command for launching install links in the default browser

## Frontend

- **Agent store** (`agent.svelte.ts`): Discovery cache loaded once at startup, shared across components
- **AgentSetupModal**: Shown when no agents are detected — lists known agents with install links and a refresh button
- **AgentDropdown**: TopBar dropdown showing installed/missing agents with selection and install links
- **AgentSelector**: Compact inline dropdown in NewSessionModal for per-session agent choice
- **Preferences**: Selected agent persisted in local storage and passed through to session creation

## Schema

Bumps to v3 — adds nullable `provider TEXT` column to the `sessions` table.