### PR TITLE
fix: prevent keyboard shortcuts from capturing input in diff commit textbox

### DIFF
--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -447,7 +447,11 @@
     }
     // Hold A to reveal AI annotations
     if (event.key === 'a' || event.key === 'A') {
-      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement)
+      if (
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement ||
+        (event.target instanceof HTMLElement && event.target.isContentEditable)
+      )
         return;
       if (!event.repeat) {
         annotationsRevealed = true;
@@ -457,7 +461,11 @@
 
   function handleKeyup(event: KeyboardEvent) {
     if (event.key === 'a' || event.key === 'A') {
-      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement)
+      if (
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement ||
+        (event.target instanceof HTMLElement && event.target.isContentEditable)
+      )
         return;
       annotationsRevealed = false;
     }

--- a/packages/diff-viewer/src/lib/utils/diffKeyboard.ts
+++ b/packages/diff-viewer/src/lib/utils/diffKeyboard.ts
@@ -161,7 +161,8 @@ export function setupDiffKeyboardNav(config: Partial<DiffNavConfig> = {}): () =>
 
   function handleKeydown(event: KeyboardEvent): void {
     const target = event.target as HTMLElement;
-    const inInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA';
+    const inInput =
+      target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 
     const key = event.key.toLowerCase();
     const ctrl = event.ctrlKey;


### PR DESCRIPTION
## Summary
- Add `isContentEditable` check to keyboard event handlers in `DiffModal.svelte` and `diffKeyboard.ts` so that typing in the contentEditable commit textbox is not intercepted by diff navigation shortcuts (e.g., 'a' for AI annotations, arrow keys for navigation)

## Test plan
- [ ] Open the diff modal and verify the commit textbox is typeable (all characters including 'a')
- [ ] Verify AI annotation reveal (hold 'a') still works when focus is outside the textbox
- [ ] Verify diff keyboard navigation still works when not focused on an input

🤖 Generated with [Claude Code](https://claude.com/claude-code)