### PR TITLE
feat(staged): expose base_branch param in add_project_repo MCP tool

### DIFF
--- a/apps/staged/src-tauri/src/project_mcp.rs
+++ b/apps/staged/src-tauri/src/project_mcp.rs
@@ -295,6 +295,10 @@ struct AddProjectRepoParams {
     /// the repo is and how it relates to the project — do not include todos or details
     /// about what needs to change.
     pub reason: Option<String>,
+    /// Base branch to branch off from (e.g. "main", "develop"). If omitted,
+    /// the repository's default branch is detected automatically via the
+    /// GitHub API.
+    pub base_branch: Option<String>,
 }
 
 #[derive(Clone)]
@@ -529,10 +533,11 @@ impl ProjectToolsHandler {
     )]
     async fn add_project_repo(&self, Parameters(p): Parameters<AddProjectRepoParams>) -> String {
         log::debug!(
-            "[project_mcp] add_project_repo called: github_repo={:?} branch_name={:?} subpath={:?}",
+            "[project_mcp] add_project_repo called: github_repo={:?} branch_name={:?} subpath={:?} base_branch={:?}",
             p.github_repo,
             p.branch_name,
             p.subpath,
+            p.base_branch,
         );
 
         // If no subpath was provided, check whether the repo is a monorepo.
@@ -577,7 +582,7 @@ impl ProjectToolsHandler {
             None,
             p.reason,
             None,
-            None, // MCP has no prefetched default branch
+            p.base_branch,
         )
         .await
         {


### PR DESCRIPTION
## Summary
- Adds an optional `base_branch` parameter to the `add_project_repo` MCP tool, allowing callers to specify which branch to branch off from (e.g. "main", "develop")
- When omitted, the repository's default branch is still detected automatically via the GitHub API
- Passes the new parameter through to the underlying repo-addition logic instead of hardcoding `None`

## Test plan
- [ ] Verify `add_project_repo` works without `base_branch` (auto-detection still functions)
- [ ] Verify `add_project_repo` with explicit `base_branch` uses the specified branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)