### PR TITLE
fix: add opener:default permission to enable external link opening

### DIFF
--- a/apps/staged/src-tauri/capabilities/default.json
+++ b/apps/staged/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "dialog:default",
     "process:allow-restart",
     "updater:default",
+    "opener:default",
     "log:default"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `opener:default` permission to Tauri capabilities, enabling the app to open external links in the user's default browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)