### PR TITLE
fix: prevent duplicate action detection on re-navigation

### DIFF
--- a/apps/staged/src-tauri/src/actions/commands.rs
+++ b/apps/staged/src-tauri/src/actions/commands.rs
@@ -116,6 +116,9 @@ pub async fn detect_repo_actions(
     let context = store
         .get_or_create_action_context(&github_repo, subpath.as_deref())
         .map_err(|e| format!("Failed to get action context: {e}"))?;
+    if context.detecting_actions {
+        return Err("Detection is already in progress for this repository".into());
+    }
     store
         .set_action_context_detecting(&context.id, true)
         .map_err(|e| format!("Failed to set detection status: {e}"))?;

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
+  import { onMount, onDestroy, untrack } from 'svelte';
   import {
     FolderGit2,
     Play,
@@ -22,7 +22,11 @@
   import ConfirmDialog from '../../shared/ConfirmDialog.svelte';
   import type { ActionContext, ProjectAction } from '../../api/commands';
   import * as commands from '../../api/commands';
-  import { detectRepoActions, type ActionType } from '../actions/actions';
+  import {
+    detectRepoActions,
+    listenToRepoActionsDetection,
+    type ActionType,
+  } from '../actions/actions';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { matchesRepoSearch } from './repoContextSearch';
 
@@ -66,10 +70,28 @@
   let badgeEditHue = $state(0);
   let badgeError = $state('');
 
+  let unlistenDetection: (() => void) | undefined;
+
   onMount(async () => {
+    listenToRepoActionsDetection((event) => {
+      const ctx = selectedContext;
+      if (!ctx) return;
+      if (event.githubRepo !== ctx.githubRepo || event.subpath !== (ctx.subpath ?? null)) return;
+      detecting = event.detecting;
+      if (!event.detecting) {
+        loadActions();
+      }
+    }).then((unlisten) => {
+      unlistenDetection = unlisten;
+    });
+
     await repoBadgeStore.loadAll();
     await loadContexts();
     await ensureBadgesForContexts(contexts);
+  });
+
+  onDestroy(() => {
+    unlistenDetection?.();
   });
 
   async function ensureBadgesForContexts(ctxs: ActionContext[]) {
@@ -254,6 +276,10 @@
   $effect(() => {
     selectedRepoKey;
     loadActions();
+  });
+
+  $effect(() => {
+    detecting = selectedContext?.detectingActions ?? false;
   });
 
   async function detectActions() {


### PR DESCRIPTION
## Summary
- Add a guard in the Rust backend to reject concurrent action detection requests for the same repository
- Listen for detection state changes via events in `ActionsSettingsPanel` so the UI stays in sync when navigating away and back
- Sync the `detecting` flag from the selected context on selection change

## Test plan
- [ ] Navigate to a repo's action settings and trigger detection
- [ ] Navigate away and back while detection is running — verify no duplicate detection starts
- [ ] Verify detection status updates correctly when it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)