### PR TITLE
fix(staged): hide session dialog button on queued timeline rows

### DIFF
--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -219,7 +219,7 @@
           Retry
         </button>
       {/if}
-      {#if hasSession && !onStartClick}
+      {#if hasSession && !onStartClick && !isQueued}
         <button class="action-btn session-btn" onclick={handleSessionClick} title="View session">
           <MessageSquare size={12} />
         </button>


### PR DESCRIPTION
## Summary
- Hide the session dialog button on queued timeline rows by adding an `!isQueued` guard to the render condition, preventing users from opening the session dialog for sessions that haven't started yet

## Test plan
- [ ] Verify queued timeline rows no longer show the session dialog button
- [ ] Verify active/completed timeline rows still show the session dialog button as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)