### PR TITLE
feat: restore subfolder autocomplete in new project dialog

### DIFF
--- a/staged/src/lib/NewProjectModal.svelte
+++ b/staged/src/lib/NewProjectModal.svelte
@@ -59,14 +59,12 @@
     }
   }
 
-  /** Select a suggestion, filling the subpath and loading next level. */
+  /** Select a suggestion, filling the subpath and closing the dropdown. */
   function selectSuggestion(entry: DirEntry) {
     const { parentDir } = getSubpathContext(subpath);
-    subpath = parentDir ? `${parentDir}/${entry.name}/` : `${entry.name}/`;
+    subpath = parentDir ? `${parentDir}/${entry.name}` : entry.name;
     showDropdown = false;
     suggestions = [];
-    // Load next level after selection
-    loadSuggestions();
     subpathInputEl?.focus();
   }
 


### PR DESCRIPTION
## Summary
- Restores the subfolder autocomplete dropdown in the new project dialog, letting users pick a subdirectory within a repo when creating a project
- Uses the existing `listDirectory` backend command with debounced loading, keyboard navigation (arrows/Enter/Tab/Escape), and mouse selection
- Fixes overflow so the dropdown can extend beyond the modal, and stops auto-diving into selected folders

## Test plan
- [ ] Open the new project dialog and select a repo
- [ ] Type in the subfolder input — verify suggestions appear listing subdirectories
- [ ] Navigate with arrow keys, select with Enter/Tab — verify selection populates input
- [ ] After selecting a folder, verify the dropdown closes and doesn't auto-dive deeper
- [ ] Type `/` after a selection to continue navigating deeper
- [ ] Verify the dropdown visually overflows the modal bounds without clipping
- [ ] Press Escape to dismiss suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)