### PR TITLE
fix(staged): strip ANSI escape codes before regex matching in run detection

### DIFF
--- a/apps/staged/src-tauri/Cargo.lock
+++ b/apps/staged/src-tauri/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "strip-ansi-escapes",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -4984,6 +4985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6196,6 +6206,15 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/apps/staged/src-tauri/Cargo.toml
+++ b/apps/staged/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ acp-client = { path = "../../../crates/acp-client" }
 blox-cli = { path = "../../../crates/blox-cli" }
 
 regex = "1"
+strip-ansi-escapes = "0.2"
 async-trait = "0.1"
 tokio-util = { version = "0.7", features = ["compat"] }
 tauri-plugin-store = "2.4.2"

--- a/apps/staged/src-tauri/src/actions/run_detector.rs
+++ b/apps/staged/src-tauri/src/actions/run_detector.rs
@@ -49,10 +49,6 @@ pub fn spawn_regex_matcher(
     has_endpoint_capture: bool,
     mut cancel_rx: watch::Receiver<bool>,
 ) {
-    log::info!(
-        "regex_matcher: started for execution_id={execution_id}, action={action_name}, pattern={pattern:?}"
-    );
-
     tokio::spawn(async move {
         // Compile the regex — if it fails, transition straight to NoDetection.
         let re = match Regex::new(&pattern) {
@@ -202,14 +198,10 @@ pub fn spawn_autodetect_poller(
     working_dir: PathBuf,
     mut cancel_rx: watch::Receiver<bool>,
 ) {
-    log::info!(
-        "autodetect_poller: started for execution_id={execution_id}, action={action_name}, command={command:?}"
-    );
-
     tokio::spawn(async move {
         let schedule = build_poll_schedule();
 
-        for (poll_index, wait_secs) in schedule.iter().enumerate() {
+        for wait_secs in &schedule {
             // ---- Wait the scheduled interval, or bail on cancel ----
             tokio::select! {
                 _ = time::sleep(Duration::from_secs(*wait_secs)) => {}
@@ -237,11 +229,6 @@ pub fn spawn_autodetect_poller(
             // Strip ANSI codes before sending to AI and before regex matching.
             let clean_lines: Vec<String> = tail.iter().map(|s| strip_ansi_codes(s)).collect();
             let output = clean_lines.join("\n");
-
-            log::info!(
-                "autodetect_poller: poll {poll_index} for {execution_id}, sending {line_count} lines to AI",
-                line_count = tail.len(),
-            );
 
             // ---- Build and send the AI prompt ----
             let prompt = format!(
@@ -314,13 +301,6 @@ If still building, set regex and has_endpoint_capture to null/false."#,
                 }
             };
 
-            log::info!(
-                "autodetect_poller: AI response for {execution_id}: status={status}, regex={regex:?}, has_endpoint_capture={has_endpoint}",
-                status = parsed.status,
-                regex = parsed.regex,
-                has_endpoint = parsed.has_endpoint_capture,
-            );
-
             // ---- Handle "building" status ----
             if parsed.status != "running" {
                 log::info!(
@@ -355,15 +335,8 @@ If still building, set regex and has_endpoint_capture to null/false."#,
             // output (using the already-stripped lines).
             let matched_line = clean_lines.iter().find(|line| re.is_match(line));
             if matched_line.is_none() {
-                let sample: Vec<_> = clean_lines
-                    .iter()
-                    .filter(|l| l.to_lowercase().contains("local"))
-                    .take(5)
-                    .map(|l| format!("{:?}", l))
-                    .collect();
                 log::warn!(
-                    "autodetect_poller: AI regex does not match any output line for {execution_id}, \
-                     pattern={pattern:?}, sample lines containing 'local': {sample:?}"
+                    "autodetect_poller: AI regex does not match any output line for {execution_id}"
                 );
                 continue;
             }

--- a/apps/staged/src-tauri/src/actions/run_detector.rs
+++ b/apps/staged/src-tauri/src/actions/run_detector.rs
@@ -237,11 +237,22 @@ Recent terminal output (last ~200 lines):
 
 Analyze this output and determine:
 1. Is the application still building/compiling, or has it reached a running/ready state?
-2. If running: identify the specific output that indicates readiness (e.g.,
-   "Listening on http://0.0.0.0:3000", "Server started on port 8080", "ready in 300ms", "Local: http://localhost:1234/").
-3. Provide a regex pattern that would match for this and future runs. Be careful to avoid volatile values like timestamps, PIDs, version numbers or build durations.
-   - If the line contains a URL/endpoint, include a named capture group `(?P<endpoint>...)` for it.
-   - The regex should be general enough to work across restarts
+2. If running: identify the specific output line from the server or build tool that
+   indicates readiness (e.g., "Listening on http://0.0.0.0:3000", "Server started
+   on port 8080", "ready in 300ms", "Local: http://localhost:1234/").
+   - IMPORTANT: Pick the server/framework readiness message, NOT application-level
+     log output. For example, Vite prints "Local: http://localhost:PORT/" when ready —
+     use that, not subsequent browser console logs or webview messages that happen
+     to contain URLs.
+   - Prefer the EARLIEST line that indicates the service is up and accepting
+     connections.
+3. Provide a regex pattern that would match this readiness line in future runs.
+   Be careful to avoid volatile values like timestamps, PIDs, version numbers,
+   or build durations.
+   - If the readiness line contains a URL/endpoint, include a named capture group
+     `(?P<endpoint>...)` for it.
+   - The regex should be general enough to work across restarts but specific enough
+     to avoid matching unrelated log lines that happen to contain URLs.
 
 Respond ONLY with JSON, no other text:
 {{

--- a/apps/staged/src-tauri/src/actions/run_detector.rs
+++ b/apps/staged/src-tauri/src/actions/run_detector.rs
@@ -347,8 +347,17 @@ If still building, set regex and has_endpoint_capture to null/false."#,
             // Validate that the regex matches at least one line in the current output.
             let matched_line = lines.iter().find(|line| re.is_match(line));
             if matched_line.is_none() {
+                // Log sample lines (escaped) so we can see ANSI codes or other
+                // hidden characters that prevent the regex from matching.
+                let sample: Vec<_> = lines
+                    .iter()
+                    .filter(|l| l.to_lowercase().contains("local"))
+                    .take(5)
+                    .map(|l| format!("{:?}", l))
+                    .collect();
                 log::warn!(
-                    "autodetect_poller: AI regex does not match any output line for {execution_id}"
+                    "autodetect_poller: AI regex does not match any output line for {execution_id}, \
+                     pattern={pattern:?}, sample lines containing 'local': {sample:?}"
                 );
                 continue;
             }

--- a/apps/staged/src-tauri/src/actions/run_detector.rs
+++ b/apps/staged/src-tauri/src/actions/run_detector.rs
@@ -42,6 +42,10 @@ pub fn spawn_regex_matcher(
     has_endpoint_capture: bool,
     mut cancel_rx: watch::Receiver<bool>,
 ) {
+    log::info!(
+        "regex_matcher: started for execution_id={execution_id}, action={action_name}, pattern={pattern:?}"
+    );
+
     tokio::spawn(async move {
         // Compile the regex — if it fails, transition straight to NoDetection.
         let re = match Regex::new(&pattern) {
@@ -190,10 +194,14 @@ pub fn spawn_autodetect_poller(
     working_dir: PathBuf,
     mut cancel_rx: watch::Receiver<bool>,
 ) {
+    log::info!(
+        "autodetect_poller: started for execution_id={execution_id}, action={action_name}, command={command:?}"
+    );
+
     tokio::spawn(async move {
         let schedule = build_poll_schedule();
 
-        for wait_secs in &schedule {
+        for (poll_index, wait_secs) in schedule.iter().enumerate() {
             // ---- Wait the scheduled interval, or bail on cancel ----
             tokio::select! {
                 _ = time::sleep(Duration::from_secs(*wait_secs)) => {}
@@ -222,6 +230,11 @@ pub fn spawn_autodetect_poller(
                 .map(|s| s.as_str())
                 .collect::<Vec<_>>()
                 .join("\n");
+
+            log::info!(
+                "autodetect_poller: poll {poll_index} for {execution_id}, sending {line_count} lines to AI",
+                line_count = tail.len(),
+            );
 
             // ---- Build and send the AI prompt ----
             let prompt = format!(
@@ -293,6 +306,13 @@ If still building, set regex and has_endpoint_capture to null/false."#,
                     continue;
                 }
             };
+
+            log::info!(
+                "autodetect_poller: AI response for {execution_id}: status={status}, regex={regex:?}, has_endpoint_capture={has_endpoint}",
+                status = parsed.status,
+                regex = parsed.regex,
+                has_endpoint = parsed.has_endpoint_capture,
+            );
 
             // ---- Handle "building" status ----
             if parsed.status != "running" {

--- a/apps/staged/src-tauri/src/actions/run_detector.rs
+++ b/apps/staged/src-tauri/src/actions/run_detector.rs
@@ -23,6 +23,13 @@ use super::registry::{ActionRegistry, RunPhase};
 
 use crate::store::Store;
 
+/// Strip ANSI escape sequences so regexes written against plain text can match
+/// terminal output that includes colour/style codes.
+fn strip_ansi_codes(s: &str) -> String {
+    let stripped = strip_ansi_escapes::strip(s);
+    String::from_utf8_lossy(&stripped).into_owned()
+}
+
 /// Spawns a background task that polls the shared output buffer every 2 seconds,
 /// applies the given regex against new lines, and transitions `RunPhase` to
 /// `Running` when the pattern matches.
@@ -106,9 +113,10 @@ pub fn spawn_regex_matcher(
                 lines
             };
 
-            // Apply regex to each new line.
+            // Apply regex to each new line (strip ANSI codes before matching).
             for line in &new_lines {
-                if let Some(caps) = re.captures(line) {
+                let clean = strip_ansi_codes(line);
+                if let Some(caps) = re.captures(&clean) {
                     let endpoint = if has_endpoint_capture {
                         caps.name("endpoint").map(|m| m.as_str().to_string())
                     } else {
@@ -225,11 +233,10 @@ pub fn spawn_autodetect_poller(
             if tail.is_empty() {
                 continue;
             }
-            let output = tail
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<_>>()
-                .join("\n");
+
+            // Strip ANSI codes before sending to AI and before regex matching.
+            let clean_lines: Vec<String> = tail.iter().map(|s| strip_ansi_codes(s)).collect();
+            let output = clean_lines.join("\n");
 
             log::info!(
                 "autodetect_poller: poll {poll_index} for {execution_id}, sending {line_count} lines to AI",
@@ -344,12 +351,11 @@ If still building, set regex and has_endpoint_capture to null/false."#,
                 }
             };
 
-            // Validate that the regex matches at least one line in the current output.
-            let matched_line = lines.iter().find(|line| re.is_match(line));
+            // Validate that the regex matches at least one line in the current
+            // output (using the already-stripped lines).
+            let matched_line = clean_lines.iter().find(|line| re.is_match(line));
             if matched_line.is_none() {
-                // Log sample lines (escaped) so we can see ANSI codes or other
-                // hidden characters that prevent the regex from matching.
-                let sample: Vec<_> = lines
+                let sample: Vec<_> = clean_lines
                     .iter()
                     .filter(|l| l.to_lowercase().contains("local"))
                     .take(5)

--- a/apps/staged/src-tauri/src/actions/run_detector.rs
+++ b/apps/staged/src-tauri/src/actions/run_detector.rs
@@ -254,6 +254,8 @@ Analyze this output and determine:
    - Prefer the EARLIEST line that indicates the service is up and accepting
      connections.
 3. Provide a regex pattern that would match this readiness line in future runs.
+   The regex is tested against each output line individually (single-line matching),
+   so it must match within a single line.
    Be careful to avoid volatile values like timestamps, PIDs, version numbers,
    or build durations.
    - If the readiness line contains a URL/endpoint, include a named capture group


### PR DESCRIPTION
## Summary
- Strip ANSI escape codes from terminal output before applying regex matching in the run detector, fixing cases where color/style codes prevented readiness patterns from matching
- Improve the autodetect AI prompt to prefer server/framework readiness messages (e.g., Vite's "Local: http://localhost:PORT/") over application-level log output
- Add `strip-ansi-escapes` crate dependency

## Test plan
- [ ] Verify run detection works for apps that emit colored terminal output (e.g., Vite, Next.js)
- [ ] Confirm autodetect correctly identifies server readiness lines over application log lines
- [ ] Check that regex matching still works for apps with plain (non-ANSI) output

🤖 Generated with [Claude Code](https://claude.com/claude-code)