### PR TITLE
fix(penpal): replace straggling npm usage with pnpm

### DIFF
--- a/apps/penpal/DEPENDENCIES.md
+++ b/apps/penpal/DEPENDENCIES.md
@@ -58,6 +58,7 @@ see-also:
 - **Used by:** Building the React frontend (Vite), running frontend tests (Vitest), running e2e tests (Playwright)
 - **Where it runs:** Dev and CI only (compiled JS/HTML assets bundled into .app)
 - **Why external:** Vite and TypeScript compiler require a Node.js runtime
+- **Note:** This project uses **pnpm** (not npm). The root `package.json` enforces this via the `packageManager` field, and `pnpm-workspace.yaml` defines the workspace. Do not use `npm install` or commit `package-lock.json` files.
 
 ## Optional Runtime Dependencies
 

--- a/apps/penpal/justfile
+++ b/apps/penpal/justfile
@@ -173,7 +173,7 @@ prepare version:
     # Update version in Cargo.toml (source of truth)
     sed -i '' 's/^version = ".*"/version = "{{version}}"/' frontend/src-tauri/Cargo.toml
     # Update version in package.json
-    cd frontend && npm version "{{version}}" --no-git-tag-version && cd ..
+    cd frontend && pnpm version "{{version}}" --no-git-tag-version && cd ..
 
     # Generate and review changelog
     just changelog {{version}}


### PR DESCRIPTION
## Summary

Replace the last remaining `npm` invocation with `pnpm` and document the pnpm-only policy in DEPENDENCIES.md.

## Changes

- **justfile**: Change `npm version` to `pnpm version` in the release recipe (line 176)
- **DEPENDENCIES.md**: Add a Note to D-DEP-NODE clarifying that pnpm is the package manager, npm must not be used, and `package-lock.json` files must not be committed

## Context

After the npm-to-pnpm migration (b000bfb) and the recent lockfile cleanup (#628), this was the last straggling npm reference in the project. The DEPENDENCIES.md note makes the policy explicit to prevent future drift.