### PR TITLE
fix(staged): emit session running event from backend and remove redundant frontend registration

### DIFF
--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -741,6 +741,28 @@ pub async fn start_branch_session(
     }
     store.create_session(&session).map_err(|e| e.to_string())?;
 
+    // Emit a "running" event so the frontend can register the session in its
+    // state stores (project list spinner, unread badges, etc.) regardless of
+    // which UI surface started the session.
+    let session_type_str = match session_type {
+        BranchSessionType::Commit => "commit",
+        BranchSessionType::Note => "note",
+        BranchSessionType::Review => "review",
+    };
+    let _ = app_handle.emit(
+        "session-status-changed",
+        session_runner::SessionStatusEvent {
+            session_id: session.id.clone(),
+            status: "running".to_string(),
+            error_message: None,
+            completion_reason: None,
+            branch_id: Some(branch_id.clone()),
+            project_id: Some(branch.project_id.clone()),
+            session_type: Some(session_type_str.to_string()),
+            is_auto_review: false,
+        },
+    );
+
     // Create artifact stub and compute pre-head SHA
     let (artifact_id, pre_head_sha) = match session_type {
         BranchSessionType::Note => {

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -749,18 +749,12 @@ pub async fn start_branch_session(
         BranchSessionType::Note => "note",
         BranchSessionType::Review => "review",
     };
-    let _ = app_handle.emit(
-        "session-status-changed",
-        session_runner::SessionStatusEvent {
-            session_id: session.id.clone(),
-            status: "running".to_string(),
-            error_message: None,
-            completion_reason: None,
-            branch_id: Some(branch_id.clone()),
-            project_id: Some(branch.project_id.clone()),
-            session_type: Some(session_type_str.to_string()),
-            is_auto_review: false,
-        },
+    session_runner::emit_session_running(
+        &app_handle,
+        &session.id,
+        &branch_id,
+        &branch.project_id,
+        session_type_str,
     );
 
     // Create artifact stub and compute pre-head SHA

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -393,15 +393,18 @@ pub fn start_session(
             )
             .unwrap_or(false);
 
-        if transitioned {
-            emit_status(
-                &app_handle,
-                &session_id_for_status,
-                new_status,
-                error_msg,
-                Some(&completion_reason),
-            );
+        // Always emit the terminal status event, even if the DB row was already
+        // deleted (e.g. user deleted the pending commit). This lets the frontend
+        // clean up sidebar "running" state as a safety net.
+        emit_status(
+            &app_handle,
+            &session_id_for_status,
+            new_status,
+            error_msg,
+            Some(&completion_reason),
+        );
 
+        if transitioned {
             let branch_id = store_for_status
                 .get_branch_id_for_session(&session_id_for_status)
                 .ok()
@@ -509,15 +512,14 @@ pub fn recover_dead_sessions(
                     Some(&CompletionReason::AppQuit),
                 )
                 .unwrap_or(false);
+            emit_status(
+                &app_handle,
+                &session.id,
+                "error",
+                None,
+                Some(&CompletionReason::AppQuit),
+            );
             if transitioned {
-                emit_status(
-                    &app_handle,
-                    &session.id,
-                    "error",
-                    None,
-                    Some(&CompletionReason::AppQuit),
-                );
-
                 let branch_id = store.get_branch_id_for_session(&session.id).ok().flatten();
                 if let Some(branch_id) = branch_id {
                     let store_for_follow_up = Arc::clone(&store);

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -42,7 +42,6 @@
   import { alerts } from '../../shared/alerts.svelte';
   import { timelineToHashtagItems, projectNotesToHashtagItems } from '../sessions/hashtagItems';
   import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
-  import { projectStateStore } from '../../stores/projectState.svelte';
 
   interface Props {
     branch: Branch;
@@ -670,14 +669,6 @@
     }
   }
 
-  function cleanupSessionState(sessionId: string) {
-    const projectId = sessionRegistry.getProjectId(sessionId);
-    if (projectId) {
-      projectStateStore.removeRunningSession(projectId, sessionId);
-    }
-    sessionRegistry.unregister(sessionId);
-  }
-
   function handleDeleteCommit(sha: string, sessionId?: string, opts?: { altKey: boolean }) {
     const doDelete = async () => {
       confirmDelete = null;
@@ -715,9 +706,11 @@
           } catch {
             // Session may already be finished
           }
-          cleanupSessionState(sessionId);
         }
         await commands.deleteNote(noteId, !!sessionId);
+        if (sessionId) {
+          sessionRegistry.cleanupSession(sessionId);
+        }
         loadTimeline();
         // Drain the next queued session now that this one has been removed.
         commands
@@ -751,9 +744,11 @@
           } catch {
             // Session may already be finished
           }
-          cleanupSessionState(sessionId);
         }
         await commands.deleteReview(reviewId, !!sessionId);
+        if (sessionId) {
+          sessionRegistry.cleanupSession(sessionId);
+        }
         loadTimeline();
         // Drain the next queued session now that this one has been removed.
         commands
@@ -786,9 +781,11 @@
         } catch {
           // Session may already be finished, that's fine
         }
-        cleanupSessionState(sessionId);
       }
       await commands.deletePendingCommit(commitId, !!sessionId);
+      if (sessionId) {
+        sessionRegistry.cleanupSession(sessionId);
+      }
       await loadTimeline();
       // Drain the next queued session now that this one has been removed.
       commands

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -41,6 +41,8 @@
   import RemoteWorkspaceStatusView from './RemoteWorkspaceStatusView.svelte';
   import { alerts } from '../../shared/alerts.svelte';
   import { timelineToHashtagItems, projectNotesToHashtagItems } from '../sessions/hashtagItems';
+  import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
+  import { projectStateStore } from '../../stores/projectState.svelte';
 
   interface Props {
     branch: Branch;
@@ -668,6 +670,14 @@
     }
   }
 
+  function cleanupSessionState(sessionId: string) {
+    const projectId = sessionRegistry.getProjectId(sessionId);
+    if (projectId) {
+      projectStateStore.removeRunningSession(projectId, sessionId);
+    }
+    sessionRegistry.unregister(sessionId);
+  }
+
   function handleDeleteCommit(sha: string, sessionId?: string, opts?: { altKey: boolean }) {
     const doDelete = async () => {
       confirmDelete = null;
@@ -705,6 +715,7 @@
           } catch {
             // Session may already be finished
           }
+          cleanupSessionState(sessionId);
         }
         await commands.deleteNote(noteId, !!sessionId);
         loadTimeline();
@@ -740,6 +751,7 @@
           } catch {
             // Session may already be finished
           }
+          cleanupSessionState(sessionId);
         }
         await commands.deleteReview(reviewId, !!sessionId);
         loadTimeline();
@@ -774,6 +786,7 @@
         } catch {
           // Session may already be finished, that's fine
         }
+        cleanupSessionState(sessionId);
       }
       await commands.deletePendingCommit(commitId, !!sessionId);
       await loadTimeline();

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -276,8 +276,6 @@ export default class BranchCardSessionManager {
         throw new Error('Failed to start session: no session ID returned');
       }
 
-      this.registerRunningSession(result.sessionId, branch.projectId, mode, branch.id);
-
       this.pendingSessionItems = this.pendingSessionItems.map((item) =>
         item.key === pendingKey
           ? {

--- a/apps/staged/src/lib/listeners/sessionStatusListener.ts
+++ b/apps/staged/src/lib/listeners/sessionStatusListener.ts
@@ -73,11 +73,6 @@ async function handleSessionEnd(sessionId: string, status: string) {
     projectStateStore.markAsUnread(sessionProjectId);
   }
 
-  // Always remove the running session from its project.
-  if (sessionProjectId) {
-    projectStateStore.removeRunningSession(sessionProjectId, sessionId);
-  }
-
   if (sessionType === 'pr' && branchId) {
     await handlePrCompletion(sessionId, branchId, status);
     prStateStore.clearSessionTracking(branchId);
@@ -88,8 +83,8 @@ async function handleSessionEnd(sessionId: string, status: string) {
     pushStateStore.clearSessionTracking(branchId);
   }
 
-  // Clean up the session from the unified registry (single point of cleanup).
-  sessionRegistry.unregister(sessionId);
+  // Remove running state from projectStateStore and unregister from the registry.
+  sessionRegistry.cleanupSession(sessionId);
 }
 
 async function handlePrCompletion(sessionId: string, branchId: string, status: string) {

--- a/apps/staged/src/lib/stores/sessionRegistry.svelte.ts
+++ b/apps/staged/src/lib/stores/sessionRegistry.svelte.ts
@@ -17,6 +17,8 @@
  * But they delegate session metadata tracking to this central registry.
  */
 
+import { projectStateStore } from './projectState.svelte';
+
 export type SessionType = 'commit' | 'pr' | 'push' | 'note' | 'review' | 'other';
 
 interface SessionMetadata {
@@ -131,6 +133,21 @@ class SessionRegistry {
   unregister(sessionId: string): void {
     this.sessions.delete(sessionId);
     this.version++;
+  }
+
+  /**
+   * Clean up a session's running state from projectStateStore and unregister it.
+   *
+   * This is the symmetric counterpart to register() — it removes the session
+   * from both the project-level running session tracking and this registry.
+   * Idempotent: safe to call even if the session is already gone.
+   */
+  cleanupSession(sessionId: string): void {
+    const projectId = this.getProjectId(sessionId);
+    if (projectId) {
+      projectStateStore.removeRunningSession(projectId, sessionId);
+    }
+    this.unregister(sessionId);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Emit a `session-status-changed` "running" event from `start_branch_session` in the Rust backend so the frontend state stores (project list spinner, unread badges, etc.) are updated regardless of which UI surface starts the session
- Remove the now-redundant `registerRunningSession` call from `BranchCardSessionManager` on the frontend, since the backend event handles it

## Test plan
- [ ] Start a branch session from different UI surfaces and verify the project list spinner and unread badges update correctly
- [ ] Verify no duplicate session registration occurs
- [ ] Confirm existing session flows (commit, note, review) still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)