### PR TITLE
refactor: replace DOMPurify with sanitize-html (MIT license)

### DIFF
--- a/staged/package-lock.json
+++ b/staged/package-lock.json
@@ -12,17 +12,17 @@
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-store": "^2.4.2",
+        "@types/sanitize-html": "^2.16.0",
         "ansi-to-html": "^0.7.2",
-        "dompurify": "^3.3.1",
         "lucide-svelte": "^0.562.0",
         "marked": "^17.0.1",
+        "sanitize-html": "^2.17.0",
         "shiki": "^3.20.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@tauri-apps/cli": "^2.10.0",
         "@tsconfig/svelte": "^5.0.6",
-        "@types/dompurify": "^3.0.5",
         "@types/node": "^24.10.1",
         "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.1",
@@ -1241,16 +1241,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/dompurify": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
-      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/trusted-types": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1286,12 +1276,14 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "devOptional": true,
-      "license": "MIT"
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1420,7 +1412,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1454,13 +1445,69 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/entities": {
@@ -1512,6 +1559,17 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esm-env": {
@@ -1606,6 +1664,45 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-reference": {
@@ -1777,7 +1874,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1820,11 +1916,16 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -1845,7 +1946,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2004,6 +2104,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/sanitize-html/-/sanitize-html-2.17.0.tgz",
+      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
     "node_modules/shiki": {
       "version": "3.22.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.22.0.tgz",
@@ -2024,7 +2138,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/staged/package.json
+++ b/staged/package.json
@@ -16,7 +16,6 @@
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tauri-apps/cli": "^2.10.0",
     "@tsconfig/svelte": "^5.0.6",
-    "@types/dompurify": "^3.0.5",
     "@types/node": "^24.10.1",
     "prettier": "^3.7.4",
     "prettier-plugin-svelte": "^3.4.1",
@@ -30,10 +29,11 @@
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-store": "^2.4.2",
+    "@types/sanitize-html": "^2.16.0",
     "ansi-to-html": "^0.7.2",
-    "dompurify": "^3.3.1",
     "lucide-svelte": "^0.562.0",
     "marked": "^17.0.1",
+    "sanitize-html": "^2.17.0",
     "shiki": "^3.20.0"
   }
 }

--- a/staged/src/lib/DiffViewer.svelte
+++ b/staged/src/lib/DiffViewer.svelte
@@ -18,7 +18,7 @@
   import { onMount } from 'svelte';
   import { MessageSquarePlus, MessageSquare, X } from 'lucide-svelte';
   import { marked } from 'marked';
-  import DOMPurify from 'dompurify';
+  import { sanitize } from './sanitize';
   import type { FileDiff, Alignment, Comment, Span, SmartDiffAnnotation } from './types';
   import {
     initHighlighter,
@@ -218,7 +218,7 @@
     const content = beforeLines.join('\n');
     if (!content.trim()) return '';
     const html = marked.parse(content, { async: false }) as string;
-    return DOMPurify.sanitize(html);
+    return sanitize(html);
   });
 
   let afterMarkdownHtml = $derived.by(() => {
@@ -226,7 +226,7 @@
     const content = afterLines.join('\n');
     if (!content.trim()) return '';
     const html = marked.parse(content, { async: false }) as string;
-    return DOMPurify.sanitize(html);
+    return sanitize(html);
   });
 
   // AI annotations for after pane (only informational ones with after_span)

--- a/staged/src/lib/NoteModal.svelte
+++ b/staged/src/lib/NoteModal.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
   import { X } from 'lucide-svelte';
   import { marked } from 'marked';
-  import DOMPurify from 'dompurify';
+  import { sanitize } from './sanitize';
 
   marked.setOptions({ breaks: true, gfm: true });
 
@@ -20,7 +20,7 @@
   let { title, content, onClose }: Props = $props();
 
   function renderMarkdown(text: string): string {
-    return DOMPurify.sanitize(marked.parse(text) as string);
+    return sanitize(marked.parse(text) as string);
   }
 
   function handleKeydown(e: KeyboardEvent) {

--- a/staged/src/lib/SessionModal.svelte
+++ b/staged/src/lib/SessionModal.svelte
@@ -40,7 +40,7 @@
     GitBranch,
   } from 'lucide-svelte';
   import { marked } from 'marked';
-  import DOMPurify from 'dompurify';
+  import { sanitize } from './sanitize';
   import type { Session, SessionMessage } from './types';
   import {
     cancelSession,
@@ -295,7 +295,7 @@
   }
 
   function renderMarkdown(content: string): string {
-    return DOMPurify.sanitize(marked.parse(content) as string);
+    return sanitize(marked.parse(content) as string);
   }
 
   // =========================================================================

--- a/staged/src/lib/sanitize.ts
+++ b/staged/src/lib/sanitize.ts
@@ -1,0 +1,37 @@
+import sanitizeHtml from 'sanitize-html';
+
+/**
+ * Sanitize HTML produced by marked (Markdown → HTML).
+ *
+ * The allowlist mirrors the subset of HTML that `marked` can emit so that
+ * rendered Markdown keeps its formatting while still stripping anything
+ * dangerous.  This replaces DOMPurify (MPL-licensed) with sanitize-html
+ * (MIT-licensed).
+ */
+export function sanitize(dirty: string): string {
+  return sanitizeHtml(dirty, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+      // Extra tags that marked can produce but sanitize-html doesn't allow by
+      // default:
+      'img',
+      'details',
+      'summary',
+      'del',
+      'ins',
+      'input',
+    ]),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      img: ['src', 'alt', 'title', 'width', 'height'],
+      input: ['type', 'checked', 'disabled'],
+      a: ['href', 'name', 'target', 'rel'],
+      td: ['align'],
+      th: ['align'],
+      code: ['class'], // for syntax-highlight class names
+      span: ['class'], // for syntax-highlight class names
+      pre: ['class'],
+    },
+    // Only allow checkbox inputs (GFM task lists)
+    allowedSchemes: ['http', 'https', 'mailto'],
+  });
+}


### PR DESCRIPTION
DOMPurify uses the MPL license which is incompatible with our project's licensing requirements. Replace it with sanitize-html (MIT-licensed).

- Add shared src/lib/sanitize.ts utility with a markdown-appropriate allowlist (covers all tags/attributes that marked can emit)
- Update DiffViewer, NoteModal, and SessionModal to use the new utility
- Remove dompurify and @types/dompurify dependencies