### PR TITLE
perf(diff-viewer): optimize buildFileEntries comment grouping

### DIFF
--- a/packages/diff-viewer/src/lib/utils/diffModalHelpers.ts
+++ b/packages/diff-viewer/src/lib/utils/diffModalHelpers.ts
@@ -34,6 +34,46 @@ export function fileStatus(summary: FileDiffSummary): 'added' | 'deleted' | 'mod
   return 'modified';
 }
 
+/** Aggregate comment count and distinct types for a single path. */
+interface CommentAgg {
+  count: number;
+  types: Set<CommentType>;
+}
+
+/** Extract the basename (last segment after '/') from a path. */
+function basename(path: string): string {
+  const idx = path.lastIndexOf('/');
+  return idx === -1 ? path : path.slice(idx + 1);
+}
+
+/**
+ * Pre-groups comments by their basename, then aggregates per unique comment
+ * path. This lets us avoid the O(files × comments) nested loop — each file
+ * only checks the (usually tiny) set of comment paths that share its basename.
+ */
+function groupCommentsByBasename(
+  comments: Comment[]
+): Map<string, Map<string, CommentAgg>> {
+  // basename → (commentPath → CommentAgg)
+  const groups = new Map<string, Map<string, CommentAgg>>();
+  for (const comment of comments) {
+    const base = basename(comment.path);
+    let byPath = groups.get(base);
+    if (!byPath) {
+      byPath = new Map();
+      groups.set(base, byPath);
+    }
+    let agg = byPath.get(comment.path);
+    if (!agg) {
+      agg = { count: 0, types: new Set() };
+      byPath.set(comment.path, agg);
+    }
+    agg.count++;
+    if (comment.commentType) agg.types.add(comment.commentType);
+  }
+  return groups;
+}
+
 export function buildFileEntries(
   files: FileDiffSummary[],
   reviewedPaths: string[],
@@ -41,17 +81,24 @@ export function buildFileEntries(
 ): FileEntry[] {
   const reviewedSet = new Set(reviewedPaths);
   const filePaths = files.map(fileSummaryPath);
+  const commentGroups = groupCommentsByBasename(comments);
 
   return files.map((summary, i) => {
     const path = filePaths[i];
     let commentCount = 0;
     const commentTypes = new Set<CommentType>();
-    for (const comment of comments) {
-      if (pathsMatch(comment.path, path)) {
-        commentCount++;
-        if (comment.commentType) commentTypes.add(comment.commentType);
+
+    // Only inspect comment paths that share this file's basename.
+    const candidates = commentGroups.get(basename(path));
+    if (candidates) {
+      for (const [commentPath, agg] of candidates) {
+        if (pathsMatch(commentPath, path)) {
+          commentCount += agg.count;
+          for (const t of agg.types) commentTypes.add(t);
+        }
       }
     }
+
     return {
       path,
       status: fileStatus(summary),


### PR DESCRIPTION
## Summary

- Eliminates O(files × comments) nested loop in `buildFileEntries` by pre-grouping comments into a `Map` keyed by basename (filename)
- Each file now only checks `pathsMatch` against the small set of comment paths sharing its basename, rather than scanning all comments
- With 200 files and 50 comments, this reduces `pathsMatch` calls from ~10,000 to a handful per derived state update

## Details

The `buildFileEntries` function is called from a `$derived` in `DiffModal.svelte`, so it re-runs on every state change (file review toggling, new comments, etc.). The previous implementation iterated all comments for every file. The new implementation:

1. Groups comments by basename into a `Map<basename, Map<commentPath, {count, types}>>` in a single O(comments) pass
2. For each file, looks up candidates by basename (O(1)) and only runs `pathsMatch` against that small group
3. Preserves the existing `pathsMatch` suffix-matching semantics exactly

## Test plan

- [x] All existing `pathsMatch` tests pass (10/10)
- [x] All staged app tests pass (28/28)
- [x] `svelte-check` passes with 0 errors, 0 warnings
- [ ] Open a diff modal with a PR that has many files and many comments; verify comment counts still show correctly on the file tree sidebar
- [ ] Toggle file review status and add comments; verify the diff modal remains responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)