### PR TITLE
feat(staged): render hashtag badges in timeline rows and fix badge overflow

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -19,6 +19,7 @@
   import type {
     Branch,
     BranchTimeline as BranchTimelineData,
+    HashtagItem,
     ProjectRepo,
     SessionStatusPayload,
   } from '../../types';
@@ -39,6 +40,7 @@
   import RemoteWorkspaceStatusBadge from './RemoteWorkspaceStatusBadge.svelte';
   import RemoteWorkspaceStatusView from './RemoteWorkspaceStatusView.svelte';
   import { alerts } from '../../shared/alerts.svelte';
+  import { buildBranchHashtagItems } from '../sessions/hashtagItems';
 
   interface Props {
     branch: Branch;
@@ -98,6 +100,20 @@
     warnings: number;
   };
   let timelineReviewDetailsById = $state<Record<string, TimelineReviewDetails>>({});
+
+  // Hashtag items for rendering #type:id badges in timeline titles
+  let hashtagItems = $state<HashtagItem[]>([]);
+  $effect(() => {
+    const branchId = branch.id;
+    const projectId = branch.projectId;
+    let stale = false;
+    buildBranchHashtagItems(branchId, projectId).then((items) => {
+      if (!stale) hashtagItems = items;
+    });
+    return () => {
+      stale = true;
+    };
+  });
   let reviewDetailsLoadVersion = 0;
   let reviewDiffTarget = $state<{
     commitSha: string;
@@ -969,6 +985,7 @@
         <BranchTimeline
           timeline={timeline ?? emptyTimeline}
           repoDir={branch.worktreePath}
+          {hashtagItems}
           pendingDropNotes={isLocal ? pendingDropNotes : undefined}
           pendingItems={sessionMgr.pendingSessionItems}
           {prunedSessionIds}

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -61,9 +61,7 @@
   import HashtagInput from './HashtagInput.svelte';
   import {
     buildBranchHashtagItems,
-    HASHTAG_TOKEN_RE,
-    hashtagTypeLabels,
-    hashtagTypeColors,
+    renderHashtagTokens as renderHashtagTokensShared,
   } from './hashtagItems';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
   import { subscribeDragDrop } from '../branches/dragDrop';
@@ -604,71 +602,18 @@
     return sanitize(marked.parse(content) as string);
   }
 
-  function escapeHtml(text: string): string {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
-  }
-
-  /** Replace #type:id tokens in plain text with inline badge HTML.
-   *  Regex-matches on raw text first, then escapes non-token segments individually
-   *  so that IDs containing HTML-special characters are looked up correctly.
-   *  Results are memoized per text string; the cache is invalidated when
-   *  hashtagItems changes (tracked via prevHashtagItems). */
+  /** Memoized wrapper around the shared renderHashtagTokens. */
   const hashtagTokenCache = new Map<string, string>();
   let prevHashtagItems: HashtagItem[] | null = null;
 
   function renderHashtagTokens(text: string, items: HashtagItem[]): string {
-    // Invalidate cache when the hashtag items array identity changes
     if (items !== prevHashtagItems) {
       hashtagTokenCache.clear();
       prevHashtagItems = items;
     }
-
     const cached = hashtagTokenCache.get(text);
     if (cached !== undefined) return cached;
-
-    const itemsByKey = new Map<string, HashtagItem>();
-    for (const item of items) {
-      itemsByKey.set(`${item.type}:${item.id}`, item);
-    }
-
-    const regex = new RegExp(HASHTAG_TOKEN_RE.source, 'g');
-    const parts: string[] = [];
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = regex.exec(text)) !== null) {
-      // Escape the plain-text segment before this token
-      if (match.index > lastIndex) {
-        parts.push(escapeHtml(text.slice(lastIndex, match.index)));
-      }
-
-      const type = match[1];
-      const id = match[2];
-      const label = hashtagTypeLabels[type] ?? type;
-      const colors = hashtagTypeColors[type] ?? { color: '--text-muted', bg: '--bg-secondary' };
-      const item = itemsByKey.get(`${type}:${id}`);
-      const title = item
-        ? item.title
-        : type === 'commit' && id.length > 12
-          ? id.slice(0, 8) + '…'
-          : id;
-      parts.push(
-        `<span class="hashtag-badge" style="background: var(${colors.bg}); color: var(${colors.color});">${escapeHtml(label)}: ${escapeHtml(title)}</span>`
-      );
-
-      lastIndex = match.index + match[0].length;
-    }
-
-    // Escape any trailing plain text
-    if (lastIndex < text.length) {
-      parts.push(escapeHtml(text.slice(lastIndex)));
-    }
-
-    const result = parts.join('');
+    const result = renderHashtagTokensShared(text, items);
     hashtagTokenCache.set(text, result);
     return result;
   }
@@ -1605,6 +1550,7 @@
     color: var(--text-primary);
     line-height: 1.5;
     word-break: break-word;
+    overflow: hidden;
   }
 
   .human-text {

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -127,3 +127,64 @@ function projectNotesToHashtagItems(notes: ProjectNote[]): HashtagItem[] {
       bgColor: '--note-bg',
     }));
 }
+
+// ── Shared rendering ─────────────────────────────────────────────────
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Returns true when `text` contains at least one `#type:id` hashtag token. */
+export function hasHashtagTokens(text: string): boolean {
+  const re = new RegExp(HASHTAG_TOKEN_RE.source);
+  return re.test(text);
+}
+
+/**
+ * Replace `#type:id` tokens in plain text with inline badge HTML.
+ * Plain-text segments are HTML-escaped; badge spans use CSS custom-property
+ * colours from `hashtagTypeColors`.
+ */
+export function renderHashtagTokens(text: string, items: HashtagItem[]): string {
+  const itemsByKey = new Map<string, HashtagItem>();
+  for (const item of items) {
+    itemsByKey.set(`${item.type}:${item.id}`, item);
+  }
+
+  const regex = new RegExp(HASHTAG_TOKEN_RE.source, 'g');
+  const parts: string[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(escapeHtml(text.slice(lastIndex, match.index)));
+    }
+
+    const type = match[1];
+    const id = match[2];
+    const label = hashtagTypeLabels[type] ?? type;
+    const colors = hashtagTypeColors[type] ?? { color: '--text-muted', bg: '--bg-secondary' };
+    const item = itemsByKey.get(`${type}:${id}`);
+    const title = item
+      ? item.title
+      : type === 'commit' && id.length > 12
+        ? id.slice(0, 8) + '…'
+        : id;
+    parts.push(
+      `<span class="hashtag-badge" style="background: var(${colors.bg}); color: var(${colors.color});">${escapeHtml(label)}: ${escapeHtml(title)}</span>`
+    );
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(escapeHtml(text.slice(lastIndex)));
+  }
+
+  return parts.join('');
+}

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -10,9 +10,10 @@
   import type { Snippet } from 'svelte';
   import { slide } from 'svelte/transition';
   import { FileText, GitCommitVertical, FileSearch } from 'lucide-svelte';
-  import type { BranchTimeline as BranchTimelineData } from '../../types';
+  import type { BranchTimeline as BranchTimelineData, HashtagItem } from '../../types';
   import TimelineRow from './TimelineRow.svelte';
   import type { TimelineItemType, TimelineBadge } from './TimelineRow.svelte';
+  import { hasHashtagTokens, renderHashtagTokens } from '../sessions/hashtagItems';
   import {
     formatRelativeTime,
     formatRelativeTimeSeconds,
@@ -81,6 +82,8 @@
     provisioningLabel?: string;
     /** Optional detail text for the provisioning row (e.g. git progress). */
     provisioningDetail?: string | null;
+    /** Hashtag items for rendering #type:id badges in timeline titles. */
+    hashtagItems?: HashtagItem[];
     footerActions?: Snippet;
   }
 
@@ -111,6 +114,7 @@
     error,
     onRetry,
     provisioningLabel,
+    hashtagItems = [],
     provisioningDetail,
     footerActions,
   }: Props = $props();
@@ -175,6 +179,8 @@
     key: string;
     type: TimelineItemType;
     title: string;
+    /** Pre-rendered HTML title with hashtag badges (set when title contains tokens). */
+    titleHtml?: string;
     meta?: string;
     secondaryMeta?: string;
     deleting?: boolean;
@@ -415,6 +421,15 @@
       });
     }
 
+    // Render hashtag badges in titles that contain #type:id tokens
+    if (hashtagItems.length > 0) {
+      for (const item of all) {
+        if (hasHashtagTokens(item.title)) {
+          item.titleHtml = renderHashtagTokens(item.title, hashtagItems);
+        }
+      }
+    }
+
     // Sort by timestamp ascending; pending/generating items at bottom, queued after those
     all.sort((a, b) => {
       const isProvisioning = (item: DisplayItem) => item.type === 'provisioning';
@@ -518,6 +533,7 @@
         <TimelineRow
           type={item.type}
           title={item.title}
+          titleHtml={item.titleHtml}
           meta={item.meta}
           secondaryMeta={item.secondaryMeta}
           badges={item.badges}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -43,6 +43,8 @@
   interface Props {
     type: TimelineItemType;
     title: string;
+    /** Pre-rendered HTML title with hashtag badges. When set, takes precedence over `title`. */
+    titleHtml?: string;
     meta?: string;
     secondaryMeta?: string;
     badges?: TimelineBadge[];
@@ -61,6 +63,7 @@
   let {
     type,
     title,
+    titleHtml,
     meta,
     secondaryMeta,
     badges,
@@ -182,9 +185,15 @@
   </div>
   <div class="timeline-content">
     <div class="timeline-info">
-      <span class="timeline-title" class:skeleton-title={isPending} class:failed-title={isFailed}
-        >{title}</span
-      >
+      {#if titleHtml}
+        <span class="timeline-title" class:skeleton-title={isPending} class:failed-title={isFailed}
+          >{@html titleHtml}</span
+        >
+      {:else}
+        <span class="timeline-title" class:skeleton-title={isPending} class:failed-title={isFailed}
+          >{title}</span
+        >
+      {/if}
       {#if meta || secondaryMeta || (badges && badges.length > 0)}
         <div class="timeline-meta">
           {#if meta}
@@ -391,6 +400,15 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     line-height: 1.4;
+  }
+
+  .timeline-title :global(.hashtag-badge) {
+    display: inline;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 500;
+    white-space: nowrap;
   }
 
   .skeleton-title {


### PR DESCRIPTION
## Summary
- Extract shared `renderHashtagTokens` and `hasHashtagTokens` helpers from `SessionModal` into `hashtagItems.ts` so they can be reused across components
- Render `#type:id` hashtag badges inline in `BranchTimeline` / `TimelineRow` titles via pre-rendered HTML (`titleHtml` prop)
- Fix badge overflow in `SessionModal` by adding `overflow: hidden` to the message text container
- Add `.hashtag-badge` styles scoped to `.timeline-title` for consistent badge appearance

## Test plan
- [ ] Verify hashtag badges render correctly in timeline rows for sessions with `#type:id` tokens in titles
- [ ] Verify badges in SessionModal still render correctly after the refactor
- [ ] Confirm no badge overflow/clipping issues in either timeline or modal views
- [ ] Check that timeline rows without hashtag tokens render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)