### PR TITLE
fix: preserve pending commit as failed when session produces no commit

### DIFF
--- a/staged/src-tauri/src/session_runner.rs
+++ b/staged/src-tauri/src/session_runner.rs
@@ -276,8 +276,10 @@ fn run_post_completion_hooks(
                     }
                 }
                 Ok(_) => {
-                    log::info!("Session {session_id}: no new commit (HEAD unchanged), cleaning up pending commit");
-                    let _ = store.delete_commit(&pending_commit.id);
+                    // Leave the pending commit record in the DB so it appears
+                    // as a failed-commit in the timeline (warning icon). The
+                    // user can choose to retry via the session or delete it.
+                    log::info!("Session {session_id}: no new commit (HEAD unchanged), leaving pending commit as failed");
                 }
                 Err(e) => {
                     log::error!("Failed to get HEAD SHA after session: {e}");


### PR DESCRIPTION
## Problem

When a session that was supposed to create a commit finishes without actually producing one (HEAD unchanged), the pending commit record was deleted from the database. This caused the timeline entry to silently disappear — the user had no indication that the session ran and failed to produce a commit.

## Solution

Stop deleting the pending commit record when HEAD hasn't moved. Instead, leave it in place with no SHA. The frontend already fully supports this "failed commit" state:

- **`BranchTimeline.svelte`** detects commits with no SHA where the session is no longer running and classifies them as `failed-commit` with the message "Session finished — no commit created"
- **`TimelineRow.svelte`** renders these with the `AlertTriangle` warning icon and appropriate styling
- Users can click the session icon to view/continue the session, or delete the failed entry

## Changes

One file changed: `src-tauri/src/session_runner.rs`

Removed the `store.delete_commit()` call in the "HEAD unchanged" branch of `run_post_completion_hooks`, replacing it with a log message. The pending commit record is preserved so the frontend can render it in the failed state.