### PR TITLE
fix(staged): include isAuto in timeline reviews and filter consistently

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -156,6 +156,7 @@ pub struct ReviewTimelineItem {
     pub completion_reason: Option<String>,
     pub title: Option<String>,
     pub comment_count: usize,
+    pub is_auto: bool,
     pub created_at: i64,
     pub updated_at: i64,
     pub completed_at: Option<i64>,

--- a/apps/staged/src-tauri/src/store/sessions.rs
+++ b/apps/staged/src-tauri/src/store/sessions.rs
@@ -224,6 +224,9 @@ impl Store {
     }
 
     /// Check whether a branch already has a running session.
+    ///
+    /// Auto-reviews (`is_auto = 1`) are excluded because they run in the
+    /// background and should never block user-initiated sessions.
     pub fn has_running_session_for_branch(&self, branch_id: &str) -> Result<bool, StoreError> {
         let conn = self.conn.lock().unwrap();
         let count: i64 = conn.query_row(
@@ -232,7 +235,7 @@ impl Store {
                AND (
                    EXISTS (SELECT 1 FROM commits c WHERE c.session_id = s.id AND c.branch_id = ?1)
                    OR EXISTS (SELECT 1 FROM notes n WHERE n.session_id = s.id AND n.branch_id = ?1)
-                   OR EXISTS (SELECT 1 FROM reviews r WHERE r.session_id = s.id AND r.branch_id = ?1)
+                   OR EXISTS (SELECT 1 FROM reviews r WHERE r.session_id = s.id AND r.branch_id = ?1 AND r.is_auto = 0)
                )",
             params![branch_id],
             |row| row.get(0),

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -167,13 +167,11 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         })
         .collect();
 
-    // Get reviews (filter out auto reviews — they're not shown in the timeline)
     let db_reviews = store
         .list_reviews_for_branch(branch_id)
         .map_err(|e| e.to_string())?;
     let reviews: Vec<ReviewTimelineItem> = db_reviews
         .into_iter()
-        .filter(|r| !r.is_auto)
         .map(|r| {
             let (session_id, session_status, completion_reason) =
                 store.resolve_session_status(r.session_id.as_deref());
@@ -187,6 +185,7 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
                 completion_reason,
                 title: r.title,
                 comment_count,
+                is_auto: r.is_auto,
                 created_at: r.created_at,
                 updated_at: r.updated_at,
                 completed_at: r.completed_at,

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -202,7 +202,9 @@
     return (
       tl.commits.some((c) => c.sessionStatus === 'queued' || c.sessionStatus === 'running') ||
       tl.notes.some((n) => n.sessionStatus === 'queued' || n.sessionStatus === 'running') ||
-      tl.reviews.some((r) => r.sessionStatus === 'queued' || r.sessionStatus === 'running')
+      tl.reviews.some(
+        (r) => !r.isAuto && (r.sessionStatus === 'queued' || r.sessionStatus === 'running')
+      )
     );
   }
 
@@ -230,6 +232,7 @@
     const candidates: Candidate[] = [];
 
     for (const review of timeline.reviews) {
+      if (review.isAuto) continue;
       const ts = Math.floor((review.completedAt ?? review.createdAt) / 1000);
       candidates.push({ kind: 'review', commentCount: review.commentCount, timestamp: ts });
     }
@@ -307,6 +310,7 @@
       if (n.id !== note.id) timestamps.push(Math.floor((n.completedAt ?? n.createdAt) / 1000));
     }
     for (const r of timeline.reviews) {
+      if (r.isAuto) continue;
       timestamps.push(Math.floor((r.completedAt ?? r.createdAt) / 1000));
     }
     if (timestamps.some((ts) => ts > noteTs)) return null;

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -62,7 +62,7 @@ export default class BranchCardSessionManager {
     return (
       tl.commits.some((c) => c.sessionStatus === 'running') ||
       tl.notes.some((n) => n.sessionStatus === 'running') ||
-      tl.reviews.some((r) => r.sessionStatus === 'running')
+      tl.reviews.some((r) => r.sessionStatus === 'running' && !r.isAuto)
     );
   });
 

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -51,7 +51,9 @@
           (c) => c.sessionStatus === 'running' || c.sessionStatus === 'queued'
         ) ||
         timeline.notes.some((n) => n.sessionStatus === 'running' || n.sessionStatus === 'queued') ||
-        timeline.reviews.some((r) => r.sessionStatus === 'running' || r.sessionStatus === 'queued');
+        timeline.reviews.some(
+          (r) => !r.isAuto && (r.sessionStatus === 'running' || r.sessionStatus === 'queued')
+        );
     } catch (e) {
       console.error('[DiffCommitSessionLauncher] Failed to load timeline:', e);
       hasRunningSession = false;

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -206,7 +206,7 @@
       if (note.sessionStatus === 'running') return true;
     }
     for (const review of timeline.reviews) {
-      if (review.sessionStatus === 'running') return true;
+      if (!review.isAuto && review.sessionStatus === 'running') return true;
     }
     for (const item of pendingItems) {
       if (item.sessionId && !item.type.startsWith('queued-')) return true;
@@ -324,6 +324,7 @@
     }
 
     for (const review of timeline.reviews) {
+      if (review.isAuto) continue;
       const breakdown = reviewCommentBreakdown[review.id];
       const commentCount = breakdown?.comments ?? review.commentCount;
       const annotationCount = breakdown?.annotations ?? 0;

--- a/apps/staged/src/lib/features/timeline/liveSessionHints.ts
+++ b/apps/staged/src/lib/features/timeline/liveSessionHints.ts
@@ -145,7 +145,7 @@ export function collectRunningSessionIds(
     }
   }
   for (const review of timeline.reviews) {
-    if (review.sessionStatus === 'running' && review.sessionId) {
+    if (!review.isAuto && review.sessionStatus === 'running' && review.sessionId) {
       ids.add(review.sessionId);
     }
   }

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -127,7 +127,7 @@ export interface ReviewTimelineItem {
   completionReason: string | null;
   title: string | null;
   commentCount: number;
-  isAuto?: boolean;
+  isAuto: boolean;
   createdAt: number;
   updatedAt: number;
   completedAt: number | null;


### PR DESCRIPTION
## Summary

Follow-up to #609 — the second commit didn't land before the merge.

- Expose `is_auto` on `ReviewTimelineItem` from the backend instead of filtering auto-reviews out of the timeline entirely
- Make `isAuto` a required field on the frontend `ReviewTimelineItem` type
- Filter auto-reviews consistently across all frontend running-session checks and display logic (BranchCard, BranchCardSessionManager, DiffCommitSessionLauncher, BranchTimeline, liveSessionHints)

Without this, the frontend `!isAuto` guards from #609 were no-ops since auto-reviews were already stripped server-side.

## Test plan

- [ ] Trigger an auto-review and verify it doesn't block starting a new session
- [ ] Verify auto-reviews don't appear in the branch timeline
- [ ] Verify manual reviews still appear and function normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)