### PR TITLE
fix: refresh branch actions when modified in settings

### DIFF
--- a/staged/src/lib/BranchCard.svelte
+++ b/staged/src/lib/BranchCard.svelte
@@ -11,7 +11,7 @@
   - Each item shows session + delete actions on hover
 -->
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import {
     GitBranch,
     GitCommitHorizontal,
@@ -126,6 +126,13 @@
   let unlistenActionStatus: UnlistenFn | null = null;
 
   // Set up event listeners immediately (synchronously) at module level like old codebase
+  // Listen for project actions changes to refresh actions list
+  function handleActionsChanged(event: CustomEvent) {
+    if (event.detail?.projectId === branch.projectId) {
+      loadActions();
+    }
+  }
+
   $effect(() => {
     const branchId = branch.id;
     const branchName = branch.branchName;
@@ -234,8 +241,16 @@
   onMount(() => {
     loadTimeline();
     loadActions();
+    // Listen for actions changes
+    window.addEventListener('project-actions-changed', handleActionsChanged as EventListener);
   });
 
+  onDestroy(() => {
+    unlistenStatus?.();
+    unlistenActionStatus?.();
+    // Clean up actions listener
+    window.removeEventListener('project-actions-changed', handleActionsChanged as EventListener);
+  });
   async function loadTimeline() {
     loading = true;
     error = null;

--- a/staged/src/lib/ProjectSettingsModal.svelte
+++ b/staged/src/lib/ProjectSettingsModal.svelte
@@ -82,6 +82,7 @@
       const existingCommands = new Set(actions.map((a) => a.command));
       let nextSortOrder = Math.max(...actions.map((a) => a.sortOrder), 0) + 1;
 
+      let actionsAdded = false;
       for (const suggestion of suggested) {
         if (!existingCommands.has(suggestion.command)) {
           const newAction = await commands.createProjectAction(
@@ -93,7 +94,15 @@
             suggestion.autoCommit
           );
           actions = [...actions, newAction];
+          actionsAdded = true;
         }
+      }
+
+      // Notify all BranchCard components to reload actions if any were added
+      if (actionsAdded) {
+        window.dispatchEvent(
+          new CustomEvent('project-actions-changed', { detail: { projectId: project.id } })
+        );
       }
     } catch (e) {
       console.error('Failed to detect actions:', e);
@@ -166,6 +175,10 @@
         );
       }
       editingAction = null;
+      // Notify all BranchCard components to reload actions
+      window.dispatchEvent(
+        new CustomEvent('project-actions-changed', { detail: { projectId: project.id } })
+      );
     } catch (e) {
       console.error('Failed to save action:', e);
     }
@@ -175,6 +188,10 @@
     try {
       await commands.deleteProjectAction(actionId);
       actions = actions.filter((a) => a.id !== actionId);
+      // Notify all BranchCard components to reload actions
+      window.dispatchEvent(
+        new CustomEvent('project-actions-changed', { detail: { projectId: project.id } })
+      );
     } catch (e) {
       console.error('Failed to delete action:', e);
     }


### PR DESCRIPTION
## Summary
- Added custom window event 'project-actions-changed' to sync action updates across components
- BranchCard components now listen for action changes and reload their actions list
- Event is dispatched when actions are created, updated, or deleted in ProjectSettingsModal
- Updated package-lock.json after formatting changes

## Problem
When actions were created, updated, or deleted in the project settings modal, the changes were not reflected in the branch menu until a page refresh.

## Solution
This PR introduces a custom event-based system that notifies BranchCard components when project actions change:
- ProjectSettingsModal dispatches a 'project-actions-changed' event when actions are modified
- BranchCard components listen for this event and reload actions when relevant to their project
- Event listeners are properly cleaned up on component destroy

## Test plan
- [x] Open project settings and create a new action - verify it appears in branch cards immediately
- [x] Edit an existing action - verify changes appear without refresh
- [x] Delete an action - verify it disappears from branch cards immediately
- [x] Verify actions only update for the correct project when multiple projects are open
- [x] Verify no memory leaks from event listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)