### PR TITLE
feat: add next-step action buttons to note modal

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -203,13 +203,13 @@
     const empty = { commit: '', note: '' };
     if (!timeline) return empty;
 
-    // Don't prefill when there are visible queued sessions — the user should wait
-    // for those to complete before starting new work.
-    const hasQueuedSessions =
-      timeline.commits.some((c) => c.sessionStatus === 'queued') ||
-      timeline.notes.some((n) => n.sessionStatus === 'queued') ||
-      timeline.reviews.some((r) => r.sessionStatus === 'queued');
-    if (hasQueuedSessions) return empty;
+    // Don't prefill when there are active (queued or running) sessions — the user
+    // should wait for those to complete before starting new work.
+    const hasActiveSessions =
+      timeline.commits.some((c) => c.sessionStatus === 'queued' || c.sessionStatus === 'running') ||
+      timeline.notes.some((n) => n.sessionStatus === 'queued' || n.sessionStatus === 'running') ||
+      timeline.reviews.some((r) => r.sessionStatus === 'queued' || r.sessionStatus === 'running');
+    if (hasActiveSessions) return empty;
 
     // Find the latest completed item across commits, notes, and reviews
     type Candidate =
@@ -291,12 +291,12 @@
     if (!note) return null;
     if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) return null;
 
-    // Check no queued sessions
-    const hasQueuedSessions =
-      timeline.commits.some((c) => c.sessionStatus === 'queued') ||
-      timeline.notes.some((n) => n.sessionStatus === 'queued') ||
-      timeline.reviews.some((r) => r.sessionStatus === 'queued');
-    if (hasQueuedSessions) return null;
+    // Check no active (queued or running) sessions
+    const hasActiveSessions =
+      timeline.commits.some((c) => c.sessionStatus === 'queued' || c.sessionStatus === 'running') ||
+      timeline.notes.some((n) => n.sessionStatus === 'queued' || n.sessionStatus === 'running') ||
+      timeline.reviews.some((r) => r.sessionStatus === 'queued' || r.sessionStatus === 'running');
+    if (hasActiveSessions) return null;
 
     // Check this note is the latest completed item
     const noteTs = Math.floor((note.completedAt ?? note.createdAt) / 1000);

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1042,8 +1042,7 @@
     }}
     onStartSession={(mode, prefill) => {
       openNote = null;
-      sessionMgr.draftPrompt = prefill;
-      sessionMgr.openNewSession(mode);
+      void sessionMgr.startOrQueueSession(mode, prefill);
     }}
   />
 {/if}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -283,38 +283,71 @@
 
   // Compute next-step suggestions for the currently open note.
   // Only shown when the note is the last completed item and there are no queued sessions.
+  // Memoized to preserve object identity across reactive re-evaluations so that
+  // NoteModal buttons don't lose hover state from unnecessary DOM re-creation.
+  let prevNextSteps: { commitStep: string | null; noteStep: string | null } | null = null;
   let openNoteNextSteps = $derived.by(() => {
-    if (!openNote || !timeline) return null;
+    if (!openNote || !timeline) {
+      prevNextSteps = null;
+      return null;
+    }
     const note = timeline.notes.find((n) => n.id === openNote.noteId);
-    if (!note) return null;
-    if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) return null;
+    if (!note) {
+      prevNextSteps = null;
+      return null;
+    }
+    if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) {
+      prevNextSteps = null;
+      return null;
+    }
 
     // Check no queued sessions
     const hasQueuedSessions =
       timeline.commits.some((c) => c.sessionStatus === 'queued') ||
       timeline.notes.some((n) => n.sessionStatus === 'queued') ||
       timeline.reviews.some((r) => r.sessionStatus === 'queued');
-    if (hasQueuedSessions) return null;
+    if (hasQueuedSessions) {
+      prevNextSteps = null;
+      return null;
+    }
 
     // Check this note is the latest completed item
     const noteTs = Math.floor((note.completedAt ?? note.createdAt) / 1000);
     for (const c of timeline.commits) {
-      if (c.sha && c.timestamp > noteTs) return null;
+      if (c.sha && c.timestamp > noteTs) {
+        prevNextSteps = null;
+        return null;
+      }
     }
     for (const n of timeline.notes) {
       if (n.id === note.id) continue;
       const ts = Math.floor((n.completedAt ?? n.createdAt) / 1000);
-      if (ts > noteTs) return null;
+      if (ts > noteTs) {
+        prevNextSteps = null;
+        return null;
+      }
     }
     for (const r of timeline.reviews) {
       const ts = Math.floor((r.completedAt ?? r.createdAt) / 1000);
-      if (ts > noteTs) return null;
+      if (ts > noteTs) {
+        prevNextSteps = null;
+        return null;
+      }
     }
 
-    return {
+    if (
+      prevNextSteps &&
+      prevNextSteps.commitStep === note.suggestedNextCommitStep &&
+      prevNextSteps.noteStep === note.suggestedNextNoteStep
+    ) {
+      return prevNextSteps;
+    }
+
+    prevNextSteps = {
       commitStep: note.suggestedNextCommitStep,
       noteStep: note.suggestedNextNoteStep,
     };
+    return prevNextSteps;
   });
 
   // Commit diff modal (opened by clicking a commit in the timeline)

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -281,74 +281,43 @@
     return empty;
   });
 
-  // Compute next-step suggestions for the currently open note.
-  // Only shown when the note is the last completed item and there are no queued sessions.
-  // Memoized to preserve object identity across reactive re-evaluations so that
-  // NoteModal buttons don't lose hover state from unnecessary DOM re-creation.
-  let prevNextSteps: { commitStep: string | null; noteStep: string | null } | null = null;
-  let openNoteNextSteps = $derived.by(() => {
-    if (!openNote || !timeline) {
-      prevNextSteps = null;
-      return null;
-    }
-    const note = timeline.notes.find((n) => n.id === openNote.noteId);
-    if (!note) {
-      prevNextSteps = null;
-      return null;
-    }
-    if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) {
-      prevNextSteps = null;
-      return null;
-    }
+  // Compute next-step suggestions for a note. Called once when the note modal
+  // is opened so the result is static and doesn't cause DOM churn from polling.
+  function computeNoteNextSteps(
+    noteId: string
+  ): { commitStep: string | null; noteStep: string | null } | null {
+    if (!timeline) return null;
+    const note = timeline.notes.find((n) => n.id === noteId);
+    if (!note) return null;
+    if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) return null;
 
     // Check no queued sessions
     const hasQueuedSessions =
       timeline.commits.some((c) => c.sessionStatus === 'queued') ||
       timeline.notes.some((n) => n.sessionStatus === 'queued') ||
       timeline.reviews.some((r) => r.sessionStatus === 'queued');
-    if (hasQueuedSessions) {
-      prevNextSteps = null;
-      return null;
-    }
+    if (hasQueuedSessions) return null;
 
     // Check this note is the latest completed item
     const noteTs = Math.floor((note.completedAt ?? note.createdAt) / 1000);
     for (const c of timeline.commits) {
-      if (c.sha && c.timestamp > noteTs) {
-        prevNextSteps = null;
-        return null;
-      }
+      if (c.sha && c.timestamp > noteTs) return null;
     }
     for (const n of timeline.notes) {
       if (n.id === note.id) continue;
       const ts = Math.floor((n.completedAt ?? n.createdAt) / 1000);
-      if (ts > noteTs) {
-        prevNextSteps = null;
-        return null;
-      }
+      if (ts > noteTs) return null;
     }
     for (const r of timeline.reviews) {
       const ts = Math.floor((r.completedAt ?? r.createdAt) / 1000);
-      if (ts > noteTs) {
-        prevNextSteps = null;
-        return null;
-      }
+      if (ts > noteTs) return null;
     }
 
-    if (
-      prevNextSteps &&
-      prevNextSteps.commitStep === note.suggestedNextCommitStep &&
-      prevNextSteps.noteStep === note.suggestedNextNoteStep
-    ) {
-      return prevNextSteps;
-    }
-
-    prevNextSteps = {
+    return {
       commitStep: note.suggestedNextCommitStep,
       noteStep: note.suggestedNextNoteStep,
     };
-    return prevNextSteps;
-  });
+  }
 
   // Commit diff modal (opened by clicking a commit in the timeline)
   let commitDiffSha = $state<string | null>(null);
@@ -359,6 +328,7 @@
     title: string;
     content: string;
     sessionId?: string;
+    nextSteps?: { commitStep: string | null; noteStep: string | null } | null;
   } | null>(null);
 
   // Image viewer modal (opened by clicking an image in the timeline)
@@ -603,7 +573,7 @@
   }
 
   function handleNoteClick(noteId: string, title: string, content: string, sessionId?: string) {
-    openNote = { noteId, title, content, sessionId };
+    openNote = { noteId, title, content, sessionId, nextSteps: computeNoteNextSteps(noteId) };
   }
 
   async function handleReviewClick(reviewId: string) {
@@ -1064,7 +1034,7 @@
     title={openNote.title}
     content={openNote.content}
     sessionId={openNote.sessionId}
-    nextSteps={openNoteNextSteps}
+    nextSteps={openNote.nextSteps}
     onClose={() => (openNote = null)}
     onOpenSession={(sid) => {
       openNote = null;
@@ -1140,7 +1110,13 @@
     onOpenNote={(noteId, title, content) => {
       const sid = sessionMgr.openSessionId;
       sessionMgr.openSessionId = null;
-      openNote = { noteId, title, content, sessionId: sid ?? undefined };
+      openNote = {
+        noteId,
+        title,
+        content,
+        sessionId: sid ?? undefined,
+        nextSteps: computeNoteNextSteps(noteId),
+      };
     }}
     onClose={async () => {
       const closedSessionId = sessionMgr.openSessionId;

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -469,6 +469,9 @@
           fresh
             .then((next) => {
               if (version !== revalidationVersion) return;
+              console.info('[BranchCard] timeline revalidated', {
+                noteModalOpen: !!openNote,
+              });
               error = null;
               timeline = next;
               prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
@@ -491,6 +494,12 @@
 
     try {
       const nextTimeline = await commands.getBranchTimeline(branch.id, { force: !isInitialLoad });
+      console.info('[BranchCard] timeline updated', {
+        isInitialLoad,
+        noteModalOpen: !!openNote,
+        commits: nextTimeline.commits.length,
+        notes: nextTimeline.notes.length,
+      });
       timeline = nextTimeline;
       prunedSessionIds = sessionMgr.prunePendingSessionItems(nextTimeline);
       void loadTimelineReviewDetails(nextTimeline.reviews);
@@ -571,7 +580,9 @@
   }
 
   function handleNoteClick(noteId: string, title: string, content: string, sessionId?: string) {
-    openNote = { noteId, title, content, sessionId, nextSteps: computeNoteNextSteps(noteId) };
+    const ns = computeNoteNextSteps(noteId);
+    console.info('[BranchCard] handleNoteClick setting openNote', { noteId, hasNextSteps: !!ns });
+    openNote = { noteId, title, content, sessionId, nextSteps: ns };
   }
 
   async function handleReviewClick(reviewId: string) {

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -469,9 +469,6 @@
           fresh
             .then((next) => {
               if (version !== revalidationVersion) return;
-              console.info('[BranchCard] timeline revalidated', {
-                noteModalOpen: !!openNote,
-              });
               error = null;
               timeline = next;
               prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
@@ -494,12 +491,6 @@
 
     try {
       const nextTimeline = await commands.getBranchTimeline(branch.id, { force: !isInitialLoad });
-      console.info('[BranchCard] timeline updated', {
-        isInitialLoad,
-        noteModalOpen: !!openNote,
-        commits: nextTimeline.commits.length,
-        notes: nextTimeline.notes.length,
-      });
       timeline = nextTimeline;
       prunedSessionIds = sessionMgr.prunePendingSessionItems(nextTimeline);
       void loadTimelineReviewDetails(nextTimeline.reviews);
@@ -580,9 +571,7 @@
   }
 
   function handleNoteClick(noteId: string, title: string, content: string, sessionId?: string) {
-    const ns = computeNoteNextSteps(noteId);
-    console.info('[BranchCard] handleNoteClick setting openNote', { noteId, hasNextSteps: !!ns });
-    openNote = { noteId, title, content, sessionId, nextSteps: ns };
+    openNote = { noteId, title, content, sessionId, nextSteps: computeNoteNextSteps(noteId) };
   }
 
   async function handleReviewClick(reviewId: string) {

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -281,11 +281,52 @@
     return empty;
   });
 
+  // Compute next-step suggestions for the currently open note.
+  // Only shown when the note is the last completed item and there are no queued sessions.
+  let openNoteNextSteps = $derived.by(() => {
+    if (!openNote || !timeline) return null;
+    const note = timeline.notes.find((n) => n.id === openNote.noteId);
+    if (!note) return null;
+    if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) return null;
+
+    // Check no queued sessions
+    const hasQueuedSessions =
+      timeline.commits.some((c) => c.sessionStatus === 'queued') ||
+      timeline.notes.some((n) => n.sessionStatus === 'queued') ||
+      timeline.reviews.some((r) => r.sessionStatus === 'queued');
+    if (hasQueuedSessions) return null;
+
+    // Check this note is the latest completed item
+    const noteTs = Math.floor((note.completedAt ?? note.createdAt) / 1000);
+    for (const c of timeline.commits) {
+      if (c.sha && c.timestamp > noteTs) return null;
+    }
+    for (const n of timeline.notes) {
+      if (n.id === note.id) continue;
+      const ts = Math.floor((n.completedAt ?? n.createdAt) / 1000);
+      if (ts > noteTs) return null;
+    }
+    for (const r of timeline.reviews) {
+      const ts = Math.floor((r.completedAt ?? r.createdAt) / 1000);
+      if (ts > noteTs) return null;
+    }
+
+    return {
+      commitStep: note.suggestedNextCommitStep,
+      noteStep: note.suggestedNextNoteStep,
+    };
+  });
+
   // Commit diff modal (opened by clicking a commit in the timeline)
   let commitDiffSha = $state<string | null>(null);
 
   // Note modal (opened by clicking a note in the timeline)
-  let openNote = $state<{ title: string; content: string; sessionId?: string } | null>(null);
+  let openNote = $state<{
+    noteId: string;
+    title: string;
+    content: string;
+    sessionId?: string;
+  } | null>(null);
 
   // Image viewer modal (opened by clicking an image in the timeline)
   let viewImageId = $state<string | null>(null);
@@ -528,8 +569,8 @@
     commitDiffSha = sha;
   }
 
-  function handleNoteClick(_noteId: string, title: string, content: string, sessionId?: string) {
-    openNote = { title, content, sessionId };
+  function handleNoteClick(noteId: string, title: string, content: string, sessionId?: string) {
+    openNote = { noteId, title, content, sessionId };
   }
 
   async function handleReviewClick(reviewId: string) {
@@ -990,10 +1031,16 @@
     title={openNote.title}
     content={openNote.content}
     sessionId={openNote.sessionId}
+    nextSteps={openNoteNextSteps}
     onClose={() => (openNote = null)}
     onOpenSession={(sid) => {
       openNote = null;
       sessionMgr.openSessionId = sid;
+    }}
+    onStartSession={(mode, prefill) => {
+      openNote = null;
+      sessionMgr.draftPrompt = prefill;
+      sessionMgr.openNewSession(mode);
     }}
   />
 {/if}
@@ -1060,7 +1107,7 @@
     onOpenNote={(noteId, title, content) => {
       const sid = sessionMgr.openSessionId;
       sessionMgr.openSessionId = null;
-      openNote = { title, content, sessionId: sid ?? undefined };
+      openNote = { noteId, title, content, sessionId: sid ?? undefined };
     }}
     onClose={async () => {
       const closedSessionId = sessionMgr.openSessionId;

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -197,6 +197,15 @@
   /** True when the branch has at least one finalized commit (code changes vs base). */
   let hasCodeChanges = $derived(timeline?.commits.some((c) => c.sha) ?? false);
 
+  /** True when the branch has at least one queued or running session. */
+  function hasActiveSessions(tl: NonNullable<typeof timeline>): boolean {
+    return (
+      tl.commits.some((c) => c.sessionStatus === 'queued' || c.sessionStatus === 'running') ||
+      tl.notes.some((n) => n.sessionStatus === 'queued' || n.sessionStatus === 'running') ||
+      tl.reviews.some((r) => r.sessionStatus === 'queued' || r.sessionStatus === 'running')
+    );
+  }
+
   // Compute suggested prefill prompts from the latest visible timeline entry.
   // Only used when the user hasn't typed a draft yet.
   let suggestedPrefill = $derived.by(() => {
@@ -205,11 +214,7 @@
 
     // Don't prefill when there are active (queued or running) sessions — the user
     // should wait for those to complete before starting new work.
-    const hasActiveSessions =
-      timeline.commits.some((c) => c.sessionStatus === 'queued' || c.sessionStatus === 'running') ||
-      timeline.notes.some((n) => n.sessionStatus === 'queued' || n.sessionStatus === 'running') ||
-      timeline.reviews.some((r) => r.sessionStatus === 'queued' || r.sessionStatus === 'running');
-    if (hasActiveSessions) return empty;
+    if (hasActiveSessions(timeline)) return empty;
 
     // Find the latest completed item across commits, notes, and reviews
     type Candidate =
@@ -225,13 +230,11 @@
     const candidates: Candidate[] = [];
 
     for (const review of timeline.reviews) {
-      if (review.sessionStatus === 'running') continue;
       const ts = Math.floor((review.completedAt ?? review.createdAt) / 1000);
       candidates.push({ kind: 'review', commentCount: review.commentCount, timestamp: ts });
     }
 
     for (const note of timeline.notes) {
-      if (note.sessionStatus === 'running') continue;
       const ts = Math.floor((note.completedAt ?? note.createdAt) / 1000);
       candidates.push({
         kind: 'note',
@@ -291,27 +294,22 @@
     if (!note) return null;
     if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) return null;
 
-    // Check no active (queued or running) sessions
-    const hasActiveSessions =
-      timeline.commits.some((c) => c.sessionStatus === 'queued' || c.sessionStatus === 'running') ||
-      timeline.notes.some((n) => n.sessionStatus === 'queued' || n.sessionStatus === 'running') ||
-      timeline.reviews.some((r) => r.sessionStatus === 'queued' || r.sessionStatus === 'running');
-    if (hasActiveSessions) return null;
+    if (hasActiveSessions(timeline)) return null;
 
-    // Check this note is the latest completed item
+    // Check this note is the latest completed item using the same approach
+    // as suggestedPrefill: collect all timestamps and compare.
     const noteTs = Math.floor((note.completedAt ?? note.createdAt) / 1000);
+    const timestamps: number[] = [];
     for (const c of timeline.commits) {
-      if (c.sha && c.timestamp > noteTs) return null;
+      if (c.sha) timestamps.push(c.timestamp);
     }
     for (const n of timeline.notes) {
-      if (n.id === note.id) continue;
-      const ts = Math.floor((n.completedAt ?? n.createdAt) / 1000);
-      if (ts > noteTs) return null;
+      if (n.id !== note.id) timestamps.push(Math.floor((n.completedAt ?? n.createdAt) / 1000));
     }
     for (const r of timeline.reviews) {
-      const ts = Math.floor((r.completedAt ?? r.createdAt) / 1000);
-      if (ts > noteTs) return null;
+      timestamps.push(Math.floor((r.completedAt ?? r.createdAt) / 1000));
     }
+    if (timestamps.some((ts) => ts > noteTs)) return null;
 
     return {
       commitStep: note.suggestedNextCommitStep,

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -227,7 +227,7 @@
             <span class="next-step-prompt">{nextSteps.noteStep}</span>
             <button
               class="next-step-btn note-btn"
-              onclick={() => onStartSession?.('note', nextSteps!.noteStep!)}
+              onclick={() => onStartSession('note', nextSteps!.noteStep!)}
             >
               Start note
             </button>
@@ -238,7 +238,7 @@
             <span class="next-step-prompt">{nextSteps.commitStep}</span>
             <button
               class="next-step-btn commit-btn"
-              onclick={() => onStartSession?.('commit', nextSteps!.commitStep!)}
+              onclick={() => onStartSession('commit', nextSteps!.commitStep!)}
             >
               Start commit
             </button>

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -17,9 +17,6 @@
 
   marked.setOptions({ breaks: true, gfm: true });
 
-  let noteModalInstanceId = Math.random().toString(36).slice(2, 8);
-  console.info(`[NoteModal] mount instance=${noteModalInstanceId}`);
-
   interface Props {
     title: string;
     content: string;
@@ -35,17 +32,6 @@
 
   let { title, content, onClose, sessionId, onOpenSession, nextSteps, onStartSession }: Props =
     $props();
-
-  $effect(() => {
-    console.info(`[NoteModal] props changed instance=${noteModalInstanceId}`, {
-      title,
-      hasContent: !!content,
-      hasNextSteps: !!nextSteps,
-      noteStep: nextSteps?.noteStep,
-      commitStep: nextSteps?.commitStep,
-      hasOnStartSession: !!onStartSession,
-    });
-  });
 
   let copied = $state(false);
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
@@ -68,27 +54,11 @@
   });
 
   onDestroy(() => {
-    console.info(`[NoteModal] destroy instance=${noteModalInstanceId}`);
     unregisterSearchTarget?.();
   });
 
   function renderMarkdown(text: string): string {
     return sanitize(marked.parse(text) as string);
-  }
-
-  // Debug action: logs when a next-step button DOM element is created/destroyed
-  function trackElement(node: HTMLElement) {
-    const label = node.textContent?.trim();
-    console.info(
-      `[NoteModal] next-step button CREATED: "${label}" instance=${noteModalInstanceId}`
-    );
-    return {
-      destroy() {
-        console.info(
-          `[NoteModal] next-step button DESTROYED: "${label}" instance=${noteModalInstanceId}`
-        );
-      },
-    };
   }
 
   async function handleShare() {
@@ -257,7 +227,6 @@
             <span class="next-step-prompt">{nextSteps.noteStep}</span>
             <button
               class="next-step-btn note-btn"
-              use:trackElement
               onclick={() => onStartSession('note', nextSteps!.noteStep!)}
             >
               Start note
@@ -269,7 +238,6 @@
             <span class="next-step-prompt">{nextSteps.commitStep}</span>
             <button
               class="next-step-btn commit-btn"
-              use:trackElement
               onclick={() => onStartSession('commit', nextSteps!.commitStep!)}
             >
               Start commit

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -542,9 +542,7 @@
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
-    transition:
-      background-color 0.1s,
-      opacity 0.1s;
+    transition: background-color 0.1s;
   }
 
   .next-step-btn.note-btn {
@@ -553,7 +551,7 @@
   }
 
   .next-step-btn.note-btn:hover {
-    opacity: 0.85;
+    background: var(--note-bg-emphasis);
   }
 
   .next-step-btn.commit-btn {
@@ -562,6 +560,6 @@
   }
 
   .next-step-btn.commit-btn:hover {
-    opacity: 0.85;
+    background: var(--commit-bg-emphasis);
   }
 </style>

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -17,6 +17,9 @@
 
   marked.setOptions({ breaks: true, gfm: true });
 
+  let noteModalInstanceId = Math.random().toString(36).slice(2, 8);
+  console.info(`[NoteModal] mount instance=${noteModalInstanceId}`);
+
   interface Props {
     title: string;
     content: string;
@@ -32,6 +35,17 @@
 
   let { title, content, onClose, sessionId, onOpenSession, nextSteps, onStartSession }: Props =
     $props();
+
+  $effect(() => {
+    console.info(`[NoteModal] props changed instance=${noteModalInstanceId}`, {
+      title,
+      hasContent: !!content,
+      hasNextSteps: !!nextSteps,
+      noteStep: nextSteps?.noteStep,
+      commitStep: nextSteps?.commitStep,
+      hasOnStartSession: !!onStartSession,
+    });
+  });
 
   let copied = $state(false);
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
@@ -54,11 +68,27 @@
   });
 
   onDestroy(() => {
+    console.info(`[NoteModal] destroy instance=${noteModalInstanceId}`);
     unregisterSearchTarget?.();
   });
 
   function renderMarkdown(text: string): string {
     return sanitize(marked.parse(text) as string);
+  }
+
+  // Debug action: logs when a next-step button DOM element is created/destroyed
+  function trackElement(node: HTMLElement) {
+    const label = node.textContent?.trim();
+    console.info(
+      `[NoteModal] next-step button CREATED: "${label}" instance=${noteModalInstanceId}`
+    );
+    return {
+      destroy() {
+        console.info(
+          `[NoteModal] next-step button DESTROYED: "${label}" instance=${noteModalInstanceId}`
+        );
+      },
+    };
   }
 
   async function handleShare() {
@@ -227,6 +257,7 @@
             <span class="next-step-prompt">{nextSteps.noteStep}</span>
             <button
               class="next-step-btn note-btn"
+              use:trackElement
               onclick={() => onStartSession('note', nextSteps!.noteStep!)}
             >
               Start note
@@ -238,6 +269,7 @@
             <span class="next-step-prompt">{nextSteps.commitStep}</span>
             <button
               class="next-step-btn commit-btn"
+              use:trackElement
               onclick={() => onStartSession('commit', nextSteps!.commitStep!)}
             >
               Start commit

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -24,9 +24,14 @@
     /** When set, shows a button to open the associated chat session. */
     sessionId?: string | null;
     onOpenSession?: (sessionId: string) => void;
+    /** Suggested next steps to show as action buttons at the bottom. */
+    nextSteps?: { commitStep: string | null; noteStep: string | null } | null;
+    /** Called when the user clicks a next-step button. */
+    onStartSession?: (mode: 'commit' | 'note', prefill: string) => void;
   }
 
-  let { title, content, onClose, sessionId, onOpenSession }: Props = $props();
+  let { title, content, onClose, sessionId, onOpenSession, nextSteps, onStartSession }: Props =
+    $props();
 
   let copied = $state(false);
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
@@ -215,6 +220,32 @@
         <p class="empty-note">This note has no content.</p>
       {/if}
     </div>
+    {#if nextSteps && onStartSession && (nextSteps.noteStep || nextSteps.commitStep)}
+      <div class="next-steps">
+        {#if nextSteps.noteStep}
+          <div class="next-step-row">
+            <span class="next-step-prompt">{nextSteps.noteStep}</span>
+            <button
+              class="next-step-btn note-btn"
+              onclick={() => onStartSession?.('note', nextSteps!.noteStep!)}
+            >
+              Start note
+            </button>
+          </div>
+        {/if}
+        {#if nextSteps.commitStep}
+          <div class="next-step-row">
+            <span class="next-step-prompt">{nextSteps.commitStep}</span>
+            <button
+              class="next-step-btn commit-btn"
+              onclick={() => onStartSession?.('commit', nextSteps!.commitStep!)}
+            >
+              Start commit
+            </button>
+          </div>
+        {/if}
+      </div>
+    {/if}
   </div>
 </div>
 
@@ -473,5 +504,64 @@
   .markdown-content :global(th) {
     background: var(--bg-primary);
     font-weight: 600;
+  }
+
+  .next-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 16px;
+    border-top: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+  }
+
+  .next-step-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: var(--bg-elevated);
+    border-radius: 8px;
+  }
+
+  .next-step-prompt {
+    flex: 1;
+    font-size: var(--size-sm);
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .next-step-btn {
+    flex-shrink: 0;
+    padding: 4px 12px;
+    border: none;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background-color 0.1s,
+      opacity 0.1s;
+  }
+
+  .next-step-btn.note-btn {
+    color: var(--note-color);
+    background: var(--note-bg);
+  }
+
+  .next-step-btn.note-btn:hover {
+    opacity: 0.85;
+  }
+
+  .next-step-btn.commit-btn {
+    color: var(--commit-color);
+    background: var(--commit-bg);
+  }
+
+  .next-step-btn.commit-btn:hover {
+    opacity: 0.85;
   }
 </style>


### PR DESCRIPTION
## Summary
- Adds "Start commit" and "Start note" action buttons at the bottom of the note modal, based on suggested next steps from the AI
- Computes next-step suggestions once when the note modal opens (not reactively) to avoid DOM churn from polling
- Hides next-step buttons when any session is queued or running, not just queued
- Extracts `hasActiveSessions()` helper to consolidate queued/running session checks across suggested prefill and next-step logic

## Test plan
- [ ] Open a note that has `suggestedNextCommitStep` / `suggestedNextNoteStep` — verify buttons appear
- [ ] Click a next-step button — verify the note modal closes and a new session starts with the correct mode and prefill
- [ ] Queue or run a session — verify next-step buttons are hidden
- [ ] Open a note that is not the latest timeline item — verify no next-step buttons appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)