### PR TITLE
fix: allow copying text from read-only comment editors

### DIFF
--- a/packages/diff-viewer/src/lib/components/CommentEditor.svelte
+++ b/packages/diff-viewer/src/lib/components/CommentEditor.svelte
@@ -144,6 +144,7 @@
     line-height: 1.5;
     resize: none;
     overflow-y: auto;
+    user-select: text;
   }
 
   .comment-textarea:focus {

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -1656,6 +1656,10 @@
   // ==========================================================================
 
   function handleCopy(event: ClipboardEvent) {
+    // Don't intercept copy from form elements (e.g. comment textareas)
+    const target = document.activeElement;
+    if (target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement) return;
+
     if (selectedLineRange) {
       event.preventDefault();
       const pane = selectedLineRange.pane === 'before' ? beforePane : afterPane;


### PR DESCRIPTION
## Summary
- Add `user-select: text` to comment textareas so text can be selected in read-only comments
- Skip the custom diff copy handler when the active element is a form input (textarea/input), allowing native copy behavior to work in comment editors

## Test plan
- [ ] Open a PR with existing comments in the diff viewer
- [ ] Select text within a read-only comment textarea
- [ ] Verify Ctrl+C / Cmd+C copies the selected comment text (not diff lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)