### PR TITLE
feat(staged): add resume button to timeline rows for resumable sessions

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -995,6 +995,12 @@
           deletingItems={timelineDeletingItems}
           reviewCommentBreakdown={timelineReviewDetailsById}
           onSessionClick={(sid) => sessionMgr.handleTimelineSessionClick(sid)}
+          onResumeClick={(sid) => {
+            commands
+              .resumeSession(sid, 'Continue where you left off.', undefined, branch.id)
+              .then(() => loadTimeline())
+              .catch((e) => console.error('Failed to resume session:', e));
+          }}
           onCommitClick={handleCommitClick}
           onNoteClick={handleNoteClick}
           onReviewClick={handleReviewClick}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -999,7 +999,15 @@
             commands
               .resumeSession(sid, 'Continue where you left off.', undefined, branch.id)
               .then(() => loadTimeline())
-              .catch((e) => console.error('Failed to resume session:', e));
+              .catch((e) => {
+                console.error('Failed to resume session:', e);
+                alerts.error(
+                  e instanceof Error
+                    ? e.message
+                    : 'Could not resume the session. Please try again.',
+                  'Resume failed'
+                );
+              });
           }}
           onCommitClick={handleCommitClick}
           onNoteClick={handleNoteClick}

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -45,6 +45,7 @@
   import Spinner from '../../shared/Spinner.svelte';
   import { marked } from 'marked';
   import { sanitize } from '../../shared/sanitize';
+  import { isResumableReason } from '../../types';
   import type { Session, SessionMessage, HashtagItem } from '../../types';
   import {
     cancelSession,
@@ -1215,7 +1216,7 @@
           <span>{session.errorMessage}</span>
         </div>
       {:else if session && session.status !== 'running' && session.status !== 'queued'}
-        {#if session.completionReason === 'crashed' || session.completionReason === 'app_quit' || session.completionReason === 'interrupted'}
+        {#if isResumableReason(session.completionReason)}
           <div
             class="session-end-banner"
             class:warning={session.completionReason === 'crashed' ||

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -49,6 +49,7 @@
     /** Existing timeline rows currently being deleted (rendered in-place as deleting). */
     deletingItems?: { type: 'commit' | 'note' | 'review' | 'image'; id: string }[];
     onSessionClick?: (sessionId: string) => void;
+    onResumeClick?: (sessionId: string) => void;
     onCommitClick?: (sha: string) => void;
     onNoteClick?: (noteId: string, title: string, content: string, sessionId?: string) => void;
     onReviewClick?: (reviewId: string) => void;
@@ -95,6 +96,7 @@
     prunedSessionIds = new Set(),
     deletingItems = [],
     onSessionClick,
+    onResumeClick,
     onCommitClick,
     onNoteClick,
     onReviewClick,
@@ -199,6 +201,7 @@
     badges?: TimelineBadge[];
     /** When set, delete button is shown but disabled with this tooltip. */
     deleteDisabledReason?: string;
+    completionReason?: string | null;
   };
 
   let runningSessionIds = $derived.by(() => collectRunningSessionIds(timeline, pendingItems));
@@ -285,6 +288,7 @@
         commitSha: commit.sha || undefined,
         commitId: commit.id ?? undefined,
         deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
+        completionReason: commit.completionReason,
       });
     }
 
@@ -326,6 +330,7 @@
         noteTitle: stripXmlTags(note.title),
         noteContent: note.content,
         deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
+        completionReason: note.completionReason,
       });
     }
 
@@ -388,6 +393,7 @@
         sessionId: review.sessionId ?? undefined,
         reviewId: review.id,
         deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
+        completionReason: review.completionReason,
       });
     }
 
@@ -488,6 +494,17 @@
     }
   }
 
+  const resumableReasons = new Set(['crashed', 'app_quit', 'interrupted']);
+
+  function isResumable(item: DisplayItem): boolean {
+    return (
+      !!item.sessionId &&
+      !!item.completionReason &&
+      resumableReasons.has(item.completionReason) &&
+      !item.deleting
+    );
+  }
+
   function handleDeleteClick(item: DisplayItem, opts?: { altKey: boolean }) {
     if (item.type === 'commit' && item.commitSha && onDeleteCommit) {
       onDeleteCommit(item.commitSha, item.sessionId, opts);
@@ -554,6 +571,9 @@
             : (opts) => handleDeleteClick(item, opts)}
           onStartClick={item.type.startsWith('queued-') && !hasActiveSession
             ? onStartQueued
+            : undefined}
+          onResumeClick={isResumable(item) && onResumeClick && item.sessionId
+            ? () => onResumeClick!(item.sessionId!)
             : undefined}
         />
       </div>

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -10,6 +10,7 @@
   import type { Snippet } from 'svelte';
   import { slide } from 'svelte/transition';
   import { FileText, GitCommitVertical, FileSearch } from 'lucide-svelte';
+  import { isResumableReason } from '../../types';
   import type { BranchTimeline as BranchTimelineData, HashtagItem } from '../../types';
   import TimelineRow from './TimelineRow.svelte';
   import type { TimelineItemType, TimelineBadge } from './TimelineRow.svelte';
@@ -494,15 +495,8 @@
     }
   }
 
-  const resumableReasons = new Set(['crashed', 'app_quit', 'interrupted']);
-
   function isResumable(item: DisplayItem): boolean {
-    return (
-      !!item.sessionId &&
-      !!item.completionReason &&
-      resumableReasons.has(item.completionReason) &&
-      !item.deleting
-    );
+    return !!item.sessionId && isResumableReason(item.completionReason) && !item.deleting;
   }
 
   function handleDeleteClick(item: DisplayItem, opts?: { altKey: boolean }) {

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -572,7 +572,7 @@
           onStartClick={item.type.startsWith('queued-') && !hasActiveSession
             ? onStartQueued
             : undefined}
-          onResumeClick={isResumable(item) && onResumeClick && item.sessionId
+          onResumeClick={isResumable(item) && onResumeClick && item.sessionId && !hasActiveSession
             ? () => onResumeClick!(item.sessionId!)
             : undefined}
         />

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -14,7 +14,6 @@
     Trash2,
     AlertTriangle,
     Clock,
-    Play,
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
 
@@ -241,7 +240,6 @@
       {/if}
       {#if onResumeClick}
         <button class="action-btn resume-btn" onclick={handleResumeClick} title="Resume session">
-          <Play size={10} />
           Resume
         </button>
       {/if}
@@ -529,9 +527,17 @@
   }
 
   .resume-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 3px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    font-weight: 500;
+    transition:
+      color 0.15s,
+      border-color 0.15s,
+      background-color 0.15s;
+  }
+
+  .resume-btn:hover {
+    border-color: var(--border-muted);
   }
 
   .start-btn {

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -14,6 +14,7 @@
     Trash2,
     AlertTriangle,
     Clock,
+    Play,
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
 
@@ -58,6 +59,7 @@
     deleteDisabledReason?: string;
     onRetryClick?: () => void;
     onStartClick?: () => void;
+    onResumeClick?: () => void;
   }
 
   let {
@@ -76,6 +78,7 @@
     deleteDisabledReason,
     onRetryClick,
     onStartClick,
+    onResumeClick,
   }: Props = $props();
 
   let isNote = $derived(
@@ -139,6 +142,11 @@
   function handleStartClick(e: MouseEvent) {
     e.stopPropagation();
     onStartClick?.();
+  }
+
+  function handleResumeClick(e: MouseEvent) {
+    e.stopPropagation();
+    onResumeClick?.();
   }
 </script>
 
@@ -217,7 +225,10 @@
         </div>
       {/if}
     </div>
-    <div class="timeline-actions" class:always-visible={!!onRetryClick || !!onStartClick}>
+    <div
+      class="timeline-actions"
+      class:always-visible={!!onRetryClick || !!onStartClick || !!onResumeClick}
+    >
       {#if onStartClick}
         <button class="action-btn start-btn" onclick={handleStartClick} title="Start">
           Start
@@ -226,6 +237,12 @@
       {#if onRetryClick}
         <button class="action-btn retry-btn" onclick={handleRetryClick} title="Retry">
           Retry
+        </button>
+      {/if}
+      {#if onResumeClick}
+        <button class="action-btn resume-btn" onclick={handleResumeClick} title="Resume session">
+          <Play size={10} />
+          Resume
         </button>
       {/if}
       {#if hasSession && !onStartClick && !isQueued}
@@ -503,11 +520,18 @@
   }
 
   .retry-btn,
-  .start-btn {
+  .start-btn,
+  .resume-btn {
     width: auto;
     padding: 0 8px;
     font-size: var(--size-xs);
     color: var(--text-muted);
+  }
+
+  .resume-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
   }
 
   .start-btn {
@@ -516,7 +540,8 @@
   }
 
   .retry-btn:hover,
-  .start-btn:hover {
+  .start-btn:hover,
+  .resume-btn:hover {
     color: var(--text-primary);
     background: var(--bg-hover);
   }

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -538,6 +538,8 @@
 
   .resume-btn:hover {
     border-color: var(--border-muted);
+    color: var(--text-primary);
+    background: var(--bg-hover);
   }
 
   .start-btn {
@@ -546,8 +548,7 @@
   }
 
   .retry-btn:hover,
-  .start-btn:hover,
-  .resume-btn:hover {
+  .start-btn:hover {
     color: var(--text-primary);
     background: var(--bg-hover);
   }

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -235,6 +235,17 @@ export type SessionStatus = 'queued' | 'running' | 'completed' | 'error' | 'canc
 
 export type CompletionReason = 'turn_complete' | 'interrupted' | 'crashed' | 'app_quit' | 'unknown';
 
+/** Completion reasons that indicate a session can be resumed. */
+export const RESUMABLE_REASONS: ReadonlySet<CompletionReason> = new Set<CompletionReason>([
+  'crashed',
+  'app_quit',
+  'interrupted',
+]);
+
+export function isResumableReason(reason: string | null | undefined): boolean {
+  return !!reason && RESUMABLE_REASONS.has(reason as CompletionReason);
+}
+
 export interface Session {
   id: string;
   prompt: string;


### PR DESCRIPTION
## Summary
- Adds a "Resume" button to timeline rows for sessions that ended due to crash, app quit, or interruption
- Extracts a shared `RESUMABLE_REASONS` constant and `isResumableReason()` helper in `types.ts` to replace duplicated checks in `SessionModal` and the new timeline logic
- Styles the resume button as a bordered pill consistent with existing action buttons

## Test plan
- [ ] Verify the Resume button appears on timeline rows for sessions with `crashed`, `app_quit`, or `interrupted` completion reasons
- [ ] Verify the Resume button does not appear when another session is already active
- [ ] Verify clicking Resume triggers session resumption and reloads the timeline
- [ ] Verify error handling shows an alert on resume failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)