### PR TITLE
fix(staged): use PR base ref as base branch when adding repos via PRs

### DIFF
--- a/apps/staged/src/lib/features/projects/AddRepoModal.svelte
+++ b/apps/staged/src/lib/features/projects/AddRepoModal.svelte
@@ -70,7 +70,7 @@
         branchName: normalizedBranch,
         subpath: normalizedSubpath,
         prNumber,
-        defaultBranch: defaultBranch ?? undefined,
+        defaultBranch: matchedPr?.baseRef ?? defaultBranch ?? undefined,
       });
       onClose();
     } catch (e) {

--- a/apps/staged/src/lib/features/projects/NewProjectForm.svelte
+++ b/apps/staged/src/lib/features/projects/NewProjectForm.svelte
@@ -92,7 +92,7 @@
         normalizedSubpath,
         normalizedBranch,
         prNumber,
-        defaultBranch ?? undefined
+        matchedPr?.baseRef ?? defaultBranch ?? undefined
       );
       onCreated(project);
     } catch (e) {


### PR DESCRIPTION
## Summary
- When adding a repo via a PR URL, use the PR's base ref as the base branch instead of the repo's default branch
- Applies to both the AddRepoModal and NewProjectForm components

This ensures diffs are computed against the correct base when a PR targets a non-default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)