### PR TITLE
fix(staged): propagate git errors and reload timeline after cache invalidation

### DIFF
--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -83,14 +83,10 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         // Local branch: fetch commits from the local worktree
         let worktree_path = Path::new(&wd.path);
         if worktree_path.exists() {
-            let git_commits = match git::get_commits_since_base(worktree_path, &branch.base_branch)
-            {
-                Ok(commits) => commits,
-                Err(e) => {
-                    log::warn!("Failed to get commits since base for branch {branch_id}: {e:?}");
-                    vec![]
-                }
-            };
+            let git_commits = git::get_commits_since_base(worktree_path, &branch.base_branch)
+                .map_err(|e| {
+                    format!("Failed to get commits since base for branch {branch_id}: {e:?}")
+                })?;
 
             // For each git commit, look up our metadata (session linkage)
             for gc in git_commits {

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -320,6 +320,9 @@ const inFlightTimelines = new Map<string, Promise<BranchTimeline>>();
 
 export function invalidateBranchTimeline(branchId: string): void {
   timelineCache.delete(branchId);
+  window.dispatchEvent(
+    new CustomEvent('timeline-invalidated', { detail: { branchIds: [branchId] } })
+  );
 }
 
 interface GetBranchTimelineOptions {
@@ -373,6 +376,7 @@ export function invalidateProjectBranchTimelines(branchIds: string[]): void {
   for (const id of branchIds) {
     timelineCache.delete(id);
   }
+  window.dispatchEvent(new CustomEvent('timeline-invalidated', { detail: { branchIds } }));
 }
 
 // =============================================================================

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -513,6 +513,18 @@
     void loadTimeline();
   });
 
+  // Re-fetch timeline when the cache is invalidated (e.g. after project-setup-progress)
+  $effect(() => {
+    const handler = (e: Event) => {
+      const { branchIds } = (e as CustomEvent<{ branchIds: string[] }>).detail;
+      if (branchIds.includes(branch.id) && (branch.worktreePath || isRemote)) {
+        void loadTimeline();
+      }
+    };
+    window.addEventListener('timeline-invalidated', handler);
+    return () => window.removeEventListener('timeline-invalidated', handler);
+  });
+
   let revalidationVersion = 0;
 
   async function loadTimeline() {

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -118,8 +118,18 @@
         ]);
         setProjects(projectsList);
         projects = projectsList;
-        branchesByProject = new Map(branchesByProject).set(projectId, branches);
-        commands.invalidateProjectBranchTimelines(branches.map((b) => b.id));
+        // Merge branches carefully: don't let a stale async response overwrite
+        // worktreePath with null when we already have it set.
+        const existingBranches = branchesByProject.get(projectId) || [];
+        const mergedBranches = branches.map((newBranch) => {
+          const existing = existingBranches.find((b) => b.id === newBranch.id);
+          if (existing?.worktreePath && !newBranch.worktreePath) {
+            return { ...newBranch, worktreePath: existing.worktreePath };
+          }
+          return newBranch;
+        });
+        branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
+        commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
         workspaceLifecycle.enqueueInitialSetup(projectId, branches);
         replaceProjectRepos(projectId, repos);
         void repoBadgeStore.ensureForRepos(


### PR DESCRIPTION
## Summary
- Propagate git errors from `build_branch_timeline` instead of silently swallowing them, so callers can react to failures
- Dispatch `timeline-invalidated` custom events when branch timeline caches are cleared, and listen for them in `BranchCard` to trigger a re-fetch
- Prevent stale async responses in `ProjectHome` from overwriting `worktreePath` with null when it's already set

## Test plan
- [ ] Create a project from a PR and verify commits appear in the timeline without needing a manual refresh
- [ ] Verify git errors in timeline building surface to the UI instead of showing an empty commit list
- [ ] Confirm that rapid project reloads don't cause worktreePath to flicker to null

🤖 Generated with [Claude Code](https://claude.com/claude-code)