### PR TITLE
fix: remove double confirmation dialog on remote branch deletion

### DIFF
--- a/staged/src/lib/ProjectHome.svelte
+++ b/staged/src/lib/ProjectHome.svelte
@@ -320,8 +320,10 @@
 <!-- Delete branch confirmation -->
 {#if branchToDelete}
   <ConfirmDialog
-    title="Delete Branch"
-    message={`Delete branch "${branchToDelete.branch.branchName}" and its worktree? This cannot be undone.`}
+    title={branchToDelete.branch.branchType === 'remote' ? 'Delete Remote Branch' : 'Delete Branch'}
+    message={branchToDelete.branch.branchType === 'remote'
+      ? `Delete branch "${branchToDelete.branch.branchName}" and stop its workspace? The workspace may be reused later, but session history will be lost.`
+      : `Delete branch "${branchToDelete.branch.branchName}" and its worktree? This cannot be undone.`}
     confirmLabel="Delete"
     danger={true}
     onConfirm={confirmDeleteBranch}

--- a/staged/src/lib/RemoteBranchCard.svelte
+++ b/staged/src/lib/RemoteBranchCard.svelte
@@ -103,15 +103,7 @@
       icon: Trash2,
       danger: true,
       action: () => {
-        confirmDelete = {
-          title: 'Delete Remote Branch',
-          message:
-            'This will delete the Blox workspace and remove the branch. This action cannot be undone.',
-          onConfirm: async () => {
-            confirmDelete = null;
-            onDelete?.();
-          },
-        };
+        onDelete?.();
       },
     },
   ]);


### PR DESCRIPTION
## Summary

Remove the redundant confirmation dialog from `RemoteBranchCard.svelte` that was triggering before the parent `ProjectHome.svelte` confirmation. Remote branch deletion now follows the same pattern as local branches: the card calls `onDelete()` directly, and `ProjectHome` handles the single confirmation dialog.

## Changes

- **`RemoteBranchCard.svelte`**: Removed the inline `confirmDelete` dialog. The delete action now calls `onDelete?.()` directly, matching the local branch pattern.
- **`ProjectHome.svelte`**: Made the shared confirmation dialog branch-type-aware:
  - **Local branches**: "Delete branch and its worktree? This cannot be undone."
  - **Remote branches**: "Delete branch and stop its workspace? The workspace may be reused later, but session history will be lost."

## Why

Previously, deleting a remote branch would show two confirmation dialogs in sequence — one from `RemoteBranchCard` and another from `ProjectHome`. This was confusing and inconsistent with the local branch deletion flow, which only showed a single confirmation.