### PR TITLE
Update repo URLs from baxen/staged to block/builderbot

### DIFF
--- a/staged/README.md
+++ b/staged/README.md
@@ -19,7 +19,7 @@ A desktop app for reviewing git changes, managing branches, and running AI codin
 Install with a single command:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/baxen/staged/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/block/builderbot/main/staged/install.sh | bash
 ```
 
 The installer will:

--- a/staged/install.sh
+++ b/staged/install.sh
@@ -70,14 +70,14 @@ check_prerequisites() {
 
 # Clone repository
 clone_repo() {
-    REPO_URL="https://github.com/baxen/staged.git"
+    REPO_URL="https://github.com/block/builderbot.git"
     TEMP_DIR=$(mktemp -d)
 
     print_info "Cloning repository to $TEMP_DIR..."
 
     if git clone --depth 1 "$REPO_URL" "$TEMP_DIR" > /dev/null 2>&1; then
         print_success "Repository cloned"
-        cd "$TEMP_DIR"
+        cd "$TEMP_DIR/staged"
     else
         print_error "Failed to clone repository"
         exit 1


### PR DESCRIPTION
## Summary
- Updates repository URLs in README and install script from `baxen/staged` to `block/builderbot` to reflect the new repo location.

## Testing
Ran `install.sh` locally and validated that it worked