### PR TITLE
fix(staged): resolve hashtag badge showing raw IDs instead of titles

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -20,6 +20,7 @@
     Branch,
     BranchTimeline as BranchTimelineData,
     HashtagItem,
+    ProjectNote,
     ProjectRepo,
     SessionStatusPayload,
   } from '../../types';

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -20,7 +20,6 @@
     Branch,
     BranchTimeline as BranchTimelineData,
     HashtagItem,
-    ProjectNote,
     ProjectRepo,
     SessionStatusPayload,
   } from '../../types';

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -40,7 +40,7 @@
   import RemoteWorkspaceStatusBadge from './RemoteWorkspaceStatusBadge.svelte';
   import RemoteWorkspaceStatusView from './RemoteWorkspaceStatusView.svelte';
   import { alerts } from '../../shared/alerts.svelte';
-  import { timelineToHashtagItems } from '../sessions/hashtagItems';
+  import { timelineToHashtagItems, projectNotesToHashtagItems } from '../sessions/hashtagItems';
 
   interface Props {
     branch: Branch;
@@ -115,15 +115,7 @@
     let stale = false;
     commands.listProjectNotes(projectId).then((notes) => {
       if (stale) return;
-      projectNoteHashtagItems = notes
-        .filter((n) => n.title.trim())
-        .map((n) => ({
-          type: 'project-note' as const,
-          id: n.id,
-          title: n.title,
-          color: '--note-color',
-          bgColor: '--note-bg',
-        }));
+      projectNoteHashtagItems = projectNotesToHashtagItems(notes);
     });
     return () => {
       stale = true;

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -116,7 +116,7 @@ export function timelineToHashtagItems(
   return items;
 }
 
-function projectNotesToHashtagItems(notes: ProjectNote[]): HashtagItem[] {
+export function projectNotesToHashtagItems(notes: ProjectNote[]): HashtagItem[] {
   return notes
     .filter((n) => n.title.trim())
     .map((n) => ({

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -101,7 +101,7 @@ export function timelineToHashtagItems(
   }
 
   for (const review of timeline.reviews) {
-    const title = review.title || `Review of ${review.commitSha.slice(0, 7)}`;
+    const title = review.title || review.commitSha.slice(0, 7);
     items.push({
       type: 'review',
       id: review.id,

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -592,6 +592,9 @@
         <TimelineRow
           type={item.type}
           title={item.title}
+          titleHtml={hashtagItems.length > 0 && hasHashtagTokens(item.title)
+            ? renderHashtagTokens(item.title, hashtagItems)
+            : undefined}
           secondaryMeta={item.sessionId
             ? (liveSessionHints[item.sessionId] ??
               item.secondaryMeta ??


### PR DESCRIPTION
## Summary
- Fix hashtag badges in BranchCard timeline to resolve titles properly by splitting `buildBranchHashtagItems` into reactive timeline-derived items and once-loaded project note items
- Export `timelineToHashtagItems` and `projectNotesToHashtagItems` for direct use in BranchCard
- Remove redundant "Review of" prefix in hashtag badge fallback for reviews
- Render hashtag badge HTML in BranchTimeline rows when hashtag tokens are present

## Test plan
- [ ] Verify hashtag badges in timeline rows display resolved titles instead of raw IDs
- [ ] Verify review hashtag badges show commit SHA without "Review of" prefix
- [ ] Confirm project note hashtag badges still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)