### PR TITLE
fix(staged): prevent double row flash in timeline when starting a session

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -480,8 +480,12 @@
             }
           });
         }
-        // Refresh the timeline so the pending note/commit stub appears immediately
-        if (!isAutoReview) {
+        // Refresh the timeline so the pending note/commit stub appears immediately.
+        // Skip if a session start is in-flight (pending item has no sessionId yet),
+        // because startBranchSessionWithPendingItem will call loadTimeline after
+        // it gets the sessionId — otherwise pruning can't match the pending item
+        // and both the pending and real items briefly render simultaneously.
+        if (!isAutoReview && !sessionMgr.isSessionStartPending) {
           loadTimeline();
         }
       }


### PR DESCRIPTION
## Summary
- Skip redundant `loadTimeline()` call when a session start is in-flight, since `startBranchSessionWithPendingItem` will call it after obtaining the sessionId
- Prevents the brief double-row flash where both the pending stub and the real timeline item render simultaneously because pruning can't match items without a sessionId

## Test plan
- [ ] Start a new session on a branch and verify no duplicate row flashes in the timeline
- [ ] Verify the pending note/commit stub still appears immediately for non-session-start actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)