### PR TITLE
fix: preserve scroll position in session viewer when scrolled up

### DIFF
--- a/staged/src/lib/SessionModal.svelte
+++ b/staged/src/lib/SessionModal.svelte
@@ -286,13 +286,24 @@
   // Helpers
   // =========================================================================
 
-  /** Whether the user is scrolled near the bottom (within 80px). */
-  let isNearBottom = $state(true);
+  /** Whether the user has intentionally scrolled up (disables auto-scroll). */
+  let userScrolledUp = $state(false);
+  let lastScrollTop = 0;
 
   function handleScroll() {
     if (!messagesEl) return;
     const { scrollTop, scrollHeight, clientHeight } = messagesEl;
-    isNearBottom = scrollHeight - scrollTop - clientHeight < 80;
+    const atBottom = scrollHeight - scrollTop - clientHeight < 1;
+
+    if (scrollTop < lastScrollTop && !atBottom) {
+      // Scroll position moved upward — user scrolled up (any input method)
+      userScrolledUp = true;
+    }
+    if (atBottom) {
+      // They're back at bottom — re-enable auto-scroll
+      userScrolledUp = false;
+    }
+    lastScrollTop = scrollTop;
   }
 
   /** Scroll to bottom unconditionally (e.g. initial load, user sends message). */
@@ -300,13 +311,14 @@
     tick().then(() => {
       if (messagesEl) {
         messagesEl.scrollTop = messagesEl.scrollHeight;
+        userScrolledUp = false;
       }
     });
   }
 
-  /** Scroll to bottom only if the user hasn't scrolled up. */
+  /** Scroll to bottom only if the user hasn't intentionally scrolled up. */
   function scrollToBottomIfNear() {
-    if (isNearBottom) {
+    if (!userScrolledUp) {
       scrollToBottom();
     }
   }


### PR DESCRIPTION
## Problem

When viewing a live session in the session modal, polling for new messages would always auto-scroll to the bottom — even if the user had intentionally scrolled up to read earlier content. This made it impossible to review previous messages during an active session.

## Solution

### Commit 1: Basic scroll preservation
Track whether the user is near the bottom of the messages container. During polling, only auto-scroll if the user was already at the bottom. Intentional scrolls (initial load, user sends a message) still force scroll to bottom unconditionally.

### Commit 2: Replace pixel threshold with intent tracking
The initial implementation used a fragile 80px pixel threshold to determine "near bottom." This was replaced with directional intent tracking — comparing `scrollTop` against `lastScrollTop` to detect when the user has scrolled upward.

| Before | After |
|--------|-------|
| `isNearBottom` — true when within 80px of bottom | `userScrolledUp` — true when user scrolls upward |
| Could misfire on short/tall containers | Works reliably regardless of container height |
| Single position check | Direction-based intent detection |

**Key behavior:**
- `userScrolledUp = true` when `scrollTop` decreases (user scrolled up)
- Cleared when user scrolls back to the exact bottom, or on explicit `scrollToBottom()` calls
- Works across all input methods: mouse wheel, keyboard, touch, scrollbar drag

## Changes
- `src/lib/SessionModal.svelte` — scroll tracking logic in the messages container