### PR TITLE
fix(staged): cap New Note modal height to prevent overflow on long prompts

### DIFF
--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -446,6 +446,12 @@
   }
 
   .modal {
+    /* Modal height budget:
+       100vh - padding-top (12vh) - bottom breathing room (4vh).
+       --modal-chrome-height is the non-editor chrome inside the modal
+       (header, padding, buttons, gaps) — used by the editor to size itself. */
+    --modal-chrome-height: 200px;
+
     display: flex;
     flex-direction: column;
     width: 580px;
@@ -627,7 +633,7 @@
     line-height: 1.5;
     resize: vertical;
     min-height: 240px;
-    max-height: calc(100vh - 12vh - 4vh - 200px);
+    max-height: calc(100vh - 12vh - 4vh - var(--modal-chrome-height));
     overflow-y: auto;
     transition: border-color 0.15s;
   }

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -598,8 +598,6 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
-    min-height: 0;
-    overflow: hidden;
   }
 
   .repo-info {
@@ -616,17 +614,6 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    min-height: 0;
-    flex: 1 1 0;
-    overflow: hidden;
-  }
-
-  .form-group :global(.hashtag-input-wrapper),
-  .form-group :global(.hashtag-input-container) {
-    min-height: 0;
-    flex: 1 1 0;
-    display: flex;
-    flex-direction: column;
   }
 
   .form-group :global(.hashtag-editor) {
@@ -640,7 +627,7 @@
     line-height: 1.5;
     resize: vertical;
     min-height: 240px;
-    flex: 1 1 0;
+    max-height: calc(100vh - 12vh - 4vh - 200px);
     overflow-y: auto;
     transition: border-color 0.15s;
   }

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -393,7 +393,7 @@
             : isCommit
               ? 'Describe the change…'
               : notePlaceholder}
-          rows={isReview ? 4 : 12}
+          rows={12}
           disabled={starting}
           items={hashtagItems}
         />

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -639,8 +639,9 @@
     font-family: inherit;
     line-height: 1.5;
     resize: vertical;
-    min-height: 0;
+    min-height: 240px;
     flex: 1 1 0;
+    overflow-y: auto;
     transition: border-color 0.15s;
   }
 

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -450,6 +450,7 @@
     flex-direction: column;
     width: 580px;
     max-width: 90vw;
+    max-height: calc(100vh - 12vh - 4vh);
     background: var(--bg-chrome);
     border: 2px solid transparent;
     border-radius: 12px;
@@ -597,6 +598,8 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
+    overflow-y: auto;
+    min-height: 0;
   }
 
   .repo-info {

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -598,7 +598,6 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
-    overflow-y: auto;
     min-height: 0;
   }
 
@@ -629,6 +628,7 @@
     line-height: 1.5;
     resize: vertical;
     min-height: 240px;
+    max-height: calc(100vh - 12vh - 4vh - 200px);
     transition: border-color 0.15s;
   }
 

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -644,9 +644,7 @@
     font-size: var(--size-sm);
     font-family: inherit;
     line-height: 1.5;
-    resize: vertical;
     flex: 1;
-    min-height: 240px;
     overflow-y: auto;
     transition: border-color 0.15s;
   }

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -599,6 +599,7 @@
     flex-direction: column;
     gap: 14px;
     min-height: 0;
+    overflow: hidden;
   }
 
   .repo-info {
@@ -615,6 +616,17 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
+    min-height: 0;
+    flex: 1 1 0;
+    overflow: hidden;
+  }
+
+  .form-group :global(.hashtag-input-wrapper),
+  .form-group :global(.hashtag-input-container) {
+    min-height: 0;
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
   }
 
   .form-group :global(.hashtag-editor) {
@@ -627,8 +639,8 @@
     font-family: inherit;
     line-height: 1.5;
     resize: vertical;
-    min-height: 240px;
-    max-height: calc(100vh - 12vh - 4vh - 200px);
+    min-height: 0;
+    flex: 1 1 0;
     transition: border-color 0.15s;
   }
 

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -446,12 +446,6 @@
   }
 
   .modal {
-    /* Modal height budget:
-       100vh - padding-top (12vh) - bottom breathing room (4vh).
-       --modal-chrome-height is the non-editor chrome inside the modal
-       (header, padding, buttons, gaps) — used by the editor to size itself. */
-    --modal-chrome-height: 200px;
-
     display: flex;
     flex-direction: column;
     width: 580px;
@@ -604,6 +598,8 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
+    flex: 1;
+    min-height: 0;
   }
 
   .repo-info {
@@ -620,6 +616,8 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
+    flex: 1;
+    min-height: 0;
   }
 
   .form-group :global(.hashtag-editor) {
@@ -632,8 +630,8 @@
     font-family: inherit;
     line-height: 1.5;
     resize: vertical;
+    flex: 1;
     min-height: 240px;
-    max-height: calc(100vh - 12vh - 4vh - var(--modal-chrome-height));
     overflow-y: auto;
     transition: border-color 0.15s;
   }

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -620,6 +620,21 @@
     min-height: 0;
   }
 
+  /* Propagate flex constraint through HashtagInput wrapper divs */
+  .form-group :global(.hashtag-input-wrapper) {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .form-group :global(.hashtag-input-container) {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
   .form-group :global(.hashtag-editor) {
     padding: 10px 12px;
     background: var(--bg-primary);


### PR DESCRIPTION
## Summary

- Caps the New Note modal's max-height to the viewport so long prompts no longer push the dialog off-screen
- Uses a flex cascade through the form and HashtagInput wrapper divs so only the text editor scrolls, keeping the rest of the modal chrome (title, buttons, hashtags) fixed
- Unifies the text editor row count across all New Session modes (was 4 for review, now 12 for all)
- Removes the fixed `min-height` and `resize: vertical` on the editor in favor of flex-based sizing with `overflow-y: auto`

## Test plan

- [ ] Open New Note modal with a very long prompt — modal should stay within viewport
- [ ] Verify the text editor area scrolls independently when content overflows
- [ ] Check New Session modal in all modes (note, commit, review) — editor height should be consistent
- [ ] Resize browser window to small viewport — modal should adapt without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)