### PR TITLE
perf(diff): add timing logs and bail out of LCS on long lines to prevent freezes

### DIFF
--- a/apps/staged/src-tauri/Cargo.lock
+++ b/apps/staged/src-tauri/Cargo.lock
@@ -1870,6 +1870,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "git2",
+ "log",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/apps/staged/src-tauri/src/diff_cache.rs
+++ b/apps/staged/src-tauri/src/diff_cache.rs
@@ -559,14 +559,33 @@ pub fn collect_branch_diff(
     head_sha: &str,
     commit_shas: &[String],
 ) -> Result<CollectedDiffs> {
+    let start = std::time::Instant::now();
+    log::info!(
+        "collect_branch_diff: branch={branch_id} workspace={workspace_name} commits={}",
+        commit_shas.len()
+    );
     // Execute the collection script in a single remote call.
     let script = build_collect_script(repo_subpath, base_branch, head_sha, commit_shas);
+    let t_exec = std::time::Instant::now();
     let output = crate::blox::ws_exec(workspace_name, &["bash", "-c", &script])
         .map_err(|e| anyhow::anyhow!("remote diff collection script failed: {e}"))?;
+    log::info!(
+        "collect_branch_diff: remote exec done in {:?}, output size={} bytes",
+        t_exec.elapsed(),
+        output.len()
+    );
 
+    let t_parse = std::time::Instant::now();
     let result: CollectScriptOutput = serde_json::from_str(&output)
         .map_err(|e| anyhow::anyhow!("failed to parse remote diff collection output: {e}"))?;
+    log::info!(
+        "collect_branch_diff: parsed JSON in {:?}, files={} commits={}",
+        t_parse.elapsed(),
+        result.files.len(),
+        result.commits.len()
+    );
 
+    let t_process = std::time::Instant::now();
     let (files, file_diffs) = parse_script_files(&result.files);
 
     let cached_at = std::time::SystemTime::now()
@@ -582,6 +601,11 @@ pub fn collect_branch_diff(
         cached_at,
     };
 
+    log::info!(
+        "collect_branch_diff: processed file diffs in {:?}",
+        t_process.elapsed()
+    );
+
     // Parse commit-level diffs.
     let mut commit_results = Vec::new();
     for commit in &result.commits {
@@ -594,6 +618,13 @@ pub fn collect_branch_diff(
         };
         commit_results.push((commit_index, commit_file_diffs));
     }
+
+    log::info!(
+        "collect_branch_diff: total {:?}, {} file diffs, {} commits",
+        start.elapsed(),
+        file_diffs.len(),
+        commit_results.len()
+    );
 
     Ok((index, file_diffs, commit_results))
 }

--- a/apps/staged/src-tauri/src/diff_commands.rs
+++ b/apps/staged/src-tauri/src/diff_commands.rs
@@ -413,13 +413,22 @@ pub async fn get_diff_files(
     commit_sha: Option<String>,
     scope: String,
 ) -> Result<DiffFilesResponse, String> {
+    let start = std::time::Instant::now();
+    log::info!("get_diff_files: branch_id={branch_id} scope={scope} commit_sha={commit_sha:?}");
     let store = crate::get_store(&store)?;
     let ctx = resolve_branch_context(&store, &branch_id)?;
     if let Some(worktree_path) = ctx.worktree_path.as_deref() {
         let worktree = Path::new(worktree_path);
         let (spec, resolved_sha) =
             build_diff_spec(worktree, &ctx.base_branch, commit_sha.as_deref(), &scope)?;
+        let t0 = std::time::Instant::now();
         let files = git::list_diff_files(worktree, &spec).map_err(|e| e.to_string())?;
+        log::info!(
+            "get_diff_files: local list_diff_files returned {} files in {:?} (total {:?})",
+            files.len(),
+            t0.elapsed(),
+            start.elapsed()
+        );
         return Ok(DiffFilesResponse {
             commit_sha: resolved_sha,
             files,
@@ -497,13 +506,35 @@ pub async fn get_file_diff(
     scope: String,
     path: String,
 ) -> Result<git::FileDiff, String> {
+    let start = std::time::Instant::now();
+    log::info!("get_file_diff: path={path} scope={scope}");
     let store = crate::get_store(&store)?;
     let ctx = resolve_branch_context(&store, &branch_id)?;
     if let Some(worktree_path) = ctx.worktree_path.as_deref() {
         let worktree = Path::new(worktree_path);
         let (spec, _) = build_diff_spec(worktree, &ctx.base_branch, Some(&commit_sha), &scope)?;
         let file_path = Path::new(&path);
-        return git::get_file_diff(worktree, &spec, file_path).map_err(|e| e.to_string());
+        let result = git::get_file_diff(worktree, &spec, file_path).map_err(|e| e.to_string())?;
+        fn file_stats(f: &Option<git::File>) -> (usize, usize) {
+            match f {
+                Some(git::File {
+                    content: git::FileContent::Text { lines },
+                    ..
+                }) => {
+                    let max_len = lines.iter().map(|l| l.len()).max().unwrap_or(0);
+                    (lines.len(), max_len)
+                }
+                _ => (0, 0),
+            }
+        }
+        let (before_lines, before_max) = file_stats(&result.before);
+        let (after_lines, after_max) = file_stats(&result.after);
+        log::info!(
+            "get_file_diff: path={path} done in {:?} before={before_lines} lines (max {before_max} chars) after={after_lines} lines (max {after_max} chars) alignments={}",
+            start.elapsed(),
+            result.alignments.len()
+        );
+        return Ok(result);
     }
 
     // Check cache for branch-scope diffs.

--- a/crates/git-diff/Cargo.toml
+++ b/crates/git-diff/Cargo.toml
@@ -9,6 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 git2 = { version = "0.20", features = ["vendored-openssl"] }
 base64 = "0.22"
+log = "0.4"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/git-diff/src/diff.rs
+++ b/crates/git-diff/src/diff.rs
@@ -325,6 +325,7 @@ pub fn parse_name_status(output: &str) -> Result<Vec<FileDiffSummary>, GitError>
 /// This is reliable and battle-tested - we use git CLI only for list_diff_files
 /// where fsmonitor support matters for performance.
 pub fn get_file_diff(repo_path: &Path, spec: &DiffSpec, path: &Path) -> Result<FileDiff, GitError> {
+    let start = std::time::Instant::now();
     // Resolve MergeBase to concrete SHA
     let spec = resolve_spec(repo_path, spec)?;
 
@@ -341,6 +342,7 @@ pub fn get_file_diff(repo_path: &Path, spec: &DiffSpec, path: &Path) -> Result<F
     };
 
     // Load file content
+    let t_load = std::time::Instant::now();
     let before = load_file_from_tree(&repo, base_tree.as_ref(), path)?;
     let after = if is_working_tree {
         load_file_from_workdir(&repo, path)?
@@ -349,8 +351,10 @@ pub fn get_file_diff(repo_path: &Path, spec: &DiffSpec, path: &Path) -> Result<F
     } else {
         load_file_from_tree(&repo, head_tree.as_ref(), path)?
     };
+    let load_elapsed = t_load.elapsed();
 
     // Get hunks via libgit2
+    let t_hunks = std::time::Instant::now();
     let hunks = get_hunks_libgit2(
         &repo,
         base_tree.as_ref(),
@@ -359,9 +363,23 @@ pub fn get_file_diff(repo_path: &Path, spec: &DiffSpec, path: &Path) -> Result<F
         is_index,
         path,
     )?;
+    let hunks_elapsed = t_hunks.elapsed();
 
     // Compute alignments from hunks
+    let t_align = std::time::Instant::now();
     let alignments = compute_alignments_from_hunks(&hunks, &before, &after);
+    let align_elapsed = t_align.elapsed();
+
+    log::info!(
+        "git-diff get_file_diff: path={} total={:?} load={:?} hunks={:?}({}) align={:?}({})",
+        path.display(),
+        start.elapsed(),
+        load_elapsed,
+        hunks_elapsed,
+        hunks.len(),
+        align_elapsed,
+        alignments.len()
+    );
 
     Ok(FileDiff {
         before,

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -522,10 +522,12 @@
     }
 
     if (highlighterReady && languageReady) {
+      const t0 = performance.now();
       const beforeCode = beforeLines.join('\n');
       const afterCode = afterLines.join('\n');
       beforeTokens = beforeCode ? highlightLines(beforeCode, language) : [];
       afterTokens = afterCode ? highlightLines(afterCode, language) : [];
+      console.info('[diff] syntax highlight', { language, beforeLines: beforeLines.length, afterLines: afterLines.length, elapsed: `${(performance.now() - t0).toFixed(1)}ms` });
     } else {
       beforeTokens = beforeLines.map((line) => [{ content: line, color: 'inherit' }]);
       afterTokens = afterLines.map((line) => [{ content: line, color: 'inherit' }]);

--- a/packages/diff-viewer/src/lib/state/diffViewerState.svelte.ts
+++ b/packages/diff-viewer/src/lib/state/diffViewerState.svelte.ts
@@ -89,11 +89,14 @@ export function createDiffViewerState(
     state.error = null;
 
     try {
+      const t0 = performance.now();
+      console.info('[diff] getDiffFiles start', { branchId: state.branchId, scope: state.scope, commitSha: state.commitSha });
       const response = await commands.getDiffFiles(
         state.branchId,
         state.commitSha ?? undefined,
         state.scope
       );
+      console.info('[diff] getDiffFiles done', { files: response.files.length, elapsed: `${(performance.now() - t0).toFixed(1)}ms` });
 
       state.commitSha = response.commitSha;
       state.files = response.files;
@@ -136,7 +139,22 @@ export function createDiffViewerState(
     state.loadingFile = path;
 
     try {
+      const t0 = performance.now();
+      console.info('[diff] getFileDiff start', { path, commitSha: state.commitSha, scope: state.scope });
       const diff = await commands.getFileDiff(state.branchId, state.commitSha, state.scope, path);
+      const beforeLineCount = diff.before?.content?.type === 'Text' ? diff.before.content.lines.length : 0;
+      const afterLineCount = diff.after?.content?.type === 'Text' ? diff.after.content.lines.length : 0;
+      const beforeMaxLen = diff.before?.content?.type === 'Text' ? Math.max(0, ...diff.before.content.lines.map((l: string) => l.length)) : 0;
+      const afterMaxLen = diff.after?.content?.type === 'Text' ? Math.max(0, ...diff.after.content.lines.map((l: string) => l.length)) : 0;
+      console.info('[diff] getFileDiff done', {
+        path,
+        elapsed: `${(performance.now() - t0).toFixed(1)}ms`,
+        beforeLines: beforeLineCount,
+        afterLines: afterLineCount,
+        beforeMaxLineLen: beforeMaxLen,
+        afterMaxLineLen: afterMaxLen,
+        alignments: diff.alignments.length,
+      });
       // New Map for reactivity.
       const newCache = new Map(state.diffCache);
       newCache.set(path, diff);

--- a/packages/diff-viewer/src/lib/utils/inlineDiff.ts
+++ b/packages/diff-viewer/src/lib/utils/inlineDiff.ts
@@ -86,7 +86,15 @@ function lcsLength(a: string, b: string): number {
 function similarity(a: string, b: string): number {
   if (a.length === 0 && b.length === 0) return 1;
   if (a.length === 0 || b.length === 0) return 0;
+  const product = a.length * b.length;
+  if (product > 1_000_000) {
+    console.info('[diff] similarity: large line pair', { aLen: a.length, bLen: b.length, product });
+  }
+  const t0 = product > 1_000_000 ? performance.now() : 0;
   const lcsLen = lcsLength(a, b);
+  if (t0 > 0) {
+    console.info('[diff] similarity done', { elapsed: `${(performance.now() - t0).toFixed(1)}ms` });
+  }
   return (2 * lcsLen) / (a.length + b.length);
 }
 
@@ -100,8 +108,12 @@ function computeCharHighlights(
   before: string,
   after: string,
 ): { beforeHighlights: CharHighlight[]; afterHighlights: CharHighlight[] } {
+  const t0 = performance.now();
   const beforeTokens = splitWords(before);
   const afterTokens = splitWords(after);
+  if (beforeTokens.length * afterTokens.length > 1_000_000) {
+    console.info('[diff] computeCharHighlights: large token pair', { beforeTokens: beforeTokens.length, afterTokens: afterTokens.length, beforeLen: before.length, afterLen: after.length });
+  }
 
   const { aIndices, bIndices } = lcsIndices(beforeTokens, afterTokens);
 
@@ -123,6 +135,11 @@ function computeCharHighlights(
       afterHighlights.push({ start: pos, end: pos + tokenLen });
     }
     pos += tokenLen;
+  }
+
+  const elapsed = performance.now() - t0;
+  if (elapsed > 10) {
+    console.info('[diff] computeCharHighlights done', { elapsed: `${elapsed.toFixed(1)}ms`, beforeLen: before.length, afterLen: after.length });
   }
 
   return {
@@ -152,6 +169,11 @@ export function computeLineDiff(
   beforeLines: string[],
   afterLines: string[],
 ): LineDiffResult {
+  const t0 = performance.now();
+  const beforeMaxLen = Math.max(0, ...beforeLines.map(l => l.length));
+  const afterMaxLen = Math.max(0, ...afterLines.map(l => l.length));
+  console.info('[diff] computeLineDiff start', { beforeLines: beforeLines.length, afterLines: afterLines.length, beforeMaxLineLen: beforeMaxLen, afterMaxLineLen: afterMaxLen });
+
   const { aIndices: lcsBeforeIndices, bIndices: lcsAfterIndices } = lcsIndices(
     beforeLines,
     afterLines,
@@ -236,6 +258,9 @@ export function computeLineDiff(
     afterClasses[unmatchedAfter[ai]] = 'added';
     ai++;
   }
+
+  const elapsed = performance.now() - t0;
+  console.info('[diff] computeLineDiff done', { modifiedPairs: modifiedPairs.length, elapsed: `${elapsed.toFixed(1)}ms` });
 
   return {
     beforeLines: beforeClasses,

--- a/packages/diff-viewer/src/lib/utils/inlineDiff.ts
+++ b/packages/diff-viewer/src/lib/utils/inlineDiff.ts
@@ -83,18 +83,17 @@ function lcsLength(a: string, b: string): number {
   return prev[n];
 }
 
+const LCS_BAILOUT_PRODUCT = 1_000_000;
+
 function similarity(a: string, b: string): number {
   if (a.length === 0 && b.length === 0) return 1;
   if (a.length === 0 || b.length === 0) return 0;
   const product = a.length * b.length;
-  if (product > 1_000_000) {
-    console.info('[diff] similarity: large line pair', { aLen: a.length, bLen: b.length, product });
+  if (product > LCS_BAILOUT_PRODUCT) {
+    console.info('[diff] similarity: bailing out on large line pair', { aLen: a.length, bLen: b.length, product });
+    return 0;
   }
-  const t0 = product > 1_000_000 ? performance.now() : 0;
   const lcsLen = lcsLength(a, b);
-  if (t0 > 0) {
-    console.info('[diff] similarity done', { elapsed: `${(performance.now() - t0).toFixed(1)}ms` });
-  }
   return (2 * lcsLen) / (a.length + b.length);
 }
 
@@ -108,13 +107,17 @@ function computeCharHighlights(
   before: string,
   after: string,
 ): { beforeHighlights: CharHighlight[]; afterHighlights: CharHighlight[] } {
-  const t0 = performance.now();
   const beforeTokens = splitWords(before);
   const afterTokens = splitWords(after);
-  if (beforeTokens.length * afterTokens.length > 1_000_000) {
-    console.info('[diff] computeCharHighlights: large token pair', { beforeTokens: beforeTokens.length, afterTokens: afterTokens.length, beforeLen: before.length, afterLen: after.length });
+  if (beforeTokens.length * afterTokens.length > LCS_BAILOUT_PRODUCT) {
+    console.info('[diff] computeCharHighlights: bailing out on large token pair', { beforeTokens: beforeTokens.length, afterTokens: afterTokens.length, beforeLen: before.length, afterLen: after.length });
+    return {
+      beforeHighlights: before.length > 0 ? [{ start: 0, end: before.length }] : [],
+      afterHighlights: after.length > 0 ? [{ start: 0, end: after.length }] : [],
+    };
   }
 
+  const t0 = performance.now();
   const { aIndices, bIndices } = lcsIndices(beforeTokens, afterTokens);
 
   const beforeHighlights: CharHighlight[] = [];


### PR DESCRIPTION
## Summary
- Add info-level timing logs across the entire diff pipeline (Rust backend, Svelte frontend state, syntax highlighting, inline diff computation) to make it easy to diagnose slow diffs
- Bail out of LCS computation when line length product exceeds 1M characters, preventing UI freezes on files with very long lines (e.g. minified JS/CSS)

## Test plan
- [ ] Verify timing logs appear in console/log output when viewing diffs
- [ ] Open a diff with very long lines (e.g. minified file) and confirm it no longer freezes
- [ ] Normal diffs still compute inline highlights correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)