### PR TITLE
feat: add suggested repos based on repo affinity tracking

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -567,6 +567,25 @@ fn list_recent_repos(
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command(rename_all = "camelCase")]
+fn get_suggested_repos(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    project_id: String,
+    limit: Option<usize>,
+) -> Result<Vec<store::SuggestedRepo>, String> {
+    let store = get_store(&store)?;
+    let repos = store
+        .list_project_repos(&project_id)
+        .map_err(|e| e.to_string())?;
+    let keys: Vec<String> = repos
+        .iter()
+        .map(|r| store::repo_affinities::repo_affinity_key(&r.github_repo, r.subpath.as_deref()))
+        .collect();
+    store
+        .get_suggested_repos(&keys, limit.unwrap_or(5))
+        .map_err(|e| e.to_string())
+}
+
 #[allow(clippy::too_many_arguments)]
 #[tauri::command(rename_all = "camelCase")]
 async fn add_project_repo(
@@ -1704,6 +1723,7 @@ pub fn run() {
             create_project,
             list_project_repos,
             list_recent_repos,
+            get_suggested_repos,
             add_project_repo,
             update_project_repo_branch_name,
             clear_project_repo_reason,

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -574,15 +574,8 @@ fn get_suggested_repos(
     limit: Option<usize>,
 ) -> Result<Vec<store::SuggestedRepo>, String> {
     let store = get_store(&store)?;
-    let repos = store
-        .list_project_repos(&project_id)
-        .map_err(|e| e.to_string())?;
-    let keys: Vec<String> = repos
-        .iter()
-        .map(|r| store::repo_affinities::repo_affinity_key(&r.github_repo, r.subpath.as_deref()))
-        .collect();
     store
-        .get_suggested_repos(&keys, limit.unwrap_or(5))
+        .get_suggested_repos_for_project(&project_id, limit.unwrap_or(5))
         .map_err(|e| e.to_string())
 }
 

--- a/apps/staged/src-tauri/src/project_commands.rs
+++ b/apps/staged/src-tauri/src/project_commands.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use crate::store::repo_affinities::repo_affinity_key;
 use crate::store::{self, Store};
 use crate::{blox, branches, git};
 
@@ -105,6 +106,15 @@ pub(crate) async fn add_project_repo_impl(
     store
         .record_recent_repo(&github_repo, subpath.clone())
         .map_err(|e| e.to_string())?;
+
+    // Record repo affinity for each existing repo in the project.
+    let new_key = repo_affinity_key(&github_repo, repo.subpath.as_deref());
+    for existing in &existing_repos {
+        let existing_key = repo_affinity_key(&existing.github_repo, existing.subpath.as_deref());
+        if let Err(e) = store.record_repo_affinity(&new_key, &existing_key) {
+            log::warn!("Failed to record repo affinity: {e}");
+        }
+    }
 
     let should_be_primary = repo.is_primary
         || store

--- a/apps/staged/src-tauri/src/store/migration_tests.rs
+++ b/apps/staged/src-tauri/src/store/migration_tests.rs
@@ -133,7 +133,7 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         )
         .unwrap();
 
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
     assert_eq!(app_version, super::APP_VERSION);
     assert!(table_exists(&conn, "projects"));
     assert!(table_exists(&conn, "project_notes"));

--- a/apps/staged/src-tauri/src/store/migrations/0010-repo-affinities/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0010-repo-affinities/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE repo_affinities (
+    repo_a       TEXT NOT NULL,
+    repo_b       TEXT NOT NULL,
+    co_use_count INTEGER NOT NULL DEFAULT 1,
+    last_seen_at INTEGER NOT NULL,
+    PRIMARY KEY (repo_a, repo_b)
+);
+-- idx on repo_a is unnecessary: the PRIMARY KEY (repo_a, repo_b) already
+-- covers lookups on repo_a alone. Only repo_b needs its own index.
+CREATE INDEX idx_repo_affinities_b ON repo_affinities(repo_b);

--- a/apps/staged/src-tauri/src/store/mod.rs
+++ b/apps/staged/src-tauri/src/store/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! Tables: app_metadata, projects, project_repos, branches, workdirs, commits,
 //! sessions, session_messages, notes, project_notes, reviews, images,
-//! action_contexts, repo_actions.
+//! action_contexts, repo_actions, repo_affinities.
 
 pub mod models;
 
@@ -24,6 +24,7 @@ mod project_notes;
 mod project_repos;
 mod projects;
 mod recent_repos;
+pub mod repo_affinities;
 pub mod repo_badges;
 mod reviews;
 mod sessions;

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -1146,6 +1146,19 @@ impl Comment {
 }
 
 // =============================================================================
+// Suggested Repos (Repo Affinities)
+// =============================================================================
+
+/// A repo that has historically been used alongside the current project's repos.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SuggestedRepo {
+    pub github_repo: String,
+    pub subpath: Option<String>,
+    pub score: i64,
+}
+
+// =============================================================================
 // Repo Badges
 // =============================================================================
 

--- a/apps/staged/src-tauri/src/store/repo_affinities.rs
+++ b/apps/staged/src-tauri/src/store/repo_affinities.rs
@@ -50,61 +50,68 @@ impl Store {
         Ok(())
     }
 
-    /// Query repos that have historically been paired with the given keys,
-    /// excluding those already in `current_keys`. Results are sorted by
+    /// Query repos that have historically been paired with the repos in the
+    /// given project, excluding those already attached. Results are sorted by
     /// aggregate affinity score (descending).
-    pub fn get_suggested_repos(
+    ///
+    /// Both the key-building and suggestion query happen under a single lock
+    /// acquisition so the result is consistent.
+    pub fn get_suggested_repos_for_project(
         &self,
-        current_keys: &[String],
+        project_id: &str,
         limit: usize,
     ) -> Result<Vec<SuggestedRepo>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+
+        // Build affinity keys from the project's current repos.
+        let current_keys: Vec<String> = {
+            let mut stmt = conn
+                .prepare("SELECT github_repo, subpath FROM project_repos WHERE project_id = ?1")?;
+            let rows = stmt.query_map(params![project_id], |row| {
+                let github_repo: String = row.get(0)?;
+                let subpath: Option<String> = row.get(1)?;
+                Ok(repo_affinity_key(&github_repo, subpath.as_deref()))
+            })?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+
         if current_keys.is_empty() {
+            drop(conn);
             return self.get_popular_repos(limit);
         }
 
-        let conn = self.conn.lock().unwrap();
-
-        // Build placeholders for the IN clauses.
-        let placeholders: String = current_keys
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        // Offset for the second copy of params (exclude list) and the third copy.
+        // Use a CTE so the current keys are bound once and reused for the
+        // IN-match and the NOT-IN exclusion.
         let n = current_keys.len();
-        let placeholders2: String = (0..n)
-            .map(|i| format!("?{}", n + i + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let exclude_placeholders: String = (0..n)
-            .map(|i| format!("?{}", 2 * n + i + 1))
+        let value_rows: String = (0..n)
+            .map(|i| format!("(?{})", i + 1))
             .collect::<Vec<_>>()
             .join(", ");
 
         let sql = format!(
-            "SELECT repo_key, SUM(co_use_count) as score
+            "WITH current(key) AS (VALUES {value_rows})
+             SELECT repo_key, SUM(co_use_count) as score
              FROM (
-                 SELECT repo_b as repo_key, co_use_count FROM repo_affinities WHERE repo_a IN ({placeholders})
+                 SELECT repo_b AS repo_key, co_use_count
+                 FROM repo_affinities
+                 WHERE repo_a IN (SELECT key FROM current)
                  UNION ALL
-                 SELECT repo_a as repo_key, co_use_count FROM repo_affinities WHERE repo_b IN ({placeholders2})
+                 SELECT repo_a AS repo_key, co_use_count
+                 FROM repo_affinities
+                 WHERE repo_b IN (SELECT key FROM current)
              )
-             WHERE repo_key NOT IN ({exclude_placeholders})
+             WHERE repo_key NOT IN (SELECT key FROM current)
              GROUP BY repo_key
              ORDER BY score DESC
              LIMIT ?{}",
-            3 * n + 1
+            n + 1
         );
 
         let mut stmt = conn.prepare(&sql)?;
 
-        // Bind parameters: current_keys x3 (two IN clauses + exclude), then limit.
         let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-        for _ in 0..3 {
-            for key in current_keys {
-                param_values.push(Box::new(key.clone()));
-            }
+        for key in &current_keys {
+            param_values.push(Box::new(key.clone()));
         }
         param_values.push(Box::new(limit as i64));
 

--- a/apps/staged/src-tauri/src/store/repo_affinities.rs
+++ b/apps/staged/src-tauri/src/store/repo_affinities.rs
@@ -1,0 +1,157 @@
+//! Repo affinity tracking — records which repos are used together in projects.
+
+use rusqlite::params;
+
+use super::models::SuggestedRepo;
+use super::{now_timestamp, Store, StoreError};
+
+/// Build the canonical affinity key for a repo, encoding the subpath when present.
+/// The `::` delimiter is safe because neither GitHub `owner/repo` names nor
+/// filesystem subpaths can contain `::`, so there is no collision risk.
+pub fn repo_affinity_key(github_repo: &str, subpath: Option<&str>) -> String {
+    match subpath.filter(|s| !s.is_empty()) {
+        Some(sub) => format!("{github_repo}::{sub}"),
+        None => github_repo.to_string(),
+    }
+}
+
+/// Parse a repo affinity key back into (github_repo, subpath).
+fn parse_affinity_key(key: &str) -> (String, Option<String>) {
+    match key.split_once("::") {
+        Some((repo, sub)) => (repo.to_string(), Some(sub.to_string())),
+        None => (key.to_string(), None),
+    }
+}
+
+impl Store {
+    /// Record (or increment) an affinity between two repo keys.
+    ///
+    /// Keys are stored in lexicographic order so `(A,B)` and `(B,A)` map to
+    /// the same row.
+    pub fn record_repo_affinity(&self, key_a: &str, key_b: &str) -> Result<(), StoreError> {
+        // Skip self-affinity (e.g. same repo+subpath added twice).
+        if key_a == key_b {
+            return Ok(());
+        }
+        let (a, b) = if key_a <= key_b {
+            (key_a, key_b)
+        } else {
+            (key_b, key_a)
+        };
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO repo_affinities (repo_a, repo_b, co_use_count, last_seen_at)
+             VALUES (?1, ?2, 1, ?3)
+             ON CONFLICT(repo_a, repo_b) DO UPDATE
+                SET co_use_count = co_use_count + 1,
+                    last_seen_at = ?3",
+            params![a, b, now_timestamp()],
+        )?;
+        Ok(())
+    }
+
+    /// Query repos that have historically been paired with the given keys,
+    /// excluding those already in `current_keys`. Results are sorted by
+    /// aggregate affinity score (descending).
+    pub fn get_suggested_repos(
+        &self,
+        current_keys: &[String],
+        limit: usize,
+    ) -> Result<Vec<SuggestedRepo>, StoreError> {
+        if current_keys.is_empty() {
+            return self.get_popular_repos(limit);
+        }
+
+        let conn = self.conn.lock().unwrap();
+
+        // Build placeholders for the IN clauses.
+        let placeholders: String = current_keys
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        // Offset for the second copy of params (exclude list) and the third copy.
+        let n = current_keys.len();
+        let placeholders2: String = (0..n)
+            .map(|i| format!("?{}", n + i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let exclude_placeholders: String = (0..n)
+            .map(|i| format!("?{}", 2 * n + i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let sql = format!(
+            "SELECT repo_key, SUM(co_use_count) as score
+             FROM (
+                 SELECT repo_b as repo_key, co_use_count FROM repo_affinities WHERE repo_a IN ({placeholders})
+                 UNION ALL
+                 SELECT repo_a as repo_key, co_use_count FROM repo_affinities WHERE repo_b IN ({placeholders2})
+             )
+             WHERE repo_key NOT IN ({exclude_placeholders})
+             GROUP BY repo_key
+             ORDER BY score DESC
+             LIMIT ?{}",
+            3 * n + 1
+        );
+
+        let mut stmt = conn.prepare(&sql)?;
+
+        // Bind parameters: current_keys x3 (two IN clauses + exclude), then limit.
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        for _ in 0..3 {
+            for key in current_keys {
+                param_values.push(Box::new(key.clone()));
+            }
+        }
+        param_values.push(Box::new(limit as i64));
+
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let rows = stmt.query_map(params_ref.as_slice(), |row| {
+            let key: String = row.get(0)?;
+            let score: i64 = row.get(1)?;
+            Ok((key, score))
+        })?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            let (key, score) = row?;
+            let (github_repo, subpath) = parse_affinity_key(&key);
+            results.push(SuggestedRepo {
+                github_repo,
+                subpath,
+                score,
+            });
+        }
+        Ok(results)
+    }
+
+    /// Return the most-added repos across all projects, ranked by distinct
+    /// project count. Used as a fallback when the current project has no repos.
+    fn get_popular_repos(&self, limit: usize) -> Result<Vec<SuggestedRepo>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT github_repo, subpath, COUNT(DISTINCT project_id) as score
+             FROM project_repos
+             GROUP BY github_repo, COALESCE(subpath, '')
+             ORDER BY score DESC
+             LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            let github_repo: String = row.get(0)?;
+            let subpath: Option<String> = row.get(1)?;
+            let score: i64 = row.get(2)?;
+            Ok(SuggestedRepo {
+                github_repo,
+                subpath,
+                score,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+}

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -30,6 +30,7 @@ import type {
   PrStatus,
   PollWorkspaceResult,
   Image,
+  SuggestedRepo,
 } from './types';
 
 // =============================================================================
@@ -124,6 +125,10 @@ export function setPrimaryProjectRepo(projectId: string, projectRepoId: string):
 
 export function clearProjectRepoReason(projectRepoId: string): Promise<void> {
   return invoke('clear_project_repo_reason', { projectRepoId });
+}
+
+export function getSuggestedRepos(projectId: string, limit?: number): Promise<SuggestedRepo[]> {
+  return invoke('get_suggested_repos', { projectId, limit: limit ?? null });
 }
 
 /** List the authenticated user's GitHub organization memberships. */

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -32,6 +32,7 @@
   import BranchCard from '../branches/BranchCard.svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import AddRepoModal from './AddRepoModal.svelte';
+  import SuggestedRepos from './SuggestedRepos.svelte';
   import type { RepoSelection as RepoPickerSelection } from '../../shared/githubUrl';
   import TimelineRow from '../timeline/TimelineRow.svelte';
   import NoteModal from '../notes/NoteModal.svelte';
@@ -60,7 +61,7 @@
     onDeleteProject?: () => void;
     onDeleteBranch?: (branchId: string) => void;
     onRenameBranch?: (branchId: string, branchName: string) => void;
-    onRepoSelected?: (selection: RepoPickerSelection) => void;
+    onRepoSelected?: (selection: RepoPickerSelection) => void | Promise<void>;
     onRetryWorktree?: (branchId: string) => void;
     onResumeWorkspace?: (workspaceName: string) => void;
     onDismissReason?: (projectRepoId: string) => void;
@@ -131,9 +132,9 @@
     }
   }
 
-  function handleRepoSelected(selection: RepoPickerSelection) {
+  async function handleRepoSelected(selection: RepoPickerSelection) {
     addRepoModalOpen = false;
-    onRepoSelected?.(selection);
+    await onRepoSelected?.(selection);
   }
 
   function repoForBranch(branch: Branch): ProjectRepo | null {
@@ -608,6 +609,8 @@
       />
     {/each}
   </div>
+
+  <SuggestedRepos {project} {reposById} {onRepoSelected} />
 </div>
 
 {#if openNote}

--- a/apps/staged/src/lib/features/projects/SuggestedRepos.svelte
+++ b/apps/staged/src/lib/features/projects/SuggestedRepos.svelte
@@ -27,17 +27,20 @@
 
   let suggestions = $state<SuggestedRepo[]>([]);
   let fetchGeneration = 0;
+  let dismissGeneration = 0;
   let addingKey = $state<string | null>(null);
   let dismissed = $state(false);
   let dismissLoaded = $state(false);
 
   const DISMISS_STORE_KEY = 'suggested-repos-dismissed';
 
-  // Load dismiss state on mount.
+  // Load dismiss state on mount / when project changes.
   $effect(() => {
-    void project.id; // re-check when project changes
+    const pid = project.id; // track project.id reactively
+    const gen = ++dismissGeneration;
     getStoreValue<Record<string, boolean>>(DISMISS_STORE_KEY).then((val) => {
-      dismissed = val?.[project.id] ?? false;
+      if (gen !== dismissGeneration) return; // discard stale response
+      dismissed = val?.[pid] ?? false;
       dismissLoaded = true;
     });
   });
@@ -54,7 +57,7 @@
     )
   );
 
-  async function fetchSuggestions() {
+  async function fetchSuggestions(currentAttachedKeys: Set<string>) {
     const gen = ++fetchGeneration;
     try {
       const result = await commands.getSuggestedRepos(project.id);
@@ -62,7 +65,7 @@
       // Filter out any that have been attached since we last fetched.
       suggestions = result.filter((s) => {
         const key = s.subpath ? `${s.githubRepo}::${s.subpath}` : s.githubRepo;
-        return !attachedKeys.has(key);
+        return !currentAttachedKeys.has(key);
       });
       // Ensure badges exist for suggestions so we can look up hues.
       if (suggestions.length > 0) {
@@ -77,9 +80,11 @@
   }
 
   // Re-fetch when the set of attached repos changes.
+  // Reading `attachedKeys` directly (not just `.size`) ensures Svelte tracks
+  // the full derived value, so swapping one repo for another still re-fires.
   $effect(() => {
-    void attachedKeys.size;
-    fetchSuggestions();
+    const keys = attachedKeys;
+    void fetchSuggestions(keys);
   });
 
   function suggestionKey(s: SuggestedRepo): string {

--- a/apps/staged/src/lib/features/projects/SuggestedRepos.svelte
+++ b/apps/staged/src/lib/features/projects/SuggestedRepos.svelte
@@ -1,0 +1,267 @@
+<!--
+  SuggestedRepos.svelte - Shows repos that have historically been used
+  alongside the current project's repos, with an "Add" button for each.
+
+  Rendered as a dotted round rect below the branch cards, with repo-badge-style
+  chips showing the full repo+subpath name. A dismiss button persists the
+  hidden state across app launches.
+-->
+<script lang="ts">
+  import { Plus, X } from 'lucide-svelte';
+  import type { Project, ProjectRepo, SuggestedRepo } from '../../types';
+  import type { RepoSelection as RepoPickerSelection } from '../../shared/githubUrl';
+  import * as commands from '../../api/commands';
+  import { repoBadgeStore } from '../../stores/repoBadges.svelte';
+  import { darkMode } from '../../stores/isDark.svelte';
+  import RepoLabel from '../../shared/RepoLabel.svelte';
+  import Spinner from '../../shared/Spinner.svelte';
+  import { getStoreValue, setStoreValue } from '../../shared/persistentStore';
+
+  interface Props {
+    project: Project;
+    reposById: Map<string, ProjectRepo>;
+    onRepoSelected?: (selection: RepoPickerSelection) => void | Promise<void>;
+  }
+
+  let { project, reposById, onRepoSelected }: Props = $props();
+
+  let suggestions = $state<SuggestedRepo[]>([]);
+  let fetchGeneration = 0;
+  let addingKey = $state<string | null>(null);
+  let dismissed = $state(false);
+  let dismissLoaded = $state(false);
+
+  const DISMISS_STORE_KEY = 'suggested-repos-dismissed';
+
+  // Load dismiss state on mount.
+  $effect(() => {
+    void project.id; // re-check when project changes
+    getStoreValue<Record<string, boolean>>(DISMISS_STORE_KEY).then((val) => {
+      dismissed = val?.[project.id] ?? false;
+      dismissLoaded = true;
+    });
+  });
+
+  // Build a set of already-attached repo keys for filtering (current project only).
+  let attachedKeys = $derived(
+    new Set(
+      [...reposById.values()]
+        .filter((r) => r.projectId === project.id)
+        .map((r) => {
+          const sub = r.subpath?.trim();
+          return sub ? `${r.githubRepo}::${sub}` : r.githubRepo;
+        })
+    )
+  );
+
+  async function fetchSuggestions() {
+    const gen = ++fetchGeneration;
+    try {
+      const result = await commands.getSuggestedRepos(project.id);
+      if (gen !== fetchGeneration) return; // discard stale response
+      // Filter out any that have been attached since we last fetched.
+      suggestions = result.filter((s) => {
+        const key = s.subpath ? `${s.githubRepo}::${s.subpath}` : s.githubRepo;
+        return !attachedKeys.has(key);
+      });
+      // Ensure badges exist for suggestions so we can look up hues.
+      if (suggestions.length > 0) {
+        await repoBadgeStore.ensureForRepos(
+          suggestions.map((s) => ({ githubRepo: s.githubRepo, subpath: s.subpath }))
+        );
+      }
+    } catch {
+      if (gen !== fetchGeneration) return;
+      suggestions = [];
+    }
+  }
+
+  // Re-fetch when the set of attached repos changes.
+  $effect(() => {
+    void attachedKeys.size;
+    fetchSuggestions();
+  });
+
+  function suggestionKey(s: SuggestedRepo): string {
+    return s.subpath ? `${s.githubRepo}::${s.subpath}` : s.githubRepo;
+  }
+
+  async function handleAdd(suggestion: SuggestedRepo) {
+    const key = suggestionKey(suggestion);
+    addingKey = key;
+    try {
+      await onRepoSelected?.({
+        nameWithOwner: suggestion.githubRepo,
+        subpath: suggestion.subpath ?? undefined,
+      });
+    } finally {
+      addingKey = null;
+    }
+  }
+
+  async function handleDismiss() {
+    dismissed = true;
+    const current = (await getStoreValue<Record<string, boolean>>(DISMISS_STORE_KEY)) ?? {};
+    await setStoreValue(DISMISS_STORE_KEY, { ...current, [project.id]: true });
+  }
+
+  function badgeHue(suggestion: SuggestedRepo): number {
+    return repoBadgeStore.lookup(suggestion.githubRepo, suggestion.subpath)?.hue ?? 210;
+  }
+
+  function badgeBg(hue: number): string {
+    return darkMode.value ? `hsl(${hue} 35% 22%)` : `hsl(${hue} 50% 92%)`;
+  }
+
+  function badgeFg(hue: number): string {
+    return darkMode.value ? `hsl(${hue} 50% 75%)` : `hsl(${hue} 55% 35%)`;
+  }
+
+  function badgeBorder(hue: number): string {
+    return darkMode.value ? `hsl(${hue} 35% 32%)` : `hsl(${hue} 45% 82%)`;
+  }
+
+  function badgeBgHover(hue: number): string {
+    return darkMode.value ? `hsl(${hue} 40% 30%)` : `hsl(${hue} 60% 85%)`;
+  }
+
+  function badgeBorderHover(hue: number): string {
+    return darkMode.value ? `hsl(${hue} 45% 45%)` : `hsl(${hue} 50% 65%)`;
+  }
+</script>
+
+{#if dismissLoaded && !dismissed && suggestions.length > 0}
+  <div class="suggested-repos">
+    <div class="suggested-header">
+      <span class="suggested-title">Suggested repos</span>
+      <button class="dismiss-btn" onclick={handleDismiss} title="Dismiss suggestions">
+        <X size={14} />
+      </button>
+    </div>
+    <div class="suggested-list">
+      {#each suggestions as suggestion (suggestionKey(suggestion))}
+        {@const hue = badgeHue(suggestion)}
+        {@const isAdding = addingKey === suggestionKey(suggestion)}
+        <button
+          class="suggested-chip"
+          style="--chip-bg: {badgeBg(hue)}; --chip-bg-hover: {badgeBgHover(
+            hue
+          )}; --chip-border: {badgeBorder(hue)}; --chip-border-hover: {badgeBorderHover(
+            hue
+          )}; --chip-fg: {badgeFg(hue)};"
+          disabled={isAdding}
+          onclick={() => handleAdd(suggestion)}
+        >
+          {#if isAdding}
+            <Spinner size={13} />
+          {:else}
+            <Plus size={13} />
+          {/if}
+          <span class="chip-name">
+            <RepoLabel githubRepo={suggestion.githubRepo} subpath={suggestion.subpath} />
+          </span>
+        </button>
+      {/each}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .suggested-repos {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px;
+    border: 1.5px dashed var(--border-muted);
+    border-radius: 10px;
+  }
+
+  .suggested-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .suggested-title {
+    color: var(--text-muted);
+    font-size: var(--size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .dismiss-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-faint);
+    cursor: pointer;
+    transition:
+      color 0.15s,
+      background 0.15s;
+  }
+
+  .dismiss-btn:hover {
+    color: var(--text-secondary);
+    background: var(--bg-hover);
+  }
+
+  .suggested-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .suggested-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    border: 1px solid var(--chip-border);
+    border-radius: 5px;
+    background: var(--chip-bg);
+    color: var(--chip-fg);
+    font-size: 12.5px;
+    font-weight: 600;
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+    line-height: 1.4;
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      border-color 0.15s;
+  }
+
+  .suggested-chip:hover:not(:disabled) {
+    background: var(--chip-bg-hover);
+    border-color: var(--chip-border-hover);
+  }
+
+  .suggested-chip:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+
+  .chip-name {
+    display: inline-flex;
+    max-width: 250px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Override RepoLabel colors to inherit from badge chip */
+  .chip-name :global(.repo-label-prefix) {
+    color: inherit;
+    opacity: 0.6;
+  }
+
+  .chip-name :global(.repo-label-emphasis) {
+    color: inherit;
+  }
+</style>

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -35,6 +35,12 @@ export interface RecentRepo {
   lastUsedAt: number;
 }
 
+export interface SuggestedRepo {
+  githubRepo: string;
+  subpath: string | null;
+  score: number;
+}
+
 export interface GitHubRepo {
   name: string;
   nameWithOwner: string;


### PR DESCRIPTION
## Summary
- Track repo affinity scores based on user interaction patterns and store them in a new `repo_affinities` table (migration 0010)
- Add a `SuggestedRepos` Svelte component that surfaces repo suggestions in the project section
- Expose `get_suggested_repos` Tauri command to the frontend

## Test plan
- [ ] Verify suggested repos appear after interacting with multiple repositories
- [ ] Confirm affinity scores update correctly over time
- [ ] Check that dismissing a suggestion removes it from the list
- [ ] Validate migration applies cleanly on fresh and existing databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)