### PR TITLE
fix: remote branch base picker shows only valid remote branches

### DIFF
--- a/staged/src-tauri/src/git/refs.rs
+++ b/staged/src-tauri/src/git/refs.rs
@@ -68,12 +68,17 @@ pub struct BranchRef {
 /// List branches (local and remote) for base branch selection.
 /// Returns branches sorted with local first, then remote.
 /// Filters out HEAD references.
+/// Prunes stale remote-tracking refs first so deleted remote branches don't appear.
 pub fn list_branches(repo: &Path) -> Result<Vec<BranchRef>, GitError> {
+    // Prune stale remote-tracking refs (branches deleted on the remote).
+    // Best-effort: ignore errors (e.g. no network, no remote configured).
+    let _ = cli::run(repo, &["remote", "prune", "origin"]);
+
     let output = cli::run(
         repo,
         &[
             "for-each-ref",
-            "--format=%(refname:short)",
+            "--format=%(refname:short)\t%(refname)",
             "refs/heads",
             "refs/remotes",
         ],
@@ -82,18 +87,19 @@ pub fn list_branches(repo: &Path) -> Result<Vec<BranchRef>, GitError> {
     let mut branches: Vec<BranchRef> = output
         .lines()
         .filter(|s| !s.is_empty() && !s.ends_with("/HEAD"))
-        .map(|name| {
-            let is_remote = name.contains('/');
+        .filter_map(|line| {
+            let (short, full) = line.split_once('\t')?;
+            let is_remote = full.starts_with("refs/remotes/");
             let remote = if is_remote {
-                name.split('/').next().map(String::from)
+                short.split('/').next().map(String::from)
             } else {
                 None
             };
-            BranchRef {
-                name: name.to_string(),
+            Some(BranchRef {
+                name: short.to_string(),
                 is_remote,
                 remote,
-            }
+            })
         })
         .collect();
 

--- a/staged/src-tauri/src/lib.rs
+++ b/staged/src-tauri/src/lib.rs
@@ -704,11 +704,15 @@ async fn create_remote_branch(
     // Resolve the source to an HTTPS git URL. The frontend passes the
     // local repo path, but blox needs a fetchable HTTPS URL.
     // Append ?ref=<branch> so the workspace checks out the correct base.
+    // Strip the "origin/" prefix since blox expects a plain branch name.
+    let ref_name = effective_base
+        .strip_prefix("origin/")
+        .unwrap_or(&effective_base);
     let resolved_source = match source {
         Some(_) => git::get_remote_url(repo_path, "origin")
             .ok()
             .filter(|u| !u.is_empty())
-            .map(|u| format!("{}?ref={}", ssh_url_to_https(&u), effective_base)),
+            .map(|u| format!("{}?ref={}", ssh_url_to_https(&u), ref_name)),
         None => None,
     };
 

--- a/staged/src/lib/NewBranchModal.svelte
+++ b/staged/src/lib/NewBranchModal.svelte
@@ -9,7 +9,7 @@
   import { onMount } from 'svelte';
   import { X, GitBranch, Search, ChevronsUpDown, Check, Monitor, Cloud } from 'lucide-svelte';
   import Spinner from './Spinner.svelte';
-  import type { Branch, Project, BranchType } from './types';
+  import type { Branch, BranchRef, Project, BranchType } from './types';
   import * as commands from './commands';
   import { runPrerunActions } from './services/actions';
 
@@ -35,7 +35,7 @@
 
   // Base branch picker
   let showBasePicker = $state(false);
-  let availableBranches = $state<string[]>([]);
+  let allBranchRefs = $state<BranchRef[]>([]);
   let baseSearchQuery = $state('');
   let baseSelectedIndex = $state(0);
 
@@ -43,6 +43,15 @@
   let baseSearchEl: HTMLInputElement | null = $state(null);
 
   let effectiveBaseBranch = $derived(selectedBaseBranch ?? detectedDefaultBranch ?? 'main');
+
+  // For remote branches, only show remote-tracking refs (branches that exist on the remote).
+  // For local branches, show all refs.
+  let availableBranches = $derived.by(() => {
+    if (branchType === 'remote') {
+      return allBranchRefs.filter((r) => r.isRemote).map((r) => r.name);
+    }
+    return allBranchRefs.map((r) => r.name);
+  });
 
   let filteredBranches = $derived.by(() => {
     if (!baseSearchQuery) return availableBranches;
@@ -82,10 +91,9 @@
 
     // Load available branches
     try {
-      const refs = await commands.listGitBranches(project.repoPath);
-      availableBranches = refs.map((r) => r.name);
+      allBranchRefs = await commands.listGitBranches(project.repoPath);
     } catch {
-      availableBranches = [];
+      allBranchRefs = [];
     }
   });
 
@@ -235,7 +243,10 @@
         <button
           class="toggle-option"
           class:active={branchType === 'local'}
-          onclick={() => (branchType = 'local')}
+          onclick={() => {
+            branchType = 'local';
+            selectedBaseBranch = null;
+          }}
         >
           <Monitor size={14} />
           Local
@@ -243,7 +254,10 @@
         <button
           class="toggle-option"
           class:active={branchType === 'remote'}
-          onclick={() => (branchType = 'remote')}
+          onclick={() => {
+            branchType = 'remote';
+            selectedBaseBranch = null;
+          }}
         >
           <Cloud size={14} />
           Remote


### PR DESCRIPTION
## Summary
- Strip `origin/` prefix from base branch ref in blox URL — blox expects plain branch names like `main`, not remote-tracking refs like `origin/main`
- Use full refname (`%(refname)`) to correctly identify remote vs local branches — branches with slashes (e.g. `matt2e/open-in`) were misidentified as remote
- Filter base branch picker to only show remote-tracking refs when creating remote workspaces, and prune stale refs so deleted remote branches don't appear
- Reset selected base branch when toggling between local/remote mode

## Test plan
- [x] Create a remote workspace and verify the base branch picker only shows remote branches
- [x] Verify branches with slashes in their name (e.g. `matt2e/open-in`) don't appear as remote
- [x] Verify stale remote-tracking refs for deleted branches are pruned
- [x] Verify creating a remote workspace with `main` as base works without `origin/` prefix error
- [x] Verify local branch creation still shows all branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)