### PR TITLE
feat: add copy worktree path option to branch card dropdown menu

### DIFF
--- a/staged/src/lib/BranchCard.svelte
+++ b/staged/src/lib/BranchCard.svelte
@@ -20,6 +20,7 @@
     FileDiff,
     StickyNote,
     Plus,
+    Copy,
   } from 'lucide-svelte';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
   import type { Branch, BranchTimeline as BranchTimelineData, BranchSessionType } from './types';
@@ -39,9 +40,23 @@
 
   let { branch, onDelete }: Props = $props();
 
-  const menuItems: MenuItem[] = [
+  async function copyWorktreePath() {
+    const path = branch.worktreePath;
+    if (path) {
+      try {
+        await navigator.clipboard.writeText(path);
+      } catch {
+        // clipboard API may fail in some contexts
+      }
+    }
+  }
+
+  const menuItems: MenuItem[] = $derived([
+    ...(branch.worktreePath
+      ? [{ label: 'Copy Worktree Path', icon: Copy, action: copyWorktreePath }]
+      : []),
     { label: 'Delete Branch', icon: Trash2, danger: true, action: () => onDelete?.() },
-  ];
+  ]);
 
   let timeline = $state<BranchTimelineData | null>(null);
   let loading = $state(true);


### PR DESCRIPTION
## Summary

Add a **Copy Worktree Path** menu item to the 3-dot dropdown on branch cards.

## Changes

- Added a 'Copy Worktree Path' option to the `DropdownMenu` on `BranchCard`
- Uses `navigator.clipboard.writeText()` consistent with existing clipboard patterns in the codebase
- The option is only shown when the branch has a worktree path
- Menu items use `$derived` to reactively respond to prop changes (avoids Svelte 5 `state_referenced_locally` warning)