### PR TITLE
feat(staged): add Cmd+Enter shortcut to submit commit from diff viewer

### DIFF
--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -99,6 +99,14 @@
     syncTextareaHeight();
   }
 
+  function handleKeydown(e: KeyboardEvent) {
+    // Cmd+Enter to submit
+    if (e.key === 'Enter' && e.metaKey && draftPrompt.trim() && !starting) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
   function syncTextareaHeight() {
     if (!textareaElement) return;
 
@@ -174,6 +182,7 @@
     rows="3"
     disabled={starting}
     oninput={handleInput}
+    onkeydown={handleKeydown}
     items={hashtagItems}
   />
   <div class="composer-footer">


### PR DESCRIPTION
Adds a keyboard shortcut (Cmd+Enter) to submit the commit message from the diff viewer's textarea, matching the common pattern used in most code editors and chat interfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)