### PR TITLE
fix(staged): pre-compute hasUserAfter to fix O(N²) UI freeze in SessionModal

### DIFF
--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -881,6 +881,19 @@
     return groups;
   });
 
+  /** For each index in `grouped`, whether a user message exists at a later index.
+   *  Pre-computed in O(N) so the template can do an O(1) lookup instead of
+   *  scanning with `findIndex` per tool group (which was O(N²) total). */
+  let hasUserAfter = $derived.by(() => {
+    const arr = new Array<boolean>(grouped.length);
+    let seen = false;
+    for (let i = grouped.length - 1; i >= 0; i--) {
+      arr[i] = seen;
+      if (grouped[i].type === 'user') seen = true;
+    }
+    return arr;
+  });
+
   /** Stable key for a message group — used to key the {#each} block for transitions.
    *  For tools groups, keys off the first pair — safe because the grouping logic
    *  in `grouped` always pushes at least one pair before creating a tools group. */
@@ -1080,7 +1093,7 @@
                 </div>
               {:else}
                 <div class="message-row tool-group">
-                  {#each groupByVerb(group.pairs, repoDir, !isLive || sending || grouped.findIndex((g, i) => i > groupIdx && g.type === 'user') !== -1) as vg, vgIdx}
+                  {#each groupByVerb(group.pairs, repoDir, !isLive || sending || hasUserAfter[groupIdx]) as vg, vgIdx}
                     {#if vg.items.length === 1}
                       {@const item = vg.items[0]}
                       {@const isExpanded = expandedTools.has(item.pair.call.id)}


### PR DESCRIPTION
## Summary
- Activity Monitor sampling identified `Array.indexOf` as the top hotspot (121/2179 samples) in the Staged web app, causing UI freezes on long sessions.
- The root cause was an inline `grouped.findIndex(...)` call inside an `{#each grouped}` template loop in `SessionModal.svelte`, resulting in O(N²) scanning.
- Added a `$derived` boolean array (`hasUserAfter`) that pre-computes in O(N) via a single reverse pass whether a user message exists after each group index, reducing per-group lookup to O(1).

## Test plan
- [ ] Open a session modal with a long session (many tool calls / hundreds of messages) and verify it renders without freezing or noticeable lag.
- [ ] Verify tool call cards show **present tense** for live running tools (e.g. "Reading file...").
- [ ] Verify tool call cards show **past tense** for completed tools and for tools that appear before a user follow-up message (e.g. "Read file").
- [ ] Verify tense behavior is the same when `sending` is true (input submitted but not yet responded to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)