### PR TITLE
fix(staged): improve badge validation UX and show unique name conflicts

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -983,6 +983,26 @@ fn update_repo_badge(
         return Err("Hue must be between 0 and 360".into());
     }
     let store = get_store(&store)?;
+
+    // Check if another badge already uses this short name.
+    if let Some(existing) = store
+        .get_repo_badge_by_short_name(&short_name)
+        .map_err(|e| e.to_string())?
+    {
+        let is_same_badge = existing.github_repo == github_repo && existing.subpath == subpath;
+        if !is_same_badge {
+            let owner = if existing.subpath.is_empty() {
+                existing.github_repo.clone()
+            } else {
+                format!("{} ({})", existing.github_repo, existing.subpath)
+            };
+            return Err(format!(
+                "Short name '{}' is already used by {}",
+                short_name, owner
+            ));
+        }
+    }
+
     store
         .update_repo_badge(&github_repo, &subpath, &short_name, hue)
         .map_err(|e| e.to_string())?;

--- a/apps/staged/src-tauri/src/store/repo_badges.rs
+++ b/apps/staged/src-tauri/src/store/repo_badges.rs
@@ -93,6 +93,32 @@ impl Store {
         Ok(())
     }
 
+    /// Look up a single badge by its short_name.
+    pub fn get_repo_badge_by_short_name(
+        &self,
+        short_name: &str,
+    ) -> Result<Option<RepoBadge>, StoreError> {
+        use rusqlite::OptionalExtension;
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT github_repo, subpath, short_name, hue, created_at
+             FROM repo_badges
+             WHERE short_name = ?1",
+            params![short_name],
+            |row| {
+                Ok(RepoBadge {
+                    github_repo: row.get(0)?,
+                    subpath: row.get(1)?,
+                    short_name: row.get(2)?,
+                    hue: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
     /// Delete a badge by (github_repo, subpath).
     pub fn delete_repo_badge(&self, github_repo: &str, subpath: &str) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -24,7 +24,7 @@
   import * as commands from '../../api/commands';
   import { detectRepoActions, type ActionType } from '../actions/actions';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
-  import { matchesRepoContextSearch } from './repoContextSearch';
+  import { matchesRepoSearch } from './repoContextSearch';
   import { alerts } from '../../shared/alerts.svelte';
 
   type RepoAttachment = {
@@ -34,8 +34,16 @@
     branchName: string;
   };
 
+  /** A repo entry from either an action context, a badge, or both. */
+  type RepoEntry = {
+    key: string;
+    githubRepo: string;
+    subpath: string;
+    context: ActionContext | null;
+  };
+
   let contexts = $state<ActionContext[]>([]);
-  let selectedContextId = $state<string | null>(null);
+  let selectedRepoKey = $state<string | null>(null);
   let loadingContexts = $state(false);
   let loadingRepoAttachments = $state(false);
   let repoAttachmentsByContext = $state<Record<string, RepoAttachment[]>>({});
@@ -58,13 +66,14 @@
   let badgeEditName = $state('');
   let badgeEditHue = $state(0);
 
-  let selectedContext = $derived(contexts.find((c) => c.id === selectedContextId) ?? null);
+  let selectedEntry = $derived(mergedEntries.find((e) => e.key === selectedRepoKey) ?? null);
+  let selectedContext = $derived(selectedEntry?.context ?? null);
   let selectedContextAttachments = $derived(
     selectedContext ? (repoAttachmentsByContext[selectedContext.id] ?? []) : []
   );
   let selectedBadge = $derived(
-    selectedContext
-      ? repoBadgeStore.lookup(selectedContext.githubRepo, selectedContext.subpath)
+    selectedEntry
+      ? repoBadgeStore.lookup(selectedEntry.githubRepo, selectedEntry.subpath)
       : undefined
   );
 
@@ -82,9 +91,9 @@
   }
 
   $effect(() => {
-    // Only re-run when the selected context changes, not when badge values
+    // Only re-run when the selected entry changes, not when badge values
     // update in the store (which would clobber in-progress edits after save).
-    void selectedContextId;
+    void selectedRepoKey;
     untrack(() => {
       const badge = selectedBadge;
       if (badge) {
@@ -95,11 +104,11 @@
   });
 
   async function saveBadge() {
-    if (!selectedContext || !badgeEditName.trim()) return;
+    if (!selectedEntry || !badgeEditName.trim()) return;
     try {
       await repoBadgeStore.update(
-        selectedContext.githubRepo,
-        selectedContext.subpath,
+        selectedEntry.githubRepo,
+        selectedEntry.subpath,
         badgeEditName.trim(),
         badgeEditHue
       );
@@ -115,17 +124,42 @@
     }
   }
 
-  function contextKey(githubRepo: string, subpath: string | null | undefined): string {
+  function repoKey(githubRepo: string, subpath: string | null | undefined): string {
     return `${githubRepo}::${subpath ?? ''}`;
   }
 
-  function contextDisplay(context: ActionContext): string {
-    return context.subpath ? `${context.githubRepo}/${context.subpath}` : context.githubRepo;
+  function repoDisplay(githubRepo: string, subpath: string | null | undefined): string {
+    return subpath ? `${githubRepo}/${subpath}` : githubRepo;
   }
 
   function formatProjectCount(count: number): string {
     return `${count} project${count === 1 ? '' : 's'}`;
   }
+
+  /** Merge action contexts and orphan badges into a single list. */
+  let mergedEntries = $derived.by<RepoEntry[]>(() => {
+    const entries: RepoEntry[] = contexts.map((c) => ({
+      key: repoKey(c.githubRepo, c.subpath),
+      githubRepo: c.githubRepo,
+      subpath: c.subpath ?? '',
+      context: c,
+    }));
+
+    const contextKeys = new Set(entries.map((e) => e.key));
+    for (const badge of repoBadgeStore.all()) {
+      const k = repoKey(badge.githubRepo, badge.subpath);
+      if (!contextKeys.has(k)) {
+        entries.push({
+          key: k,
+          githubRepo: badge.githubRepo,
+          subpath: badge.subpath,
+          context: null,
+        });
+      }
+    }
+
+    return entries;
+  });
 
   async function loadRepoAttachments(actionContexts: ActionContext[]) {
     const generation = ++repoAttachmentLoadGeneration;
@@ -142,10 +176,7 @@
       }
 
       const contextIdByRepo = new Map(
-        actionContexts.map((context) => [
-          contextKey(context.githubRepo, context.subpath),
-          context.id,
-        ])
+        actionContexts.map((context) => [repoKey(context.githubRepo, context.subpath), context.id])
       );
       const projects = await commands.listProjects();
       const reposByProject = await Promise.all(
@@ -157,7 +188,7 @@
 
       for (const { project, repos } of reposByProject) {
         for (const repo of repos) {
-          const contextId = contextIdByRepo.get(contextKey(repo.githubRepo, repo.subpath));
+          const contextId = contextIdByRepo.get(repoKey(repo.githubRepo, repo.subpath));
           if (!contextId) continue;
           byContext[contextId] = [
             ...byContext[contextId],
@@ -192,10 +223,10 @@
       const nextContexts = await commands.listActionContexts();
       contexts = nextContexts;
       await loadRepoAttachments(nextContexts);
-      if (!selectedContextId && contexts.length > 0) {
-        selectedContextId = contexts[0].id;
-      } else if (selectedContextId && !contexts.some((c) => c.id === selectedContextId)) {
-        selectedContextId = contexts.length > 0 ? contexts[0].id : null;
+      if (!selectedRepoKey && mergedEntries.length > 0) {
+        selectedRepoKey = mergedEntries[0].key;
+      } else if (selectedRepoKey && !mergedEntries.some((e) => e.key === selectedRepoKey)) {
+        selectedRepoKey = mergedEntries.length > 0 ? mergedEntries[0].key : null;
       }
       await loadActions();
     } catch (e) {
@@ -225,7 +256,7 @@
   }
 
   $effect(() => {
-    selectedContextId;
+    selectedRepoKey;
     loadActions();
   });
 
@@ -235,7 +266,7 @@
     // Capture context before the async gap so that switching repo contexts
     // while detection is in-flight doesn't cause actions to be saved to
     // the wrong context.
-    const contextId = selectedContextId;
+    const entryKey = selectedRepoKey;
     const githubRepo = selectedContext.githubRepo;
     const subpath = selectedContext.subpath ?? undefined;
 
@@ -261,7 +292,7 @@
           nextSortOrder++,
           suggestion.autoCommit
         );
-        if (selectedContextId === contextId) {
+        if (selectedRepoKey === entryKey) {
           actions = [...actions, newAction];
         }
         actionsAdded = true;
@@ -305,7 +336,7 @@
     // if the user switches repo contexts while the save is in-flight.
     const githubRepo = selectedContext.githubRepo;
     const subpath = selectedContext.subpath ?? undefined;
-    const contextId = selectedContextId;
+    const entryKey = selectedRepoKey;
 
     try {
       if (!editingAction?.id) {
@@ -319,7 +350,7 @@
           nextSortOrder,
           editForm.autoCommit
         );
-        if (selectedContextId === contextId) {
+        if (selectedRepoKey === entryKey) {
           actions = [...actions, newAction];
         }
       } else {
@@ -365,14 +396,14 @@
   async function deleteAllActions() {
     if (!selectedContext) return;
 
-    // Capture the context id before the await so a concurrent context
+    // Capture the entry key before the await so a concurrent context
     // switch doesn't clear the wrong context's actions from the UI.
-    const contextId = selectedContextId;
+    const entryKey = selectedRepoKey;
     const repoContextId = selectedContext.id;
 
     try {
       await commands.deleteAllRepoActions(repoContextId);
-      if (selectedContextId === contextId) {
+      if (selectedRepoKey === entryKey) {
         actions = [];
       }
       showDeleteAllConfirm = false;
@@ -383,21 +414,27 @@
   }
 
   async function deleteRepo() {
-    if (!selectedContext) return;
+    if (!selectedEntry) return;
 
-    const contextId = selectedContext.id;
-    const attachments = [...(repoAttachmentsByContext[contextId] ?? [])];
+    const entry = selectedEntry;
+    const entryKey = entry.key;
 
     deletingRepo = true;
     try {
-      for (const attachment of attachments) {
-        await commands.removeProjectRepo(attachment.projectId, attachment.projectRepoId);
+      if (entry.context) {
+        const contextId = entry.context.id;
+        const attachments = [...(repoAttachmentsByContext[contextId] ?? [])];
+
+        for (const attachment of attachments) {
+          await commands.removeProjectRepo(attachment.projectId, attachment.projectRepoId);
+        }
+
+        await commands.deleteActionContext(contextId);
       }
 
-      await commands.deleteActionContext(contextId);
-      await commands.deleteRepoBadge(selectedContext.githubRepo, selectedContext.subpath ?? '');
-      repoBadgeStore.remove(selectedContext.githubRepo, selectedContext.subpath);
-      if (selectedContextId === contextId) {
+      await commands.deleteRepoBadge(entry.githubRepo, entry.subpath);
+      repoBadgeStore.remove(entry.githubRepo, entry.subpath);
+      if (selectedRepoKey === entryKey) {
         actions = [];
       }
       showDeleteRepoConfirm = false;
@@ -431,19 +468,21 @@
     }
   }
 
-  let sortedContexts = $derived.by(() => {
-    return [...contexts].sort((a, b) => {
+  let sortedEntries = $derived.by(() => {
+    return [...mergedEntries].sort((a, b) => {
       const aDisplay = a.subpath ? `${a.githubRepo}/${a.subpath}` : a.githubRepo;
       const bDisplay = b.subpath ? `${b.githubRepo}/${b.subpath}` : b.githubRepo;
       return aDisplay.localeCompare(bDisplay);
     });
   });
 
-  let filteredContexts = $derived.by(() => {
+  let filteredEntries = $derived.by(() => {
     const query = repoSearch.trim();
-    if (!query) return sortedContexts;
+    if (!query) return sortedEntries;
 
-    return sortedContexts.filter((context) => matchesRepoContextSearch(context, query));
+    return sortedEntries.filter((entry) =>
+      matchesRepoSearch(entry.githubRepo, entry.subpath, query)
+    );
   });
 
   let groupedActions = $derived.by(() => {
@@ -482,31 +521,33 @@
       </label>
       {#if loadingContexts}
         <div class="loading-side"><Spinner size={14} /> Loading...</div>
-      {:else if contexts.length === 0}
+      {:else if mergedEntries.length === 0}
         <div class="empty-side">No repo contexts yet</div>
-      {:else if filteredContexts.length === 0}
+      {:else if filteredEntries.length === 0}
         <div class="empty-side">No repos match "{repoSearch.trim()}"</div>
       {:else}
         <div class="context-list">
-          {#each filteredContexts as context (context.id)}
-            {@const badge = repoBadgeStore.lookup(context.githubRepo, context.subpath)}
+          {#each filteredEntries as entry (entry.key)}
+            {@const badge = repoBadgeStore.lookup(entry.githubRepo, entry.subpath)}
             <button
               class="context-item"
-              class:selected={context.id === selectedContextId}
-              onclick={() => (selectedContextId = context.id)}
+              class:selected={entry.key === selectedRepoKey}
+              onclick={() => (selectedRepoKey = entry.key)}
             >
               <div class="context-item-main">
                 <div class="context-item-header">
-                  <RepoLabel githubRepo={context.githubRepo} subpath={context.subpath} />
+                  <RepoLabel githubRepo={entry.githubRepo} subpath={entry.subpath} />
                 </div>
                 <span class="context-meta">
                   {#if loadingRepoAttachments}
                     Loading usage...
-                  {:else if badge}
-                    {@const count = (repoAttachmentsByContext[context.id] ?? []).length}
+                  {:else if badge && entry.context}
+                    {@const count = (repoAttachmentsByContext[entry.context.id] ?? []).length}
                     <RepoBadge shortName={formatProjectCount(count)} hue={badge.hue} small />
-                  {:else}
-                    {formatProjectCount((repoAttachmentsByContext[context.id] ?? []).length)}
+                  {:else if entry.context}
+                    {formatProjectCount((repoAttachmentsByContext[entry.context.id] ?? []).length)}
+                  {:else if badge}
+                    <RepoBadge shortName="orphan" hue={badge.hue} small />
                   {/if}
                 </span>
               </div>
@@ -517,17 +558,19 @@
     </aside>
 
     <section class="main-panel">
-      {#if !selectedContext}
-        <div class="empty-main">Select a repo context to configure actions</div>
+      {#if !selectedEntry}
+        <div class="empty-main">Select a repo to configure actions</div>
       {:else}
         <div class="repo-overview">
           <div class="repo-overview-main">
-            <RepoLabel githubRepo={selectedContext.githubRepo} subpath={selectedContext.subpath} />
+            <RepoLabel githubRepo={selectedEntry.githubRepo} subpath={selectedEntry.subpath} />
             <span class="repo-overview-meta">
               {#if loadingRepoAttachments}
                 Loading usage...
-              {:else}
+              {:else if selectedContext}
                 {formatProjectCount(selectedContextAttachments.length)}
+              {:else}
+                Badge only (no action context)
               {/if}
             </span>
           </div>
@@ -572,16 +615,18 @@
             </div>
           {/if}
 
-          {#if selectedContextAttachments.length > 0}
-            <div class="repo-attachments">
-              {#each selectedContextAttachments as attachment (attachment.projectRepoId)}
-                <span class="attachment-chip"
-                  >{attachment.projectName} ({attachment.branchName})</span
-                >
-              {/each}
-            </div>
-          {:else}
-            <div class="repo-empty-attachments">This repo is not attached to any projects.</div>
+          {#if selectedContext}
+            {#if selectedContextAttachments.length > 0}
+              <div class="repo-attachments">
+                {#each selectedContextAttachments as attachment (attachment.projectRepoId)}
+                  <span class="attachment-chip"
+                    >{attachment.projectName} ({attachment.branchName})</span
+                  >
+                {/each}
+              </div>
+            {:else}
+              <div class="repo-empty-attachments">This repo is not attached to any projects.</div>
+            {/if}
           {/if}
         </div>
 
@@ -598,35 +643,39 @@
             {/if}
             Delete Repo
           </button>
-          {#if actions.length > 0}
+          {#if selectedContext}
+            {#if actions.length > 0}
+              <button
+                class="secondary-btn"
+                onclick={() => (showDeleteAllConfirm = true)}
+                disabled={deletingRepo}
+              >
+                <Trash2 size={14} />
+                Delete All Actions
+              </button>
+            {/if}
             <button
               class="secondary-btn"
-              onclick={() => (showDeleteAllConfirm = true)}
-              disabled={deletingRepo}
+              onclick={detectActions}
+              disabled={detecting || deletingRepo}
             >
-              <Trash2 size={14} />
-              Delete All Actions
+              {#if detecting}
+                <Spinner size={14} />
+              {:else}
+                <Zap size={14} />
+              {/if}
+              Detect Actions
+            </button>
+            <button class="primary-btn" onclick={startAddAction} disabled={deletingRepo}>
+              <Plus size={14} />
+              Add Action
             </button>
           {/if}
-          <button
-            class="secondary-btn"
-            onclick={detectActions}
-            disabled={detecting || deletingRepo}
-          >
-            {#if detecting}
-              <Spinner size={14} />
-            {:else}
-              <Zap size={14} />
-            {/if}
-            Detect Actions
-          </button>
-          <button class="primary-btn" onclick={startAddAction} disabled={deletingRepo}>
-            <Plus size={14} />
-            Add Action
-          </button>
         </div>
 
-        {#if loadingActions}
+        {#if !selectedContext}
+          <!-- Badge-only entry: no actions to show -->
+        {:else if loadingActions}
           <div class="loading-state">
             <Spinner size={24} />
             <span>Loading...</span>
@@ -710,12 +759,12 @@
   {/if}
 </div>
 
-{#if showDeleteRepoConfirm && selectedContext}
+{#if showDeleteRepoConfirm && selectedEntry}
   <ConfirmDialog
     title="Delete Repo"
     message={selectedContextAttachments.length > 0
-      ? `Delete "${contextDisplay(selectedContext)}" from Staged? This removes ${formatProjectCount(selectedContextAttachments.length)} and deletes tracked worktrees/workspaces tied to this repo.`
-      : `Delete "${contextDisplay(selectedContext)}" from Staged? This removes its repo settings and actions.`}
+      ? `Delete "${repoDisplay(selectedEntry.githubRepo, selectedEntry.subpath)}" from Staged? This removes ${formatProjectCount(selectedContextAttachments.length)} and deletes tracked worktrees/workspaces tied to this repo.`
+      : `Delete "${repoDisplay(selectedEntry.githubRepo, selectedEntry.subpath)}" from Staged? This removes its repo settings and actions.`}
     confirmLabel="Delete Repo"
     danger={true}
     onConfirm={deleteRepo}

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -25,6 +25,7 @@
   import { detectRepoActions, type ActionType } from '../actions/actions';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { matchesRepoContextSearch } from './repoContextSearch';
+  import { alerts } from '../../shared/alerts.svelte';
 
   type RepoAttachment = {
     projectId: string;
@@ -103,7 +104,14 @@
         badgeEditHue
       );
     } catch (e) {
-      console.error('Failed to update badge:', e);
+      const msg = typeof e === 'string' ? e : e instanceof Error ? e.message : String(e);
+      alerts.error(msg, 'Badge update failed');
+      // Revert edit fields to the last saved values.
+      const badge = selectedBadge;
+      if (badge) {
+        badgeEditName = badge.shortName;
+        badgeEditHue = badge.hue;
+      }
     }
   }
 

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -117,12 +117,6 @@
     } catch (e) {
       const msg = typeof e === 'string' ? e : e instanceof Error ? e.message : String(e);
       badgeError = msg;
-      // Revert edit fields to the last saved values.
-      const badge = selectedBadge;
-      if (badge) {
-        badgeEditName = badge.shortName;
-        badgeEditHue = badge.hue;
-      }
     }
   }
 

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -579,12 +579,6 @@
 
           {#if selectedBadge}
             <div class="badge-editor">
-              <div class="badge-editor-preview">
-                <RepoBadge
-                  shortName={badgeEditName || selectedBadge.shortName}
-                  hue={badgeEditHue}
-                />
-              </div>
               <div class="badge-editor-fields">
                 <label class="badge-field">
                   <span class="badge-field-label">Short name</span>
@@ -618,6 +612,12 @@
                     onchange={saveBadge}
                   />
                 </label>
+              </div>
+              <div class="badge-editor-preview">
+                <RepoBadge
+                  shortName={badgeEditName || selectedBadge.shortName}
+                  hue={badgeEditHue}
+                />
               </div>
             </div>
           {/if}

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -25,7 +25,6 @@
   import { detectRepoActions, type ActionType } from '../actions/actions';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { matchesRepoSearch } from './repoContextSearch';
-  import { alerts } from '../../shared/alerts.svelte';
 
   type RepoAttachment = {
     projectId: string;
@@ -65,6 +64,7 @@
   });
   let badgeEditName = $state('');
   let badgeEditHue = $state(0);
+  let badgeError = $state('');
 
   let selectedEntry = $derived(mergedEntries.find((e) => e.key === selectedRepoKey) ?? null);
   let selectedContext = $derived(selectedEntry?.context ?? null);
@@ -95,6 +95,7 @@
     // update in the store (which would clobber in-progress edits after save).
     void selectedRepoKey;
     untrack(() => {
+      badgeError = '';
       const badge = selectedBadge;
       if (badge) {
         badgeEditName = badge.shortName;
@@ -105,6 +106,7 @@
 
   async function saveBadge() {
     if (!selectedEntry || !badgeEditName.trim()) return;
+    badgeError = '';
     try {
       await repoBadgeStore.update(
         selectedEntry.githubRepo,
@@ -114,7 +116,7 @@
       );
     } catch (e) {
       const msg = typeof e === 'string' ? e : e instanceof Error ? e.message : String(e);
-      alerts.error(msg, 'Badge update failed');
+      badgeError = msg;
       // Revert edit fields to the last saved values.
       const badge = selectedBadge;
       if (badge) {
@@ -588,16 +590,21 @@
                   <span class="badge-field-label">Short name</span>
                   <input
                     class="badge-input"
+                    class:badge-input-error={badgeError}
                     type="text"
                     maxlength="6"
                     autocapitalize="off"
                     autocorrect="off"
                     bind:value={badgeEditName}
+                    oninput={() => (badgeError = '')}
                     onblur={saveBadge}
                     onkeydown={(e) => {
                       if (e.key === 'Enter') saveBadge();
                     }}
                   />
+                  {#if badgeError}
+                    <span class="badge-error">{badgeError}</span>
+                  {/if}
                 </label>
                 <label class="badge-field">
                   <span class="badge-field-label">Hue</span>
@@ -992,6 +999,7 @@
   .badge-field {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 6px;
     font-size: var(--size-xs);
     color: var(--text-muted);
@@ -1010,6 +1018,17 @@
     color: var(--text-primary);
     font-family: 'SF Mono', Menlo, Consolas, monospace;
     font-size: var(--size-xs);
+  }
+
+  .badge-input-error {
+    border-color: var(--danger);
+  }
+
+  .badge-error {
+    color: var(--danger);
+    font-size: var(--size-xs);
+    display: block;
+    margin-top: 2px;
   }
 
   .badge-hue-slider {

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -579,7 +579,7 @@
 
           {#if selectedBadge}
             <div class="badge-editor">
-              <div class="badge-editor-fields">
+              <div class="badge-editor-row">
                 <label class="badge-field">
                   <span class="badge-field-label">Short name</span>
                   <input
@@ -596,9 +596,6 @@
                       if (e.key === 'Enter') saveBadge();
                     }}
                   />
-                  {#if badgeError}
-                    <span class="badge-error">{badgeError}</span>
-                  {/if}
                 </label>
                 <label class="badge-field">
                   <span class="badge-field-label">Hue</span>
@@ -612,13 +609,16 @@
                     onchange={saveBadge}
                   />
                 </label>
+                <div class="badge-editor-preview">
+                  <RepoBadge
+                    shortName={badgeEditName || selectedBadge.shortName}
+                    hue={badgeEditHue}
+                  />
+                </div>
               </div>
-              <div class="badge-editor-preview">
-                <RepoBadge
-                  shortName={badgeEditName || selectedBadge.shortName}
-                  hue={badgeEditHue}
-                />
-              </div>
+              {#if badgeError}
+                <span class="badge-error">{badgeError}</span>
+              {/if}
             </div>
           {/if}
 
@@ -976,29 +976,28 @@
 
   .badge-editor {
     display: flex;
-    align-items: center;
-    gap: 12px;
+    flex-direction: column;
+    gap: 6px;
     padding: 8px 10px;
     border: 1px solid var(--border-subtle);
     border-radius: 8px;
     background: var(--bg-primary);
   }
 
-  .badge-editor-preview {
-    flex-shrink: 0;
-  }
-
-  .badge-editor-fields {
+  .badge-editor-row {
     display: flex;
     align-items: center;
     gap: 12px;
     min-width: 0;
   }
 
+  .badge-editor-preview {
+    flex-shrink: 0;
+  }
+
   .badge-field {
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
     gap: 6px;
     font-size: var(--size-xs);
     color: var(--text-muted);
@@ -1026,8 +1025,6 @@
   .badge-error {
     color: var(--ui-danger);
     font-size: var(--size-xs);
-    flex-basis: 100%;
-    margin-top: 2px;
   }
 
   .badge-hue-slider {

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -590,7 +590,7 @@
                     autocapitalize="off"
                     autocorrect="off"
                     bind:value={badgeEditName}
-                    oninput={() => (badgeError = '')}
+                    oninput={saveBadge}
                     onblur={saveBadge}
                     onkeydown={(e) => {
                       if (e.key === 'Enter') saveBadge();
@@ -1020,11 +1020,11 @@
   }
 
   .badge-input-error {
-    border-color: var(--danger);
+    border-color: var(--ui-danger);
   }
 
   .badge-error {
-    color: var(--danger);
+    color: var(--ui-danger);
     font-size: var(--size-xs);
     flex-basis: 100%;
     margin-top: 2px;

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -992,7 +992,6 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    flex: 1;
     min-width: 0;
   }
 
@@ -1027,7 +1026,7 @@
   .badge-error {
     color: var(--danger);
     font-size: var(--size-xs);
-    display: block;
+    flex-basis: 100%;
     margin-top: 2px;
   }
 

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -66,17 +66,6 @@
   let badgeEditHue = $state(0);
   let badgeError = $state('');
 
-  let selectedEntry = $derived(mergedEntries.find((e) => e.key === selectedRepoKey) ?? null);
-  let selectedContext = $derived(selectedEntry?.context ?? null);
-  let selectedContextAttachments = $derived(
-    selectedContext ? (repoAttachmentsByContext[selectedContext.id] ?? []) : []
-  );
-  let selectedBadge = $derived(
-    selectedEntry
-      ? repoBadgeStore.lookup(selectedEntry.githubRepo, selectedEntry.subpath)
-      : undefined
-  );
-
   onMount(async () => {
     await repoBadgeStore.loadAll();
     await loadContexts();
@@ -156,6 +145,17 @@
 
     return entries;
   });
+
+  let selectedEntry = $derived(mergedEntries.find((e) => e.key === selectedRepoKey) ?? null);
+  let selectedContext = $derived(selectedEntry?.context ?? null);
+  let selectedContextAttachments = $derived(
+    selectedContext ? (repoAttachmentsByContext[selectedContext.id] ?? []) : []
+  );
+  let selectedBadge = $derived(
+    selectedEntry
+      ? repoBadgeStore.lookup(selectedEntry.githubRepo, selectedEntry.subpath)
+      : undefined
+  );
 
   async function loadRepoAttachments(actionContexts: ActionContext[]) {
     const generation = ++repoAttachmentLoadGeneration;

--- a/apps/staged/src/lib/features/settings/repoContextSearch.ts
+++ b/apps/staged/src/lib/features/settings/repoContextSearch.ts
@@ -1,19 +1,27 @@
 import type { ActionContext } from '../../api/commands';
 
-function searchTerms(context: ActionContext): string[] {
-  const githubRepo = context.githubRepo.toLowerCase();
-  const [org = '', repoName = ''] = githubRepo.split('/');
-  const subpath = context.subpath?.toLowerCase() ?? '';
-  const subpathParts = subpath.split('/').filter(Boolean);
+function searchTerms(githubRepo: string, subpath: string | null | undefined): string[] {
+  const repo = githubRepo.toLowerCase();
+  const [org = '', repoName = ''] = repo.split('/');
+  const sub = subpath?.toLowerCase() ?? '';
+  const subpathParts = sub.split('/').filter(Boolean);
 
-  return [githubRepo, org, repoName, subpath, ...subpathParts].filter(Boolean);
+  return [repo, org, repoName, sub, ...subpathParts].filter(Boolean);
 }
 
 export function matchesRepoContextSearch(context: ActionContext, query: string): boolean {
+  return matchesRepoSearch(context.githubRepo, context.subpath, query);
+}
+
+export function matchesRepoSearch(
+  githubRepo: string,
+  subpath: string | null | undefined,
+  query: string
+): boolean {
   const tokens = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
 
   if (tokens.length === 0) return true;
 
-  const terms = searchTerms(context);
+  const terms = searchTerms(githubRepo, subpath);
   return tokens.every((token) => terms.some((term) => term.includes(token)));
 }

--- a/apps/staged/src/lib/stores/repoBadges.svelte.ts
+++ b/apps/staged/src/lib/stores/repoBadges.svelte.ts
@@ -15,6 +15,11 @@ function badgeKey(githubRepo: string, subpath: string): string {
 class RepoBadgeStore {
   private badges = $state<Map<string, RepoBadge>>(new Map());
 
+  /** Return all loaded badges. */
+  all(): RepoBadge[] {
+    return Array.from(this.badges.values());
+  }
+
   /** Look up a badge for a repo+subpath. Returns undefined if not yet loaded. */
   lookup(githubRepo: string, subpath: string | null | undefined): RepoBadge | undefined {
     return this.badges.get(badgeKey(githubRepo, subpath ?? ''));


### PR DESCRIPTION
## Summary
- Show which repo owns a short name on unique constraint conflict
- Show toast when badge short name update fails
- Show orphan repo badges in settings
- Show badge errors inline instead of as toasts with per-keystroke validation
- Move badge preview to the right of editor fields with improved positioning
- Fix variable declaration ordering to resolve type check error

## Test plan
- [ ] Verify badge short name validation errors appear inline on each keystroke
- [ ] Verify unique constraint conflicts show which repo owns the name
- [ ] Verify orphan repo badges appear in settings panel
- [ ] Verify badge preview renders correctly to the right of editor fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)