### PR TITLE
fix(staged): show live agent message subtitle for project session timeline rows

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -5,7 +5,7 @@
   project notes, repo controls, and all branch cards for this project.
 -->
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { listen } from '@tauri-apps/api/event';
   import { untrack } from 'svelte';
   import {
@@ -52,6 +52,7 @@
   import { isImageFile } from '../branches/branchCardHelpers';
   import { createImage, createImageFromData, deleteImage, getImageData } from '../../api/commands';
   import { formatRelativeTime, minuteNow } from '../../shared/relativeTime.svelte';
+  import { createLiveSessionHints } from '../timeline/liveSessionHints';
 
   interface Props {
     project: Project;
@@ -163,6 +164,34 @@
   );
   /** Session IDs for running project sessions (all produce notes). */
   let activeSessionIds = $state<Set<string>>(new Set());
+
+  // ── Live session hints (show latest agent message for running notes) ──
+  let liveSessionHints = $state<Record<string, string>>({});
+  const liveSessionHintPoller = createLiveSessionHints((nextHints) => {
+    liveSessionHints = nextHints;
+  });
+
+  /** Collect session IDs from running project notes + activeSessionIds. */
+  let runningNoteSessionIds = $derived.by(() => {
+    const ids = new Set<string>();
+    for (const note of projectNotes) {
+      if (!note.title.trim() && !note.content.trim() && note.sessionId) {
+        ids.add(note.sessionId);
+      }
+    }
+    for (const sid of activeSessionIds) {
+      ids.add(sid);
+    }
+    return Array.from(ids);
+  });
+
+  $effect(() => {
+    liveSessionHintPoller.syncRunningSessionIds(runningNoteSessionIds);
+  });
+
+  onDestroy(() => {
+    liveSessionHintPoller.destroy();
+  });
 
   // Hashtag reference items
   let hashtagItems = $state<HashtagItem[]>([]);
@@ -578,6 +607,8 @@
           {@const isRunning = !note.title.trim() && !note.content.trim()}
           {@const isFailed = !isRunning && !!note.sessionId && !note.content.trim()}
           {@const noteType = isRunning ? 'generating-note' : isFailed ? 'failed-note' : 'note'}
+          {@const liveHint =
+            isRunning && note.sessionId ? liveSessionHints[note.sessionId] : undefined}
           <TimelineRow
             type={noteType}
             title={isRunning
@@ -585,9 +616,11 @@
               : isFailed
                 ? 'Session finished — no note created'
                 : note.title || 'Untitled note'}
-            secondaryMeta={isRunning || isFailed
-              ? undefined
-              : formatRelativeTime(note.completedAt ?? note.createdAt, nowMs)}
+            secondaryMeta={isRunning
+              ? (liveHint ?? 'Generating note')
+              : isFailed
+                ? undefined
+                : formatRelativeTime(note.completedAt ?? note.createdAt, nowMs)}
             deleting={deletingNoteIds.has(note.id)}
             isLast={index === timelineNotes.length - 1}
             sessionId={note.sessionId ?? undefined}

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -167,9 +167,12 @@
 
   // ── Live session hints (show latest agent message for running notes) ──
   let liveSessionHints = $state<Record<string, string>>({});
-  const liveSessionHintPoller = createLiveSessionHints((nextHints) => {
-    liveSessionHints = nextHints;
-  });
+  const liveSessionHintPoller = createLiveSessionHints(
+    (nextHints) => {
+      liveSessionHints = nextHints;
+    },
+    () => branches.find((b) => b.worktreePath)?.worktreePath ?? null
+  );
 
   /** Collect session IDs from running project notes + activeSessionIds. */
   let runningNoteSessionIds = $derived.by(() => {


### PR DESCRIPTION
## Summary
- Integrate `createLiveSessionHints` into `ProjectSection` to poll for the latest agent message during running project sessions
- Display the live agent message as the subtitle (`secondaryMeta`) on project session timeline rows instead of a static "Generating note" label
- Fix missing `getRepoDir` parameter in the `createLiveSessionHints` call

## Test plan
- [ ] Start a project session and verify the timeline row subtitle updates with live agent messages
- [ ] Confirm subtitle falls back to "Generating note" when no hint is available
- [ ] Verify completed/failed notes still display correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)