### PR TITLE
fix(staged): filter auto reviews from hashtag mention options

### DIFF
--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -101,6 +101,7 @@ export function timelineToHashtagItems(
   }
 
   for (const review of timeline.reviews) {
+    if (review.isAuto) continue;
     const title = review.title || review.commitSha.slice(0, 7);
     items.push({
       type: 'review',


### PR DESCRIPTION
## Summary
- Filters out auto-generated code reviews from the hashtag mention options dropdown, so only human-created reviews appear as mentionable items.

## Test plan
- [ ] Verify that auto reviews no longer appear in hashtag mention suggestions
- [ ] Verify that manual reviews still appear correctly in hashtag mention suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)