### PR TITLE
feat: skip delete confirmation dialog when Option key is held

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -555,89 +555,108 @@
     }
   }
 
-  function handleDeleteCommit(sha: string, sessionId?: string) {
+  function handleDeleteCommit(sha: string, sessionId?: string, opts?: { altKey: boolean }) {
+    const doDelete = async () => {
+      confirmDelete = null;
+      deletingCommitKeys = new Set([...deletingCommitKeys, sha]);
+      try {
+        await commands.deleteCommit(branch.id, sha, !!sessionId);
+        await loadTimeline();
+      } catch (e) {
+        console.error('Failed to delete commit:', e);
+        notifyError('Failed to delete commit', e);
+      } finally {
+        deletingCommitKeys = new Set([...deletingCommitKeys].filter((k) => k !== sha));
+      }
+    };
+    if (opts?.altKey) {
+      doDelete();
+      return;
+    }
     confirmDelete = {
       title: 'Delete Commit',
       message:
         'This will reset the branch to the parent commit, removing this commit and its changes.' +
         (sessionId ? ' The linked session will also be deleted.' : ''),
-      onConfirm: async () => {
-        confirmDelete = null;
-        deletingCommitKeys = new Set([...deletingCommitKeys, sha]);
-        try {
-          await commands.deleteCommit(branch.id, sha, !!sessionId);
-          await loadTimeline();
-        } catch (e) {
-          console.error('Failed to delete commit:', e);
-          notifyError('Failed to delete commit', e);
-        } finally {
-          deletingCommitKeys = new Set([...deletingCommitKeys].filter((k) => k !== sha));
-        }
-      },
+      onConfirm: doDelete,
     };
   }
 
-  function handleDeleteNote(noteId: string, sessionId?: string) {
+  function handleDeleteNote(noteId: string, sessionId?: string, opts?: { altKey: boolean }) {
+    const doDelete = async () => {
+      confirmDelete = null;
+      try {
+        if (sessionId) {
+          try {
+            await commands.cancelSession(sessionId);
+          } catch {
+            // Session may already be finished
+          }
+        }
+        await commands.deleteNote(noteId, !!sessionId);
+        loadTimeline();
+        // Drain the next queued session now that this one has been removed.
+        commands
+          .drainQueuedSessions(branch.id)
+          .catch((e) => console.error('Failed to drain queued sessions:', e));
+      } catch (e) {
+        console.error('Failed to delete note:', e);
+        notifyError('Failed to delete note', e);
+      }
+    };
+    if (opts?.altKey) {
+      doDelete();
+      return;
+    }
     confirmDelete = {
       title: 'Delete Note',
       message:
         'Are you sure you want to delete this note?' +
         (sessionId ? ' The linked session will also be deleted.' : ''),
-      onConfirm: async () => {
-        confirmDelete = null;
-        try {
-          if (sessionId) {
-            try {
-              await commands.cancelSession(sessionId);
-            } catch {
-              // Session may already be finished
-            }
-          }
-          await commands.deleteNote(noteId, !!sessionId);
-          loadTimeline();
-          // Drain the next queued session now that this one has been removed.
-          commands
-            .drainQueuedSessions(branch.id)
-            .catch((e) => console.error('Failed to drain queued sessions:', e));
-        } catch (e) {
-          console.error('Failed to delete note:', e);
-          notifyError('Failed to delete note', e);
-        }
-      },
+      onConfirm: doDelete,
     };
   }
 
-  function handleDeleteReview(reviewId: string, sessionId?: string) {
+  function handleDeleteReview(reviewId: string, sessionId?: string, opts?: { altKey: boolean }) {
+    const doDelete = async () => {
+      confirmDelete = null;
+      try {
+        if (sessionId) {
+          try {
+            await commands.cancelSession(sessionId);
+          } catch {
+            // Session may already be finished
+          }
+        }
+        await commands.deleteReview(reviewId, !!sessionId);
+        loadTimeline();
+        // Drain the next queued session now that this one has been removed.
+        commands
+          .drainQueuedSessions(branch.id)
+          .catch((e) => console.error('Failed to drain queued sessions:', e));
+      } catch (e) {
+        console.error('Failed to delete review:', e);
+        notifyError('Failed to delete review', e);
+      }
+    };
+    if (opts?.altKey) {
+      doDelete();
+      return;
+    }
     confirmDelete = {
       title: 'Delete Review',
       message:
         'Are you sure you want to delete this review and all its comments?' +
         (sessionId ? ' The linked session will also be deleted.' : ''),
-      onConfirm: async () => {
-        confirmDelete = null;
-        try {
-          if (sessionId) {
-            try {
-              await commands.cancelSession(sessionId);
-            } catch {
-              // Session may already be finished
-            }
-          }
-          await commands.deleteReview(reviewId, !!sessionId);
-          loadTimeline();
-          // Drain the next queued session now that this one has been removed.
-          commands
-            .drainQueuedSessions(branch.id)
-            .catch((e) => console.error('Failed to drain queued sessions:', e));
-        } catch (e) {
-          console.error('Failed to delete review:', e);
-          notifyError('Failed to delete review', e);
-        }
-      },
+      onConfirm: doDelete,
     };
   }
 
-  async function handleDeletePendingCommit(commitId: string, sessionId?: string) {
+  async function handleDeletePendingCommit(
+    commitId: string,
+    sessionId?: string,
+    _opts?: { altKey: boolean }
+  ) {
     deletingCommitKeys = new Set([...deletingCommitKeys, commitId]);
     try {
       if (sessionId) {
@@ -669,26 +688,31 @@
     }
   }
 
-  function handleDeleteImage(imageId: string) {
+  function handleDeleteImage(imageId: string, opts?: { altKey: boolean }) {
+    const doDelete = async () => {
+      confirmDelete = null;
+      deletingImageIds = new Set([...deletingImageIds, imageId]);
+      if (viewImageId === imageId) {
+        viewImageId = null;
+      }
+      try {
+        await commands.deleteImage(imageId);
+        loadTimeline();
+      } catch (e) {
+        console.error('Failed to delete image:', e);
+        notifyError('Failed to delete image', e);
+      } finally {
+        deletingImageIds = new Set([...deletingImageIds].filter((id) => id !== imageId));
+      }
+    };
+    if (opts?.altKey) {
+      doDelete();
+      return;
+    }
     confirmDelete = {
       title: 'Delete Image',
       message: 'Are you sure you want to delete this image?',
-      onConfirm: async () => {
-        confirmDelete = null;
-        deletingImageIds = new Set([...deletingImageIds, imageId]);
-        if (viewImageId === imageId) {
-          viewImageId = null;
-        }
-        try {
-          await commands.deleteImage(imageId);
-          loadTimeline();
-        } catch (e) {
-          console.error('Failed to delete image:', e);
-          notifyError('Failed to delete image', e);
-        } finally {
-          deletingImageIds = new Set([...deletingImageIds].filter((id) => id !== imageId));
-        }
-      },
+      onConfirm: doDelete,
     };
   }
 

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -652,11 +652,7 @@
     };
   }
 
-  async function handleDeletePendingCommit(
-    commitId: string,
-    sessionId?: string,
-    _opts?: { altKey: boolean }
-  ) {
+  async function handleDeletePendingCommit(commitId: string, sessionId?: string) {
     deletingCommitKeys = new Set([...deletingCommitKeys, commitId]);
     try {
       if (sessionId) {

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -52,11 +52,15 @@
     onNoteClick?: (noteId: string, title: string, content: string, sessionId?: string) => void;
     onReviewClick?: (reviewId: string) => void;
     onImageClick?: (imageId: string) => void;
-    onDeleteCommit?: (sha: string, sessionId?: string) => void;
-    onDeletePendingCommit?: (commitId: string, sessionId?: string) => void;
-    onDeleteNote?: (noteId: string, sessionId?: string) => void;
-    onDeleteReview?: (reviewId: string, sessionId?: string) => void;
-    onDeleteImage?: (imageId: string) => void;
+    onDeleteCommit?: (sha: string, sessionId?: string, opts?: { altKey: boolean }) => void;
+    onDeletePendingCommit?: (
+      commitId: string,
+      sessionId?: string,
+      opts?: { altKey: boolean }
+    ) => void;
+    onDeleteNote?: (noteId: string, sessionId?: string, opts?: { altKey: boolean }) => void;
+    onDeleteReview?: (reviewId: string, sessionId?: string, opts?: { altKey: boolean }) => void;
+    onDeleteImage?: (imageId: string, opts?: { altKey: boolean }) => void;
     onStartQueued?: () => void;
     /** Optional per-review breakdown of visible comments vs hold-to-reveal annotations. */
     reviewCommentBreakdown?: Record<
@@ -472,9 +476,9 @@
     }
   }
 
-  function handleDeleteClick(item: DisplayItem) {
+  function handleDeleteClick(item: DisplayItem, opts?: { altKey: boolean }) {
     if (item.type === 'commit' && item.commitSha && onDeleteCommit) {
-      onDeleteCommit(item.commitSha, item.sessionId);
+      onDeleteCommit(item.commitSha, item.sessionId, opts);
     } else if (
       (item.type === 'failed-commit' ||
         item.type === 'pending-commit' ||
@@ -482,7 +486,7 @@
       item.commitId &&
       onDeletePendingCommit
     ) {
-      onDeletePendingCommit(item.commitId, item.sessionId);
+      onDeletePendingCommit(item.commitId, item.sessionId, opts);
     } else if (
       (item.type === 'note' ||
         item.type === 'failed-note' ||
@@ -491,7 +495,7 @@
       item.noteId &&
       onDeleteNote
     ) {
-      onDeleteNote(item.noteId, item.sessionId);
+      onDeleteNote(item.noteId, item.sessionId, opts);
     } else if (
       (item.type === 'review' ||
         item.type === 'failed-review' ||
@@ -500,9 +504,9 @@
       item.reviewId &&
       onDeleteReview
     ) {
-      onDeleteReview(item.reviewId, item.sessionId);
+      onDeleteReview(item.reviewId, item.sessionId, opts);
     } else if (item.type === 'image' && item.imageId && onDeleteImage) {
-      onDeleteImage(item.imageId);
+      onDeleteImage(item.imageId, opts);
     }
   }
 </script>
@@ -532,7 +536,9 @@
           deleteDisabledReason={item.deleteDisabledReason}
           {onSessionClick}
           onItemClick={() => handleItemClick(item)}
-          onDeleteClick={item.deleteDisabledReason ? undefined : () => handleDeleteClick(item)}
+          onDeleteClick={item.deleteDisabledReason
+            ? undefined
+            : (opts) => handleDeleteClick(item, opts)}
           onStartClick={item.type.startsWith('queued-') && !hasActiveSession
             ? onStartQueued
             : undefined}

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -53,11 +53,7 @@
     onReviewClick?: (reviewId: string) => void;
     onImageClick?: (imageId: string) => void;
     onDeleteCommit?: (sha: string, sessionId?: string, opts?: { altKey: boolean }) => void;
-    onDeletePendingCommit?: (
-      commitId: string,
-      sessionId?: string,
-      opts?: { altKey: boolean }
-    ) => void;
+    onDeletePendingCommit?: (commitId: string, sessionId?: string) => void;
     onDeleteNote?: (noteId: string, sessionId?: string, opts?: { altKey: boolean }) => void;
     onDeleteReview?: (reviewId: string, sessionId?: string, opts?: { altKey: boolean }) => void;
     onDeleteImage?: (imageId: string, opts?: { altKey: boolean }) => void;
@@ -486,7 +482,7 @@
       item.commitId &&
       onDeletePendingCommit
     ) {
-      onDeletePendingCommit(item.commitId, item.sessionId, opts);
+      onDeletePendingCommit(item.commitId, item.sessionId);
     } else if (
       (item.type === 'note' ||
         item.type === 'failed-note' ||

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -51,7 +51,7 @@
     sessionId?: string;
     onItemClick?: () => void;
     onSessionClick?: (sessionId: string) => void;
-    onDeleteClick?: (opts: { altKey: boolean }) => void;
+    onDeleteClick?: (opts?: { altKey: boolean }) => void;
     /** When set, the delete button is shown but disabled with this tooltip. */
     deleteDisabledReason?: string;
     onRetryClick?: () => void;

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -51,7 +51,7 @@
     sessionId?: string;
     onItemClick?: () => void;
     onSessionClick?: (sessionId: string) => void;
-    onDeleteClick?: () => void;
+    onDeleteClick?: (opts: { altKey: boolean }) => void;
     /** When set, the delete button is shown but disabled with this tooltip. */
     deleteDisabledReason?: string;
     onRetryClick?: () => void;
@@ -125,7 +125,7 @@
 
   function handleDeleteClick(e: MouseEvent) {
     e.stopPropagation();
-    onDeleteClick?.();
+    onDeleteClick?.({ altKey: e.altKey });
   }
 
   function handleRetryClick(e: MouseEvent) {


### PR DESCRIPTION
## Summary
- When the Option (Alt) key is held while clicking a delete button on timeline items (commits, notes, reviews, images), the confirmation dialog is bypassed and the item is deleted immediately
- Propagates the `altKey` state from the mouse event through the component hierarchy (`TimelineRow` → `BranchTimeline` → `BranchCard`)
- Refactors delete handlers to extract the deletion logic into a `doDelete` closure, used by both the instant-delete path and the confirmation dialog's `onConfirm` callback

## Test plan
- [ ] Click delete on a timeline item without holding Option — confirm dialog should appear as before
- [ ] Hold Option and click delete on a commit, note, review, and image — each should delete immediately without confirmation
- [ ] Verify error handling still works (e.g., failed deletes show error notification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)