### PR TITLE
feat(staged): adopt and resume interrupted autoreviews

### DIFF
--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1466,15 +1466,10 @@ fn cancel_in_flight_auto_review_for_branch(
     if !cancelled {
         let current = store.get_session(session_id).map_err(|e| e.to_string())?;
         return match current.map(|session| session.status) {
-            None => Ok(true),
-            Some(store::SessionStatus::Cancelled) => {
-                store.delete_review(&review.id).map_err(|e| e.to_string())?;
-                Ok(true)
-            }
+            None | Some(store::SessionStatus::Cancelled) => Ok(true),
             _ => Ok(false),
         };
     }
-    store.delete_review(&review.id).map_err(|e| e.to_string())?;
 
     Ok(true)
 }
@@ -2680,8 +2675,10 @@ mod tests {
             cancel_in_flight_auto_review_for_branch(&store, &registry, &branch.id).unwrap();
 
         assert!(cancelled);
-        assert!(store.get_session(&session.id).unwrap().is_none());
-        assert!(store.get_review(&review.id).unwrap().is_none());
+        // Session transitions to Cancelled but both records survive for potential adoption
+        let session = store.get_session(&session.id).unwrap().unwrap();
+        assert_eq!(session.status, store::SessionStatus::Cancelled);
+        assert!(store.get_review(&review.id).unwrap().is_some());
     }
 
     #[test]
@@ -2695,8 +2692,10 @@ mod tests {
             cancel_in_flight_auto_review_for_branch(&store, &registry, &branch.id).unwrap();
 
         assert!(cancelled);
-        assert!(store.get_session(&session.id).unwrap().is_none());
-        assert!(store.get_review(&review.id).unwrap().is_none());
+        // Session transitions to Cancelled but both records survive for potential adoption
+        let session = store.get_session(&session.id).unwrap().unwrap();
+        assert_eq!(session.status, store::SessionStatus::Cancelled);
+        assert!(store.get_review(&review.id).unwrap().is_some());
     }
 
     #[test]

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -170,9 +170,6 @@ export default class BranchCardSessionManager {
     if (this.autoReviewSessionId) {
       commands.cancelSession(this.autoReviewSessionId).catch(() => {});
     }
-    if (this.autoReviewId) {
-      commands.deleteReview(this.autoReviewId).catch(() => {});
-    }
     this.autoReviewSessionId = null;
     this.autoReviewId = null;
   }
@@ -191,6 +188,19 @@ export default class BranchCardSessionManager {
       if (this.autoReviewSessionId) {
         sessionRegistry.register(this.autoReviewSessionId, branch.projectId, 'review', branch.id);
         projectStateStore.addRunningSession(branch.projectId, this.autoReviewSessionId);
+      }
+
+      // If the autoreview was interrupted before completing, resume it
+      const needsResume = !review.completedAt && review.sessionId && !this.autoReviewSessionId;
+      if (needsResume) {
+        await commands.resumeSession(
+          review.sessionId!,
+          'Continue reviewing the code changes on this branch.',
+          undefined,
+          branch.id
+        );
+        sessionRegistry.register(review.sessionId!, branch.projectId, 'review', branch.id);
+        projectStateStore.addRunningSession(branch.projectId, review.sessionId!);
       }
 
       this.autoReviewSessionId = null;

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -170,6 +170,9 @@ export default class BranchCardSessionManager {
     if (this.autoReviewSessionId) {
       commands.cancelSession(this.autoReviewSessionId).catch(() => {});
     }
+    if (this.autoReviewId) {
+      commands.deleteReview(this.autoReviewId).catch(() => {});
+    }
     this.autoReviewSessionId = null;
     this.autoReviewId = null;
   }

--- a/packages/diff-viewer/src/lib/types.ts
+++ b/packages/diff-viewer/src/lib/types.ts
@@ -96,6 +96,8 @@ export interface Review {
   referenceFiles: string[];
   createdAt: number;
   updatedAt: number;
+  /** When the AI session finished producing this review. `null` while running. */
+  completedAt: number | null;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- When an autoreview is interrupted (e.g. app crash/restart), the cancelled session and review records are now preserved instead of deleted
- On branch card mount, if a review exists without a `completedAt` timestamp and has no running session, it is automatically resumed
- Adds `completedAt` field to the `Review` type to distinguish completed vs interrupted reviews

## Test plan
- [ ] Verify that interrupting an autoreview (e.g. by restarting the app) preserves the review and session records
- [ ] Verify that reopening a branch with an interrupted autoreview automatically resumes the review session
- [ ] Verify that normally completed autoreviews are not re-triggered on branch card mount
- [ ] Verify existing tests pass (`crates-test`, `staged-ci`, `differ-ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)