### PR TITLE
fix: skip diff navigation shortcuts when focus is in a text input

### DIFF
--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -405,15 +405,20 @@
   // ==========================================================================
 
   function handleKeydown(event: KeyboardEvent) {
+    const inInput =
+      event.target instanceof HTMLInputElement ||
+      event.target instanceof HTMLTextAreaElement ||
+      (event.target instanceof HTMLElement && event.target.isContentEditable);
+
     // Command+Left Arrow to go back
-    if (event.key === 'ArrowLeft' && event.metaKey) {
+    if (event.key === 'ArrowLeft' && event.metaKey && !inInput) {
       event.preventDefault();
       event.stopPropagation();
       onClose();
       return;
     }
     // Command+Up/Down Arrow to navigate between files
-    if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && event.metaKey) {
+    if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && event.metaKey && !inInput) {
       event.preventDefault();
       event.stopPropagation();
       const currentPath = diffViewer.state.selectedFile;

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -404,11 +404,17 @@
   // Keyboard
   // ==========================================================================
 
+  /** True when the event target is an editable element (input, textarea, contentEditable). */
+  function isEditableTarget(target: EventTarget | null): boolean {
+    return (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    );
+  }
+
   function handleKeydown(event: KeyboardEvent) {
-    const inInput =
-      event.target instanceof HTMLInputElement ||
-      event.target instanceof HTMLTextAreaElement ||
-      (event.target instanceof HTMLElement && event.target.isContentEditable);
+    const inInput = isEditableTarget(event.target);
 
     // Command+Left Arrow to go back
     if (event.key === 'ArrowLeft' && event.metaKey && !inInput) {
@@ -430,10 +436,9 @@
       }
       return;
     }
-    // Escape to dismiss layers, then close modal (skip if focused on an input/textarea)
+    // Escape to dismiss layers, then close modal (skip if focused on an editable element)
     if (event.key === 'Escape') {
-      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement)
-        return;
+      if (inInput) return;
       // If DiffViewer already handled this Escape (e.g. clearing selection/comment state),
       // don't also close the modal. Both handlers are on `document`, so stopPropagation
       // doesn't help — check defaultPrevented instead.
@@ -452,12 +457,7 @@
     }
     // Hold A to reveal AI annotations
     if (event.key === 'a' || event.key === 'A') {
-      if (
-        event.target instanceof HTMLInputElement ||
-        event.target instanceof HTMLTextAreaElement ||
-        (event.target instanceof HTMLElement && event.target.isContentEditable)
-      )
-        return;
+      if (inInput) return;
       if (!event.repeat) {
         annotationsRevealed = true;
       }
@@ -466,12 +466,7 @@
 
   function handleKeyup(event: KeyboardEvent) {
     if (event.key === 'a' || event.key === 'A') {
-      if (
-        event.target instanceof HTMLInputElement ||
-        event.target instanceof HTMLTextAreaElement ||
-        (event.target instanceof HTMLElement && event.target.isContentEditable)
-      )
-        return;
+      if (isEditableTarget(event.target)) return;
       annotationsRevealed = false;
     }
   }


### PR DESCRIPTION
## Summary
- Adds an `inInput` guard to the `handleKeydown` function in `DiffModal.svelte` so that `Cmd+Left`, `Cmd+Up`, and `Cmd+Down` shortcuts are skipped when focus is inside an `<input>`, `<textarea>`, or `contentEditable` element
- Prevents the diff modal from intercepting standard text-editing shortcuts (e.g., move cursor to start of line) when typing in search or other input fields

## Test plan
- [ ] Open the diff modal and verify `Cmd+Left` still closes it when no input is focused
- [ ] Open the diff modal and verify `Cmd+Up`/`Cmd+Down` still navigate between files when no input is focused
- [ ] Focus the search input inside the diff modal and verify `Cmd+Left` moves the cursor instead of closing the modal
- [ ] Focus the search input and verify `Cmd+Up`/`Cmd+Down` do not navigate files

🤖 Generated with [Claude Code](https://claude.com/claude-code)