### PR TITLE
fix: prevent UI lockup when deleting a branch

### DIFF
--- a/staged/src-tauri/src/lib.rs
+++ b/staged/src-tauri/src/lib.rs
@@ -530,7 +530,7 @@ fn create_branch(
 }
 
 #[tauri::command]
-fn delete_branch(
+async fn delete_branch(
     store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
     branch_id: String,
 ) -> Result<(), String> {

--- a/staged/src/lib/BranchCard.svelte
+++ b/staged/src/lib/BranchCard.svelte
@@ -35,10 +35,11 @@
 
   interface Props {
     branch: Branch;
+    deleting?: boolean;
     onDelete?: () => void;
   }
 
-  let { branch, onDelete }: Props = $props();
+  let { branch, deleting = false, onDelete }: Props = $props();
 
   async function copyWorktreePath() {
     const path = branch.worktreePath;
@@ -274,72 +275,79 @@
 
 <svelte:window onclick={handlePickerClickOutside} onkeydown={handlePickerKeydown} />
 
-<div class="branch-card">
-  <div class="card-header">
-    <div class="branch-info">
-      <GitBranch size={16} class="branch-icon" />
-      <span class="branch-name">{branch.branchName}</span>
-      <span class="branch-separator">›</span>
-      <span class="base-branch-name">{formatBaseBranch(branch.baseBranch)}</span>
+<div class="branch-card" class:deleting>
+  {#if deleting}
+    <div class="deleting-overlay">
+      <Loader2 size={16} class="spinner" />
+      <span>Deleting…</span>
     </div>
-    <div class="header-actions">
-      <button class="view-diff-btn" onclick={() => (showBranchDiff = true)} title="View diff">
-        <FileDiff size={16} />
-      </button>
-      <DropdownMenu items={menuItems} />
+  {:else}
+    <div class="card-header">
+      <div class="branch-info">
+        <GitBranch size={16} class="branch-icon" />
+        <span class="branch-name">{branch.branchName}</span>
+        <span class="branch-separator">›</span>
+        <span class="base-branch-name">{formatBaseBranch(branch.baseBranch)}</span>
+      </div>
+      <div class="header-actions">
+        <button class="view-diff-btn" onclick={() => (showBranchDiff = true)} title="View diff">
+          <FileDiff size={16} />
+        </button>
+        <DropdownMenu items={menuItems} />
+      </div>
     </div>
-  </div>
 
-  <div class="card-content">
-    {#if loading}
-      <div class="loading">
-        <Loader2 size={14} class="spinner" />
-        <span>Loading...</span>
-      </div>
-    {:else if error}
-      <div class="error">
-        <span>{error}</span>
-      </div>
-    {:else if timeline}
-      <BranchTimeline
-        {timeline}
-        onSessionClick={handleTimelineSessionClick}
-        onCommitClick={handleCommitClick}
-        onNoteClick={handleNoteClick}
-        onDeleteCommit={handleDeleteCommit}
-        onDeletePendingCommit={handleDeletePendingCommit}
-        onDeleteNote={handleDeleteNote}
-      />
-    {/if}
-  </div>
-
-  <!-- Footer with single action button -->
-  <div class="card-footer">
-    <div class="new-btn-container" bind:this={pickerRef}>
-      <button
-        class="new-btn"
-        onpointerdown={handlePointerDown}
-        onpointerup={handlePointerUp}
-        onpointerleave={handlePointerLeave}
-        disabled={showNewSession}
-        title="New commit (hold for options)"
-      >
-        <Plus size={14} />
-      </button>
-      {#if showPicker}
-        <div class="picker-dropdown">
-          <button class="picker-item" onclick={() => openNewSession('commit')}>
-            <GitCommitHorizontal size={14} />
-            <span>Commit</span>
-          </button>
-          <button class="picker-item" onclick={() => openNewSession('note')}>
-            <StickyNote size={14} />
-            <span>Note</span>
-          </button>
+    <div class="card-content">
+      {#if loading}
+        <div class="loading">
+          <Loader2 size={14} class="spinner" />
+          <span>Loading...</span>
         </div>
+      {:else if error}
+        <div class="error">
+          <span>{error}</span>
+        </div>
+      {:else if timeline}
+        <BranchTimeline
+          {timeline}
+          onSessionClick={handleTimelineSessionClick}
+          onCommitClick={handleCommitClick}
+          onNoteClick={handleNoteClick}
+          onDeleteCommit={handleDeleteCommit}
+          onDeletePendingCommit={handleDeletePendingCommit}
+          onDeleteNote={handleDeleteNote}
+        />
       {/if}
     </div>
-  </div>
+
+    <!-- Footer with single action button -->
+    <div class="card-footer">
+      <div class="new-btn-container" bind:this={pickerRef}>
+        <button
+          class="new-btn"
+          onpointerdown={handlePointerDown}
+          onpointerup={handlePointerUp}
+          onpointerleave={handlePointerLeave}
+          disabled={showNewSession}
+          title="New commit (hold for options)"
+        >
+          <Plus size={14} />
+        </button>
+        {#if showPicker}
+          <div class="picker-dropdown">
+            <button class="picker-item" onclick={() => openNewSession('commit')}>
+              <GitCommitHorizontal size={14} />
+              <span>Commit</span>
+            </button>
+            <button class="picker-item" onclick={() => openNewSession('note')}>
+              <StickyNote size={14} />
+              <span>Note</span>
+            </button>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
 </div>
 
 {#if showBranchDiff}
@@ -409,8 +417,22 @@
     transition: border-color 0.15s ease;
   }
 
-  .branch-card:hover {
+  .branch-card:hover:not(.deleting) {
     border-color: var(--border-muted);
+  }
+
+  .branch-card.deleting {
+    opacity: 0.6;
+  }
+
+  /* Deleting overlay */
+  .deleting-overlay {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 20px 16px;
+    color: var(--text-muted);
+    font-size: var(--size-sm);
   }
 
   /* Header */

--- a/staged/src/lib/ProjectHome.svelte
+++ b/staged/src/lib/ProjectHome.svelte
@@ -35,6 +35,7 @@
   // Delete confirmation state
   let projectToDelete = $state<Project | null>(null);
   let branchToDelete = $state<{ branch: Branch; project: Project } | null>(null);
+  let deletingBranches = $state<Set<string>>(new Set());
 
   onMount(() => {
     checkStoreAndLoad();
@@ -161,8 +162,12 @@
     const { branch } = branchToDelete;
     branchToDelete = null;
 
+    // Show "Deleting…" state on the card immediately
+    deletingBranches = new Set([...deletingBranches, branch.id]);
+
     try {
       await commands.deleteBranch(branch.id);
+      // Remove the branch from the list on success
       const existing = branchesByProject.get(branch.projectId) || [];
       branchesByProject = new Map(branchesByProject).set(
         branch.projectId,
@@ -170,6 +175,10 @@
       );
     } catch (e) {
       console.error('Failed to delete branch:', e);
+    } finally {
+      const next = new Set(deletingBranches);
+      next.delete(branch.id);
+      deletingBranches = next;
     }
   }
 
@@ -268,6 +277,7 @@
           <ProjectSection
             {project}
             branches={branchesByProject.get(project.id) || []}
+            {deletingBranches}
             onDeleteProject={() => handleDeleteProjectRequest(project)}
             onDeleteBranch={(branchId) => handleDeleteBranchRequest(branchId, project)}
             onNewBranch={() => handleNewBranch(project)}

--- a/staged/src/lib/ProjectSection.svelte
+++ b/staged/src/lib/ProjectSection.svelte
@@ -14,12 +14,20 @@
   interface Props {
     project: Project;
     branches: Branch[];
+    deletingBranches?: Set<string>;
     onDeleteProject?: () => void;
     onDeleteBranch?: (branchId: string) => void;
     onNewBranch?: () => void;
   }
 
-  let { project, branches, onDeleteProject, onDeleteBranch, onNewBranch }: Props = $props();
+  let {
+    project,
+    branches,
+    deletingBranches = new Set(),
+    onDeleteProject,
+    onDeleteBranch,
+    onNewBranch,
+  }: Props = $props();
 
   const projectMenuItems: MenuItem[] = [
     { label: 'Remove Project', icon: Trash2, danger: true, action: () => onDeleteProject?.() },
@@ -38,7 +46,11 @@
   </div>
   <div class="branches-list">
     {#each branches as branch (branch.id)}
-      <BranchCard {branch} onDelete={() => onDeleteBranch?.(branch.id)} />
+      <BranchCard
+        {branch}
+        deleting={deletingBranches.has(branch.id)}
+        onDelete={() => onDeleteBranch?.(branch.id)}
+      />
     {/each}
     <!-- New branch button -->
     <button class="new-branch-button" onclick={() => onNewBranch?.()}>


### PR DESCRIPTION
## Problem

Deleting a branch blocks the main thread because `delete_branch` runs synchronous git worktree removal on the Tauri main thread. This causes the UI to freeze until the operation completes.

## Solution

### Backend
- Make `delete_branch` a Tauri `async` command so the git worktree removal runs on a background thread instead of blocking the main thread.

### Frontend
- Add a `deleting` state that shows a spinner overlay on the branch card while the backend operation runs.
- The confirm dialog dismisses immediately after the user confirms.
- The branch card shows a "Deleting…" spinner overlay while the async operation is in progress.
- On success, the card is removed from the list.
- On failure, the deleting state is cleared and the card returns to normal.

## Changes

- **`src-tauri/src/lib.rs`** — Mark `delete_branch` as async
- **`src/lib/BranchCard.svelte`** — Accept `deleting` prop, render spinner overlay when active
- **`src/lib/ProjectHome.svelte`** — Track `deletingBranches` set, manage async delete lifecycle
- **`src/lib/ProjectSection.svelte`** — Pass `deletingBranches` through to `BranchCard`