### PR TITLE
fix(staged): don't let auto-reviews block new sessions from starting

### DIFF
--- a/apps/staged/src-tauri/src/store/sessions.rs
+++ b/apps/staged/src-tauri/src/store/sessions.rs
@@ -224,6 +224,9 @@ impl Store {
     }
 
     /// Check whether a branch already has a running session.
+    ///
+    /// Auto-reviews (`is_auto = 1`) are excluded because they run in the
+    /// background and should never block user-initiated sessions.
     pub fn has_running_session_for_branch(&self, branch_id: &str) -> Result<bool, StoreError> {
         let conn = self.conn.lock().unwrap();
         let count: i64 = conn.query_row(
@@ -232,7 +235,7 @@ impl Store {
                AND (
                    EXISTS (SELECT 1 FROM commits c WHERE c.session_id = s.id AND c.branch_id = ?1)
                    OR EXISTS (SELECT 1 FROM notes n WHERE n.session_id = s.id AND n.branch_id = ?1)
-                   OR EXISTS (SELECT 1 FROM reviews r WHERE r.session_id = s.id AND r.branch_id = ?1)
+                   OR EXISTS (SELECT 1 FROM reviews r WHERE r.session_id = s.id AND r.branch_id = ?1 AND r.is_auto = 0)
                )",
             params![branch_id],
             |row| row.get(0),

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -62,7 +62,7 @@ export default class BranchCardSessionManager {
     return (
       tl.commits.some((c) => c.sessionStatus === 'running') ||
       tl.notes.some((n) => n.sessionStatus === 'running') ||
-      tl.reviews.some((r) => r.sessionStatus === 'running')
+      tl.reviews.some((r) => r.sessionStatus === 'running' && !r.isAuto)
     );
   });
 


### PR DESCRIPTION
## Summary
- Exclude auto-reviews (`is_auto = 1`) from the running-session check in both the Rust store query and the Svelte frontend session manager
- Auto-reviews run in the background and should never prevent users from starting new sessions on a branch

## Test plan
- [ ] Verify that starting a new session on a branch with a running auto-review no longer gets queued
- [ ] Verify that a branch with a running user-initiated review still correctly blocks new sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)