### PR TITLE
fix(staged): eliminate timeline flash and animation on project switch

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -434,7 +434,7 @@
     isLocalVal: boolean,
     isRemoteVal: boolean,
     worktreePath: string | undefined | null,
-    remoteStatus: string | undefined
+    remoteStatus: string | null | undefined
   ): string | null {
     if (isLocalVal && !worktreePath) return null;
     if (!isLocalVal && (!isRemoteVal || remoteStatus !== 'running')) return null;

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -431,7 +431,7 @@
    */
   function applyCachedTimeline(
     cached: BranchTimelineData,
-    fresh: Promise<BranchTimelineData> | undefined
+    fresh: Promise<BranchTimelineData> | null
   ) {
     timeline = cached;
     loading = false;
@@ -463,7 +463,7 @@
   // Synchronously hydrate timeline from cache so isSettingUp is never true
   // on remount (e.g. project switch). This prevents the "Looking for changes…"
   // flash and the slide-in animation for already-cached rows.
-  {
+  untrack(() => {
     const ready = isLocal ? !!branch.worktreePath : remoteWorkspaceStatus === 'running';
     if (ready) {
       const key = isRemote ? `${branch.id}:<remote>` : `${branch.id}:${branch.worktreePath}`;
@@ -473,7 +473,7 @@
         applyCachedTimeline(cached, fresh);
       }
     }
-  }
+  });
 
   /** Number of finalized commits on this branch. */
   let commitCount = $derived(timeline?.commits.filter((c) => c.sha).length ?? 0);

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -463,17 +463,27 @@
   // Synchronously hydrate timeline from cache so isSettingUp is never true
   // on remount (e.g. project switch). This prevents the "Looking for changes…"
   // flash and the slide-in animation for already-cached rows.
-  untrack(() => {
-    const ready = isLocal ? !!branch.worktreePath : remoteWorkspaceStatus === 'running';
-    if (ready) {
-      const key = isRemote ? `${branch.id}:<remote>` : `${branch.id}:${branch.worktreePath}`;
-      const { cached, fresh } = commands.getBranchTimelineWithRevalidation(branch.id);
-      if (cached) {
-        loadedTimelineKey = key;
-        applyCachedTimeline(cached, fresh);
+  {
+    const initIsLocal = isLocal;
+    const initIsRemote = isRemote;
+    const initBranch = branch;
+    const initRemoteWorkspaceStatus = remoteWorkspaceStatus;
+    untrack(() => {
+      const ready = initIsLocal
+        ? !!initBranch.worktreePath
+        : initRemoteWorkspaceStatus === 'running';
+      if (ready) {
+        const key = initIsRemote
+          ? `${initBranch.id}:<remote>`
+          : `${initBranch.id}:${initBranch.worktreePath}`;
+        const { cached, fresh } = commands.getBranchTimelineWithRevalidation(initBranch.id);
+        if (cached) {
+          loadedTimelineKey = key;
+          applyCachedTimeline(cached, fresh);
+        }
       }
-    }
-  });
+    });
+  }
 
   /** Number of finalized commits on this branch. */
   let commitCount = $derived(timeline?.commits.filter((c) => c.sha).length ?? 0);

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -421,6 +421,45 @@
 
   let revalidationVersion = 0;
 
+  /**
+   * Apply a cached timeline immediately and, if a `fresh` promise is provided,
+   * set up revalidation handlers guarded by `revalidationVersion` so stale
+   * responses are discarded.
+   *
+   * Shared by the synchronous-hydration block (below) and the `isInitialLoad`
+   * path inside `loadTimeline()`.
+   */
+  function applyCachedTimeline(
+    cached: BranchTimelineData,
+    fresh: Promise<BranchTimelineData> | undefined
+  ) {
+    timeline = cached;
+    loading = false;
+    prunedSessionIds = sessionMgr.prunePendingSessionItems(cached);
+    if (fresh) {
+      revalidating = true;
+      const version = ++revalidationVersion;
+      fresh
+        .then((next) => {
+          if (version !== revalidationVersion) return;
+          error = null;
+          timeline = next;
+          prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
+          void loadTimelineReviewDetails(next.reviews);
+        })
+        .catch((e) => {
+          if (version !== revalidationVersion) return;
+          error = e instanceof Error ? e.message : String(e);
+        })
+        .finally(() => {
+          if (version !== revalidationVersion) return;
+          revalidating = false;
+        });
+    } else {
+      void loadTimelineReviewDetails(cached.reviews);
+    }
+  }
+
   // Synchronously hydrate timeline from cache so isSettingUp is never true
   // on remount (e.g. project switch). This prevents the "Looking for changes…"
   // flash and the slide-in animation for already-cached rows.
@@ -430,32 +469,8 @@
       const key = isRemote ? `${branch.id}:<remote>` : `${branch.id}:${branch.worktreePath}`;
       const { cached, fresh } = commands.getBranchTimelineWithRevalidation(branch.id);
       if (cached) {
-        timeline = cached;
-        loading = false;
         loadedTimelineKey = key;
-        prunedSessionIds = sessionMgr.prunePendingSessionItems(cached);
-        if (fresh) {
-          revalidating = true;
-          const version = ++revalidationVersion;
-          fresh
-            .then((next) => {
-              if (version !== revalidationVersion) return;
-              error = null;
-              timeline = next;
-              prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
-              void loadTimelineReviewDetails(next.reviews);
-            })
-            .catch((e) => {
-              if (version !== revalidationVersion) return;
-              error = e instanceof Error ? e.message : String(e);
-            })
-            .finally(() => {
-              if (version !== revalidationVersion) return;
-              revalidating = false;
-            });
-        } else {
-          void loadTimelineReviewDetails(cached.reviews);
-        }
+        applyCachedTimeline(cached, fresh);
       }
     }
   }
@@ -568,32 +583,7 @@
     if (isInitialLoad) {
       const { cached, fresh } = commands.getBranchTimelineWithRevalidation(branch.id);
       if (cached) {
-        // Show stale data immediately
-        timeline = cached;
-        loading = false;
-        prunedSessionIds = sessionMgr.prunePendingSessionItems(cached);
-        if (!fresh) {
-          void loadTimelineReviewDetails(cached.reviews);
-        } else {
-          revalidating = true;
-          const version = revalidationVersion;
-          fresh
-            .then((next) => {
-              if (version !== revalidationVersion) return;
-              error = null;
-              timeline = next;
-              prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
-              void loadTimelineReviewDetails(next.reviews);
-            })
-            .catch((e) => {
-              if (version !== revalidationVersion) return;
-              error = e instanceof Error ? e.message : String(e);
-            })
-            .finally(() => {
-              if (version !== revalidationVersion) return;
-              revalidating = false;
-            });
-        }
+        applyCachedTimeline(cached, fresh);
         return;
       }
       // No cache — show loading spinner as before

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -464,9 +464,13 @@
   // on remount (e.g. project switch). This prevents the "Looking for changes…"
   // flash and the slide-in animation for already-cached rows.
   {
+    // svelte-ignore state_referenced_locally
     const initIsLocal = isLocal;
+    // svelte-ignore state_referenced_locally
     const initIsRemote = isRemote;
+    // svelte-ignore state_referenced_locally
     const initBranch = branch;
+    // svelte-ignore state_referenced_locally
     const initRemoteWorkspaceStatus = remoteWorkspaceStatus;
     untrack(() => {
       const ready = initIsLocal

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -419,6 +419,47 @@
     getTimeline: () => timeline,
   });
 
+  let revalidationVersion = 0;
+
+  // Synchronously hydrate timeline from cache so isSettingUp is never true
+  // on remount (e.g. project switch). This prevents the "Looking for changes…"
+  // flash and the slide-in animation for already-cached rows.
+  {
+    const ready = isLocal ? !!branch.worktreePath : remoteWorkspaceStatus === 'running';
+    if (ready) {
+      const key = isRemote ? `${branch.id}:<remote>` : `${branch.id}:${branch.worktreePath}`;
+      const { cached, fresh } = commands.getBranchTimelineWithRevalidation(branch.id);
+      if (cached) {
+        timeline = cached;
+        loading = false;
+        loadedTimelineKey = key;
+        prunedSessionIds = sessionMgr.prunePendingSessionItems(cached);
+        if (fresh) {
+          revalidating = true;
+          const version = ++revalidationVersion;
+          fresh
+            .then((next) => {
+              if (version !== revalidationVersion) return;
+              error = null;
+              timeline = next;
+              prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
+              void loadTimelineReviewDetails(next.reviews);
+            })
+            .catch((e) => {
+              if (version !== revalidationVersion) return;
+              error = e instanceof Error ? e.message : String(e);
+            })
+            .finally(() => {
+              if (version !== revalidationVersion) return;
+              revalidating = false;
+            });
+        } else {
+          void loadTimelineReviewDetails(cached.reviews);
+        }
+      }
+    }
+  }
+
   /** Number of finalized commits on this branch. */
   let commitCount = $derived(timeline?.commits.filter((c) => c.sha).length ?? 0);
 
@@ -517,8 +558,6 @@
     window.addEventListener('timeline-invalidated', handler);
     return () => window.removeEventListener('timeline-invalidated', handler);
   });
-
-  let revalidationVersion = 0;
 
   async function loadTimeline() {
     const isInitialLoad = !timeline;

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -422,6 +422,26 @@
   let revalidationVersion = 0;
 
   /**
+   * Compute the timeline cache key for a branch, or null if the branch is
+   * not yet ready for timeline loading.
+   *
+   * Shared between the synchronous hydration block and the $effect that
+   * triggers loadTimeline(), so the readiness conditions and key format
+   * stay in sync.
+   */
+  function getTimelineKey(
+    branchId: string,
+    isLocalVal: boolean,
+    isRemoteVal: boolean,
+    worktreePath: string | undefined | null,
+    remoteStatus: string | undefined
+  ): string | null {
+    if (isLocalVal && !worktreePath) return null;
+    if (!isLocalVal && (!isRemoteVal || remoteStatus !== 'running')) return null;
+    return isRemoteVal ? `${branchId}:<remote>` : `${branchId}:${worktreePath}`;
+  }
+
+  /**
    * Apply a cached timeline immediately and, if a `fresh` promise is provided,
    * set up revalidation handlers guarded by `revalidationVersion` so stale
    * responses are discarded.
@@ -473,13 +493,14 @@
     // svelte-ignore state_referenced_locally
     const initRemoteWorkspaceStatus = remoteWorkspaceStatus;
     untrack(() => {
-      const ready = initIsLocal
-        ? !!initBranch.worktreePath
-        : initRemoteWorkspaceStatus === 'running';
-      if (ready) {
-        const key = initIsRemote
-          ? `${initBranch.id}:<remote>`
-          : `${initBranch.id}:${initBranch.worktreePath}`;
+      const key = getTimelineKey(
+        initBranch.id,
+        initIsLocal,
+        initIsRemote,
+        initBranch.worktreePath,
+        initRemoteWorkspaceStatus
+      );
+      if (key) {
         const { cached, fresh } = commands.getBranchTimelineWithRevalidation(initBranch.id);
         if (cached) {
           loadedTimelineKey = key;
@@ -566,11 +587,14 @@
 
   // Load timeline when a branch becomes timeline-ready
   $effect(() => {
-    if (isLocal && !branch.worktreePath) return;
-    if (isRemote && remoteWorkspaceStatus !== 'running') return;
-
-    const timelineKey = isRemote ? `${branch.id}:<remote>` : `${branch.id}:${branch.worktreePath}`;
-    if (timelineKey === loadedTimelineKey) return;
+    const timelineKey = getTimelineKey(
+      branch.id,
+      isLocal,
+      isRemote,
+      branch.worktreePath,
+      remoteWorkspaceStatus
+    );
+    if (!timelineKey || timelineKey === loadedTimelineKey) return;
 
     loadedTimelineKey = timelineKey;
     void loadTimeline();


### PR DESCRIPTION
## Summary
- Synchronously hydrate timeline from cache on component remount (e.g. project switch) so the "Looking for changes…" spinner and slide-in animation are never shown for already-cached branches
- Extract `applyCachedTimeline` helper to deduplicate cache hydration logic between the synchronous path and `loadTimeline()`
- Guard revalidation callbacks with a version counter to discard stale responses

## Test plan
- [ ] Switch between projects with cached branches and verify no timeline flash or animation occurs
- [ ] Verify fresh data still loads via revalidation after the cached data is shown
- [ ] Verify branches without cached data still show the loading spinner as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)