### PR TITLE
fix: include code blocks in note search results

### DIFF
--- a/apps/staged/src/lib/shared/textHighlight.ts
+++ b/apps/staged/src/lib/shared/textHighlight.ts
@@ -45,11 +45,6 @@ export function highlightMatches(
       if (node.parentElement?.tagName === 'MARK') {
         return NodeFilter.FILTER_REJECT;
       }
-      // Skip text nodes inside <code> or <pre> blocks
-      const parent = node.parentElement;
-      if (parent?.tagName === 'CODE' || parent?.closest('pre')) {
-        return NodeFilter.FILTER_REJECT;
-      }
       return NodeFilter.FILTER_ACCEPT;
     },
   });


### PR DESCRIPTION
## Summary
- Removed the filter that excluded `<code>` and `<pre>` elements from note search highlighting, so search queries now match and highlight text inside code blocks.

## Test plan
- [ ] Search for text that appears inside a code block in a note and verify it is found and highlighted
- [ ] Verify search still works correctly for regular (non-code) text

🤖 Generated with [Claude Code](https://claude.com/claude-code)