### PR TITLE
feat: add hashtag references to notes, commits & reviews in prompt textareas

### DIFF
--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -2338,6 +2338,7 @@ fn image_timeline_entries(store: &Arc<Store>, branch_id: &str) -> Vec<TimelineEn
         .collect()
 }
 
+/// Parse `#type:id` tokens from the prompt and resolve their content from the store.
 /// Assemble the full prompt from action instructions + branch context + user prompt.
 fn build_full_prompt(
     user_prompt: &str,

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -2338,7 +2338,6 @@ fn image_timeline_entries(store: &Arc<Store>, branch_id: &str) -> Vec<TimelineEn
         .collect()
 }
 
-/// Parse `#type:id` tokens from the prompt and resolve their content from the store.
 /// Assemble the full prompt from action instructions + branch context + user prompt.
 fn build_full_prompt(
     user_prompt: &str,

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1009,6 +1009,7 @@
 {#if showBranchDiff}
   <DiffModal
     branchId={branch.id}
+    projectId={branch.projectId}
     commitSha={reviewDiffTarget?.commitSha}
     scope={reviewDiffTarget?.scope ?? 'branch'}
     reviewId={reviewDiffTarget?.reviewId}
@@ -1032,6 +1033,7 @@
 {#if commitDiffSha}
   <DiffModal
     branchId={branch.id}
+    projectId={branch.projectId}
     commitSha={commitDiffSha}
     scope="commit"
     beforeLabel="parent"

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -209,7 +209,7 @@
   // Compute suggested prefill prompts from the latest visible timeline entry.
   // Only used when the user hasn't typed a draft yet.
   let suggestedPrefill = $derived.by(() => {
-    const empty = { commit: '', note: '' };
+    const empty = { commit: '', note: '', commitRef: '', noteRef: '' };
     if (!timeline) return empty;
 
     // Don't prefill when there are active (queued or running) sessions — the user
@@ -218,9 +218,10 @@
 
     // Find the latest completed item across commits, notes, and reviews
     type Candidate =
-      | { kind: 'review'; commentCount: number; timestamp: number }
+      | { kind: 'review'; id: string; commentCount: number; timestamp: number }
       | {
           kind: 'note';
+          id: string;
           title: string;
           timestamp: number;
           suggestedNextCommitStep: string | null;
@@ -231,13 +232,19 @@
 
     for (const review of timeline.reviews) {
       const ts = Math.floor((review.completedAt ?? review.createdAt) / 1000);
-      candidates.push({ kind: 'review', commentCount: review.commentCount, timestamp: ts });
+      candidates.push({
+        kind: 'review',
+        id: review.id,
+        commentCount: review.commentCount,
+        timestamp: ts,
+      });
     }
 
     for (const note of timeline.notes) {
       const ts = Math.floor((note.completedAt ?? note.createdAt) / 1000);
       candidates.push({
         kind: 'note',
+        id: note.id,
         title: note.title,
         timestamp: ts,
         suggestedNextCommitStep: note.suggestedNextCommitStep,
@@ -264,21 +271,39 @@
       latest.kind === 'note' &&
       (latest.suggestedNextCommitStep || latest.suggestedNextNoteStep)
     ) {
+      const ref = `Re: #note:${latest.id}`;
       return {
         commit: latest.suggestedNextCommitStep ?? '',
         note: latest.suggestedNextNoteStep ?? '',
+        commitRef: latest.suggestedNextCommitStep ? ref : '',
+        noteRef: latest.suggestedNextNoteStep ? ref : '',
       };
     }
 
     // Fallback to existing heuristics for reviews and notes without suggestions
     if (latest.kind === 'review' && latest.commentCount > 0) {
-      return { commit: 'Resolve code review comments', note: '' };
+      return {
+        commit: 'Resolve code review comments',
+        note: '',
+        commitRef: `Re: #review:${latest.id}`,
+        noteRef: '',
+      };
     }
     if (latest.kind === 'note' && latest.title.toLowerCase().includes('plan')) {
-      return { commit: 'Implement plan', note: '' };
+      return {
+        commit: 'Implement plan',
+        note: '',
+        commitRef: `Re: #note:${latest.id}`,
+        noteRef: '',
+      };
     }
     if (latest.kind === 'note' && latest.title.toLowerCase().endsWith(' log')) {
-      return { commit: 'Read the latest note which contains logs. Look for any issues.', note: '' };
+      return {
+        commit: 'Read the latest note which contains logs. Look for any issues.',
+        note: '',
+        commitRef: `Re: #note:${latest.id}`,
+        noteRef: '',
+      };
     }
 
     return empty;
@@ -1061,8 +1086,9 @@
       sessionMgr.openSessionId = sid;
     }}
     onStartSession={(mode, prefill) => {
+      const noteRef = openNote?.noteId ? `Re: #note:${openNote.noteId}` : '';
       openNote = null;
-      void sessionMgr.startOrQueueSession(mode, prefill);
+      void sessionMgr.startOrQueueSession(mode, noteRef ? `${noteRef}\n${prefill}` : prefill);
     }}
   />
 {/if}
@@ -1083,12 +1109,18 @@
 {/if}
 
 {#if sessionMgr.showNewSession}
-  {@const commitPrefill = suggestedPrefill.commit}
-  {@const notePrefill = suggestedPrefill.note}
+  {@const commitPrefillBase = suggestedPrefill.commit}
+  {@const notePrefillBase = suggestedPrefill.note}
+  {@const commitPrefill = suggestedPrefill.commitRef
+    ? `${suggestedPrefill.commitRef}\n${commitPrefillBase}`
+    : commitPrefillBase}
+  {@const notePrefill = suggestedPrefill.noteRef
+    ? `${suggestedPrefill.noteRef}\n${notePrefillBase}`
+    : notePrefillBase}
   {@const usePrefill =
     !sessionMgr.draftPrompt &&
-    ((sessionMgr.newSessionMode === 'commit' && !!commitPrefill) ||
-      (sessionMgr.newSessionMode === 'note' && !!notePrefill))}
+    ((sessionMgr.newSessionMode === 'commit' && !!commitPrefillBase) ||
+      (sessionMgr.newSessionMode === 'note' && !!notePrefillBase))}
   {@const prefillText =
     sessionMgr.newSessionMode === 'note'
       ? notePrefill

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -6,10 +6,13 @@
   import { alerts } from '../../shared/alerts.svelte';
   import * as commands from '../../api/commands';
   import { getCommitPrefillFromReviewComments } from '../branches/commitSessionPrefill';
-  import type { SessionStatusPayload } from '../../types';
+  import type { SessionStatusPayload, HashtagItem } from '../../types';
+  import HashtagInput from '../sessions/HashtagInput.svelte';
+  import { buildBranchHashtagItems } from '../sessions/hashtagItems';
 
   interface Props {
     branchId: string;
+    projectId?: string | null;
     commitSha: string;
     scope: 'branch' | 'commit';
     reviewId?: string;
@@ -17,14 +20,23 @@
     onStarted: () => void;
   }
 
-  let { branchId, commitSha, scope, reviewId, visibleCommentCount, onStarted }: Props = $props();
+  let { branchId, projectId, commitSha, scope, reviewId, visibleCommentCount, onStarted }: Props =
+    $props();
 
   let draftPrompt = $state('');
   let isDirty = $state(false);
   let starting = $state(false);
   let timelineLoading = $state(true);
   let hasRunningSession = $state(false);
-  let textareaElement = $state<HTMLTextAreaElement | null>(null);
+  let textareaElement = $state<HTMLElement | null>(null);
+
+  // Hashtag reference items
+  let hashtagItems = $state<HashtagItem[]>([]);
+  $effect(() => {
+    buildBranchHashtagItems(branchId, projectId ?? null).then((items) => {
+      hashtagItems = items;
+    });
+  });
 
   const MIN_TEXTAREA_HEIGHT_PX = 80;
   const MAX_TEXTAREA_HEIGHT_PX = 260;
@@ -76,9 +88,9 @@
     };
   });
 
-  function handleInput(event: Event) {
-    draftPrompt = (event.currentTarget as HTMLTextAreaElement).value;
+  function handleInput(_event: Event) {
     isDirty = true;
+    syncTextareaHeight();
   }
 
   function syncTextareaHeight() {
@@ -143,15 +155,16 @@
 </script>
 
 <div class="composer">
-  <textarea
-    bind:this={textareaElement}
+  <HashtagInput
+    bind:textareaEl={textareaElement}
+    bind:value={draftPrompt}
     class="composer-input"
-    value={draftPrompt}
     placeholder="Describe any changes you want"
     rows="3"
     disabled={starting}
     oninput={handleInput}
-  ></textarea>
+    items={hashtagItems}
+  />
   <div class="composer-footer">
     <button
       class="composer-submit"
@@ -180,7 +193,7 @@
     background: color-mix(in srgb, var(--bg-chrome) 94%, var(--bg-hover));
   }
 
-  .composer-input {
+  .composer :global(.composer-input) {
     padding: 10px 12px;
     background: var(--bg-primary);
     border: 1px solid var(--border-muted);
@@ -196,13 +209,9 @@
     transition: border-color 0.15s;
   }
 
-  .composer-input:focus {
+  .composer :global(.composer-input):focus {
     outline: none;
     border-color: var(--border-emphasis);
-  }
-
-  .composer-input::placeholder {
-    color: var(--text-faint);
   }
 
   .composer-footer {

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -33,9 +33,13 @@
   // Hashtag reference items
   let hashtagItems = $state<HashtagItem[]>([]);
   $effect(() => {
+    let stale = false;
     buildBranchHashtagItems(branchId, projectId ?? null).then((items) => {
-      hashtagItems = items;
+      if (!stale) hashtagItems = items;
     });
+    return () => {
+      stale = true;
+    };
   });
 
   const MIN_TEXTAREA_HEIGHT_PX = 80;

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -104,8 +104,13 @@
   }
 
   async function handleSubmit() {
-    const finalPrompt = draftPrompt.trim();
+    let finalPrompt = draftPrompt.trim();
     if (!finalPrompt || starting) return;
+
+    // Prepend a reference to the review when launched from a review context
+    if (reviewId) {
+      finalPrompt = `Re: #review:${reviewId}\n${finalPrompt}`;
+    }
 
     starting = true;
     try {

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -51,6 +51,8 @@
 
   interface Props {
     branchId: string;
+    /** Project ID for scoping hashtag references to include project-level notes. */
+    projectId?: string | null;
     /** Optional — for branch scope, resolved automatically. */
     commitSha?: string;
     scope?: 'branch' | 'commit';
@@ -73,6 +75,7 @@
 
   let {
     branchId,
+    projectId,
     commitSha,
     scope = 'branch',
     reviewId,
@@ -622,6 +625,7 @@
             {#if !readonly && diffViewer.state.commitSha}
               <DiffCommitSessionLauncher
                 {branchId}
+                {projectId}
                 commitSha={diffViewer.state.commitSha}
                 {scope}
                 {reviewId}

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -23,10 +23,19 @@
     X,
     ImagePlus,
   } from 'lucide-svelte';
-  import type { Project, ProjectRepo, Branch, WorkspaceStatus, ProjectNote } from '../../types';
+  import type {
+    Project,
+    ProjectRepo,
+    Branch,
+    WorkspaceStatus,
+    ProjectNote,
+    HashtagItem,
+  } from '../../types';
   import { projectDisplayName } from '../../shared/utils';
   import { goHome } from '../layout/navigation.svelte';
   import * as commands from '../../api/commands';
+  import HashtagInput from '../sessions/HashtagInput.svelte';
+  import { buildProjectHashtagItems } from '../sessions/hashtagItems';
   import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
   import { projectStateStore } from '../../stores/projectState.svelte';
   import BranchCard from '../branches/BranchCard.svelte';
@@ -143,7 +152,7 @@
 
   // ── Project session input ──────────────────────────────────────────────
   let promptText = $state('');
-  let promptTextarea = $state<HTMLTextAreaElement | null>(null);
+  let promptTextarea = $state<HTMLElement | null>(null);
   let availableAgents = $derived(agentState.providers);
   let preferredProvider = $derived(
     getPreferredAgentForProject(project.id, availableAgents) ?? undefined
@@ -154,6 +163,14 @@
   );
   /** Session IDs for running project sessions (all produce notes). */
   let activeSessionIds = $state<Set<string>>(new Set());
+
+  // Hashtag reference items
+  let hashtagItems = $state<HashtagItem[]>([]);
+  $effect(() => {
+    buildProjectHashtagItems(project.id, branches, reposById).then((items) => {
+      hashtagItems = items;
+    });
+  });
 
   // Image attachment state
   let imageIds = $state<string[]>([]);
@@ -268,7 +285,7 @@
     return unsub;
   });
 
-  function autoResize(el: HTMLTextAreaElement) {
+  function autoResize(el: HTMLElement) {
     el.style.height = 'auto';
     el.style.height = `${el.scrollHeight}px`;
   }
@@ -499,16 +516,17 @@
             <Paperclip size={14} />
           </button>
         {/if}
-        <textarea
+        <HashtagInput
           class="prompt-input"
           placeholder="Ask about this project…"
           bind:value={promptText}
-          bind:this={promptTextarea}
+          bind:textareaEl={promptTextarea}
           onkeydown={handleKeydown}
-          oninput={(e) => autoResize(e.currentTarget)}
+          oninput={(e) => autoResize(e.currentTarget as HTMLElement)}
           onpaste={handleImagePaste}
           rows={1}
-        ></textarea>
+          items={hashtagItems}
+        />
         <div class="prompt-actions">
           <AgentSelector projectId={project.id} />
           <button
@@ -942,7 +960,7 @@
     background-color: var(--ui-selection);
   }
 
-  .prompt-input {
+  .prompt-input-row :global(.prompt-input) {
     flex: 1;
     margin: 0;
     padding: 4px 0;
@@ -959,8 +977,8 @@
     overflow-y: auto;
   }
 
-  .prompt-input::placeholder {
-    color: var(--text-faint);
+  .prompt-input-row :global(.hashtag-input-wrapper) {
+    flex: 1;
   }
 
   .prompt-actions {
@@ -1125,7 +1143,7 @@
       padding: 6px;
     }
 
-    .prompt-input {
+    .prompt-input-row :global(.prompt-input) {
       padding: 4px 2px;
       font-size: var(--size-xs);
     }

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -1,0 +1,580 @@
+<!--
+  HashtagInput.svelte — Contenteditable editor with inline hashtag badges
+
+  Wraps a contenteditable <div> and adds:
+  - Dropdown triggered by typing `#` (filtered by subsequent chars)
+  - Inline badge spans replacing #type:id tokens within the text
+  - Keyboard navigation (Arrow keys, Enter, Escape)
+
+  Props:
+    value      — bindable raw text including #type:id tokens (for backend consumption)
+    placeholder
+    disabled
+    items      — full list of HashtagItems (parent provides, scoped correctly)
+    class      — pass-through for styling
+    rows       — approximate initial height in rows
+    onkeydown  — pass-through keydown handler (called after hashtag handling)
+    oninput    — pass-through input handler
+    onpaste    — pass-through paste handler (e.g. for image paste)
+    textareaEl — bindable element reference (the contenteditable div)
+-->
+<script lang="ts">
+  import { tick } from 'svelte';
+  import type { HashtagItem } from '../../types';
+
+  interface Props {
+    value: string;
+    placeholder?: string;
+    disabled?: boolean;
+    items: HashtagItem[];
+    class?: string;
+    rows?: number | string;
+    onkeydown?: (e: KeyboardEvent) => void;
+    oninput?: (e: Event) => void;
+    onpaste?: (e: ClipboardEvent) => void;
+    textareaEl?: HTMLElement | null;
+  }
+
+  let {
+    value = $bindable(''),
+    placeholder = '',
+    disabled = false,
+    items = [],
+    class: className = '',
+    rows = 1,
+    onkeydown,
+    oninput,
+    onpaste,
+    textareaEl = $bindable(null),
+  }: Props = $props();
+
+  let editorEl: HTMLDivElement | undefined = $state();
+  let showDropdown = $state(false);
+  let filterText = $state('');
+  let selectedIndex = $state(0);
+  let dropdownEl: HTMLDivElement | undefined = $state();
+  let wrapperEl: HTMLDivElement | undefined = $state();
+  let dropdownPosition = $state<'above' | 'below'>('below');
+  let dropdownStyle = $state('');
+  let pendingInsert: { textNode: Text; hashPos: number; cursorPos: number } | null = null;
+
+  const TOKEN_REGEX = /#(note|commit|review|project-note):([^\s]+)/g;
+  const MAX_RESULTS = 10;
+
+  const typeLabels: Record<string, string> = {
+    note: 'Note',
+    commit: 'Commit',
+    review: 'Review',
+    'project-note': 'Note',
+  };
+
+  // Sync editorEl to the textareaEl binding
+  $effect(() => {
+    textareaEl = editorEl ?? null;
+  });
+
+  let itemsById = $derived.by(() => {
+    const map = new Map<string, HashtagItem>();
+    for (const item of items) {
+      map.set(`${item.type}:${item.id}`, item);
+    }
+    return map;
+  });
+
+  let selectedTokenKeys = $derived.by(() => {
+    const keys = new Set<string>();
+    const regex = new RegExp(TOKEN_REGEX.source, 'g');
+    let m;
+    while ((m = regex.exec(value)) !== null) {
+      keys.add(`${m[1]}:${m[2]}`);
+    }
+    return keys;
+  });
+
+  let filteredItems = $derived.by(() => {
+    if (!showDropdown) return [];
+    const filter = filterText.toLowerCase();
+    return items
+      .filter((item) => !selectedTokenKeys.has(`${item.type}:${item.id}`))
+      .filter((item) => item.title.toLowerCase().includes(filter))
+      .slice(0, MAX_RESULTS);
+  });
+
+  let lastExtractedValue = '';
+
+  // When value changes from outside, re-render the editor content
+  $effect(() => {
+    if (value !== lastExtractedValue && editorEl) {
+      renderContent(value);
+      lastExtractedValue = value;
+    }
+  });
+
+  function createBadgeElement(item: HashtagItem): HTMLSpanElement {
+    const badge = document.createElement('span');
+    badge.className = 'hashtag-badge';
+    badge.contentEditable = 'false';
+    badge.dataset.token = `#${item.type}:${item.id}`;
+    const label = typeLabels[item.type] ?? item.type;
+    badge.textContent = `${label}: ${item.title}`;
+    badge.style.cssText = `background: var(${item.bgColor}); color: var(${item.color});`;
+    return badge;
+  }
+
+  function renderContent(val: string) {
+    if (!editorEl) return;
+    editorEl.innerHTML = '';
+
+    const regex = new RegExp(TOKEN_REGEX.source, 'g');
+    let lastIndex = 0;
+    let match;
+
+    while ((match = regex.exec(val)) !== null) {
+      if (match.index > lastIndex) {
+        appendTextNodes(editorEl, val.slice(lastIndex, match.index));
+      }
+
+      const type = match[1];
+      const id = match[2];
+      const item = itemsById.get(`${type}:${id}`);
+      if (item) {
+        editorEl.appendChild(createBadgeElement(item));
+        // Zero-width space so cursor can be placed after badge
+        editorEl.appendChild(document.createTextNode('\u200B'));
+      } else {
+        editorEl.appendChild(document.createTextNode(match[0]));
+      }
+
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < val.length) {
+      appendTextNodes(editorEl, val.slice(lastIndex));
+    }
+  }
+
+  function appendTextNodes(parent: HTMLElement, text: string) {
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (i > 0) parent.appendChild(document.createElement('br'));
+      if (lines[i]) parent.appendChild(document.createTextNode(lines[i]));
+    }
+  }
+
+  function extractValue(): string {
+    if (!editorEl) return '';
+    return extractFromNode(editorEl);
+  }
+
+  function extractFromNode(node: Node): string {
+    let result = '';
+    for (const child of node.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        result += (child.textContent ?? '').replace(/\u200B/g, '');
+      } else if (child instanceof HTMLBRElement) {
+        result += '\n';
+      } else if (child instanceof HTMLElement) {
+        if (child.dataset.token) {
+          result += child.dataset.token;
+        } else if (child.tagName === 'DIV') {
+          // Browsers sometimes wrap lines in <div> elements on Enter
+          const innerText = extractFromNode(child);
+          if (result.length > 0 && !result.endsWith('\n')) {
+            result += '\n';
+          }
+          result += innerText;
+        } else {
+          result += extractFromNode(child);
+        }
+      }
+    }
+    return result;
+  }
+
+  function handleInput(e: Event) {
+    const extracted = extractValue();
+    lastExtractedValue = extracted;
+    value = extracted;
+    detectHashtag();
+    oninput?.(e);
+  }
+
+  function detectHashtag() {
+    const sel = window.getSelection();
+    if (!sel || !sel.rangeCount || !editorEl) return;
+
+    const range = sel.getRangeAt(0);
+    if (!range.collapsed) {
+      closeDropdown();
+      return;
+    }
+
+    const node = range.startContainer;
+    if (node.nodeType !== Node.TEXT_NODE || !editorEl.contains(node)) {
+      closeDropdown();
+      return;
+    }
+
+    const text = node.textContent ?? '';
+    const pos = range.startOffset;
+
+    let hashPos = -1;
+    for (let i = pos - 1; i >= 0; i--) {
+      const ch = text[i];
+      if (ch === '#') {
+        if (i > 0 && /\w/.test(text[i - 1])) break;
+        hashPos = i;
+        break;
+      }
+      if (ch === ' ' || ch === '\n' || ch === '\r' || ch === '\t') break;
+    }
+
+    if (hashPos >= 0) {
+      const fragment = text.slice(hashPos + 1, pos);
+      if (/#?(note|commit|review|project-note):[^\s]+/.test('#' + fragment)) {
+        closeDropdown();
+        return;
+      }
+      showDropdown = true;
+      filterText = fragment;
+      selectedIndex = 0;
+      pendingInsert = { textNode: node as Text, hashPos, cursorPos: pos };
+      updateDropdownPosition();
+    } else {
+      closeDropdown();
+    }
+  }
+
+  function updateDropdownPosition() {
+    const sel = window.getSelection();
+    if (!sel || !sel.rangeCount) return;
+
+    const range = sel.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+    const editorRect = editorEl?.getBoundingClientRect();
+    if (!editorRect) return;
+
+    const caretTop = rect.top || editorRect.top;
+    const caretBottom = rect.bottom || editorRect.top + 20;
+    const caretLeft = rect.left || editorRect.left;
+
+    const maxHeight = 280;
+    const spaceBelow = window.innerHeight - caretBottom;
+    const spaceAbove = caretTop;
+
+    if (spaceBelow >= maxHeight || spaceBelow > spaceAbove) {
+      dropdownPosition = 'below';
+      dropdownStyle = `position:fixed; top:${caretBottom + 4}px; left:${caretLeft}px;`;
+    } else {
+      dropdownPosition = 'above';
+      dropdownStyle = `position:fixed; bottom:${window.innerHeight - caretTop + 4}px; left:${caretLeft}px;`;
+    }
+  }
+
+  function closeDropdown() {
+    showDropdown = false;
+    filterText = '';
+    selectedIndex = 0;
+    pendingInsert = null;
+  }
+
+  function selectItem(item: HashtagItem) {
+    if (!editorEl || !pendingInsert) return;
+
+    const { textNode, hashPos, cursorPos } = pendingInsert;
+
+    if (!editorEl.contains(textNode)) {
+      closeDropdown();
+      return;
+    }
+
+    const text = textNode.textContent ?? '';
+    const before = text.slice(0, hashPos);
+    const after = text.slice(cursorPos);
+
+    // Replace the #filter text with a badge
+    textNode.textContent = before;
+
+    const badge = createBadgeElement(item);
+    const afterNode = document.createTextNode('\u200B' + after);
+
+    const parent = textNode.parentNode!;
+    const nextSibling = textNode.nextSibling;
+    parent.insertBefore(badge, nextSibling);
+    parent.insertBefore(afterNode, badge.nextSibling);
+
+    // Place cursor after the badge
+    const sel = window.getSelection();
+    if (sel) {
+      const range = document.createRange();
+      range.setStart(afterNode, 1);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+
+    closeDropdown();
+
+    const extracted = extractValue();
+    lastExtractedValue = extracted;
+    value = extracted;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (showDropdown && filteredItems.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        selectedIndex = (selectedIndex + 1) % filteredItems.length;
+        scrollSelectedIntoView();
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        selectedIndex = (selectedIndex - 1 + filteredItems.length) % filteredItems.length;
+        scrollSelectedIntoView();
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey && !e.metaKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        selectItem(filteredItems[selectedIndex]);
+        return;
+      }
+    }
+
+    if (e.key === 'Escape' && showDropdown) {
+      e.preventDefault();
+      e.stopPropagation();
+      closeDropdown();
+      return;
+    }
+
+    onkeydown?.(e);
+  }
+
+  function handlePaste(e: ClipboardEvent) {
+    if (onpaste) {
+      onpaste(e);
+      if (e.defaultPrevented) return;
+    }
+
+    // Strip HTML and insert plain text
+    e.preventDefault();
+    const text = e.clipboardData?.getData('text/plain') ?? '';
+    document.execCommand('insertText', false, text);
+  }
+
+  function scrollSelectedIntoView() {
+    tick().then(() => {
+      if (!dropdownEl) return;
+      const selected = dropdownEl.querySelector('.hashtag-dropdown-item.selected');
+      if (selected) {
+        selected.scrollIntoView({ block: 'nearest' });
+      }
+    });
+  }
+
+  function handleBlur(e: FocusEvent) {
+    if (wrapperEl && e.relatedTarget instanceof Node && wrapperEl.contains(e.relatedTarget)) {
+      return;
+    }
+    closeDropdown();
+  }
+</script>
+
+<div class="hashtag-input-wrapper" bind:this={wrapperEl}>
+  <div class="hashtag-input-container">
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      bind:this={editorEl}
+      class="hashtag-editor {className}"
+      class:is-empty={!value}
+      contenteditable={disabled ? 'false' : 'true'}
+      role="textbox"
+      aria-multiline="true"
+      data-placeholder={placeholder}
+      style="min-height: {Number(rows) * 1.5}em"
+      oninput={handleInput}
+      onkeydown={handleKeydown}
+      onblur={handleBlur}
+      onpaste={handlePaste}
+    ></div>
+
+    <!-- Dropdown -->
+    {#if showDropdown && filteredItems.length > 0}
+      <div
+        class="hashtag-dropdown"
+        class:above={dropdownPosition === 'above'}
+        class:below={dropdownPosition === 'below'}
+        style={dropdownStyle}
+        bind:this={dropdownEl}
+      >
+        {#each filteredItems as item, i}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="hashtag-dropdown-item"
+            class:selected={i === selectedIndex}
+            onmousedown={(e) => {
+              e.preventDefault();
+              selectItem(item);
+            }}
+            onmouseenter={() => (selectedIndex = i)}
+          >
+            <span class="hashtag-item-icon {item.type}-icon">
+              {typeLabels[item.type] ?? item.type}
+            </span>
+            <span class="hashtag-item-title">{item.title}</span>
+            {#if item.repoSlug || item.branchName}
+              <span class="hashtag-item-context">
+                {#if item.repoSlug}{item.repoSlug}{/if}
+                {#if item.repoSlug && item.branchName}
+                  &middot;
+                {/if}
+                {#if item.branchName}{item.branchName}{/if}
+              </span>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {:else if showDropdown && filterText.length > 0}
+      <div
+        class="hashtag-dropdown"
+        class:above={dropdownPosition === 'above'}
+        class:below={dropdownPosition === 'below'}
+        style={dropdownStyle}
+      >
+        <div class="hashtag-dropdown-empty">No matching items</div>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .hashtag-input-wrapper {
+    position: relative;
+  }
+
+  .hashtag-input-container {
+    position: relative;
+  }
+
+  /* Contenteditable editor styled like a textarea */
+  .hashtag-editor {
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    overflow-y: auto;
+    outline: none;
+    line-height: 1.5;
+  }
+
+  /* Placeholder via ::before when empty */
+  .hashtag-editor.is-empty::before {
+    content: attr(data-placeholder);
+    color: var(--text-faint);
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: inherit;
+  }
+
+  /* Inline badge for referenced items */
+  .hashtag-editor :global(.hashtag-badge) {
+    display: inline;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: default;
+    vertical-align: baseline;
+    user-select: all;
+  }
+
+  /* Dropdown — fixed-positioned near the caret via inline style */
+  .hashtag-dropdown {
+    width: 340px;
+    max-width: calc(100vw - 32px);
+    background: var(--bg-chrome);
+    border: 1px solid var(--border-muted);
+    border-radius: 8px;
+    max-height: 280px;
+    overflow-y: auto;
+    z-index: 9999;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    padding: 4px;
+  }
+
+  .hashtag-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.1s;
+    overflow: hidden;
+  }
+
+  .hashtag-dropdown-item:hover,
+  .hashtag-dropdown-item.selected {
+    background: var(--bg-hover);
+  }
+
+  .hashtag-item-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    font-size: var(--size-xs);
+    font-weight: 600;
+  }
+
+  .hashtag-item-icon.note-icon,
+  .hashtag-item-icon.project-note-icon {
+    background-color: var(--note-bg);
+    color: var(--note-color);
+  }
+
+  .hashtag-item-icon.commit-icon {
+    background-color: var(--commit-bg);
+    color: var(--commit-color);
+  }
+
+  .hashtag-item-icon.review-icon {
+    background-color: var(--review-bg);
+    color: var(--review-color);
+  }
+
+  .hashtag-item-title {
+    flex: 1;
+    font-size: var(--size-sm);
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .hashtag-item-context {
+    font-size: var(--size-xs);
+    color: var(--text-faint);
+    flex-shrink: 0;
+    max-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .hashtag-dropdown-empty {
+    padding: 8px 12px;
+    font-size: var(--size-sm);
+    color: var(--text-faint);
+    text-align: center;
+  }
+</style>

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -21,6 +21,7 @@
 <script lang="ts">
   import { tick } from 'svelte';
   import type { HashtagItem } from '../../types';
+  import { HASHTAG_TOKEN_RE, hashtagTypeLabels } from './hashtagItems';
 
   interface Props {
     value: string;
@@ -58,15 +59,7 @@
   let dropdownStyle = $state('');
   let pendingInsert: { textNode: Text; hashPos: number; cursorPos: number } | null = null;
 
-  const TOKEN_REGEX = /#(note|commit|review|project-note):([^\s]+)/g;
   const MAX_RESULTS = 10;
-
-  const typeLabels: Record<string, string> = {
-    note: 'Note',
-    commit: 'Commit',
-    review: 'Review',
-    'project-note': 'Note',
-  };
 
   // Sync editorEl to the textareaEl binding
   $effect(() => {
@@ -83,7 +76,7 @@
 
   let selectedTokenKeys = $derived.by(() => {
     const keys = new Set<string>();
-    const regex = new RegExp(TOKEN_REGEX.source, 'g');
+    const regex = new RegExp(HASHTAG_TOKEN_RE.source, 'g');
     let m;
     while ((m = regex.exec(value)) !== null) {
       keys.add(`${m[1]}:${m[2]}`);
@@ -135,7 +128,7 @@
     badge.className = 'hashtag-badge';
     badge.contentEditable = 'false';
     badge.dataset.token = `#${item.type}:${item.id}`;
-    const label = typeLabels[item.type] ?? item.type;
+    const label = hashtagTypeLabels[item.type] ?? item.type;
     badge.textContent = `${label}: ${item.title}`;
     badge.style.cssText = `background: var(${item.bgColor}); color: var(${item.color});`;
     return badge;
@@ -145,7 +138,7 @@
     if (!editorEl) return;
     editorEl.innerHTML = '';
 
-    const regex = new RegExp(TOKEN_REGEX.source, 'g');
+    const regex = new RegExp(HASHTAG_TOKEN_RE.source, 'g');
     let lastIndex = 0;
     let match;
     let unresolved = false;
@@ -446,7 +439,7 @@
             onmouseenter={() => (selectedIndex = i)}
           >
             <span class="hashtag-item-icon {item.type}-icon">
-              {typeLabels[item.type] ?? item.type}
+              {hashtagTypeLabels[item.type] ?? item.type}
             </span>
             <span class="hashtag-item-title">{item.title}</span>
             {#if item.repoSlug || item.branchName}

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -101,12 +101,21 @@
   });
 
   let lastExtractedValue = '';
+  let hasUnresolvedTokens = false;
 
   // When value changes from outside, re-render the editor content
   $effect(() => {
     if (value !== lastExtractedValue && editorEl) {
       renderContent(value);
       lastExtractedValue = value;
+    }
+  });
+
+  // When items become available, re-render to resolve plain-text tokens into badges
+  $effect(() => {
+    const _items = itemsById;
+    if (hasUnresolvedTokens && _items.size > 0 && editorEl) {
+      renderContent(value);
     }
   });
 
@@ -128,6 +137,7 @@
     const regex = new RegExp(TOKEN_REGEX.source, 'g');
     let lastIndex = 0;
     let match;
+    let unresolved = false;
 
     while ((match = regex.exec(val)) !== null) {
       if (match.index > lastIndex) {
@@ -143,6 +153,7 @@
         editorEl.appendChild(document.createTextNode('\u200B'));
       } else {
         editorEl.appendChild(document.createTextNode(match[0]));
+        unresolved = true;
       }
 
       lastIndex = match.index + match[0].length;
@@ -151,6 +162,8 @@
     if (lastIndex < val.length) {
       appendTextNodes(editorEl, val.slice(lastIndex));
     }
+
+    hasUnresolvedTokens = unresolved;
   }
 
   function appendTextNodes(parent: HTMLElement, text: string) {

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -409,6 +409,7 @@
 <div class="hashtag-input-wrapper" bind:this={wrapperEl}>
   <div class="hashtag-input-container">
     <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <!-- svelte-ignore a11y_interactive_supports_focus -->
     <div
       bind:this={editorEl}
       class="hashtag-editor {className}"

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -115,7 +115,18 @@
   $effect(() => {
     const _items = itemsById;
     if (hasUnresolvedTokens && _items.size > 0 && editorEl) {
+      // Preserve selection state across re-render (e.g. prefilled select-all)
+      const sel = window.getSelection();
+      const hadSelection = sel && !sel.isCollapsed && editorEl.contains(sel.anchorNode);
+
       renderContent(value);
+
+      if (hadSelection && sel) {
+        const range = document.createRange();
+        range.selectNodeContents(editorEl);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
     }
   });
 

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -19,9 +19,11 @@
   import { tick, untrack } from 'svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
-  import type { Branch, BranchSessionType, ProjectRepo } from '../../types';
+  import type { Branch, BranchSessionType, HashtagItem, ProjectRepo } from '../../types';
   import AgentSelector from '../agents/AgentSelector.svelte';
   import ImageAttachment from './ImageAttachment.svelte';
+  import HashtagInput from './HashtagInput.svelte';
+  import { buildBranchHashtagItems } from './hashtagItems';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
   import { subscribeDragDrop } from '../branches/dragDrop';
   import { isImageFile } from '../branches/branchCardHelpers';
@@ -65,7 +67,7 @@
   let currentMode = $state<BranchSessionType>('commit');
   let starting = $state(false);
   let initialized = false;
-  let textareaEl: HTMLTextAreaElement | null = $state(null);
+  let textareaEl: HTMLElement | null = $state(null);
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: handleClose });
 
   let isCommit = $derived(currentMode === 'commit');
@@ -156,9 +158,14 @@
       prompt = modePrefill;
       // Select all so typing replaces the suggestion
       tick().then(() => {
-        if (textareaEl && textareaEl.value.length > 0) {
-          textareaEl.selectionStart = 0;
-          textareaEl.selectionEnd = textareaEl.value.length;
+        if (textareaEl && textareaEl.textContent) {
+          const sel = window.getSelection();
+          if (sel) {
+            const range = document.createRange();
+            range.selectNodeContents(textareaEl);
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
           textareaEl.focus();
         }
       });
@@ -173,6 +180,14 @@
       modeMenuOpen = false;
     }
   }
+
+  // Hashtag reference items
+  let hashtagItems = $state<HashtagItem[]>([]);
+  $effect(() => {
+    buildBranchHashtagItems(branch.id, branch.projectId).then((items) => {
+      hashtagItems = items;
+    });
+  });
 
   // Image attachment state
   let imageIds = $state<string[]>([]);
@@ -199,13 +214,22 @@
       const shouldSelect = prefilled;
       tick().then(() => {
         el.focus();
-        if (shouldSelect && el.value.length > 0) {
-          // Select all so typing replaces the suggested text
-          el.selectionStart = 0;
-          el.selectionEnd = el.value.length;
-        } else {
-          // Place cursor at end
-          el.selectionStart = el.selectionEnd = el.value.length;
+        const sel = window.getSelection();
+        if (sel) {
+          if (shouldSelect && el.textContent) {
+            // Select all so typing replaces the suggested text
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            sel.removeAllRanges();
+            sel.addRange(range);
+          } else {
+            // Place cursor at end
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            range.collapse(false);
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
         }
       });
     }
@@ -354,8 +378,8 @@
       {/if}
 
       <div class="form-group">
-        <textarea
-          bind:this={textareaEl}
+        <HashtagInput
+          bind:textareaEl
           bind:value={prompt}
           placeholder={isReview
             ? 'Optional: focus the review on specific areas…'
@@ -364,7 +388,8 @@
               : notePlaceholder}
           rows={isReview ? 4 : 12}
           disabled={starting}
-        ></textarea>
+          items={hashtagItems}
+        />
         <span class="hint">{willQueue ? '⌘ Enter to queue' : '⌘ Enter to start'}</span>
       </div>
 
@@ -583,7 +608,8 @@
     gap: 4px;
   }
 
-  .form-group textarea {
+  .form-group textarea,
+  .form-group :global(.hashtag-editor) {
     padding: 10px 12px;
     background: var(--bg-primary);
     border: 1px solid var(--border-muted);
@@ -597,7 +623,8 @@
     transition: border-color 0.15s;
   }
 
-  .form-group textarea:focus {
+  .form-group textarea:focus,
+  .form-group :global(.hashtag-editor):focus {
     outline: none;
     border-color: var(--border-emphasis);
   }

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -184,9 +184,13 @@
   // Hashtag reference items
   let hashtagItems = $state<HashtagItem[]>([]);
   $effect(() => {
+    let stale = false;
     buildBranchHashtagItems(branch.id, branch.projectId).then((items) => {
-      hashtagItems = items;
+      if (!stale) hashtagItems = items;
     });
+    return () => {
+      stale = true;
+    };
   });
 
   // Image attachment state

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -608,7 +608,6 @@
     gap: 4px;
   }
 
-  .form-group textarea,
   .form-group :global(.hashtag-editor) {
     padding: 10px 12px;
     background: var(--bg-primary);
@@ -623,18 +622,9 @@
     transition: border-color 0.15s;
   }
 
-  .form-group textarea:focus,
   .form-group :global(.hashtag-editor):focus {
     outline: none;
     border-color: var(--border-emphasis);
-  }
-
-  .form-group textarea::placeholder {
-    color: var(--text-faint);
-  }
-
-  .form-group textarea:disabled {
-    opacity: 0.6;
   }
 
   .hint {

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -45,7 +45,7 @@
   import Spinner from '../../shared/Spinner.svelte';
   import { marked } from 'marked';
   import { sanitize } from '../../shared/sanitize';
-  import type { Session, SessionMessage } from '../../types';
+  import type { Session, SessionMessage, HashtagItem } from '../../types';
   import {
     cancelSession,
     createImage,
@@ -58,6 +58,8 @@
     handleExternalLinkClick,
     resumeSession,
   } from '../../api/commands';
+  import HashtagInput from './HashtagInput.svelte';
+  import { buildBranchHashtagItems } from './hashtagItems';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
   import { subscribeDragDrop } from '../branches/dragDrop';
   import { isImageFile } from '../branches/branchCardHelpers';
@@ -102,7 +104,7 @@
   let error = $state<string | null>(null);
   let cancelling = $state(false);
   let messagesEl: HTMLDivElement;
-  let inputEl: HTMLTextAreaElement;
+  let inputEl: HTMLElement | null = $state(null);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let pollInFlight = false;
   let closed = false;
@@ -121,6 +123,16 @@
 
   /** Whether the initial load has rendered — transitions are suppressed until then. */
   let animateNewMessages = false;
+
+  // Hashtag reference items
+  let hashtagItems = $state<HashtagItem[]>([]);
+  $effect(() => {
+    if (branchId) {
+      buildBranchHashtagItems(branchId, projectId ?? null).then((items) => {
+        hashtagItems = items;
+      });
+    }
+  });
 
   // Image attachment state (available when project context is provided; branchId is optional)
   let canAttachImages = $derived(!!projectId);
@@ -582,6 +594,51 @@
     return sanitize(marked.parse(content) as string);
   }
 
+  const HASHTAG_TOKEN_RE = /#(note|commit|review|project-note):([^\s]+)/g;
+  const hashtagTypeLabels: Record<string, string> = {
+    note: 'Note',
+    commit: 'Commit',
+    review: 'Review',
+    'project-note': 'Note',
+  };
+  const hashtagTypeColors: Record<string, { color: string; bg: string }> = {
+    note: { color: '--note-color', bg: '--note-bg' },
+    commit: { color: '--commit-color', bg: '--commit-bg' },
+    review: { color: '--review-color', bg: '--review-bg' },
+    'project-note': { color: '--note-color', bg: '--note-bg' },
+  };
+
+  function escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /** Replace #type:id tokens in plain text with inline badge HTML. */
+  function renderHashtagTokens(text: string, items: HashtagItem[]): string {
+    const itemsByKey = new Map<string, HashtagItem>();
+    for (const item of items) {
+      itemsByKey.set(`${item.type}:${item.id}`, item);
+    }
+    const escaped = escapeHtml(text);
+    return escaped.replace(
+      new RegExp(HASHTAG_TOKEN_RE.source, 'g'),
+      (_match, type: string, id: string) => {
+        const label = hashtagTypeLabels[type] ?? type;
+        const colors = hashtagTypeColors[type] ?? { color: '--text-muted', bg: '--bg-secondary' };
+        const item = itemsByKey.get(`${type}:${id}`);
+        const title = item
+          ? item.title
+          : type === 'commit' && id.length > 12
+            ? id.slice(0, 8) + '…'
+            : id;
+        return `<span class="hashtag-badge" style="background: var(${colors.bg}); color: var(${colors.color});">${escapeHtml(label)}: ${escapeHtml(title)}</span>`;
+      }
+    );
+  }
+
   // =========================================================================
   // XML tag parsing (action / branch-history blocks)
   // =========================================================================
@@ -950,7 +1007,9 @@
                   <div class="message-row human-message">
                     <div class="human-bubble">
                       {#if userText.trim()}
-                        <span class="human-text">{userText.trim()}</span>
+                        <span class="human-text"
+                          >{@html renderHashtagTokens(userText.trim(), hashtagItems)}</span
+                        >
                       {/if}
                       {#if group.message.imageIds && group.message.imageIds.length > 0}
                         <div class="message-images">
@@ -1219,15 +1278,16 @@
             </button>
           {/if}
         {/if}
-        <textarea
-          bind:this={inputEl}
+        <HashtagInput
+          bind:textareaEl={inputEl}
           bind:value={inputText}
           class="message-input"
           placeholder={isLive ? 'Type to queue a follow-up…' : 'Send a message…'}
           rows={1}
           onkeydown={handleInputKeydown}
           oninput={autoResize}
-        ></textarea>
+          items={hashtagItems}
+        />
         {#if isLive}
           <button
             class="action-btn stop-btn"
@@ -1462,6 +1522,15 @@
   .human-text {
     display: block;
     white-space: pre-wrap;
+  }
+
+  .human-text :global(.hashtag-badge) {
+    display: inline;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 500;
+    white-space: nowrap;
   }
 
   .human-bubble .inline-copy {
@@ -2039,7 +2108,7 @@
     cursor: not-allowed;
   }
 
-  .message-input {
+  .input-area :global(.message-input) {
     flex: 1;
     padding: 8px 12px;
     background: var(--bg-primary);
@@ -2055,13 +2124,13 @@
     max-height: 120px;
   }
 
-  .message-input::placeholder {
-    color: var(--text-faint);
-  }
-
-  .message-input:focus {
+  .input-area :global(.message-input):focus {
     outline: none;
     border-color: var(--border-emphasis);
+  }
+
+  .input-area :global(.hashtag-input-wrapper) {
+    flex: 1;
   }
 
   .action-btn {

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -59,7 +59,12 @@
     resumeSession,
   } from '../../api/commands';
   import HashtagInput from './HashtagInput.svelte';
-  import { buildBranchHashtagItems } from './hashtagItems';
+  import {
+    buildBranchHashtagItems,
+    HASHTAG_TOKEN_RE,
+    hashtagTypeLabels,
+    hashtagTypeColors,
+  } from './hashtagItems';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
   import { subscribeDragDrop } from '../branches/dragDrop';
   import { isImageFile } from '../branches/branchCardHelpers';
@@ -128,9 +133,13 @@
   let hashtagItems = $state<HashtagItem[]>([]);
   $effect(() => {
     if (branchId) {
+      let stale = false;
       buildBranchHashtagItems(branchId, projectId ?? null).then((items) => {
-        hashtagItems = items;
+        if (!stale) hashtagItems = items;
       });
+      return () => {
+        stale = true;
+      };
     }
   });
 
@@ -594,20 +603,6 @@
     return sanitize(marked.parse(content) as string);
   }
 
-  const HASHTAG_TOKEN_RE = /#(note|commit|review|project-note):([^\s]+)/g;
-  const hashtagTypeLabels: Record<string, string> = {
-    note: 'Note',
-    commit: 'Commit',
-    review: 'Review',
-    'project-note': 'Note',
-  };
-  const hashtagTypeColors: Record<string, { color: string; bg: string }> = {
-    note: { color: '--note-color', bg: '--note-bg' },
-    commit: { color: '--commit-color', bg: '--commit-bg' },
-    review: { color: '--review-color', bg: '--review-bg' },
-    'project-note': { color: '--note-color', bg: '--note-bg' },
-  };
-
   function escapeHtml(text: string): string {
     return text
       .replace(/&/g, '&amp;')
@@ -616,27 +611,49 @@
       .replace(/"/g, '&quot;');
   }
 
-  /** Replace #type:id tokens in plain text with inline badge HTML. */
+  /** Replace #type:id tokens in plain text with inline badge HTML.
+   *  Regex-matches on raw text first, then escapes non-token segments individually
+   *  so that IDs containing HTML-special characters are looked up correctly. */
   function renderHashtagTokens(text: string, items: HashtagItem[]): string {
     const itemsByKey = new Map<string, HashtagItem>();
     for (const item of items) {
       itemsByKey.set(`${item.type}:${item.id}`, item);
     }
-    const escaped = escapeHtml(text);
-    return escaped.replace(
-      new RegExp(HASHTAG_TOKEN_RE.source, 'g'),
-      (_match, type: string, id: string) => {
-        const label = hashtagTypeLabels[type] ?? type;
-        const colors = hashtagTypeColors[type] ?? { color: '--text-muted', bg: '--bg-secondary' };
-        const item = itemsByKey.get(`${type}:${id}`);
-        const title = item
-          ? item.title
-          : type === 'commit' && id.length > 12
-            ? id.slice(0, 8) + '…'
-            : id;
-        return `<span class="hashtag-badge" style="background: var(${colors.bg}); color: var(${colors.color});">${escapeHtml(label)}: ${escapeHtml(title)}</span>`;
+
+    const regex = new RegExp(HASHTAG_TOKEN_RE.source, 'g');
+    const parts: string[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(text)) !== null) {
+      // Escape the plain-text segment before this token
+      if (match.index > lastIndex) {
+        parts.push(escapeHtml(text.slice(lastIndex, match.index)));
       }
-    );
+
+      const type = match[1];
+      const id = match[2];
+      const label = hashtagTypeLabels[type] ?? type;
+      const colors = hashtagTypeColors[type] ?? { color: '--text-muted', bg: '--bg-secondary' };
+      const item = itemsByKey.get(`${type}:${id}`);
+      const title = item
+        ? item.title
+        : type === 'commit' && id.length > 12
+          ? id.slice(0, 8) + '…'
+          : id;
+      parts.push(
+        `<span class="hashtag-badge" style="background: var(${colors.bg}); color: var(${colors.color});">${escapeHtml(label)}: ${escapeHtml(title)}</span>`
+      );
+
+      lastIndex = match.index + match[0].length;
+    }
+
+    // Escape any trailing plain text
+    if (lastIndex < text.length) {
+      parts.push(escapeHtml(text.slice(lastIndex)));
+    }
+
+    return parts.join('');
   }
 
   // =========================================================================

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -1,0 +1,110 @@
+import type { BranchTimeline, HashtagItem, ProjectNote, Branch, ProjectRepo } from '../../types';
+import { getBranchTimeline, listProjectNotes } from '../../commands';
+
+/**
+ * Build hashtag items for a single branch scope (+ optional project notes).
+ */
+export async function buildBranchHashtagItems(
+  branchId: string,
+  projectId: string | null
+): Promise<HashtagItem[]> {
+  const items: HashtagItem[] = [];
+
+  const [timeline, projectNotes] = await Promise.all([
+    getBranchTimeline(branchId),
+    projectId ? listProjectNotes(projectId) : Promise.resolve([]),
+  ]);
+
+  items.push(...timelineToHashtagItems(timeline));
+  items.push(...projectNotesToHashtagItems(projectNotes));
+
+  return items;
+}
+
+/**
+ * Build hashtag items for a project scope (all branches + project notes).
+ */
+export async function buildProjectHashtagItems(
+  projectId: string,
+  branches: Branch[],
+  reposById?: Map<string, ProjectRepo>
+): Promise<HashtagItem[]> {
+  const items: HashtagItem[] = [];
+
+  const [timelines, projectNotes] = await Promise.all([
+    Promise.all(
+      branches.map((b) => getBranchTimeline(b.id).then((t) => ({ branch: b, timeline: t })))
+    ),
+    listProjectNotes(projectId),
+  ]);
+
+  for (const { branch, timeline } of timelines) {
+    const repo = branch.projectRepoId && reposById ? reposById.get(branch.projectRepoId) : null;
+    const repoSlug = repo?.githubRepo;
+    items.push(...timelineToHashtagItems(timeline, branch.branchName, repoSlug));
+  }
+
+  items.push(...projectNotesToHashtagItems(projectNotes));
+
+  return items;
+}
+
+function timelineToHashtagItems(
+  timeline: BranchTimeline,
+  branchName?: string,
+  repoSlug?: string
+): HashtagItem[] {
+  const items: HashtagItem[] = [];
+
+  for (const note of timeline.notes) {
+    if (!note.title.trim()) continue;
+    items.push({
+      type: 'note',
+      id: note.id,
+      title: note.title,
+      color: '--note-color',
+      bgColor: '--note-bg',
+      branchName,
+      repoSlug,
+    });
+  }
+
+  for (const commit of timeline.commits) {
+    items.push({
+      type: 'commit',
+      id: commit.sha,
+      title: `${commit.shortSha} ${commit.subject}`,
+      color: '--commit-color',
+      bgColor: '--commit-bg',
+      branchName,
+      repoSlug,
+    });
+  }
+
+  for (const review of timeline.reviews) {
+    const title = review.title || `Review of ${review.commitSha.slice(0, 7)}`;
+    items.push({
+      type: 'review',
+      id: review.id,
+      title,
+      color: '--review-color',
+      bgColor: '--review-bg',
+      branchName,
+      repoSlug,
+    });
+  }
+
+  return items;
+}
+
+function projectNotesToHashtagItems(notes: ProjectNote[]): HashtagItem[] {
+  return notes
+    .filter((n) => n.title.trim())
+    .map((n) => ({
+      type: 'project-note' as const,
+      id: n.id,
+      title: n.title,
+      color: '--note-color',
+      bgColor: '--note-bg',
+    }));
+}

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -1,6 +1,25 @@
 import type { BranchTimeline, HashtagItem, ProjectNote, Branch, ProjectRepo } from '../../types';
 import { getBranchTimeline, listProjectNotes } from '../../commands';
 
+/** Regex matching `#type:id` hashtag tokens in plain text. Use with `new RegExp(source, 'g')` for stateful iteration. */
+export const HASHTAG_TOKEN_RE = /#(note|commit|review|project-note):([^\s]+)/g;
+
+/** Human-readable labels for each hashtag type. */
+export const hashtagTypeLabels: Record<string, string> = {
+  note: 'Note',
+  commit: 'Commit',
+  review: 'Review',
+  'project-note': 'Note',
+};
+
+/** CSS custom-property names for each hashtag type's foreground and background colors. */
+export const hashtagTypeColors: Record<string, { color: string; bg: string }> = {
+  note: { color: '--note-color', bg: '--note-bg' },
+  commit: { color: '--commit-color', bg: '--commit-bg' },
+  review: { color: '--review-color', bg: '--review-bg' },
+  'project-note': { color: '--note-color', bg: '--note-bg' },
+};
+
 /**
  * Build hashtag items for a single branch scope (+ optional project notes).
  */

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -324,6 +324,20 @@ export type {
 } from '@builderbot/diff-viewer/types';
 
 // =============================================================================
+// Hashtag references
+// =============================================================================
+
+export interface HashtagItem {
+  type: 'note' | 'commit' | 'review' | 'project-note';
+  id: string;
+  title: string;
+  color: string;
+  bgColor: string;
+  branchName?: string;
+  repoSlug?: string;
+}
+
+// =============================================================================
 // Blox workspace types
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- Add a new `HashtagInput` component that lets users reference notes, commits, and reviews using `#type:id` hashtag syntax with autocomplete and badge rendering
- Prepend `Re: #type:id` reference lines to prefilled prompts when launching sessions from diff/review contexts
- Resolve prefilled hashtag tokens into visual badges once referenced items finish loading
- Fix select-all behavior to work correctly across hashtag badge re-renders

## Test plan
- [ ] Verify hashtag autocomplete appears when typing `#` in session prompt textareas
- [ ] Verify selecting a hashtag item inserts a styled badge
- [ ] Verify prefilled prompts from diff/review launchers include `Re:` reference lines
- [ ] Verify select-all (Cmd+A) works correctly in the hashtag input

🤖 Generated with [Claude Code](https://claude.com/claude-code)