### PR TITLE
fix(project_mcp): gate note/commit artifact data on terminal session state

### DIFF
--- a/apps/staged/src-tauri/src/project_mcp.rs
+++ b/apps/staged/src-tauri/src/project_mcp.rs
@@ -238,39 +238,39 @@ impl ProjectToolsHandler {
             payload["error_message"] = serde_json::Value::String(error.clone());
         }
 
-        match handle.artifact_kind {
-            RepoArtifactKind::Note => {
-                let note = self
-                    .store
-                    .get_note(&handle.artifact_id)
-                    .map_err(|e| format!("Error loading note: {e}"))?;
-                if let Some(note) = note {
-                    payload["note"] = serde_json::json!({
-                        "id": note.id,
-                        "title": note.title,
-                        "content": note.content,
-                        "completed_at": note.completed_at,
-                    });
-                }
-            }
-            RepoArtifactKind::Commit => {
-                let commit = self
-                    .store
-                    .get_commit(&handle.artifact_id)
-                    .map_err(|e| format!("Error loading commit: {e}"))?;
-                if let Some(commit) = commit {
-                    payload["commit"] = serde_json::json!({
-                        "id": commit.id,
-                        "sha": commit.sha,
-                    });
-                }
-            }
-        }
-
         if matches!(
             session_status,
             SessionStatus::Completed | SessionStatus::Cancelled | SessionStatus::Error
         ) {
+            match handle.artifact_kind {
+                RepoArtifactKind::Note => {
+                    let note = self
+                        .store
+                        .get_note(&handle.artifact_id)
+                        .map_err(|e| format!("Error loading note: {e}"))?;
+                    if let Some(note) = note {
+                        payload["note"] = serde_json::json!({
+                            "id": note.id,
+                            "title": note.title,
+                            "content": note.content,
+                            "completed_at": note.completed_at,
+                        });
+                    }
+                }
+                RepoArtifactKind::Commit => {
+                    let commit = self
+                        .store
+                        .get_commit(&handle.artifact_id)
+                        .map_err(|e| format!("Error loading commit: {e}"))?;
+                    if let Some(commit) = commit {
+                        payload["commit"] = serde_json::json!({
+                            "id": commit.id,
+                            "sha": commit.sha,
+                        });
+                    }
+                }
+            }
+
             payload["output"] =
                 serde_json::Value::String(self.last_assistant_output(&handle.session_id));
         }


### PR DESCRIPTION
## Summary
- Moves note and commit artifact data loading inside the terminal session status check (Completed/Cancelled/Error), so in-progress sessions don't return potentially stale or incomplete artifact data in the MCP tool response.

## Test plan
- [ ] Verify that completed/cancelled/error sessions still include note and commit data in the response
- [ ] Verify that in-progress sessions no longer include note/commit artifact data

🤖 Generated with [Claude Code](https://claude.com/claude-code)