### PR TITLE
fix(staged): handle fork PRs correctly and fetch PRs by number

### DIFF
--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -885,7 +885,15 @@ fn create_and_link_worktree(
     // Reuse any existing worktree for this branch; otherwise create one.
     // Only consider worktrees within this project's directory to avoid
     // picking up stale worktrees from deleted projects.
-    let project_root = git::project_worktree_root_for(&branch.project_id).ok();
+    let project_root = git::project_worktree_root_for(&branch.project_id)
+        .inspect_err(|e| {
+            log::debug!(
+                "Could not determine worktree root for project '{}': {e}; \
+                 falling back to accepting any matching worktree",
+                branch.project_id
+            );
+        })
+        .ok();
     let project_root_ref = project_root.as_deref();
 
     // When a stale worktree from another project holds the branch name, pick

--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -459,17 +459,56 @@ pub(crate) async fn setup_remote_repo_clone(
     Ok(())
 }
 
+/// Result of searching for an existing worktree for a branch name.
+enum ExistingWorktree {
+    /// A worktree was found under the current project's directory.
+    Found(PathBuf),
+    /// No worktree exists for this branch name.
+    None,
+    /// A worktree exists but under a different project's directory (stale).
+    /// The local branch name is taken so the caller must use a different one.
+    Stale,
+}
+
+/// Find an existing git worktree checked out on `branch_name`.
+///
+/// When `project_root` is provided, only worktrees whose path lives under that
+/// directory are considered a match.  Worktrees that match by branch name but
+/// live under a *different* project return [`ExistingWorktree::Stale`] so the
+/// caller can use a different local branch name.
 fn find_existing_worktree_for_branch(
     repo_path: &Path,
     branch_name: &str,
-) -> Result<Option<PathBuf>, String> {
-    Ok(git::list_worktrees(repo_path)
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .find_map(|(path, wt_branch)| match wt_branch.as_deref() {
-            Some(name) if name == branch_name => Some(path),
-            _ => None,
-        }))
+    project_root: Option<&Path>,
+) -> Result<ExistingWorktree, String> {
+    let worktrees = git::list_worktrees(repo_path).map_err(|e| e.to_string())?;
+
+    for (path, wt_branch) in worktrees {
+        if wt_branch.as_deref() != Some(branch_name) {
+            continue;
+        }
+
+        // If no project_root filter, accept the first match (legacy behaviour).
+        let Some(root) = project_root else {
+            return Ok(ExistingWorktree::Found(path));
+        };
+
+        if path.starts_with(root) {
+            return Ok(ExistingWorktree::Found(path));
+        }
+
+        // Worktree belongs to another (likely deleted) project — the local
+        // branch name is taken so the caller should pick a different one.
+        log::info!(
+            "[find_existing_worktree_for_branch] Stale worktree '{}' for branch '{}' (outside project root '{}')",
+            path.display(),
+            branch_name,
+            root.display(),
+        );
+        return Ok(ExistingWorktree::Stale);
+    }
+
+    Ok(ExistingWorktree::None)
 }
 
 fn is_worktree_path_exists_error(err: &str) -> bool {
@@ -494,10 +533,25 @@ fn fallback_worktree_path_for(desired_path: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Generate a unique local branch name by appending `-2`, `-3`, etc.
+fn unique_branch_name(repo_path: &Path, base_name: &str) -> Result<String, String> {
+    for suffix in 2..=50 {
+        let candidate = format!("{base_name}-{suffix}");
+        if !git::branch_exists(repo_path, &candidate).map_err(|e| e.to_string())? {
+            return Ok(candidate);
+        }
+    }
+    Err(format!(
+        "Could not find a unique branch name for '{base_name}' (tried {base_name}-2 through \
+         {base_name}-50). Delete unused worktrees or branches with `git branch -d` to free up names."
+    ))
+}
+
 fn create_worktree_for_existing_branch_with_fallback(
     repo_path: &Path,
     branch_name: &str,
     desired_worktree_path: &Path,
+    project_root: Option<&Path>,
 ) -> Result<PathBuf, String> {
     match git::create_worktree_for_existing_branch_at_path(
         repo_path,
@@ -506,7 +560,9 @@ fn create_worktree_for_existing_branch_with_fallback(
     ) {
         Ok(path) => Ok(path),
         Err(err) => {
-            if let Some(path) = find_existing_worktree_for_branch(repo_path, branch_name)? {
+            if let ExistingWorktree::Found(path) =
+                find_existing_worktree_for_branch(repo_path, branch_name, project_root)?
+            {
                 log::warn!(
                     "Reusing existing worktree '{}' for branch '{}' after create retry",
                     path.display(),
@@ -544,11 +600,14 @@ fn create_worktree_with_fallback(
     branch_name: &str,
     base_branch: &str,
     desired_worktree_path: &Path,
+    project_root: Option<&Path>,
 ) -> Result<PathBuf, String> {
     match git::create_worktree_at_path(repo_path, branch_name, base_branch, desired_worktree_path) {
         Ok(path) => Ok(path),
         Err(err) => {
-            if let Some(path) = find_existing_worktree_for_branch(repo_path, branch_name)? {
+            if let ExistingWorktree::Found(path) =
+                find_existing_worktree_for_branch(repo_path, branch_name, project_root)?
+            {
                 log::warn!(
                     "Reusing existing worktree '{}' for branch '{}' after create failure",
                     path.display(),
@@ -854,25 +913,48 @@ pub async fn setup_worktree(
     }
 
     // Reuse any existing worktree for this branch; otherwise create one.
-    let existing_worktree_path =
-        find_existing_worktree_for_branch(&repo_path, &branch.branch_name)?;
+    // Only consider worktrees within this project's directory to avoid
+    // picking up stale worktrees from deleted projects.
+    let project_root = git::project_worktree_root_for(&branch.project_id).ok();
+    let project_root_ref = project_root.as_deref();
 
-    let worktree_path = if let Some(path) = existing_worktree_path {
+    // When a stale worktree from another project holds the branch name, pick
+    // a unique local branch name so we don't collide.
+    let mut local_branch_name = branch.branch_name.clone();
+    let existing_worktree =
+        find_existing_worktree_for_branch(&repo_path, &branch.branch_name, project_root_ref)?;
+    if let ExistingWorktree::Stale = &existing_worktree {
+        local_branch_name = unique_branch_name(&repo_path, &branch.branch_name)?;
+        log::info!(
+            "Branch '{}' is checked out in a stale worktree; using '{}' instead",
+            branch.branch_name,
+            local_branch_name,
+        );
+    }
+
+    let worktree_path = if let ExistingWorktree::Found(path) = existing_worktree {
         path
-    } else if git::branch_exists(&repo_path, &branch.branch_name).map_err(|e| e.to_string())? {
+    } else if local_branch_name == branch.branch_name
+        && git::branch_exists(&repo_path, &local_branch_name).map_err(|e| e.to_string())?
+    {
         create_worktree_for_existing_branch_with_fallback(
             &repo_path,
-            &branch.branch_name,
+            &local_branch_name,
             &desired_worktree_path,
+            project_root_ref,
         )
         .map_err(|e| e.to_string())?
     } else {
-        // If the branch exists on the remote (e.g. from an existing PR),
-        // start the new local branch from the remote tracking ref so it
-        // includes the PR's commits. Otherwise fall back to base_branch
-        // for genuinely new branches.
+        // For PRs, always start from `refs/pull/<N>/head` — the branch
+        // name on origin may belong to a different branch when the PR
+        // comes from a fork repo.  For non-PR branches, fall back to the
+        // remote tracking ref or base_branch.
         let remote_ref = format!("origin/{}", branch.branch_name);
-        let start_point = if git::remote_branch_exists(&repo_path, &branch.branch_name)
+        let pr_head_sha;
+        let start_point = if let Some(pr_num) = branch.pr_number {
+            pr_head_sha = git::fetch_pr_head_sha(&repo_path, pr_num).map_err(|e| e.to_string())?;
+            &pr_head_sha
+        } else if git::remote_branch_exists(&repo_path, &branch.branch_name)
             .map_err(|e| e.to_string())?
         {
             &remote_ref
@@ -881,35 +963,37 @@ pub async fn setup_worktree(
         };
         match create_worktree_with_fallback(
             &repo_path,
-            &branch.branch_name,
+            &local_branch_name,
             start_point,
             &desired_worktree_path,
+            project_root_ref,
         ) {
             Ok(path) => path,
             Err(create_err) => {
-                if let Some(path) =
-                    find_existing_worktree_for_branch(&repo_path, &branch.branch_name)?
-                {
+                if let ExistingWorktree::Found(path) = find_existing_worktree_for_branch(
+                    &repo_path,
+                    &local_branch_name,
+                    project_root_ref,
+                )? {
                     log::warn!(
                         "Reusing existing worktree '{}' for branch '{}' after create failure",
                         path.display(),
-                        branch.branch_name
+                        local_branch_name
                     );
                     path
-                } else if git::branch_exists(&repo_path, &branch.branch_name)
+                } else if git::branch_exists(&repo_path, &local_branch_name)
                     .map_err(|e| e.to_string())?
                 {
-                    // Handle races/stale refs where the branch appears between our
-                    // pre-check and `git worktree add -b ...`.
                     log::warn!(
                         "Branch '{}' already exists after create attempt; retrying with existing branch in repo '{}'",
-                        branch.branch_name,
+                        local_branch_name,
                         repo_slug
                     );
                     create_worktree_for_existing_branch_with_fallback(
                         &repo_path,
-                        &branch.branch_name,
+                        &local_branch_name,
                         &desired_worktree_path,
+                        project_root_ref,
                     )
                     .map_err(|e| e.to_string())?
                 } else {
@@ -918,6 +1002,26 @@ pub async fn setup_worktree(
             }
         }
     };
+
+    // For PR branches created from a SHA, git won't have set upstream tracking
+    // automatically. Set it to origin/<branch_name> if the remote branch exists
+    // (same-repo PRs). Fork PRs won't have a matching remote branch, so this
+    // is a best-effort no-op for them.
+    if branch.pr_number.is_some() {
+        let _ = git::set_upstream_to_origin(&repo_path, &local_branch_name, &branch.branch_name);
+    }
+
+    // If we picked a different local branch name, persist it.
+    if local_branch_name != branch.branch_name {
+        store
+            .update_branch_name(&branch.id, &local_branch_name)
+            .map_err(|e| e.to_string())?;
+        if let Some(repo_id) = &branch.project_repo_id {
+            store
+                .update_project_repo_branch_name(&branch.project_id, repo_id, &local_branch_name)
+                .map_err(|e| e.to_string())?;
+        }
+    }
 
     let worktree_str = worktree_path
         .to_str()
@@ -2156,26 +2260,48 @@ pub(crate) fn setup_worktree_sync(
 
     emit_progress("creating_worktree", None);
     // Reuse any existing worktree for this branch; otherwise create one.
-    let existing_worktree_path =
-        find_existing_worktree_for_branch(&repo_path, &branch.branch_name)?;
+    // Only consider worktrees within this project's directory to avoid
+    // picking up stale worktrees from deleted projects.
+    let project_root = crate::git::project_worktree_root_for(&branch.project_id).ok();
+    let project_root_ref = project_root.as_deref();
 
-    let worktree_path = if let Some(path) = existing_worktree_path {
+    // When a stale worktree from another project holds the branch name, pick
+    // a unique local branch name so we don't collide.
+    let mut local_branch_name = branch.branch_name.clone();
+    let existing_worktree =
+        find_existing_worktree_for_branch(&repo_path, &branch.branch_name, project_root_ref)?;
+    if let ExistingWorktree::Stale = &existing_worktree {
+        local_branch_name = unique_branch_name(&repo_path, &branch.branch_name)?;
+        log::info!(
+            "Branch '{}' is checked out in a stale worktree; using '{}' instead",
+            branch.branch_name,
+            local_branch_name,
+        );
+    }
+
+    let worktree_path = if let ExistingWorktree::Found(path) = existing_worktree {
         path
-    } else if crate::git::branch_exists(&repo_path, &branch.branch_name)
-        .map_err(|e| e.to_string())?
+    } else if local_branch_name == branch.branch_name
+        && crate::git::branch_exists(&repo_path, &local_branch_name).map_err(|e| e.to_string())?
     {
         create_worktree_for_existing_branch_with_fallback(
             &repo_path,
-            &branch.branch_name,
+            &local_branch_name,
             &desired_worktree_path,
+            project_root_ref,
         )?
     } else {
-        // If the branch exists on the remote (e.g. from an existing PR),
-        // start the new local branch from the remote tracking ref so it
-        // includes the PR's commits. Otherwise fall back to base_branch
-        // for genuinely new branches.
+        // For PRs, always start from `refs/pull/<N>/head` — the branch
+        // name on origin may belong to a different branch when the PR
+        // comes from a fork repo.  For non-PR branches, fall back to the
+        // remote tracking ref or base_branch.
         let remote_ref = format!("origin/{}", branch.branch_name);
-        let start_point = if crate::git::remote_branch_exists(&repo_path, &branch.branch_name)
+        let pr_head_sha;
+        let start_point = if let Some(pr_num) = branch.pr_number {
+            pr_head_sha =
+                crate::git::fetch_pr_head_sha(&repo_path, pr_num).map_err(|e| e.to_string())?;
+            &pr_head_sha
+        } else if crate::git::remote_branch_exists(&repo_path, &branch.branch_name)
             .map_err(|e| e.to_string())?
         {
             &remote_ref
@@ -2184,32 +2310,36 @@ pub(crate) fn setup_worktree_sync(
         };
         match create_worktree_with_fallback(
             &repo_path,
-            &branch.branch_name,
+            &local_branch_name,
             start_point,
             &desired_worktree_path,
+            project_root_ref,
         ) {
             Ok(path) => path,
             Err(create_err) => {
-                if let Some(path) =
-                    find_existing_worktree_for_branch(&repo_path, &branch.branch_name)?
-                {
+                if let ExistingWorktree::Found(path) = find_existing_worktree_for_branch(
+                    &repo_path,
+                    &local_branch_name,
+                    project_root_ref,
+                )? {
                     log::warn!(
                         "[setup_worktree_sync] Reusing existing worktree '{}' for branch '{}' after create failure",
                         path.display(),
-                        branch.branch_name
+                        local_branch_name
                     );
                     path
-                } else if crate::git::branch_exists(&repo_path, &branch.branch_name)
+                } else if crate::git::branch_exists(&repo_path, &local_branch_name)
                     .map_err(|e| e.to_string())?
                 {
                     log::warn!(
                         "[setup_worktree_sync] Branch '{}' already exists after create attempt; retrying with existing branch",
-                        branch.branch_name
+                        local_branch_name
                     );
                     create_worktree_for_existing_branch_with_fallback(
                         &repo_path,
-                        &branch.branch_name,
+                        &local_branch_name,
                         &desired_worktree_path,
+                        project_root_ref,
                     )?
                 } else {
                     return Err(create_err);
@@ -2217,6 +2347,27 @@ pub(crate) fn setup_worktree_sync(
             }
         }
     };
+
+    // For PR branches created from a SHA, git won't have set upstream tracking
+    // automatically. Set it to origin/<branch_name> if the remote branch exists
+    // (same-repo PRs). Fork PRs won't have a matching remote branch, so this
+    // is a best-effort no-op for them.
+    if branch.pr_number.is_some() {
+        let _ =
+            crate::git::set_upstream_to_origin(&repo_path, &local_branch_name, &branch.branch_name);
+    }
+
+    // If we picked a different local branch name, persist it.
+    if local_branch_name != branch.branch_name {
+        store
+            .update_branch_name(&branch.id, &local_branch_name)
+            .map_err(|e| e.to_string())?;
+        if let Some(repo_id) = &branch.project_repo_id {
+            store
+                .update_project_repo_branch_name(&branch.project_id, repo_id, &local_branch_name)
+                .map_err(|e| e.to_string())?;
+        }
+    }
 
     let worktree_str = worktree_path
         .to_str()

--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -854,50 +854,20 @@ pub fn create_branch(
     Ok(to_branch_with_workdir(branch, None))
 }
 
-/// Create the git worktree for a local branch and record its workdir.
+/// Core worktree creation + DB linkage logic shared by [`setup_worktree`] and
+/// [`setup_worktree_sync`].
 ///
-/// Separated from `create_branch` so the frontend can dismiss the modal
-/// immediately and show a "Creating worktree…" spinner on the branch card
-/// while this runs in the background.
-#[tauri::command(rename_all = "camelCase")]
-pub async fn setup_worktree(
-    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
-    branch_id: String,
-) -> Result<BranchWithWorkdir, String> {
-    let store = get_store(&store)?;
-
-    let branch = store
-        .get_branch(&branch_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
-
-    let project = store
-        .get_project(&branch.project_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Project not found: {}", branch.project_id))?;
-
-    // Idempotent fast-path: if this branch already has a workdir, reuse it.
-    if let Some(existing) = store
-        .get_workdir_for_branch(&branch.id)
-        .map_err(|e| e.to_string())?
-    {
-        return Ok(to_branch_with_workdir(branch, Some(existing.path)));
-    }
-
-    // Ensure we have a local clone, then fetch the specific refs we need.
-    let repo_slug = resolve_branch_repo_slug(&store, &project, &branch)?;
-    let repo_path = git::ensure_local_clone(&repo_slug).map_err(|e| e.to_string())?;
-    git::fetch_for_worktree(
-        &repo_path,
-        &repo_slug,
-        &branch.branch_name,
-        &branch.base_branch,
-    )
-    .map_err(|e| e.to_string())?;
-    let desired_worktree_path =
-        git::project_worktree_path_for(&branch.project_id, &repo_slug, &branch.branch_name)
-            .map_err(|e| e.to_string())?;
-
+/// Acquires the per-branch worktree lock, creates (or reuses) a git worktree,
+/// sets upstream tracking for PR branches, persists any branch-name changes,
+/// and links the workdir in the database.
+///
+/// Returns the worktree path as a string.
+fn create_and_link_worktree(
+    store: &Arc<Store>,
+    branch: &store::Branch,
+    repo_path: &std::path::Path,
+    desired_worktree_path: &std::path::Path,
+) -> Result<String, String> {
     // Serialize worktree creation per branch so that concurrent callers
     // (frontend `setup_worktree` vs backend `setup_worktree_sync`) do not race.
     let lock = worktree_setup_lock_for(&branch.id);
@@ -909,7 +879,7 @@ pub async fn setup_worktree(
         .get_workdir_for_branch(&branch.id)
         .map_err(|e| e.to_string())?
     {
-        return Ok(to_branch_with_workdir(branch, Some(existing.path)));
+        return Ok(existing.path);
     }
 
     // Reuse any existing worktree for this branch; otherwise create one.
@@ -922,9 +892,9 @@ pub async fn setup_worktree(
     // a unique local branch name so we don't collide.
     let mut local_branch_name = branch.branch_name.clone();
     let existing_worktree =
-        find_existing_worktree_for_branch(&repo_path, &branch.branch_name, project_root_ref)?;
+        find_existing_worktree_for_branch(repo_path, &branch.branch_name, project_root_ref)?;
     if let ExistingWorktree::Stale = &existing_worktree {
-        local_branch_name = unique_branch_name(&repo_path, &branch.branch_name)?;
+        local_branch_name = unique_branch_name(repo_path, &branch.branch_name)?;
         log::info!(
             "Branch '{}' is checked out in a stale worktree; using '{}' instead",
             branch.branch_name,
@@ -935,12 +905,12 @@ pub async fn setup_worktree(
     let worktree_path = if let ExistingWorktree::Found(path) = existing_worktree {
         path
     } else if local_branch_name == branch.branch_name
-        && git::branch_exists(&repo_path, &local_branch_name).map_err(|e| e.to_string())?
+        && git::branch_exists(repo_path, &local_branch_name).map_err(|e| e.to_string())?
     {
         create_worktree_for_existing_branch_with_fallback(
-            &repo_path,
+            repo_path,
             &local_branch_name,
-            &desired_worktree_path,
+            desired_worktree_path,
             project_root_ref,
         )
         .map_err(|e| e.to_string())?
@@ -952,9 +922,9 @@ pub async fn setup_worktree(
         let remote_ref = format!("origin/{}", branch.branch_name);
         let pr_head_sha;
         let start_point = if let Some(pr_num) = branch.pr_number {
-            pr_head_sha = git::fetch_pr_head_sha(&repo_path, pr_num).map_err(|e| e.to_string())?;
+            pr_head_sha = git::fetch_pr_head_sha(repo_path, pr_num).map_err(|e| e.to_string())?;
             &pr_head_sha
-        } else if git::remote_branch_exists(&repo_path, &branch.branch_name)
+        } else if git::remote_branch_exists(repo_path, &branch.branch_name)
             .map_err(|e| e.to_string())?
         {
             &remote_ref
@@ -962,16 +932,16 @@ pub async fn setup_worktree(
             &branch.base_branch
         };
         match create_worktree_with_fallback(
-            &repo_path,
+            repo_path,
             &local_branch_name,
             start_point,
-            &desired_worktree_path,
+            desired_worktree_path,
             project_root_ref,
         ) {
             Ok(path) => path,
             Err(create_err) => {
                 if let ExistingWorktree::Found(path) = find_existing_worktree_for_branch(
-                    &repo_path,
+                    repo_path,
                     &local_branch_name,
                     project_root_ref,
                 )? {
@@ -981,18 +951,17 @@ pub async fn setup_worktree(
                         local_branch_name
                     );
                     path
-                } else if git::branch_exists(&repo_path, &local_branch_name)
+                } else if git::branch_exists(repo_path, &local_branch_name)
                     .map_err(|e| e.to_string())?
                 {
                     log::warn!(
-                        "Branch '{}' already exists after create attempt; retrying with existing branch in repo '{}'",
-                        local_branch_name,
-                        repo_slug
+                        "Branch '{}' already exists after create attempt; retrying with existing branch",
+                        local_branch_name
                     );
                     create_worktree_for_existing_branch_with_fallback(
-                        &repo_path,
+                        repo_path,
                         &local_branch_name,
-                        &desired_worktree_path,
+                        desired_worktree_path,
                         project_root_ref,
                     )
                     .map_err(|e| e.to_string())?
@@ -1008,7 +977,7 @@ pub async fn setup_worktree(
     // (same-repo PRs). Fork PRs won't have a matching remote branch, so this
     // is a best-effort no-op for them.
     if branch.pr_number.is_some() {
-        let _ = git::set_upstream_to_origin(&repo_path, &local_branch_name, &branch.branch_name);
+        let _ = git::set_upstream_to_origin(repo_path, &local_branch_name, &branch.branch_name);
     }
 
     // If we picked a different local branch name, persist it.
@@ -1058,6 +1027,56 @@ pub async fn setup_worktree(
     }
 
     // _guard dropped here, releasing the per-branch lock.
+    Ok(worktree_str)
+}
+
+/// Create the git worktree for a local branch and record its workdir.
+///
+/// Separated from `create_branch` so the frontend can dismiss the modal
+/// immediately and show a "Creating worktree…" spinner on the branch card
+/// while this runs in the background.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn setup_worktree(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    branch_id: String,
+) -> Result<BranchWithWorkdir, String> {
+    let store = get_store(&store)?;
+
+    let branch = store
+        .get_branch(&branch_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+    let project = store
+        .get_project(&branch.project_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Project not found: {}", branch.project_id))?;
+
+    // Idempotent fast-path: if this branch already has a workdir, reuse it.
+    if let Some(existing) = store
+        .get_workdir_for_branch(&branch.id)
+        .map_err(|e| e.to_string())?
+    {
+        return Ok(to_branch_with_workdir(branch, Some(existing.path)));
+    }
+
+    // Ensure we have a local clone, then fetch the specific refs we need.
+    let repo_slug = resolve_branch_repo_slug(&store, &project, &branch)?;
+    let repo_path = git::ensure_local_clone(&repo_slug).map_err(|e| e.to_string())?;
+    git::fetch_for_worktree(
+        &repo_path,
+        &repo_slug,
+        &branch.branch_name,
+        &branch.base_branch,
+    )
+    .map_err(|e| e.to_string())?;
+    let desired_worktree_path =
+        git::project_worktree_path_for(&branch.project_id, &repo_slug, &branch.branch_name)
+            .map_err(|e| e.to_string())?;
+
+    let worktree_str =
+        create_and_link_worktree(&store, &branch, &repo_path, &desired_worktree_path)?;
+
     Ok(to_branch_with_workdir(branch, Some(worktree_str)))
 }
 
@@ -2166,8 +2185,10 @@ fn parse_git_progress_line(line: &str) -> Option<(String, u32)> {
 
 /// Set up a git worktree for a branch synchronously.
 ///
-/// This replicates the core logic from `branches::setup_worktree` without
-/// requiring Tauri state, so it can be called from the MCP server.
+/// Like [`setup_worktree`] but callable without Tauri state (e.g. from the
+/// MCP server). Handles cloning with optional progress reporting, then
+/// delegates to [`create_and_link_worktree`] for worktree creation and DB
+/// linkage.
 pub(crate) fn setup_worktree_sync(
     store: &Arc<Store>,
     branch_id: &str,
@@ -2244,166 +2265,10 @@ pub(crate) fn setup_worktree_sync(
         crate::git::project_worktree_path_for(&branch.project_id, &repo_slug, &branch.branch_name)
             .map_err(|e| e.to_string())?;
 
-    // Serialize worktree creation per branch so that concurrent callers
-    // (frontend `setup_worktree` vs backend `setup_worktree_sync`) do not race.
-    let lock = worktree_setup_lock_for(&branch.id);
-    let _guard = lock.lock().unwrap_or_else(|p| p.into_inner());
-
-    // Re-check the DB fast-path under the lock — the other caller may have
-    // finished while we were waiting.
-    if let Some(existing) = store
-        .get_workdir_for_branch(&branch.id)
-        .map_err(|e| e.to_string())?
-    {
-        return Ok(existing.path);
-    }
-
     emit_progress("creating_worktree", None);
-    // Reuse any existing worktree for this branch; otherwise create one.
-    // Only consider worktrees within this project's directory to avoid
-    // picking up stale worktrees from deleted projects.
-    let project_root = crate::git::project_worktree_root_for(&branch.project_id).ok();
-    let project_root_ref = project_root.as_deref();
+    let worktree_str =
+        create_and_link_worktree(store, &branch, &repo_path, &desired_worktree_path)?;
 
-    // When a stale worktree from another project holds the branch name, pick
-    // a unique local branch name so we don't collide.
-    let mut local_branch_name = branch.branch_name.clone();
-    let existing_worktree =
-        find_existing_worktree_for_branch(&repo_path, &branch.branch_name, project_root_ref)?;
-    if let ExistingWorktree::Stale = &existing_worktree {
-        local_branch_name = unique_branch_name(&repo_path, &branch.branch_name)?;
-        log::info!(
-            "Branch '{}' is checked out in a stale worktree; using '{}' instead",
-            branch.branch_name,
-            local_branch_name,
-        );
-    }
-
-    let worktree_path = if let ExistingWorktree::Found(path) = existing_worktree {
-        path
-    } else if local_branch_name == branch.branch_name
-        && crate::git::branch_exists(&repo_path, &local_branch_name).map_err(|e| e.to_string())?
-    {
-        create_worktree_for_existing_branch_with_fallback(
-            &repo_path,
-            &local_branch_name,
-            &desired_worktree_path,
-            project_root_ref,
-        )?
-    } else {
-        // For PRs, always start from `refs/pull/<N>/head` — the branch
-        // name on origin may belong to a different branch when the PR
-        // comes from a fork repo.  For non-PR branches, fall back to the
-        // remote tracking ref or base_branch.
-        let remote_ref = format!("origin/{}", branch.branch_name);
-        let pr_head_sha;
-        let start_point = if let Some(pr_num) = branch.pr_number {
-            pr_head_sha =
-                crate::git::fetch_pr_head_sha(&repo_path, pr_num).map_err(|e| e.to_string())?;
-            &pr_head_sha
-        } else if crate::git::remote_branch_exists(&repo_path, &branch.branch_name)
-            .map_err(|e| e.to_string())?
-        {
-            &remote_ref
-        } else {
-            &branch.base_branch
-        };
-        match create_worktree_with_fallback(
-            &repo_path,
-            &local_branch_name,
-            start_point,
-            &desired_worktree_path,
-            project_root_ref,
-        ) {
-            Ok(path) => path,
-            Err(create_err) => {
-                if let ExistingWorktree::Found(path) = find_existing_worktree_for_branch(
-                    &repo_path,
-                    &local_branch_name,
-                    project_root_ref,
-                )? {
-                    log::warn!(
-                        "[setup_worktree_sync] Reusing existing worktree '{}' for branch '{}' after create failure",
-                        path.display(),
-                        local_branch_name
-                    );
-                    path
-                } else if crate::git::branch_exists(&repo_path, &local_branch_name)
-                    .map_err(|e| e.to_string())?
-                {
-                    log::warn!(
-                        "[setup_worktree_sync] Branch '{}' already exists after create attempt; retrying with existing branch",
-                        local_branch_name
-                    );
-                    create_worktree_for_existing_branch_with_fallback(
-                        &repo_path,
-                        &local_branch_name,
-                        &desired_worktree_path,
-                        project_root_ref,
-                    )?
-                } else {
-                    return Err(create_err);
-                }
-            }
-        }
-    };
-
-    // For PR branches created from a SHA, git won't have set upstream tracking
-    // automatically. Set it to origin/<branch_name> if the remote branch exists
-    // (same-repo PRs). Fork PRs won't have a matching remote branch, so this
-    // is a best-effort no-op for them.
-    if branch.pr_number.is_some() {
-        let _ =
-            crate::git::set_upstream_to_origin(&repo_path, &local_branch_name, &branch.branch_name);
-    }
-
-    // If we picked a different local branch name, persist it.
-    if local_branch_name != branch.branch_name {
-        store
-            .update_branch_name(&branch.id, &local_branch_name)
-            .map_err(|e| e.to_string())?;
-        if let Some(repo_id) = &branch.project_repo_id {
-            store
-                .update_project_repo_branch_name(&branch.project_id, repo_id, &local_branch_name)
-                .map_err(|e| e.to_string())?;
-        }
-    }
-
-    let worktree_str = worktree_path
-        .to_str()
-        .ok_or("Invalid worktree path")?
-        .to_string();
-
-    // Link this path to the branch in DB (create or assign existing record).
-    let tracked_workdir = store
-        .list_workdirs_for_project(&branch.project_id)
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .find(|wd| wd.path == worktree_str);
-
-    match tracked_workdir {
-        Some(wd) => match wd.branch_id.as_deref() {
-            Some(existing_branch_id) if existing_branch_id != branch.id => {
-                return Err(format!(
-                    "Worktree '{}' is already assigned to another branch",
-                    wd.path
-                ));
-            }
-            Some(_) => {}
-            None => {
-                store
-                    .assign_workdir(&wd.id, &branch.id)
-                    .map_err(|e| e.to_string())?;
-            }
-        },
-        None => {
-            let workdir = crate::store::Workdir::new(&branch.project_id, &worktree_str)
-                .with_branch(&branch.id);
-            store.create_workdir(&workdir).map_err(|e| e.to_string())?;
-        }
-    }
-
-    // _guard dropped here, releasing the per-branch lock.
     Ok(worktree_str)
 }
 

--- a/apps/staged/src-tauri/src/git/github.rs
+++ b/apps/staged/src-tauri/src/git/github.rs
@@ -582,6 +582,29 @@ pub fn get_pr_for_repo(github_repo: &str, pr_number: u64) -> Result<PullRequest,
     Ok(item.into())
 }
 
+/// Find the open PR (if any) whose head branch matches `branch_name`.
+pub fn get_pr_for_branch_for_repo(
+    github_repo: &str,
+    branch_name: &str,
+) -> Result<Option<PullRequest>, GitError> {
+    let output = run_gh_global(&[
+        "pr",
+        "list",
+        "-R",
+        github_repo,
+        "--head",
+        branch_name,
+        "--state=open",
+        "--limit=1",
+        "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
+    ])?;
+
+    let items: Vec<GhPrListItem> =
+        serde_json::from_str(&output).map_err(|e| GitError::CommandFailed(e.to_string()))?;
+
+    Ok(items.into_iter().next().map(Into::into))
+}
+
 /// List open pull requests for a repo using `-R owner/repo` (no local dir needed).
 pub fn list_pull_requests_for_repo(github_repo: &str) -> Result<Vec<PullRequest>, GitError> {
     let output = run_gh_global(&[

--- a/apps/staged/src-tauri/src/git/github.rs
+++ b/apps/staged/src-tauri/src/git/github.rs
@@ -36,6 +36,9 @@ pub struct PullRequest {
     pub base_ref: String,
     /// Source branch (e.g., "feature-x") - not useful for forks
     pub head_ref: String,
+    /// The repository the PR's head branch lives in (e.g., "fork-owner/repo" for fork PRs).
+    /// None if the head repository has been deleted.
+    pub head_repo: Option<String>,
     pub draft: bool,
     pub updated_at: String,
 }
@@ -84,6 +87,25 @@ pub struct Issue {
     pub author: String,
     pub updated_at: String,
     pub labels: Vec<String>,
+}
+
+/// Owner login for deserializing `gh repo view --json=parent`.
+#[derive(Deserialize)]
+struct RepoOwner {
+    login: String,
+}
+
+/// Parent repo info from `gh repo view --json=parent`.
+#[derive(Deserialize)]
+struct ParentRepoInfo {
+    owner: RepoOwner,
+    name: String,
+}
+
+/// Top-level response from `gh repo view --json=parent`.
+#[derive(Deserialize)]
+struct ParentRepoView {
+    parent: Option<ParentRepoInfo>,
 }
 
 // =============================================================================
@@ -552,7 +574,7 @@ pub fn list_pull_requests_for_repo(github_repo: &str) -> Result<Vec<PullRequest>
         github_repo,
         "--state=open",
         "--limit=50",
-        "--json=number,title,author,baseRefName,headRefName,isDraft,updatedAt",
+        "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
     ])?;
 
     let items: Vec<GhPrListItem> =
@@ -1073,6 +1095,8 @@ struct GhPrListItem {
     base_ref_name: String,
     #[serde(rename = "headRefName")]
     head_ref_name: String,
+    #[serde(rename = "headRepository")]
+    head_repository: Option<GhRepository>,
     #[serde(rename = "isDraft")]
     is_draft: bool,
     #[serde(rename = "updatedAt")]
@@ -1084,6 +1108,12 @@ struct GhAuthor {
     login: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct GhRepository {
+    #[serde(rename = "nameWithOwner")]
+    name_with_owner: String,
+}
+
 impl From<GhPrListItem> for PullRequest {
     fn from(item: GhPrListItem) -> Self {
         PullRequest {
@@ -1092,6 +1122,7 @@ impl From<GhPrListItem> for PullRequest {
             author: item.author.login,
             base_ref: item.base_ref_name,
             head_ref: item.head_ref_name,
+            head_repo: item.head_repository.map(|r| r.name_with_owner),
             draft: item.is_draft,
             updated_at: item.updated_at,
         }
@@ -1112,7 +1143,7 @@ pub fn list_pull_requests(repo: &Path) -> Result<Vec<PullRequest>, GitError> {
             "list",
             "--state=open",
             "--limit=50",
-            "--json=number,title,author,baseRefName,headRefName,isDraft,updatedAt",
+            "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
         ],
     )?;
 
@@ -1139,7 +1170,7 @@ pub fn search_pull_requests(repo: &Path, query: &str) -> Result<Vec<PullRequest>
             "--state=open",
             "--limit=50",
             &format!("--search={query}"),
-            "--json=number,title,author,baseRefName,headRefName,isDraft,updatedAt",
+            "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
         ],
     )?;
 
@@ -1233,15 +1264,10 @@ pub fn search_issues(repo: &Path, query: &str) -> Result<Vec<Issue>, GitError> {
 /// Returns DiffSpec with two concrete SHAs: Rev(merge_base)..Rev(head_sha)
 pub fn fetch_pr(repo: &Path, base_ref: &str, pr_number: u64) -> Result<DiffSpec, GitError> {
     use super::cli;
+    use super::worktree::fetch_pr_head_sha;
 
-    // Fetch the PR head ref
-    let pr_ref = format!("refs/pull/{pr_number}/head");
-    cli::run(repo, &["fetch", "origin", &pr_ref])?;
-
-    // Get the SHA of the fetched PR head IMMEDIATELY (before next fetch overwrites FETCH_HEAD)
-    let head_sha = cli::run(repo, &["rev-parse", "FETCH_HEAD"])?
-        .trim()
-        .to_string();
+    // Fetch the PR head ref using a named local ref (safe for concurrent use)
+    let head_sha = fetch_pr_head_sha(repo, pr_number)?;
 
     // Fetch the base branch
     let base_remote_ref = format!("origin/{base_ref}");
@@ -2013,6 +2039,73 @@ pub fn fetch_pr_status_for_repo(github_repo: &str, pr_number: u64) -> Result<PrS
         },
         head_sha: item.head_ref_oid,
     })
+}
+
+/// Fetch the canonical GitHub URL for a pull request.
+///
+/// PRs always live on the base (upstream) repository, but the stored repo may
+/// be the fork (head) repo for fork PRs. This function first tries the given
+/// repo, then falls back to checking if it's a fork and querying the parent.
+pub fn fetch_pr_url(github_repo: &str, pr_number: u64) -> Result<String, GitError> {
+    let pr_num_str = pr_number.to_string();
+
+    // Try the stored repo first — works when it's already the base repo.
+    if let Ok(url) = fetch_pr_url_from_repo(github_repo, &pr_num_str) {
+        return Ok(url);
+    }
+
+    // The PR wasn't found — the stored repo may be the fork. Check for a parent.
+    let parent_args = &["repo", "view", github_repo, "--json=parent"];
+    let parent_output = run_gh_global(parent_args).map_err(|e| {
+        log::warn!(
+            "fetch_pr_url: failed to look up parent repo for {}: {}",
+            github_repo,
+            e
+        );
+        e
+    })?;
+
+    let view: ParentRepoView = serde_json::from_str(&parent_output)
+        .map_err(|e| GitError::CommandFailed(format!("Failed to parse parent repo: {e}")))?;
+
+    match view.parent {
+        Some(parent) => {
+            let parent_slug = format!("{}/{}", parent.owner.login, parent.name);
+            fetch_pr_url_from_repo(&parent_slug, &pr_num_str)
+        }
+        None => {
+            // Not a fork — fall back to constructing the URL.
+            Ok(format!(
+                "https://github.com/{}/pull/{}",
+                github_repo, pr_number
+            ))
+        }
+    }
+}
+
+/// If `github_repo` is a fork, return the parent repo slug. Returns `None` otherwise.
+pub fn get_parent_repo(github_repo: &str) -> Result<Option<String>, GitError> {
+    let args = &["repo", "view", github_repo, "--json=parent"];
+    let output = run_gh_global(args)?;
+
+    let view: ParentRepoView = serde_json::from_str(&output)
+        .map_err(|e| GitError::CommandFailed(format!("Failed to parse repo view: {e}")))?;
+
+    Ok(view.parent.map(|p| format!("{}/{}", p.owner.login, p.name)))
+}
+
+fn fetch_pr_url_from_repo(github_repo: &str, pr_num_str: &str) -> Result<String, GitError> {
+    let args = &["pr", "view", pr_num_str, "-R", github_repo, "--json=url"];
+    let output = run_gh_global(args)?;
+
+    #[derive(Deserialize)]
+    struct PrUrl {
+        url: String,
+    }
+
+    let parsed: PrUrl = serde_json::from_str(&output)
+        .map_err(|e| GitError::CommandFailed(format!("Failed to parse PR URL: {e}")))?;
+    Ok(parsed.url)
 }
 
 /// Push a branch to the remote.

--- a/apps/staged/src-tauri/src/git/github.rs
+++ b/apps/staged/src-tauri/src/git/github.rs
@@ -565,6 +565,23 @@ pub fn search_github_repos(query: &str, owner: Option<&str>) -> Result<Vec<GitHu
         .collect())
 }
 
+/// Fetch a single pull request by number using `-R owner/repo` (no local dir needed).
+pub fn get_pr_for_repo(github_repo: &str, pr_number: u64) -> Result<PullRequest, GitError> {
+    let output = run_gh_global(&[
+        "pr",
+        "view",
+        &pr_number.to_string(),
+        "-R",
+        github_repo,
+        "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
+    ])?;
+
+    let item: GhPrListItem =
+        serde_json::from_str(&output).map_err(|e| GitError::CommandFailed(e.to_string()))?;
+
+    Ok(item.into())
+}
+
 /// List open pull requests for a repo using `-R owner/repo` (no local dir needed).
 pub fn list_pull_requests_for_repo(github_repo: &str) -> Result<Vec<PullRequest>, GitError> {
     let output = run_gh_global(&[

--- a/apps/staged/src-tauri/src/git/mod.rs
+++ b/apps/staged/src-tauri/src/git/mod.rs
@@ -14,7 +14,7 @@ pub use files::{get_file_at_ref, search_files};
 pub use github::{
     check_github_auth, check_monorepo_modules, create_pull_request, detect_default_branch_for_repo,
     ensure_local_clone, ensure_local_clone_with_progress, fetch_for_worktree, fetch_github_repo,
-    fetch_pr, fetch_pr_status, fetch_pr_status_for_repo, get_pr_for_branch,
+    fetch_pr, fetch_pr_status, fetch_pr_status_for_repo, fetch_pr_url, get_pr_for_branch,
     invalidate_cache as invalidate_pr_cache, list_branches_for_repo, list_github_orgs,
     list_github_repos, list_issues, list_issues_for_repo, list_pull_requests,
     list_pull_requests_for_repo, list_repo_directories, list_user_repos, prune_remote_for_repo,
@@ -31,8 +31,9 @@ pub use types::*;
 pub use worktree::{
     branch_exists, create_worktree, create_worktree_at_path, create_worktree_for_existing_branch,
     create_worktree_for_existing_branch_at_path, create_worktree_from_pr,
-    create_worktree_from_pr_at_path, get_commits_since_base, get_full_commit_log, get_head_sha,
-    get_parent_commit, has_unpushed_commits, list_worktrees, project_worktree_path_for,
-    project_worktree_root_for, remote_branch_exists, remove_worktree, reset_to_commit,
-    switch_branch, update_branch_from_pr, worktree_path_for, CommitInfo, UpdateFromPrResult,
+    create_worktree_from_pr_at_path, fetch_pr_head_sha, get_commits_since_base,
+    get_full_commit_log, get_head_sha, get_parent_commit, has_unpushed_commits, list_worktrees,
+    project_worktree_path_for, project_worktree_root_for, remote_branch_exists, remove_worktree,
+    reset_to_commit, set_upstream_to_origin, switch_branch, update_branch_from_pr,
+    worktree_path_for, CommitInfo, UpdateFromPrResult,
 };

--- a/apps/staged/src-tauri/src/git/worktree.rs
+++ b/apps/staged/src-tauri/src/git/worktree.rs
@@ -122,9 +122,10 @@ pub fn create_worktree_at_path(
     ensure_worktree_parent_exists(worktree_path)?;
     ensure_worktree_absent(worktree_path)?;
 
-    // Normalise the start point to "origin/<branch>" form.
-    // The caller (setup_worktree) already fetched via fetch_for_worktree.
-    let remote_start = if start_point.starts_with("origin/") {
+    // Normalise the start point to "origin/<branch>" form unless it's
+    // already a full ref or a bare SHA (e.g. from fetch_pr_head_sha).
+    let is_sha = start_point.len() == 40 && start_point.chars().all(|c| c.is_ascii_hexdigit());
+    let remote_start = if is_sha || start_point.starts_with("origin/") {
         start_point.to_string()
     } else {
         format!("origin/{start_point}")
@@ -407,11 +408,53 @@ pub fn branch_exists(repo: &Path, branch_name: &str) -> Result<bool, GitError> {
     Ok(result.is_ok())
 }
 
+/// Set the upstream tracking branch for a local branch.
+///
+/// Runs `git branch --set-upstream-to=origin/<remote_branch> <local_branch>`.
+/// Returns `Ok(true)` if the upstream was set, `Ok(false)` if the remote branch
+/// doesn't exist (so there's nothing to track).
+pub fn set_upstream_to_origin(
+    repo: &Path,
+    local_branch: &str,
+    remote_branch: &str,
+) -> Result<bool, GitError> {
+    if !remote_branch_exists(repo, remote_branch)? {
+        return Ok(false);
+    }
+    let upstream = format!("origin/{remote_branch}");
+    cli::run(
+        repo,
+        &["branch", "--set-upstream-to", &upstream, local_branch],
+    )?;
+    Ok(true)
+}
+
 /// Check whether a remote tracking branch (`origin/<branch_name>`) exists.
 pub fn remote_branch_exists(repo: &Path, branch_name: &str) -> Result<bool, GitError> {
     let ref_name = format!("refs/remotes/origin/{branch_name}");
     let result = cli::run(repo, &["rev-parse", "--verify", &ref_name]);
     Ok(result.is_ok())
+}
+
+/// Fetch a PR's head ref and return the resulting commit SHA.
+/// Works for fork PRs because GitHub exposes `refs/pull/<N>/head` regardless
+/// of whether the head branch lives in the same repo or a fork.
+///
+/// Fetches into a named local ref (`refs/staged/pr/<N>`) instead of relying on
+/// `FETCH_HEAD`, which makes this safe for concurrent use across different PRs.
+pub fn fetch_pr_head_sha(repo: &Path, pr_number: u64) -> Result<String, GitError> {
+    let pr_ref = format!("refs/pull/{pr_number}/head");
+    let local_ref = format!("refs/staged/pr/{pr_number}");
+    let refspec = format!("+{pr_ref}:{local_ref}");
+    cli::run(repo, &["fetch", "origin", &refspec])?;
+    let sha = cli::run(repo, &["rev-parse", &local_ref])?
+        .trim()
+        .to_string();
+    // Clean up the temporary local ref to avoid accumulating refs over time
+    if let Err(e) = cli::run(repo, &["update-ref", "-d", &local_ref]) {
+        log::warn!("failed to clean up temporary ref {local_ref}: {e}");
+    }
+    Ok(sha)
 }
 
 /// Reset HEAD to a specific commit (hard reset).
@@ -468,14 +511,8 @@ pub fn create_worktree_from_pr_at_path(
     ensure_worktree_parent_exists(worktree_path)?;
     ensure_worktree_absent(worktree_path)?;
 
-    // Fetch the PR head ref
-    let pr_ref = format!("refs/pull/{pr_number}/head");
-    cli::run(repo, &["fetch", "origin", &pr_ref])?;
-
-    // Get the SHA of the fetched PR head
-    let head_sha = cli::run(repo, &["rev-parse", "FETCH_HEAD"])?
-        .trim()
-        .to_string();
+    // Fetch the PR head ref into a named local ref (safe for concurrent use)
+    let head_sha = fetch_pr_head_sha(repo, pr_number)?;
 
     let worktree_str = worktree_path
         .to_str()
@@ -528,14 +565,8 @@ pub fn update_branch_from_pr(
     // Get the current HEAD before update
     let old_sha = get_head_sha(worktree)?;
 
-    // Fetch the PR head ref
-    let pr_ref = format!("refs/pull/{pr_number}/head");
-    cli::run(worktree, &["fetch", "origin", &pr_ref])?;
-
-    // Get the SHA of the fetched PR head
-    let new_sha = cli::run(worktree, &["rev-parse", "FETCH_HEAD"])?
-        .trim()
-        .to_string();
+    // Fetch the PR head ref into a named local ref (safe for concurrent use)
+    let new_sha = fetch_pr_head_sha(worktree, pr_number)?;
 
     // If already up to date, return early
     if old_sha == new_sha {
@@ -555,11 +586,11 @@ pub fn update_branch_from_pr(
 
     if is_fast_forward {
         // Fast-forward: just move HEAD to the new commit
-        cli::run(worktree, &["merge", "--ff-only", "FETCH_HEAD"])?;
+        cli::run(worktree, &["merge", "--ff-only", &new_sha])?;
     } else {
         // Not a fast-forward (PR was force-pushed or rebased)
         // Hard reset to the new PR head
-        cli::run(worktree, &["reset", "--hard", "FETCH_HEAD"])?;
+        cli::run(worktree, &["reset", "--hard", &new_sha])?;
     }
 
     // Count how many commits were added

--- a/apps/staged/src-tauri/src/git/worktree.rs
+++ b/apps/staged/src-tauri/src/git/worktree.rs
@@ -442,6 +442,9 @@ pub fn remote_branch_exists(repo: &Path, branch_name: &str) -> Result<bool, GitE
 ///
 /// Fetches into a named local ref (`refs/staged/pr/<N>`) instead of relying on
 /// `FETCH_HEAD`, which makes this safe for concurrent use across different PRs.
+/// The local ref is intentionally kept after use — refs are tiny and harmless
+/// to accumulate, and deleting them would race with concurrent callers fetching
+/// the same PR number.
 pub fn fetch_pr_head_sha(repo: &Path, pr_number: u64) -> Result<String, GitError> {
     let pr_ref = format!("refs/pull/{pr_number}/head");
     let local_ref = format!("refs/staged/pr/{pr_number}");
@@ -450,10 +453,6 @@ pub fn fetch_pr_head_sha(repo: &Path, pr_number: u64) -> Result<String, GitError
     let sha = cli::run(repo, &["rev-parse", &local_ref])?
         .trim()
         .to_string();
-    // Clean up the temporary local ref to avoid accumulating refs over time
-    if let Err(e) = cli::run(repo, &["update-ref", "-d", &local_ref]) {
-        log::warn!("failed to clean up temporary ref {local_ref}: {e}");
-    }
     Ok(sha)
 }
 

--- a/apps/staged/src-tauri/src/github_commands.rs
+++ b/apps/staged/src-tauri/src/github_commands.rs
@@ -126,6 +126,19 @@ pub async fn check_existing_local_branch(
     }
 }
 
+/// Fetch a single pull request by number (via `-R owner/repo`).
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_pr_for_repo(
+    github_repo: String,
+    pr_number: u64,
+) -> Result<git::github::PullRequest, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        git::github::get_pr_for_repo(&github_repo, pr_number).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 /// List open pull requests for a repository (via `-R owner/repo`).
 #[tauri::command(rename_all = "camelCase")]
 pub async fn list_pull_requests(

--- a/apps/staged/src-tauri/src/github_commands.rs
+++ b/apps/staged/src-tauri/src/github_commands.rs
@@ -128,12 +128,33 @@ pub async fn check_existing_local_branch(
 
 /// List open pull requests for a repository (via `-R owner/repo`).
 #[tauri::command(rename_all = "camelCase")]
-pub fn list_pull_requests(github_repo: String) -> Result<Vec<git::github::PullRequest>, String> {
-    git::list_pull_requests_for_repo(&github_repo).map_err(|e| e.to_string())
+pub async fn list_pull_requests(
+    github_repo: String,
+) -> Result<Vec<git::github::PullRequest>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        git::list_pull_requests_for_repo(&github_repo).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// If `github_repo` is a fork, return the parent repo slug (e.g. `"base-owner/repo"`).
+/// Returns `null` when the repo is not a fork.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_parent_repo(github_repo: String) -> Result<Option<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        git::github::get_parent_repo(&github_repo).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 /// List open issues for a repository (via `-R owner/repo`).
 #[tauri::command(rename_all = "camelCase")]
-pub fn list_issues(github_repo: String) -> Result<Vec<git::github::Issue>, String> {
-    git::list_issues_for_repo(&github_repo).map_err(|e| e.to_string())
+pub async fn list_issues(github_repo: String) -> Result<Vec<git::github::Issue>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        git::list_issues_for_repo(&github_repo).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }

--- a/apps/staged/src-tauri/src/github_commands.rs
+++ b/apps/staged/src-tauri/src/github_commands.rs
@@ -139,6 +139,20 @@ pub async fn get_pr_for_repo(
     .map_err(|e| e.to_string())?
 }
 
+/// Find the open PR (if any) whose head branch matches `branch_name`.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_pr_for_branch(
+    github_repo: String,
+    branch_name: String,
+) -> Result<Option<git::github::PullRequest>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        git::github::get_pr_for_branch_for_repo(&github_repo, &branch_name)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 /// List open pull requests for a repository (via `-R owner/repo`).
 #[tauri::command(rename_all = "camelCase")]
 pub async fn list_pull_requests(

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -1810,6 +1810,7 @@ pub fn run() {
             github_commands::detect_default_branch_cmd,
             github_commands::prune_remote_refs,
             github_commands::check_existing_local_branch,
+            github_commands::get_pr_for_repo,
             github_commands::list_pull_requests,
             github_commands::get_parent_repo,
             github_commands::list_issues,

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -1811,6 +1811,7 @@ pub fn run() {
             github_commands::prune_remote_refs,
             github_commands::check_existing_local_branch,
             github_commands::get_pr_for_repo,
+            github_commands::get_pr_for_branch,
             github_commands::list_pull_requests,
             github_commands::get_parent_repo,
             github_commands::list_issues,

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -354,6 +354,7 @@ fn create_project(
     branch_name: Option<String>,
     pr_number: Option<u64>,
     default_branch: Option<String>,
+    head_repo: Option<String>,
 ) -> Result<store::Project, String> {
     let store = get_store(&store)?;
     let trimmed = name.trim();
@@ -404,8 +405,9 @@ fn create_project(
     }
 
     if let Some(repo) = github_repo {
-        let project_repo =
+        let mut project_repo =
             store::ProjectRepo::new(&project.id, &repo, &inferred_branch_name, subpath).primary();
+        project_repo.head_repo = head_repo;
         store
             .create_project_repo(&project_repo)
             .map_err(|e| e.to_string())?;
@@ -592,6 +594,7 @@ async fn add_project_repo(
     set_as_primary: Option<bool>,
     pr_number: Option<u64>,
     default_branch: Option<String>,
+    head_repo: Option<String>,
 ) -> Result<store::ProjectRepo, String> {
     let store = get_store(&store)?;
     let repo = project_commands::add_project_repo_impl(
@@ -604,6 +607,7 @@ async fn add_project_repo(
         None,
         pr_number,
         default_branch,
+        head_repo,
     )
     .await?;
 
@@ -1807,6 +1811,7 @@ pub fn run() {
             github_commands::prune_remote_refs,
             github_commands::check_existing_local_branch,
             github_commands::list_pull_requests,
+            github_commands::get_parent_repo,
             github_commands::list_issues,
             // PRs
             prs::create_pr,

--- a/apps/staged/src-tauri/src/project_commands.rs
+++ b/apps/staged/src-tauri/src/project_commands.rs
@@ -20,6 +20,7 @@ pub(crate) async fn add_project_repo_impl(
     reason: Option<String>,
     pr_number: Option<u64>,
     default_branch: Option<String>,
+    head_repo: Option<String>,
 ) -> Result<store::ProjectRepo, String> {
     let project = store
         .get_project(&project_id)
@@ -71,6 +72,7 @@ pub(crate) async fn add_project_repo_impl(
         repo = repo.primary();
     }
     repo.reason = reason;
+    repo.head_repo = head_repo;
     if project.location == store::ProjectLocation::Remote {
         let ws_name = branches::resolve_project_workspace_name(&store, &project, None)?;
         let ws_info = tauri::async_runtime::spawn_blocking({

--- a/apps/staged/src-tauri/src/project_mcp.rs
+++ b/apps/staged/src-tauri/src/project_mcp.rs
@@ -572,18 +572,51 @@ impl ProjectToolsHandler {
             }
         }
 
-        let github_repo = p.github_repo.clone();
+        // Detect fork repos: if the provided github_repo is a fork, use the
+        // parent (upstream) repo for cloning/API calls and record the fork as
+        // head_repo so the UI displays the correct source.
+        let (effective_repo, head_repo) = {
+            let slug = p.github_repo.clone();
+            match tauri::async_runtime::spawn_blocking(move || {
+                crate::git::github::get_parent_repo(&slug)
+            })
+            .await
+            {
+                Ok(Ok(Some(parent))) => {
+                    log::info!(
+                        "[project_mcp] detected fork: {} -> parent {}",
+                        p.github_repo,
+                        parent
+                    );
+                    (parent, Some(p.github_repo.clone()))
+                }
+                Ok(Ok(None)) => (p.github_repo.clone(), None),
+                Ok(Err(e)) => {
+                    log::warn!(
+                        "[project_mcp] failed to check if {} is a fork: {e}",
+                        p.github_repo
+                    );
+                    (p.github_repo.clone(), None)
+                }
+                Err(e) => {
+                    log::warn!("[project_mcp] fork check task panicked: {e}");
+                    (p.github_repo.clone(), None)
+                }
+            }
+        };
+
+        let github_repo = effective_repo.clone();
         let repo = match crate::project_commands::add_project_repo_impl(
             Arc::clone(&self.store),
             self.project_id.clone(),
-            p.github_repo,
+            effective_repo,
             p.branch_name,
             p.subpath,
             None,
             p.reason,
             None,
             p.base_branch,
-            None, // MCP has no head_repo for fork PRs
+            head_repo,
         )
         .await
         {

--- a/apps/staged/src-tauri/src/project_mcp.rs
+++ b/apps/staged/src-tauri/src/project_mcp.rs
@@ -583,6 +583,7 @@ impl ProjectToolsHandler {
             p.reason,
             None,
             p.base_branch,
+            None, // MCP has no head_repo for fork PRs
         )
         .await
         {

--- a/apps/staged/src-tauri/src/prs.rs
+++ b/apps/staged/src-tauri/src/prs.rs
@@ -177,9 +177,14 @@ This is critical - the application parses this to link the PR.
     Ok(session.id)
 }
 
-/// Build the GitHub PR URL for a branch from its repo slug and PR number.
+/// Build the GitHub PR URL for a branch.
+///
+/// For fork PRs the stored repo may be the fork (head) repo, but PRs always
+/// live on the base (upstream) repo. This queries the GitHub API to resolve
+/// the canonical URL, falling back to the parent repo when the stored repo
+/// is a fork.
 #[tauri::command(rename_all = "camelCase")]
-pub fn get_pr_url(
+pub async fn get_pr_url(
     store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
     branch_id: String,
     pr_number: u64,
@@ -197,15 +202,11 @@ pub fn get_pr_url(
         .ok_or_else(|| format!("Project not found: {}", branch.project_id))?;
 
     let (repo_slug, _) = resolve_branch_repo_and_subpath(&store, &project, &branch)?;
-    let parts: Vec<&str> = repo_slug.splitn(2, '/').collect();
-    if parts.len() != 2 {
-        return Err(format!("Invalid github_repo format: {}", repo_slug));
-    }
-    let (owner, repo_name) = (parts[0], parts[1]);
 
-    Ok(format!(
-        "https://github.com/{owner}/{repo_name}/pull/{pr_number}"
-    ))
+    tauri::async_runtime::spawn_blocking(move || git::fetch_pr_url(&repo_slug, pr_number))
+        .await
+        .map_err(|e| format!("get_pr_url task failed: {e}"))?
+        .map_err(|e| e.to_string())
 }
 
 /// Update the PR number for a branch.

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1767,7 +1767,8 @@ fn build_project_session_context(
     } else {
         lines.push("Repositories in this project:".to_string());
         for repo in &repos {
-            let label = format_repo_label(&repo.github_repo, repo.subpath.as_deref());
+            let display_repo = repo.head_repo.as_deref().unwrap_or(&repo.github_repo);
+            let label = format_repo_label(display_repo, repo.subpath.as_deref());
             let primary_tag = if repo.is_primary { " (primary)" } else { "" };
             let reason_tag = repo
                 .reason

--- a/apps/staged/src-tauri/src/store/migration_tests.rs
+++ b/apps/staged/src-tauri/src/store/migration_tests.rs
@@ -133,7 +133,7 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         )
         .unwrap();
 
-    assert_eq!(version, 10);
+    assert_eq!(version, 11);
     assert_eq!(app_version, super::APP_VERSION);
     assert!(table_exists(&conn, "projects"));
     assert!(table_exists(&conn, "project_notes"));

--- a/apps/staged/src-tauri/src/store/migrations/0011-add-head-repo/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0011-add-head-repo/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE project_repos ADD COLUMN head_repo TEXT;

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -127,6 +127,10 @@ pub struct ProjectRepo {
     pub subpath: Option<String>,
     pub is_primary: bool,
     pub reason: Option<String>,
+    /// For fork PRs, the head (fork) repo that differs from `github_repo` (the
+    /// base repo used for cloning and API calls).  `None` when the PR is not
+    /// from a fork.
+    pub head_repo: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -147,6 +151,7 @@ impl ProjectRepo {
             subpath,
             is_primary: false,
             reason: None,
+            head_repo: None,
             created_at: now,
             updated_at: now,
         }

--- a/apps/staged/src-tauri/src/store/project_repos.rs
+++ b/apps/staged/src-tauri/src/store/project_repos.rs
@@ -9,8 +9,8 @@ impl Store {
     pub fn create_project_repo(&self, repo: &ProjectRepo) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         if let Err(e) = conn.execute(
-            "INSERT INTO project_repos (id, project_id, github_repo, branch_name, subpath, is_primary, reason, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            "INSERT INTO project_repos (id, project_id, github_repo, branch_name, subpath, is_primary, reason, head_repo, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 repo.id,
                 repo.project_id,
@@ -19,6 +19,7 @@ impl Store {
                 repo.subpath,
                 if repo.is_primary { 1 } else { 0 },
                 repo.reason,
+                repo.head_repo,
                 repo.created_at,
                 repo.updated_at,
             ],
@@ -44,7 +45,7 @@ impl Store {
     pub fn get_project_repo(&self, id: &str) -> Result<Option<ProjectRepo>, StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, project_id, github_repo, branch_name, subpath, is_primary, reason, created_at, updated_at
+            "SELECT id, project_id, github_repo, branch_name, subpath, is_primary, reason, head_repo, created_at, updated_at
              FROM project_repos WHERE id = ?1",
             params![id],
             Self::row_to_project_repo,
@@ -56,7 +57,7 @@ impl Store {
     pub fn list_project_repos(&self, project_id: &str) -> Result<Vec<ProjectRepo>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, project_id, github_repo, branch_name, subpath, is_primary, reason, created_at, updated_at
+            "SELECT id, project_id, github_repo, branch_name, subpath, is_primary, reason, head_repo, created_at, updated_at
              FROM project_repos WHERE project_id = ?1
              ORDER BY is_primary DESC, created_at ASC",
         )?;
@@ -70,7 +71,7 @@ impl Store {
     ) -> Result<Option<ProjectRepo>, StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, project_id, github_repo, branch_name, subpath, is_primary, reason, created_at, updated_at
+            "SELECT id, project_id, github_repo, branch_name, subpath, is_primary, reason, head_repo, created_at, updated_at
              FROM project_repos WHERE project_id = ?1 AND is_primary = 1
              ORDER BY created_at ASC LIMIT 1",
             params![project_id],
@@ -137,8 +138,9 @@ impl Store {
             subpath: row.get(4)?,
             is_primary: is_primary_i64 == 1,
             reason: row.get(6)?,
-            created_at: row.get(7)?,
-            updated_at: row.get(8)?,
+            head_repo: row.get(7)?,
+            created_at: row.get(8)?,
+            updated_at: row.get(9)?,
         })
     }
 }

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -810,6 +810,14 @@ export function getPrForRepo(githubRepo: string, prNumber: number): Promise<Pull
   return invoke('get_pr_for_repo', { githubRepo, prNumber });
 }
 
+/** Find the open PR (if any) whose head branch matches `branchName`. */
+export function getPrForBranch(
+  githubRepo: string,
+  branchName: string
+): Promise<PullRequest | null> {
+  return invoke('get_pr_for_branch', { githubRepo, branchName });
+}
+
 export function listPullRequests(githubRepo: string): Promise<PullRequest[]> {
   return invoke('list_pull_requests', { githubRepo });
 }

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -62,7 +62,8 @@ export function createProject(
   subpath?: string,
   branchName?: string,
   prNumber?: number,
-  defaultBranch?: string
+  defaultBranch?: string,
+  headRepo?: string
 ): Promise<Project> {
   return invoke('create_project', {
     name,
@@ -72,6 +73,7 @@ export function createProject(
     branchName: branchName ?? null,
     prNumber: prNumber ?? null,
     defaultBranch: defaultBranch ?? null,
+    headRepo: headRepo ?? null,
   });
 }
 
@@ -94,7 +96,8 @@ export function addProjectRepo(
   subpath?: string,
   setAsPrimary?: boolean,
   prNumber?: number,
-  defaultBranch?: string
+  defaultBranch?: string,
+  headRepo?: string
 ): Promise<ProjectRepo> {
   return invoke('add_project_repo', {
     projectId,
@@ -104,6 +107,7 @@ export function addProjectRepo(
     setAsPrimary: setAsPrimary ?? null,
     prNumber: prNumber ?? null,
     defaultBranch: defaultBranch ?? null,
+    headRepo: headRepo ?? null,
   });
 }
 
@@ -803,6 +807,11 @@ export function checkExistingLocalBranch(projectId: string, branchName: string):
 
 export function listPullRequests(githubRepo: string): Promise<PullRequest[]> {
   return invoke('list_pull_requests', { githubRepo });
+}
+
+/** If the repo is a fork, return the parent repo slug (e.g. `"base-owner/repo"`). */
+export function getParentRepo(githubRepo: string): Promise<string | null> {
+  return invoke('get_parent_repo', { githubRepo });
 }
 
 export function listIssues(githubRepo: string): Promise<Issue[]> {

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -805,6 +805,11 @@ export function checkExistingLocalBranch(projectId: string, branchName: string):
   return invoke('check_existing_local_branch', { projectId, branchName });
 }
 
+/** Fetch a single PR by number. Throws if not found. */
+export function getPrForRepo(githubRepo: string, prNumber: number): Promise<PullRequest> {
+  return invoke('get_pr_for_repo', { githubRepo, prNumber });
+}
+
 export function listPullRequests(githubRepo: string): Promise<PullRequest[]> {
   return invoke('list_pull_requests', { githubRepo });
 }

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1106,7 +1106,7 @@
       ? reviewDiffTarget.commitSha.slice(0, 7)
       : branch.branchName}
     {projectName}
-    githubRepo={repoLabel?.githubRepo}
+    githubRepo={repoLabel?.headRepo ?? repoLabel?.githubRepo}
     subpath={repoLabel?.subpath}
     onClose={() => {
       showBranchDiff = false;
@@ -1125,7 +1125,7 @@
     beforeLabel="parent"
     afterLabel={commitDiffSha.slice(0, 7)}
     {projectName}
-    githubRepo={repoLabel?.githubRepo}
+    githubRepo={repoLabel?.headRepo ?? repoLabel?.githubRepo}
     subpath={repoLabel?.subpath}
     readonly
     onClose={() => {

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -15,7 +15,10 @@
 <div class="header-left">
   {#if repoLabel}
     <span class="repo-name"
-      ><RepoLabel githubRepo={repoLabel.githubRepo} subpath={repoLabel.subpath} /></span
+      ><RepoLabel
+        githubRepo={repoLabel.headRepo ?? repoLabel.githubRepo}
+        subpath={repoLabel.subpath}
+      /></span
     >
     <div class="header-meta">
       <span class="branch-name">{branchName}</span>

--- a/apps/staged/src/lib/features/projects/AddRepoModal.svelte
+++ b/apps/staged/src/lib/features/projects/AddRepoModal.svelte
@@ -23,6 +23,7 @@
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
 
   let selectedRepo = $state<string | null>(null);
+  let headRepo = $state<string | null>(null);
   let subpath = $state('');
   let branchName = $state('');
   let isNewBranch = $state(false);
@@ -71,6 +72,7 @@
         subpath: normalizedSubpath,
         prNumber,
         defaultBranch: matchedPr?.baseRef ?? defaultBranch ?? undefined,
+        headRepo: headRepo ?? undefined,
       });
       onClose();
     } catch (e) {
@@ -127,6 +129,7 @@
       <div class="add-repo-form">
         <RepoConfigForm
           bind:selectedRepo
+          bind:headRepo
           bind:subpath
           bind:branchName
           bind:isNewBranch

--- a/apps/staged/src/lib/features/projects/BranchPicker.svelte
+++ b/apps/staged/src/lib/features/projects/BranchPicker.svelte
@@ -205,13 +205,30 @@
                 { focus: false }
               );
             } else {
-              // Branch not in the list — just set the value (will show as "New branch")
+              // Branch not in the list — just set the value (will show as "New branch").
+              // Still check for an associated PR via --head lookup.
               value = branchNameToFind;
               onSelect?.({
                 kind: 'branch',
                 branchName: branchNameToFind,
                 label: branchNameToFind,
               });
+              if (ghRepo) {
+                commands
+                  .getPrForBranch(ghRepo, branchNameToFind)
+                  .then((pr) => {
+                    if (pr && value === branchNameToFind) {
+                      if (!pullRequests.some((p) => p.number === pr.number)) {
+                        pullRequests = [pr, ...pullRequests];
+                      }
+                      matchedPr = pr;
+                      if (pr.headRepo && pr.headRepo !== repo) {
+                        onRepoChange?.(pr.headRepo);
+                      }
+                    }
+                  })
+                  .catch(() => {});
+              }
             }
           }
           initialBranchName = null;
@@ -313,6 +330,27 @@
       }
     } else {
       matchedPr = null;
+      // The branch might have a PR outside the top-50 list — look it up by head ref.
+      if (repo) {
+        const branchName = item.branchName;
+        commands
+          .getPrForBranch(repo, branchName)
+          .then((pr) => {
+            // Only apply if the user hasn't changed selection since we fired.
+            if (pr && value === branchName) {
+              if (!pullRequests.some((p) => p.number === pr.number)) {
+                pullRequests = [pr, ...pullRequests];
+              }
+              matchedPr = pr;
+              if (pr.headRepo && pr.headRepo !== repo) {
+                onRepoChange?.(pr.headRepo);
+              }
+            }
+          })
+          .catch(() => {
+            /* no PR for this branch — that's fine */
+          });
+      }
     }
 
     // For PRs, pass the PR title (strip the "#123 " prefix); for branches, pass the branch name.

--- a/apps/staged/src/lib/features/projects/BranchPicker.svelte
+++ b/apps/staged/src/lib/features/projects/BranchPicker.svelte
@@ -68,14 +68,22 @@
   /** Repo slug whose data is already loaded — prevents redundant re-fetch after fork switch. */
   let loadedRepo: string | null = null;
 
-  // Fetch PRs and branches when repo changes
+  // Fetch PRs and branches when repo changes.
+  //
+  // The `loadedRepo` guard prevents an infinite re-fetch loop during fork
+  // detection: when `onBaseRepoSwitch` sets `selectedRepo = baseRepo` in the
+  // parent, this effect re-fires with the new repo value. But BranchPicker
+  // already set `loadedRepo = parentRepo` (which equals `baseRepo`) before
+  // invoking the callback, so `r === loadedRepo` short-circuits the fetch.
   $effect(() => {
     const r = repo; // read `repo` to track it as a dependency
     if (r) {
-      // Skip if we already loaded data for this repo (e.g. pre-fetched after fork detection).
       if (r === loadedRepo && pullRequests.length > 0) return;
       fetchData(r);
     } else {
+      // Repo cleared (e.g. cancel button) — discard any in-flight fetch
+      // results by bumping the generation counter alongside clearing state.
+      ++fetchGeneration;
       pullRequests = [];
       branches = [];
       loadedRepo = null;

--- a/apps/staged/src/lib/features/projects/BranchPicker.svelte
+++ b/apps/staged/src/lib/features/projects/BranchPicker.svelte
@@ -88,112 +88,125 @@
     loading = true;
 
     try {
-      // When we have an initialPrNumber, speculatively check if the repo is
-      // a fork in parallel with fetching PRs — saves a round-trip if the PR
-      // isn't found on this repo (common for pasted fork URLs).
-      const parentRepoPromise =
-        prNum != null ? commands.getParentRepo(ghRepo).catch(() => null) : null;
-
-      const [prs, refs] = await Promise.all([
-        commands.listPullRequests(ghRepo).catch(() => [] as PullRequest[]),
-        commands.listGitBranches(ghRepo).catch(() => [] as BranchRef[]),
-      ]);
-
-      // Discard results if a newer fetch was started while we were waiting
-      if (gen !== fetchGeneration) return;
-      pullRequests = prs;
-      branches = refs;
-      loadedRepo = ghRepo;
-
-      // Auto-select a PR if initialPrNumber was provided (e.g. from a pasted PR URL).
+      // When we have an initialPrNumber, fetch the specific PR directly
+      // instead of searching a potentially incomplete list. This works
+      // regardless of how many open PRs the repo has and also works for
+      // closed/merged PRs.
       if (prNum != null && initialPrNumber === prNum) {
-        const pr = prs.find((p) => p.number === prNum);
-        if (pr) {
+        // Fetch the PR directly and check parent repo in parallel with list data.
+        const [directPr, parentRepo, prs, refs] = await Promise.all([
+          commands.getPrForRepo(ghRepo, prNum).catch(() => null),
+          commands.getParentRepo(ghRepo).catch(() => null),
+          commands.listPullRequests(ghRepo).catch(() => [] as PullRequest[]),
+          commands.listGitBranches(ghRepo).catch(() => [] as BranchRef[]),
+        ]);
+
+        if (gen !== fetchGeneration) return;
+        pullRequests = prs;
+        branches = refs;
+        loadedRepo = ghRepo;
+
+        if (directPr && initialPrNumber === prNum) {
           selectItem(
             {
               kind: 'pr',
-              label: `#${pr.number} ${pr.title}`,
-              branchName: pr.headRef,
-              detail: pr.headRef,
+              label: `#${directPr.number} ${directPr.title}`,
+              branchName: directPr.headRef,
+              detail: directPr.headRef,
             },
             { focus: false }
           );
-          initialPrNumber = null;
-        } else {
-          // PR not found — check the speculative parent repo result and
-          // pre-fetch PRs for the parent repo inline to avoid a second
-          // round-trip through the effect cycle.
-          const parentRepo = await parentRepoPromise;
-          if (gen !== fetchGeneration) return;
-          if (parentRepo && initialPrNumber === prNum) {
-            const [parentPrs, parentRefs] = await Promise.all([
-              commands.listPullRequests(parentRepo).catch(() => [] as PullRequest[]),
-              commands.listGitBranches(parentRepo).catch(() => [] as BranchRef[]),
-            ]);
-            if (gen !== fetchGeneration) return;
-
-            // Pre-populate data so the effect-triggered fetchData is skipped.
-            pullRequests = parentPrs;
-            branches = parentRefs;
-            loadedRepo = parentRepo;
-
-            // Signal the repo switch (triggers monorepo check, default branch, etc.)
-            onBaseRepoSwitch?.(parentRepo, ghRepo);
-
-            // Auto-select the PR from the parent repo's data.
-            const parentPr = parentPrs.find((p) => p.number === prNum);
-            if (parentPr) {
-              selectItem(
-                {
-                  kind: 'pr',
-                  label: `#${parentPr.number} ${parentPr.title}`,
-                  branchName: parentPr.headRef,
-                  detail: parentPr.headRef,
-                },
-                { focus: false }
-              );
-            }
-            initialPrNumber = null;
-          } else {
-            initialPrNumber = null;
+          // Add to pullRequests if not already present so the PR card shows.
+          if (!prs.some((p) => p.number === directPr.number)) {
+            pullRequests = [directPr, ...prs];
           }
-        }
-      }
-      // Auto-fill a branch name if initialBranchName was provided (e.g. from a pasted branch URL).
-      // Skip focusing the input — the user didn't interact with the picker directly.
-      else if (initialBranchName) {
-        const branchNameToFind = initialBranchName;
-        // Check PRs first — a branch might back a PR
-        const prForBranch = prs.find((p) => p.headRef === branchNameToFind);
-        if (prForBranch) {
-          selectItem(
-            {
-              kind: 'pr',
-              label: `#${prForBranch.number} ${prForBranch.title}`,
-              branchName: prForBranch.headRef,
-              detail: prForBranch.headRef,
-            },
-            { focus: false }
-          );
-        } else {
-          // Check remote branches
-          const refName = refs.find((r) => r.name.replace(/^origin\//, '') === branchNameToFind);
-          if (refName) {
+          initialPrNumber = null;
+        } else if (parentRepo && initialPrNumber === prNum) {
+          // PR not on this repo — try the parent (upstream) repo.
+          const [parentPr, parentPrs, parentRefs] = await Promise.all([
+            commands.getPrForRepo(parentRepo, prNum).catch(() => null),
+            commands.listPullRequests(parentRepo).catch(() => [] as PullRequest[]),
+            commands.listGitBranches(parentRepo).catch(() => [] as BranchRef[]),
+          ]);
+          if (gen !== fetchGeneration) return;
+
+          pullRequests = parentPrs;
+          branches = parentRefs;
+          loadedRepo = parentRepo;
+
+          onBaseRepoSwitch?.(parentRepo, ghRepo);
+
+          if (parentPr) {
             selectItem(
               {
-                kind: 'branch',
-                label: branchNameToFind,
-                branchName: branchNameToFind,
+                kind: 'pr',
+                label: `#${parentPr.number} ${parentPr.title}`,
+                branchName: parentPr.headRef,
+                detail: parentPr.headRef,
+              },
+              { focus: false }
+            );
+            if (!parentPrs.some((p) => p.number === parentPr.number)) {
+              pullRequests = [parentPr, ...parentPrs];
+            }
+          }
+          initialPrNumber = null;
+        } else {
+          initialPrNumber = null;
+        }
+      }
+      // No initialPrNumber — normal fetch for branches / initialBranchName.
+      else {
+        const [prs, refs] = await Promise.all([
+          commands.listPullRequests(ghRepo).catch(() => [] as PullRequest[]),
+          commands.listGitBranches(ghRepo).catch(() => [] as BranchRef[]),
+        ]);
+
+        if (gen !== fetchGeneration) return;
+        pullRequests = prs;
+        branches = refs;
+        loadedRepo = ghRepo;
+
+        // Auto-fill a branch name if initialBranchName was provided (e.g. from a pasted branch URL).
+        // Skip focusing the input — the user didn't interact with the picker directly.
+        if (initialBranchName) {
+          const branchNameToFind = initialBranchName;
+          // Check PRs first — a branch might back a PR
+          const prForBranch = prs.find((p) => p.headRef === branchNameToFind);
+          if (prForBranch) {
+            selectItem(
+              {
+                kind: 'pr',
+                label: `#${prForBranch.number} ${prForBranch.title}`,
+                branchName: prForBranch.headRef,
+                detail: prForBranch.headRef,
               },
               { focus: false }
             );
           } else {
-            // Branch not in the list — just set the value (will show as "New branch")
-            value = branchNameToFind;
-            onSelect?.({ kind: 'branch', branchName: branchNameToFind, label: branchNameToFind });
+            // Check remote branches
+            const refName = refs.find((r) => r.name.replace(/^origin\//, '') === branchNameToFind);
+            if (refName) {
+              selectItem(
+                {
+                  kind: 'branch',
+                  label: branchNameToFind,
+                  branchName: branchNameToFind,
+                },
+                { focus: false }
+              );
+            } else {
+              // Branch not in the list — just set the value (will show as "New branch")
+              value = branchNameToFind;
+              onSelect?.({
+                kind: 'branch',
+                branchName: branchNameToFind,
+                label: branchNameToFind,
+              });
+            }
           }
+          initialBranchName = null;
         }
-        initialBranchName = null;
       }
     } finally {
       loading = false;

--- a/apps/staged/src/lib/features/projects/BranchPicker.svelte
+++ b/apps/staged/src/lib/features/projects/BranchPicker.svelte
@@ -38,6 +38,10 @@
     /** When set, auto-fill this branch name after data loads. Cleared after use. */
     initialBranchName?: string | null;
     onSelect?: (selection: BranchSelection) => void;
+    /** Called when a fork PR is detected and the repo should switch to the head repo. */
+    onRepoChange?: (newRepo: string) => void;
+    /** Called when a pasted PR URL points to a fork and the base repo should be used instead. */
+    onBaseRepoSwitch?: (baseRepo: string, forkRepo: string) => void;
   }
 
   let {
@@ -49,6 +53,8 @@
     initialPrNumber = $bindable(null),
     initialBranchName = $bindable(null),
     onSelect,
+    onRepoChange,
+    onBaseRepoSwitch,
   }: Props = $props();
 
   let pullRequests = $state<PullRequest[]>([]);
@@ -59,22 +65,35 @@
   let inputEl: HTMLInputElement | undefined = $state();
   /** Generation counter to discard stale async responses when repo changes rapidly. */
   let fetchGeneration = 0;
+  /** Repo slug whose data is already loaded — prevents redundant re-fetch after fork switch. */
+  let loadedRepo: string | null = null;
 
   // Fetch PRs and branches when repo changes
   $effect(() => {
-    if (repo) {
-      fetchData(repo);
+    const r = repo; // read `repo` to track it as a dependency
+    if (r) {
+      // Skip if we already loaded data for this repo (e.g. pre-fetched after fork detection).
+      if (r === loadedRepo && pullRequests.length > 0) return;
+      fetchData(r);
     } else {
       pullRequests = [];
       branches = [];
+      loadedRepo = null;
     }
   });
 
   async function fetchData(ghRepo: string) {
     const gen = ++fetchGeneration;
+    const prNum = initialPrNumber;
     loading = true;
 
     try {
+      // When we have an initialPrNumber, speculatively check if the repo is
+      // a fork in parallel with fetching PRs — saves a round-trip if the PR
+      // isn't found on this repo (common for pasted fork URLs).
+      const parentRepoPromise =
+        prNum != null ? commands.getParentRepo(ghRepo).catch(() => null) : null;
+
       const [prs, refs] = await Promise.all([
         commands.listPullRequests(ghRepo).catch(() => [] as PullRequest[]),
         commands.listGitBranches(ghRepo).catch(() => [] as BranchRef[]),
@@ -84,11 +103,11 @@
       if (gen !== fetchGeneration) return;
       pullRequests = prs;
       branches = refs;
+      loadedRepo = ghRepo;
 
       // Auto-select a PR if initialPrNumber was provided (e.g. from a pasted PR URL).
-      // Skip focusing the input — the user didn't interact with the picker directly.
-      if (initialPrNumber != null) {
-        const pr = prs.find((p) => p.number === initialPrNumber);
+      if (prNum != null && initialPrNumber === prNum) {
+        const pr = prs.find((p) => p.number === prNum);
         if (pr) {
           selectItem(
             {
@@ -99,8 +118,46 @@
             },
             { focus: false }
           );
+          initialPrNumber = null;
+        } else {
+          // PR not found — check the speculative parent repo result and
+          // pre-fetch PRs for the parent repo inline to avoid a second
+          // round-trip through the effect cycle.
+          const parentRepo = await parentRepoPromise;
+          if (gen !== fetchGeneration) return;
+          if (parentRepo && initialPrNumber === prNum) {
+            const [parentPrs, parentRefs] = await Promise.all([
+              commands.listPullRequests(parentRepo).catch(() => [] as PullRequest[]),
+              commands.listGitBranches(parentRepo).catch(() => [] as BranchRef[]),
+            ]);
+            if (gen !== fetchGeneration) return;
+
+            // Pre-populate data so the effect-triggered fetchData is skipped.
+            pullRequests = parentPrs;
+            branches = parentRefs;
+            loadedRepo = parentRepo;
+
+            // Signal the repo switch (triggers monorepo check, default branch, etc.)
+            onBaseRepoSwitch?.(parentRepo, ghRepo);
+
+            // Auto-select the PR from the parent repo's data.
+            const parentPr = parentPrs.find((p) => p.number === prNum);
+            if (parentPr) {
+              selectItem(
+                {
+                  kind: 'pr',
+                  label: `#${parentPr.number} ${parentPr.title}`,
+                  branchName: parentPr.headRef,
+                  detail: parentPr.headRef,
+                },
+                { focus: false }
+              );
+            }
+            initialPrNumber = null;
+          } else {
+            initialPrNumber = null;
+          }
         }
-        initialPrNumber = null;
       }
       // Auto-fill a branch name if initialBranchName was provided (e.g. from a pasted branch URL).
       // Skip focusing the input — the user didn't interact with the picker directly.
@@ -228,6 +285,10 @@
     // Update matched PR: set when selecting a PR item, clear for branches
     if (item.kind === 'pr') {
       matchedPr = pullRequests.find((pr) => pr.headRef === item.branchName) ?? null;
+      // For fork PRs, signal repo change so the displayed repo updates
+      if (matchedPr?.headRepo && matchedPr.headRepo !== repo) {
+        onRepoChange?.(matchedPr.headRepo);
+      }
     } else {
       matchedPr = null;
     }

--- a/apps/staged/src/lib/features/projects/BranchPicker.svelte
+++ b/apps/staged/src/lib/features/projects/BranchPicker.svelte
@@ -107,6 +107,10 @@
         loadedRepo = ghRepo;
 
         if (directPr && initialPrNumber === prNum) {
+          // Prepend before selectItem so the PR is findable in pullRequests.
+          if (!prs.some((p) => p.number === directPr.number)) {
+            pullRequests = [directPr, ...prs];
+          }
           selectItem(
             {
               kind: 'pr',
@@ -116,10 +120,6 @@
             },
             { focus: false }
           );
-          // Add to pullRequests if not already present so the PR card shows.
-          if (!prs.some((p) => p.number === directPr.number)) {
-            pullRequests = [directPr, ...prs];
-          }
           initialPrNumber = null;
         } else if (parentRepo && initialPrNumber === prNum) {
           // PR not on this repo — try the parent (upstream) repo.
@@ -137,6 +137,10 @@
           onBaseRepoSwitch?.(parentRepo, ghRepo);
 
           if (parentPr) {
+            // Prepend before selectItem so the PR is findable in pullRequests.
+            if (!parentPrs.some((p) => p.number === parentPr.number)) {
+              pullRequests = [parentPr, ...parentPrs];
+            }
             selectItem(
               {
                 kind: 'pr',
@@ -146,9 +150,6 @@
               },
               { focus: false }
             );
-            if (!parentPrs.some((p) => p.number === parentPr.number)) {
-              pullRequests = [parentPr, ...parentPrs];
-            }
           }
           initialPrNumber = null;
         } else {

--- a/apps/staged/src/lib/features/projects/BranchPicker.svelte
+++ b/apps/staged/src/lib/features/projects/BranchPicker.svelte
@@ -78,7 +78,7 @@
   $effect(() => {
     const r = repo; // read `repo` to track it as a dependency
     if (r) {
-      if (r === loadedRepo && pullRequests.length > 0) return;
+      if (r === loadedRepo) return;
       fetchData(r);
     } else {
       // Repo cleared (e.g. cancel button) — discard any in-flight fetch
@@ -136,7 +136,7 @@
             commands.listPullRequests(parentRepo).catch(() => [] as PullRequest[]),
             commands.listGitBranches(parentRepo).catch(() => [] as BranchRef[]),
           ]);
-          if (gen !== fetchGeneration) return;
+          if (gen !== fetchGeneration || initialPrNumber !== prNum) return;
 
           pullRequests = parentPrs;
           branches = parentRefs;

--- a/apps/staged/src/lib/features/projects/BranchPicker.svelte
+++ b/apps/staged/src/lib/features/projects/BranchPicker.svelte
@@ -333,11 +333,12 @@
       // The branch might have a PR outside the top-50 list — look it up by head ref.
       if (repo) {
         const branchName = item.branchName;
+        const gen = fetchGeneration;
         commands
           .getPrForBranch(repo, branchName)
           .then((pr) => {
-            // Only apply if the user hasn't changed selection since we fired.
-            if (pr && value === branchName) {
+            // Only apply if the user hasn't changed selection or repo since we fired.
+            if (pr && value === branchName && gen === fetchGeneration) {
               if (!pullRequests.some((p) => p.number === pr.number)) {
                 pullRequests = [pr, ...pullRequests];
               }

--- a/apps/staged/src/lib/features/projects/NewProjectForm.svelte
+++ b/apps/staged/src/lib/features/projects/NewProjectForm.svelte
@@ -41,6 +41,7 @@
   let isNewBranch = $state(false);
   let matchedPr = $state<PullRequest | null>(null);
   let defaultBranch = $state<string | null>(null);
+  let headRepo = $state<string | null>(null);
 
   let saving = $state(false);
   let error = $state<string | null>(null);
@@ -92,7 +93,8 @@
         normalizedSubpath,
         normalizedBranch,
         prNumber,
-        matchedPr?.baseRef ?? defaultBranch ?? undefined
+        matchedPr?.baseRef ?? defaultBranch ?? undefined,
+        headRepo ?? undefined
       );
       onCreated(project);
     } catch (e) {
@@ -190,6 +192,7 @@
 
   <RepoConfigForm
     bind:selectedRepo
+    bind:headRepo
     bind:subpath
     bind:branchName
     bind:isNewBranch

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -548,7 +548,8 @@
         selection.subpath,
         undefined,
         selection.prNumber,
-        selection.defaultBranch ?? undefined
+        selection.defaultBranch ?? undefined,
+        selection.headRepo ?? undefined
       );
       const [projectsList, branches, repos] = await Promise.all([
         commands.listProjects(),

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -66,12 +66,13 @@
       const repos = reposByProject.get(project.id) ?? [];
       if (repos.length > 0) {
         for (const r of repos) {
-          const key = `${r.githubRepo}:${r.subpath ?? ''}`;
+          const displayRepo = r.headRepo ?? r.githubRepo;
+          const key = `${displayRepo}:${r.subpath ?? ''}`;
           const entry = counts.get(key);
           if (entry) {
             entry.count++;
           } else {
-            counts.set(key, { repo: r.githubRepo, subpath: r.subpath ?? '', count: 1 });
+            counts.set(key, { repo: displayRepo, subpath: r.subpath ?? '', count: 1 });
           }
         }
       } else if (project.githubRepo) {
@@ -120,7 +121,9 @@
     return projects.filter((p) => {
       const repos = reposByProject.get(p.id) ?? [];
       if (repos.length > 0) {
-        return repos.some((r) => r.githubRepo === repo && (r.subpath ?? '') === subpath);
+        return repos.some(
+          (r) => (r.headRepo ?? r.githubRepo) === repo && (r.subpath ?? '') === subpath
+        );
       }
       return p.githubRepo === repo && (p.subpath ?? '') === subpath;
     });
@@ -560,11 +563,11 @@
                             darkMode.value
                           )};"
                         >
-                          <RepoLabel githubRepo={r.githubRepo} subpath={r.subpath} />
+                          <RepoLabel githubRepo={r.headRepo ?? r.githubRepo} subpath={r.subpath} />
                         </span>
                       {:else}
                         <span class="repo-line">
-                          <RepoLabel githubRepo={r.githubRepo} subpath={r.subpath} />
+                          <RepoLabel githubRepo={r.headRepo ?? r.githubRepo} subpath={r.subpath} />
                         </span>
                       {/if}
                     {/each}

--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -11,11 +11,12 @@
 
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { slide } from 'svelte/transition';
+  import { slide, fade } from 'svelte/transition';
   import { GitBranch, X, Clock, Command } from 'lucide-svelte';
   import type { RecentRepo, PullRequest } from '../../types';
   import * as commands from '../../api/commands';
   import RepoLabel from '../../shared/RepoLabel.svelte';
+  import Spinner from '../../shared/Spinner.svelte';
   import RepoSearchInput from './RepoSearchInput.svelte';
   import SubpathInput from './SubpathInput.svelte';
   import type { SubpathInputApi } from './SubpathInput.svelte';
@@ -25,6 +26,8 @@
   interface Props {
     // Bindable state
     selectedRepo?: string | null;
+    /** For fork PRs, the head (fork) repo slug that differs from selectedRepo. */
+    headRepo?: string | null;
     subpath?: string;
     branchName?: string;
     isNewBranch?: boolean;
@@ -52,6 +55,7 @@
 
   let {
     selectedRepo = $bindable(null),
+    headRepo = $bindable(null),
     subpath = $bindable(''),
     branchName = $bindable(''),
     isNewBranch = $bindable(false),
@@ -84,6 +88,20 @@
 
   let pendingPrNumber = $state<number | null>(null);
   let pendingBranchName = $state<string | null>(null);
+
+  /** For fork PRs, the head repo differs from the base repo. We display the
+   *  head repo name but keep selectedRepo as the base repo for all API calls
+   *  (monorepo check, default branch, subpath, project creation) since
+   *  refs/pull/<N>/head only exists on the base repo's clone. */
+  let displayRepo = $state<string | null>(null);
+
+  /** True while resolving a PR from a pasted URL (fetching PRs, detecting forks). */
+  let resolvingPr = $state(false);
+
+  // Clear resolvingPr once a PR is matched or the pending PR number is cleared.
+  $effect(() => {
+    if (matchedPr || pendingPrNumber == null) resolvingPr = false;
+  });
 
   onMount(async () => {
     try {
@@ -151,9 +169,11 @@
     if (branchPickerTimer) clearTimeout(branchPickerTimer);
     showBranchPicker = false;
     selectedRepo = selection.nameWithOwner;
+    displayRepo = selection.nameWithOwner;
     subpath = selection.subpath ?? '';
     pendingPrNumber = selection.prNumber ?? null;
     pendingBranchName = selection.branchName ?? null;
+    resolvingPr = selection.prNumber != null;
     // Mount BranchPicker after the slide animation completes.
     // BranchPicker is expensive to mount in WebKit, so deferring it
     // keeps the initial repo selection feeling responsive.
@@ -181,106 +201,209 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="form-group">
-  <label for="project-repo-select"
-    >Repository
-    {#if repoRequired && !selectedRepo}
-      <span class="field-badge required">Required</span>
-    {/if}</label
-  >
-  {#if selectedRepo}
-    <div class="repo-info" class:disabled>
-      <GitBranch size={14} class="repo-info-icon" />
-      <div class="repo-details">
-        <span class="repo-name">{selectedRepo}</span>
-      </div>
+<!-- Grid stacking: both the overlay and form occupy the same cell so the form
+     always contributes to layout height, avoiding a jump when the overlay disappears. -->
+<div class="repo-fields-stack">
+  {#if resolvingPr}
+    <div class="pr-loading-overlay" transition:fade={{ duration: 100 }}>
+      <Spinner size={20} />
+      <span class="pr-loading-text">Loading PR&hellip;</span>
       <button
-        class="clear-button"
+        class="pr-loading-cancel"
         onclick={() => {
+          resolvingPr = false;
+          pendingPrNumber = null;
           if (branchPickerTimer) clearTimeout(branchPickerTimer);
           showBranchPicker = false;
           selectedRepo = null;
+          displayRepo = null;
+          headRepo = null;
           subpath = '';
           branchName = '';
           matchedPr = null;
-          pendingPrNumber = null;
           pendingBranchName = null;
         }}
       >
-        <X size={14} />
+        Cancel
       </button>
     </div>
-  {:else}
-    <RepoSearchInput onSelect={handleRepoSelected} {disabled} {excludeRepos} />
   {/if}
 
-  {#if !selectedRepo && filteredRecentRepos.length > 0}
-    <div class="recent-repos" out:slide={{ duration: SLIDE_DURATION }}>
-      {#each filteredRecentRepos.slice(0, 5) as recent, i}
-        <button
-          class="recent-repo-item"
-          onclick={() =>
-            handleRepoSelected({
-              nameWithOwner: recent.githubRepo,
-              subpath: recent.subpath ?? undefined,
-            })}
-        >
-          <Clock size={12} class="recent-repo-icon" />
-          <span class="recent-repo-label">
-            <RepoLabel githubRepo={recent.githubRepo} subpath={recent.subpath} />
-          </span>
-          <span class="recent-repo-shortcut">
-            <Command size={9} />
-            {i + 1}
-          </span>
-        </button>
-      {/each}
+  <!-- Keep form fields in the DOM so BranchPicker can resolve the PR, but hide
+     them while the loading overlay is visible. -->
+  <div class="repo-fields" class:resolving-hidden={resolvingPr}>
+    <div class="form-group">
+      <label for="project-repo-select"
+        >Repository
+        {#if repoRequired && !selectedRepo}
+          <span class="field-badge required">Required</span>
+        {/if}</label
+      >
+      {#if selectedRepo}
+        <div class="repo-info" class:disabled>
+          <GitBranch size={14} class="repo-info-icon" />
+          <div class="repo-details">
+            <span class="repo-name">{displayRepo ?? selectedRepo}</span>
+          </div>
+          <button
+            class="clear-button"
+            onclick={() => {
+              if (branchPickerTimer) clearTimeout(branchPickerTimer);
+              showBranchPicker = false;
+              selectedRepo = null;
+              displayRepo = null;
+              headRepo = null;
+              subpath = '';
+              branchName = '';
+              matchedPr = null;
+              pendingPrNumber = null;
+              pendingBranchName = null;
+            }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+      {:else}
+        <RepoSearchInput onSelect={handleRepoSelected} {disabled} {excludeRepos} />
+      {/if}
+
+      {#if !selectedRepo && filteredRecentRepos.length > 0}
+        <div class="recent-repos" out:slide={{ duration: SLIDE_DURATION }}>
+          {#each filteredRecentRepos.slice(0, 5) as recent, i}
+            <button
+              class="recent-repo-item"
+              onclick={() =>
+                handleRepoSelected({
+                  nameWithOwner: recent.githubRepo,
+                  subpath: recent.subpath ?? undefined,
+                })}
+            >
+              <Clock size={12} class="recent-repo-icon" />
+              <span class="recent-repo-label">
+                <RepoLabel githubRepo={recent.githubRepo} subpath={recent.subpath} />
+              </span>
+              <span class="recent-repo-shortcut">
+                <Command size={9} />
+                {i + 1}
+              </span>
+            </button>
+          {/each}
+        </div>
+      {/if}
     </div>
-  {/if}
-</div>
 
-{#if selectedRepo}
-  <div class="form-group" transition:slide={{ duration: SLIDE_DURATION }}>
-    <label for="project-subpath"
-      >Subpath
-      <span class="field-badge {isMonorepo ? 'recommended' : 'optional'}"
-        >{isMonorepo ? 'Recommended' : 'Optional'}</span
-      ></label
-    >
-    <SubpathInput bind:value={subpath} repo={selectedRepo} {disabled} bind:api={subpathApi} />
-  </div>
+    {#if selectedRepo}
+      <div class="form-group" transition:slide={{ duration: SLIDE_DURATION }}>
+        <label for="project-subpath"
+          >Subpath
+          <span class="field-badge {isMonorepo ? 'recommended' : 'optional'}"
+            >{isMonorepo ? 'Recommended' : 'Optional'}</span
+          ></label
+        >
+        <SubpathInput bind:value={subpath} repo={selectedRepo} {disabled} bind:api={subpathApi} />
+      </div>
 
-  <div class="form-group" transition:slide={{ duration: SLIDE_DURATION }}>
-    <label for="project-branch"
-      >PR or Branch
-      <span class="field-badge {isNewBranch ? 'new-branch' : 'optional'}"
-        >{isNewBranch ? 'New branch' : 'Optional'}</span
-      ></label
-    >
-    {#if showBranchPicker}
-      <BranchPicker
-        bind:value={branchName}
-        bind:isNewBranch
-        bind:matchedPr
-        bind:initialPrNumber={pendingPrNumber}
-        bind:initialBranchName={pendingBranchName}
-        repo={selectedRepo}
-        {disabled}
-        onSelect={onBranchSelected}
-      />
-    {:else}
-      <input
-        class="branch-picker-placeholder"
-        type="text"
-        placeholder="Search PRs or branches…"
-        readonly
-        tabindex="-1"
-      />
+      <div class="form-group" transition:slide={{ duration: SLIDE_DURATION }}>
+        <label for="project-branch"
+          >PR or Branch
+          <span class="field-badge {isNewBranch ? 'new-branch' : 'optional'}"
+            >{isNewBranch ? 'New branch' : 'Optional'}</span
+          ></label
+        >
+        {#if showBranchPicker}
+          <BranchPicker
+            bind:value={branchName}
+            bind:isNewBranch
+            bind:matchedPr
+            bind:initialPrNumber={pendingPrNumber}
+            bind:initialBranchName={pendingBranchName}
+            repo={selectedRepo}
+            {disabled}
+            onSelect={onBranchSelected}
+            onRepoChange={(newRepo) => {
+              displayRepo = newRepo;
+              headRepo = newRepo !== selectedRepo ? newRepo : null;
+            }}
+            onBaseRepoSwitch={(baseRepo, forkRepo) => {
+              // A pasted fork URL needs the base repo for API calls/cloning.
+              // Switch selectedRepo to the base repo (triggers PR re-fetch)
+              // while keeping the fork as the display/head repo.
+              displayRepo = forkRepo;
+              headRepo = forkRepo;
+              selectedRepo = baseRepo;
+            }}
+          />
+        {:else}
+          <input
+            class="branch-picker-placeholder"
+            type="text"
+            placeholder="Search PRs or branches…"
+            readonly
+            tabindex="-1"
+          />
+        {/if}
+      </div>
     {/if}
   </div>
-{/if}
+
+  <!-- /resolving-hidden wrapper -->
+</div>
+
+<!-- /repo-fields-stack -->
 
 <style>
+  .repo-fields-stack {
+    display: grid;
+  }
+
+  .repo-fields-stack > * {
+    grid-area: 1 / 1;
+  }
+
+  .pr-loading-overlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 32px 16px;
+    border-radius: 10px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    z-index: 1;
+  }
+
+  .pr-loading-text {
+    font-size: var(--size-sm);
+    color: var(--text-muted);
+  }
+
+  .pr-loading-cancel {
+    font-size: var(--size-xs);
+    color: var(--text-faint);
+    background: none;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    padding: 4px 10px;
+    cursor: pointer;
+    transition: color 0.1s;
+  }
+
+  .pr-loading-cancel:hover {
+    color: var(--text-primary);
+    border-color: var(--border-default);
+  }
+
+  .repo-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .resolving-hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+
   .form-group {
     display: flex;
     flex-direction: column;

--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -95,12 +95,21 @@
    *  refs/pull/<N>/head only exists on the base repo's clone. */
   let displayRepo = $state<string | null>(null);
 
-  /** True while resolving a PR from a pasted URL (fetching PRs, detecting forks). */
+  /** True while resolving a PR from a pasted URL (fetching PRs, detecting forks).
+   *  Set explicitly in handleRepoSelected; cleared explicitly when BranchPicker
+   *  finishes (pendingPrNumber transitions from non-null to null) or on cancel. */
   let resolvingPr = $state(false);
+  let prevPendingPrNumber: number | null = null;
 
-  // Clear resolvingPr once a PR is matched or the pending PR number is cleared.
+  // Clear resolvingPr when BranchPicker signals completion by nulling pendingPrNumber.
+  // This avoids the old derived approach where a stale matchedPr from a previous
+  // selection could prematurely clear the flag.
   $effect(() => {
-    if (matchedPr || pendingPrNumber == null) resolvingPr = false;
+    const cur = pendingPrNumber;
+    if (prevPendingPrNumber != null && cur == null) {
+      resolvingPr = false;
+    }
+    prevPendingPrNumber = cur;
   });
 
   onMount(async () => {
@@ -168,6 +177,7 @@
   function handleRepoSelected(selection: RepoSelection) {
     if (branchPickerTimer) clearTimeout(branchPickerTimer);
     showBranchPicker = false;
+    matchedPr = null;
     selectedRepo = selection.nameWithOwner;
     displayRepo = selection.nameWithOwner;
     subpath = selection.subpath ?? '';

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -377,7 +377,10 @@
     <form class="modal-body" onsubmit={handleSubmit}>
       {#if repoLabel}
         <div class="repo-info">
-          <RepoLabel githubRepo={repoLabel.githubRepo} subpath={repoLabel.subpath} />
+          <RepoLabel
+            githubRepo={repoLabel.headRepo ?? repoLabel.githubRepo}
+            subpath={repoLabel.subpath}
+          />
         </div>
       {/if}
 

--- a/apps/staged/src/lib/shared/githubUrl.ts
+++ b/apps/staged/src/lib/shared/githubUrl.ts
@@ -5,6 +5,8 @@ export interface RepoSelection {
   branchName?: string;
   /** Pre-fetched default branch to avoid a slow API call during project/repo creation. */
   defaultBranch?: string | null;
+  /** For fork PRs, the head (fork) repo slug when it differs from nameWithOwner. */
+  headRepo?: string | null;
 }
 
 /**

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -24,6 +24,8 @@ export interface ProjectRepo {
   subpath: string | null;
   isPrimary: boolean;
   reason: string | null;
+  /** For fork PRs, the head (fork) repo slug. Null for non-fork PRs. */
+  headRepo: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -192,6 +194,8 @@ export interface PullRequest {
   author: string;
   baseRef: string;
   headRef: string;
+  /** The repository the PR's head branch lives in (e.g. "fork-owner/repo" for fork PRs). */
+  headRepo: string | null;
   draft: boolean;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Fix project creation from fork PRs by tracking the head repo separately from the base repo, using `refs/pull/<N>/head` as the worktree start point instead of `origin/<branch>` which doesn't exist for fork branches
- Fetch specific PRs by number via the GitHub API instead of searching a limited list, preventing missed PRs when the repo has many open PRs
- Handle stale worktrees from deleted projects by detecting out-of-project worktrees and generating unique local branch names to avoid collisions

## Test plan
- [ ] Create a project from a fork PR and verify the correct repo/branch is checked out
- [ ] Verify PR details display correctly for fork PRs (showing head repo info)
- [ ] Confirm that repos with many open PRs still find the correct PR by number
- [ ] Test that stale worktrees from deleted projects don't block new project creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)