### PR TITLE
fix(staged): show 'Looking for changes' and fix delayed commits after project-from-PR creation

### DIFF
--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -83,8 +83,14 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         // Local branch: fetch commits from the local worktree
         let worktree_path = Path::new(&wd.path);
         if worktree_path.exists() {
-            let git_commits =
-                git::get_commits_since_base(worktree_path, &branch.base_branch).unwrap_or_default();
+            let git_commits = match git::get_commits_since_base(worktree_path, &branch.base_branch)
+            {
+                Ok(commits) => commits,
+                Err(e) => {
+                    log::warn!("Failed to get commits since base for branch {branch_id}: {e:?}");
+                    vec![]
+                }
+            };
 
             // For each git commit, look up our metadata (session linkage)
             for gc in git_commits {

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -176,26 +176,23 @@
 
   /** Label for the provisioning timeline row, if applicable. */
   let provisioningLabel = $derived.by(() => {
-    if (isLocal && !branch.worktreePath && !worktreeError) {
-      if (setupPhase) {
-        const labels: Record<string, string> = {
-          cloning: 'Cloning repository…',
-          fetching: 'Fetching latest changes…',
-          creating_worktree: 'Creating worktree…',
-          running_setup_actions: 'Running setup actions…',
-        };
-        return labels[setupPhase] ?? 'Setting up…';
+    if (!isSettingUp) return undefined;
+    if (isProvisioning) {
+      if (isLocal) {
+        if (setupPhase) {
+          const labels: Record<string, string> = {
+            cloning: 'Cloning repository…',
+            fetching: 'Fetching latest changes…',
+            creating_worktree: 'Creating worktree…',
+            running_setup_actions: 'Running setup actions…',
+          };
+          return labels[setupPhase] ?? 'Setting up…';
+        }
+        return 'Setting up…';
       }
-      return 'Setting up…';
-    }
-    if (isRemote && remoteWorkspaceStatus === 'starting') {
       return 'Starting workspace…';
     }
-    // Worktree is ready but timeline hasn't loaded yet
-    if (isLocal && branch.worktreePath && !timeline && !error) {
-      return 'Looking for changes…';
-    }
-    return undefined;
+    return 'Looking for changes…';
   });
 
   /** Map blox orchestrator CommandType enum names to display labels. */
@@ -208,15 +205,14 @@
 
   /** Detail text for the provisioning row (e.g. git progress percentages or step info). */
   let provisioningDetail = $derived.by(() => {
-    if (isLocal && !branch.worktreePath && !worktreeError) return setupDetail;
-    if (isRemote && remoteWorkspaceStatus === 'starting') {
-      if (setupDetail && setupPhase) {
-        const label = remoteCommandLabels[setupPhase] ?? setupPhase;
-        return `${setupDetail} · ${label}`;
-      }
-      return setupDetail;
+    if (!isProvisioning) return null;
+    if (isLocal) return setupDetail;
+    // Remote workspace starting
+    if (setupDetail && setupPhase) {
+      const label = remoteCommandLabels[setupPhase] ?? setupPhase;
+      return `${setupDetail} · ${label}`;
     }
-    return null;
+    return setupDetail;
   });
 
   /** True when the branch has at least one finalized commit (code changes vs base). */
@@ -958,7 +954,7 @@
           {repoLabel}
           {isLocal}
           {isRemote}
-          isProvisioning={isSettingUp}
+          {isSettingUp}
           {remoteWorkspaceStatus}
           {onDelete}
           {onRename}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -127,6 +127,11 @@
       (isRemote && remoteWorkspaceStatus === 'starting')
   );
 
+  /** True during provisioning OR the gap between worktree-ready and timeline-loaded. */
+  let isSettingUp = $derived(
+    isProvisioning || (isLocal && !!branch.worktreePath && !timeline && !error)
+  );
+
   /** Empty timeline used during provisioning so the action buttons render. */
   const emptyTimeline: BranchTimelineData = { commits: [], notes: [], reviews: [], images: [] };
 
@@ -185,6 +190,10 @@
     }
     if (isRemote && remoteWorkspaceStatus === 'starting') {
       return 'Starting workspace…';
+    }
+    // Worktree is ready but timeline hasn't loaded yet
+    if (isLocal && branch.worktreePath && !timeline && !error) {
+      return 'Looking for changes…';
     }
     return undefined;
   });
@@ -446,6 +455,7 @@
           return;
         }
 
+        commands.invalidateBranchTimeline(branch.id);
         loadTimeline();
         // Handle PR session completion
         if (prButton && eventSessionId === prButton.getPrSessionId()) {
@@ -948,7 +958,7 @@
           {repoLabel}
           {isLocal}
           {isRemote}
-          {isProvisioning}
+          isProvisioning={isSettingUp}
           {remoteWorkspaceStatus}
           {onDelete}
           {onRename}
@@ -971,7 +981,7 @@
           {workspaceError}
           fallbackError={error}
         />
-      {:else if loading && !isProvisioning}
+      {:else if loading && !isSettingUp}
         <div class="loading">
           <Spinner size={14} />
           <span>Loading...</span>
@@ -981,7 +991,7 @@
           <span>{error}</span>
           <button class="retry-btn" onclick={() => loadTimeline()}>Retry</button>
         </div>
-      {:else if timeline || isProvisioning}
+      {:else if timeline || isSettingUp}
         <BranchTimeline
           timeline={timeline ?? emptyTimeline}
           repoDir={branch.worktreePath}

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -61,7 +61,7 @@
     repoLabel?: ProjectRepo | null;
     isLocal: boolean;
     isRemote: boolean;
-    isProvisioning: boolean;
+    isSettingUp: boolean;
     remoteWorkspaceStatus: string | null;
     onDelete?: () => void;
     onRename?: (branchName: string) => void;
@@ -77,7 +77,7 @@
     repoLabel = null,
     isLocal,
     isRemote,
-    isProvisioning,
+    isSettingUp,
     remoteWorkspaceStatus,
     onDelete,
     onRename,
@@ -617,7 +617,7 @@
     </div>
   {/each}
   <!-- Primary run action button -->
-  {#if !isProvisioning && primaryRunAction}
+  {#if !isSettingUp && primaryRunAction}
     {@const execution = primaryActionExecution}
     {@const isRunning = execution?.status === 'running'}
     {@const isStopping = execution && stoppingExecutions.has(execution.executionId)}
@@ -755,7 +755,7 @@
   </button>
   {#if showMoreMenu}
     <div class="more-menu">
-      {#if !isProvisioning}
+      {#if !isSettingUp}
         <!-- Remote-only: Copy workspace name -->
         {#if isRemote && branch.workspaceName}
           <button

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -119,6 +119,7 @@
         setProjects(projectsList);
         projects = projectsList;
         branchesByProject = new Map(branchesByProject).set(projectId, branches);
+        commands.invalidateProjectBranchTimelines(branches.map((b) => b.id));
         workspaceLifecycle.enqueueInitialSetup(projectId, branches);
         replaceProjectRepos(projectId, repos);
         void repoBadgeStore.ensureForRepos(


### PR DESCRIPTION
## Summary

- Show "Looking for changes…" status during the gap between worktree provisioning completing and the timeline loading, instead of briefly showing an empty branch card with enlarged action buttons
- Ensure timeline data is fresh by invalidating caches when worktree setup completes and before reloading after session completion
- Log git errors in timeline construction instead of silently swallowing them with `unwrap_or_default()`
- Refactor `provisioningLabel`/`provisioningDetail` to derive from `isSettingUp`/`isProvisioning` computed values instead of duplicating conditions

## Test plan

- [ ] Create a project from a PR and verify "Looking for changes…" appears during setup
- [ ] Verify commits appear correctly once the timeline loads
- [ ] Verify no empty state / enlarged buttons flash during provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)