### PR TITLE
fix(staged): fix "Looking for changes" stuck after adding project from PR

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -558,8 +558,19 @@
       ]);
       setProjects(projectsList);
       projects = projectsList;
-      branchesByProject = new Map(branchesByProject).set(projectId, branches);
-      workspaceLifecycle.enqueueInitialSetup(projectId, branches);
+      // Merge branches carefully: don't let a stale async response overwrite
+      // worktreePath with null when the setup-progress handler already set it.
+      const existingBranches = branchesByProject.get(projectId) || [];
+      const mergedBranches = branches.map((newBranch) => {
+        const existing = existingBranches.find((b) => b.id === newBranch.id);
+        if (existing?.worktreePath && !newBranch.worktreePath) {
+          return { ...newBranch, worktreePath: existing.worktreePath };
+        }
+        return newBranch;
+      });
+      branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
+      commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
+      workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);
       replaceProjectRepos(projectId, repos);
       void repoBadgeStore.ensureForRepos(
         repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -25,6 +25,20 @@
   import { projectRunActionsStore } from '../../stores/projectRunActions.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
 
+  /**
+   * Merge incoming branches with existing ones, preserving worktreePath when
+   * a stale async response would overwrite an already-populated value with null.
+   */
+  function mergeBranchesPreservingWorktree(existing: Branch[], incoming: Branch[]): Branch[] {
+    return incoming.map((newBranch) => {
+      const prev = existing.find((b) => b.id === newBranch.id);
+      if (prev?.worktreePath && !newBranch.worktreePath) {
+        return { ...newBranch, worktreePath: prev.worktreePath };
+      }
+      return newBranch;
+    });
+  }
+
   interface Props {
     selectedProjectId?: string | null;
   }
@@ -118,19 +132,13 @@
         ]);
         setProjects(projectsList);
         projects = projectsList;
-        // Merge branches carefully: don't let a stale async response overwrite
-        // worktreePath with null when we already have it set.
-        const existingBranches = branchesByProject.get(projectId) || [];
-        const mergedBranches = branches.map((newBranch) => {
-          const existing = existingBranches.find((b) => b.id === newBranch.id);
-          if (existing?.worktreePath && !newBranch.worktreePath) {
-            return { ...newBranch, worktreePath: existing.worktreePath };
-          }
-          return newBranch;
-        });
+        const mergedBranches = mergeBranchesPreservingWorktree(
+          branchesByProject.get(projectId) || [],
+          branches
+        );
         branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
         commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
-        workspaceLifecycle.enqueueInitialSetup(projectId, branches);
+        workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);
         replaceProjectRepos(projectId, repos);
         void repoBadgeStore.ensureForRepos(
           repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
@@ -558,16 +566,10 @@
       ]);
       setProjects(projectsList);
       projects = projectsList;
-      // Merge branches carefully: don't let a stale async response overwrite
-      // worktreePath with null when the setup-progress handler already set it.
-      const existingBranches = branchesByProject.get(projectId) || [];
-      const mergedBranches = branches.map((newBranch) => {
-        const existing = existingBranches.find((b) => b.id === newBranch.id);
-        if (existing?.worktreePath && !newBranch.worktreePath) {
-          return { ...newBranch, worktreePath: existing.worktreePath };
-        }
-        return newBranch;
-      });
+      const mergedBranches = mergeBranchesPreservingWorktree(
+        branchesByProject.get(projectId) || [],
+        branches
+      );
       branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
       commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
       workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);


### PR DESCRIPTION
## Summary
- Extract `mergeBranchesPreservingWorktree` helper to prevent stale async responses from overwriting populated `worktreePath` values with null
- Apply the same merge-and-invalidate logic to the "add project from PR" code path, which was missing it — causing the "Looking for changes" state to persist indefinitely
- Pass merged branches (with preserved worktree paths) to `enqueueInitialSetup` so workspace lifecycle correctly detects existing worktrees

## Test plan
- [ ] Add a project from a PR link and verify the timeline loads without getting stuck on "Looking for changes"
- [ ] Switch between projects and verify worktree paths are preserved correctly
- [ ] Verify existing project loading still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)