### PR TITLE
fix(staged): simplify log prefilled text

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -302,7 +302,7 @@
     }
     if (latest.kind === 'note' && latest.title.toLowerCase().endsWith(' log')) {
       return {
-        commit: 'Read the latest note which contains logs. Look for any issues.',
+        commit: 'Read the referenced note which contains logs. Look for any issues.',
         note: '',
         commitRef: `Re: #note:${latest.id}`,
         noteRef: '',

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -302,7 +302,7 @@
     }
     if (latest.kind === 'note' && latest.title.toLowerCase().endsWith(' log')) {
       return {
-        commit: 'Read the referenced note which contains logs. Look for any issues.',
+        commit: 'Look for any issues.',
         note: '',
         commitRef: `Re: #note:${latest.id}`,
         noteRef: '',


### PR DESCRIPTION
## Summary
- Simplifies the prefilled commit text when a log note is detected, changing it from "Read the latest note which contains logs. Look for any issues." to just "Look for any issues."

## Test plan
- [ ] Verify that when a branch's latest action is a note ending in "log", the prefilled commit text shows "Look for any issues."

🤖 Generated with [Claude Code](https://claude.com/claude-code)