### PR TITLE
fix: spinner not animating due to Svelte scoped @keyframes

### DIFF
--- a/staged/src/lib/Spinner.svelte
+++ b/staged/src/lib/Spinner.svelte
@@ -32,12 +32,14 @@
     will-change: transform;
   }
 
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
+  :global {
+    @keyframes spin {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- The `@keyframes spin` definition was being hash-suffixed by Svelte's CSS scoping, but the `.spinner` class (made global via `:global()`) still referenced the unscoped name `spin`
- Wrapping the `@keyframes` block in `:global { }` prevents the hash-suffixing so the animation name matches

## Test plan
- [x] Verify the spinner animates correctly in branches that are loading/syncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)