### PR TITLE
fix: preserve output and allow retry for failed branch actions

### DIFF
--- a/crates/builderbot-actions/src/executor.rs
+++ b/crates/builderbot-actions/src/executor.rs
@@ -386,6 +386,13 @@ impl ActionExecutor {
         let running = self.running.lock().unwrap();
         running.keys().cloned().collect()
     }
+
+    /// Clear buffered output for a completed execution
+    /// This removes the output from the completed actions map
+    pub fn clear_execution(&self, execution_id: &str) -> bool {
+        let mut completed = self.completed.lock().unwrap();
+        completed.remove(execution_id).is_some()
+    }
 }
 
 /// Get current timestamp in milliseconds

--- a/staged/src-tauri/src/actions/commands.rs
+++ b/staged/src-tauri/src/actions/commands.rs
@@ -138,6 +138,15 @@ pub fn get_action_output_buffer(
     Ok(executor.get_buffered_output(&execution_id))
 }
 
+/// Clear buffered output for a completed execution
+#[tauri::command]
+pub fn clear_action_execution(
+    execution_id: String,
+    executor: State<'_, Arc<ActionExecutor>>,
+) -> Result<bool, String> {
+    Ok(executor.clear_execution(&execution_id))
+}
+
 /// Run all prerun actions for a branch after creation
 #[tauri::command]
 pub async fn run_prerun_actions(

--- a/staged/src-tauri/src/lib.rs
+++ b/staged/src-tauri/src/lib.rs
@@ -1509,6 +1509,7 @@ pub fn run() {
             actions::commands::stop_branch_action,
             actions::commands::get_running_branch_actions,
             actions::commands::get_action_output_buffer,
+            actions::commands::clear_action_execution,
             actions::commands::run_prerun_actions,
             // Diff
             get_diff_files,

--- a/staged/src/lib/ActionOutputModal.svelte
+++ b/staged/src/lib/ActionOutputModal.svelte
@@ -32,6 +32,7 @@
   import {
     getActionOutputBuffer,
     stopBranchAction,
+    clearActionExecution,
     listenToActionOutput,
     listenToActionStatus,
   } from './services/actions';
@@ -40,9 +41,10 @@
     executionId: string;
     actionName: string;
     onClose: () => void;
+    onRemove?: (executionId: string) => void;
   }
 
-  let { executionId, actionName, onClose }: Props = $props();
+  let { executionId, actionName, onClose, onRemove }: Props = $props();
 
   // =========================================================================
   // State
@@ -188,6 +190,20 @@
     }
   }
 
+  async function handleRemove() {
+    try {
+      // Clear the execution from the backend
+      await clearActionExecution(executionId);
+      // Notify parent to remove from UI
+      onRemove?.(executionId);
+      // Close the modal
+      onClose();
+    } catch (e: any) {
+      error = e?.message || 'Failed to remove execution';
+      console.error('Failed to remove execution:', e);
+    }
+  }
+
   // =========================================================================
   // Rendering helpers
   // =========================================================================
@@ -267,6 +283,11 @@
           <button class="stop-btn" onclick={handleStop} title="Stop action">
             <CircleStop size={14} />
             <span>Stop</span>
+          </button>
+        {/if}
+        {#if status === 'failed' && onRemove}
+          <button class="remove-btn" onclick={handleRemove} title="Remove this failed run">
+            <span>Remove</span>
           </button>
         {/if}
         <button class="close-btn" onclick={onClose} title="Close (Esc)">
@@ -416,6 +437,26 @@
   .stop-btn:hover {
     background: rgba(239, 68, 68, 0.15);
     border-color: rgba(239, 68, 68, 0.3);
+  }
+
+  .remove-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .remove-btn:hover {
+    background: var(--bg-hover);
+    border-color: var(--border-focus);
   }
 
   .close-btn {

--- a/staged/src/lib/BranchCard.svelte
+++ b/staged/src/lib/BranchCard.svelte
@@ -165,12 +165,8 @@
         runningActions[existingIndex].exitCode = payload.exitCode;
         runningActions[existingIndex].completedAt = payload.completedAt;
 
-        // Auto-remove completed/failed/stopped actions (with fade for secondary, instant for primary)
-        if (
-          payload.status === 'completed' ||
-          payload.status === 'failed' ||
-          payload.status === 'stopped'
-        ) {
+        // Auto-remove only completed and stopped actions (not failed)
+        if (payload.status === 'completed' || payload.status === 'stopped') {
           const action = runningActions[existingIndex];
           const isPrimaryAction = primaryRunAction && action.actionId === primaryRunAction.id;
 
@@ -304,6 +300,12 @@
       return;
     }
 
+    // If the same action has a previous execution (completed, failed, or stopped),
+    // remove it before starting a new one
+    if (existingExecution) {
+      runningActions = runningActions.filter((a) => a.actionId !== action.id);
+    }
+
     // Start the action silently (don't open modal)
     try {
       const executionId = await runBranchAction(branch.id, action.id);
@@ -321,6 +323,11 @@
       executionId: execution.executionId,
       actionName: execution.actionName,
     };
+  }
+
+  // Handle removing a failed action execution
+  function handleRemoveExecution(executionId: string) {
+    runningActions = runningActions.filter((a) => a.executionId !== executionId);
   }
 
   // Close dropdowns when clicking outside
@@ -789,6 +796,7 @@
     executionId={actionOutputModal.executionId}
     actionName={actionOutputModal.actionName}
     onClose={() => (actionOutputModal = null)}
+    onRemove={handleRemoveExecution}
   />
 {/if}
 

--- a/staged/src/lib/services/actions.ts
+++ b/staged/src/lib/services/actions.ts
@@ -110,6 +110,14 @@ export function getActionOutputBuffer(executionId: string): Promise<OutputChunk[
 }
 
 /**
+ * Clear buffered output for a completed action execution.
+ * Returns true if the execution was found and cleared, false otherwise.
+ */
+export function clearActionExecution(executionId: string): Promise<boolean> {
+  return invoke<boolean>('clear_action_execution', { executionId });
+}
+
+/**
  * Run all prerun actions for a branch after creation.
  * Returns an array of execution IDs for the started actions.
  */


### PR DESCRIPTION
## Summary

This PR improves the handling of failed branch actions with two key improvements:

1. **Preserve output and enable retry for failed actions** - When actions fail, users can now see the output and retry the action
2. **Manual removal of failed actions** - Failed actions persist with their output until explicitly removed, providing better debugging visibility

## Changes

### Preserve Output and Enable Retry (commit 81566f6)

**Problem:**
When branch actions failed, users encountered three issues:
- Output dialog showed no output after failure
- Stop button remained visible despite action completion
- Unable to retry the failed action

**Solution:**
- Added `completed` HashMap to ActionExecutor to store output buffers after completion
- Modified `get_buffered_output()` to check both running and completed maps
- Auto-remove completed/failed/stopped actions from UI after display timeout
- Changed retry logic to only block if action status is 'running'

### Manual Removal of Failed Actions (commit d19943f)

**Problem:**
Auto-removal of failed actions meant users lost visibility into what went wrong before they could investigate.

**Solution:**
- Failed actions now persist until manually removed
- Two removal options:
  1. Running the same action again automatically clears the previous execution
  2. A "Remove" button in the output dialog for explicit cleanup
- Completed/stopped actions still auto-remove as before

## Files Changed

- `crates/builderbot-actions/src/executor.rs` - Output preservation and clear execution method
- `staged/src-tauri/src/actions/commands.rs` - New clear_action_execution command
- `staged/src-tauri/src/lib.rs` - Register new command
- `staged/src/lib/services/actions.ts` - clearActionExecution API function
- `staged/src/lib/ActionOutputModal.svelte` - Remove button for failed actions
- `staged/src/lib/BranchCard.svelte` - Manual removal and retry logic

## Test Plan

- [x] Verify failed actions display their output
- [x] Verify failed actions can be retried
- [x] Verify failed actions persist until manually removed
- [x] Verify "Remove" button clears failed actions
- [x] Verify running the same action again clears previous execution
- [x] Verify completed/stopped actions still auto-remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)