### PR TITLE
feat: soft delete code review comments

### DIFF
--- a/apps/differ/src/App.svelte
+++ b/apps/differ/src/App.svelte
@@ -435,6 +435,7 @@
       author: 'user',
       commentType: null,
       createdAt: Date.now(),
+      deletedAt: null,
     };
     localComments = [...localComments, comment];
   }

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -1870,6 +1870,7 @@ pub fn run() {
             review_commands::add_comment,
             review_commands::update_comment,
             review_commands::delete_comment,
+            review_commands::delete_all_comments,
             review_commands::restore_comment,
             review_commands::get_deleted_comments,
             review_commands::add_reference_file,

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -1870,6 +1870,8 @@ pub fn run() {
             review_commands::add_comment,
             review_commands::update_comment,
             review_commands::delete_comment,
+            review_commands::restore_comment,
+            review_commands::get_deleted_comments,
             review_commands::add_reference_file,
             review_commands::remove_reference_file,
             // Doctor

--- a/apps/staged/src-tauri/src/review_commands.rs
+++ b/apps/staged/src-tauri/src/review_commands.rs
@@ -118,6 +118,17 @@ pub async fn delete_comment(
         .map_err(|e| e.to_string())
 }
 
+/// Soft-delete all active comments for a review in one atomic operation.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn delete_all_comments(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    review_id: String,
+) -> Result<(), String> {
+    crate::get_store(&store)?
+        .delete_all_comments(&review_id)
+        .map_err(|e| e.to_string())
+}
+
 /// Restore a soft-deleted comment.
 #[tauri::command(rename_all = "camelCase")]
 pub async fn restore_comment(

--- a/apps/staged/src-tauri/src/review_commands.rs
+++ b/apps/staged/src-tauri/src/review_commands.rs
@@ -118,6 +118,28 @@ pub async fn delete_comment(
         .map_err(|e| e.to_string())
 }
 
+/// Restore a soft-deleted comment.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn restore_comment(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    comment_id: String,
+) -> Result<(), String> {
+    crate::get_store(&store)?
+        .restore_comment(&comment_id)
+        .map_err(|e| e.to_string())
+}
+
+/// Get soft-deleted comments for a review.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_deleted_comments(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    review_id: String,
+) -> Result<Vec<crate::store::Comment>, String> {
+    crate::get_store(&store)?
+        .get_deleted_comments(&review_id)
+        .map_err(|e| e.to_string())
+}
+
 /// Add a reference file to a review.
 #[tauri::command(rename_all = "camelCase")]
 pub async fn add_reference_file(

--- a/apps/staged/src-tauri/src/store/migration_tests.rs
+++ b/apps/staged/src-tauri/src/store/migration_tests.rs
@@ -133,7 +133,7 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         )
         .unwrap();
 
-    assert_eq!(version, 11);
+    assert_eq!(version, 12);
     assert_eq!(app_version, super::APP_VERSION);
     assert!(table_exists(&conn, "projects"));
     assert!(table_exists(&conn, "project_notes"));

--- a/apps/staged/src-tauri/src/store/migrations/0012-soft-delete-comments/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0012-soft-delete-comments/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comments ADD COLUMN deleted_at INTEGER;

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -1124,6 +1124,8 @@ pub struct Comment {
     /// The type/severity of this comment. `None` for user-authored comments.
     pub comment_type: Option<CommentType>,
     pub created_at: i64,
+    /// When the comment was soft-deleted. `None` means active.
+    pub deleted_at: Option<i64>,
 }
 
 impl Comment {
@@ -1136,6 +1138,7 @@ impl Comment {
             author: CommentAuthor::User,
             comment_type: None,
             created_at: now_timestamp(),
+            deleted_at: None,
         }
     }
 

--- a/apps/staged/src-tauri/src/store/reviews.rs
+++ b/apps/staged/src-tauri/src/store/reviews.rs
@@ -221,10 +221,15 @@ impl Store {
         Ok(())
     }
 
-    /// Delete a comment.
+    /// Soft-delete a comment by setting `deleted_at` to the current timestamp.
     pub fn delete_comment(&self, comment_id: &str) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
-        // Get parent review before deleting
+        let now = now_timestamp();
+        conn.execute(
+            "UPDATE comments SET deleted_at = ?1 WHERE id = ?2",
+            params![now, comment_id],
+        )?;
+        // Touch the parent review
         let review_id: Option<String> = conn
             .query_row(
                 "SELECT review_id FROM comments WHERE id = ?1",
@@ -232,11 +237,57 @@ impl Store {
                 |row| row.get(0),
             )
             .optional()?;
-        conn.execute("DELETE FROM comments WHERE id = ?1", params![comment_id])?;
         if let Some(rid) = review_id {
             Self::touch_review(&conn, &rid)?;
         }
         Ok(())
+    }
+
+    /// Restore a soft-deleted comment by clearing `deleted_at`.
+    pub fn restore_comment(&self, comment_id: &str) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE comments SET deleted_at = NULL WHERE id = ?1",
+            params![comment_id],
+        )?;
+        let review_id: Option<String> = conn
+            .query_row(
+                "SELECT review_id FROM comments WHERE id = ?1",
+                params![comment_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(rid) = review_id {
+            Self::touch_review(&conn, &rid)?;
+        }
+        Ok(())
+    }
+
+    /// Get soft-deleted comments for a review, ordered by deletion time (newest first).
+    pub fn get_deleted_comments(&self, review_id: &str) -> Result<Vec<Comment>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, path, span_start, span_end, content, author, comment_type, created_at, deleted_at
+             FROM comments WHERE review_id = ?1 AND deleted_at IS NOT NULL ORDER BY deleted_at DESC",
+        )?;
+        let comments = stmt
+            .query_map(params![review_id], |row| {
+                let author_str: String = row.get(5)?;
+                let comment_type_str: Option<String> = row.get(6)?;
+                Ok(Comment {
+                    id: row.get(0)?,
+                    path: row.get(1)?,
+                    span: Span::new(row.get(2)?, row.get(3)?),
+                    content: row.get(4)?,
+                    author: super::models::CommentAuthor::parse(&author_str)
+                        .unwrap_or(super::models::CommentAuthor::User),
+                    comment_type: comment_type_str.as_deref().and_then(CommentType::parse),
+                    created_at: row.get(7)?,
+                    deleted_at: row.get(8)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(comments)
     }
 
     /// Add a reference file path.
@@ -440,10 +491,10 @@ impl Store {
             .query_map(params![&review.id], |row| row.get(0))?
             .collect::<Result<Vec<_>, _>>()?;
 
-        // Load comments
+        // Load comments (only active — soft-deleted comments are excluded)
         let mut stmt = conn.prepare(
             "SELECT id, path, span_start, span_end, content, author, comment_type, created_at
-             FROM comments WHERE review_id = ?1 ORDER BY created_at ASC",
+             FROM comments WHERE review_id = ?1 AND deleted_at IS NULL ORDER BY created_at ASC",
         )?;
         review.comments = stmt
             .query_map(params![&review.id], |row| {
@@ -458,6 +509,7 @@ impl Store {
                         .unwrap_or(super::models::CommentAuthor::User),
                     comment_type: comment_type_str.as_deref().and_then(CommentType::parse),
                     created_at: row.get(7)?,
+                    deleted_at: None,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;

--- a/apps/staged/src-tauri/src/store/reviews.rs
+++ b/apps/staged/src-tauri/src/store/reviews.rs
@@ -207,17 +207,7 @@ impl Store {
             "UPDATE comments SET content = ?1 WHERE id = ?2",
             params![content, comment_id],
         )?;
-        // Touch the parent review
-        let review_id: Option<String> = conn
-            .query_row(
-                "SELECT review_id FROM comments WHERE id = ?1",
-                params![comment_id],
-                |row| row.get(0),
-            )
-            .optional()?;
-        if let Some(rid) = review_id {
-            Self::touch_review(&conn, &rid)?;
-        }
+        Self::touch_review_for_comment(&conn, comment_id)?;
         Ok(())
     }
 
@@ -226,20 +216,22 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let now = now_timestamp();
         conn.execute(
-            "UPDATE comments SET deleted_at = ?1 WHERE id = ?2",
+            "UPDATE comments SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
             params![now, comment_id],
         )?;
-        // Touch the parent review
-        let review_id: Option<String> = conn
-            .query_row(
-                "SELECT review_id FROM comments WHERE id = ?1",
-                params![comment_id],
-                |row| row.get(0),
-            )
-            .optional()?;
-        if let Some(rid) = review_id {
-            Self::touch_review(&conn, &rid)?;
-        }
+        Self::touch_review_for_comment(&conn, comment_id)?;
+        Ok(())
+    }
+
+    /// Soft-delete all active comments for a review in a single statement.
+    pub fn delete_all_comments(&self, review_id: &str) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let now = now_timestamp();
+        conn.execute(
+            "UPDATE comments SET deleted_at = ?1 WHERE review_id = ?2 AND deleted_at IS NULL",
+            params![now, review_id],
+        )?;
+        Self::touch_review(&conn, review_id)?;
         Ok(())
     }
 
@@ -247,19 +239,10 @@ impl Store {
     pub fn restore_comment(&self, comment_id: &str) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "UPDATE comments SET deleted_at = NULL WHERE id = ?1",
+            "UPDATE comments SET deleted_at = NULL WHERE id = ?1 AND deleted_at IS NOT NULL",
             params![comment_id],
         )?;
-        let review_id: Option<String> = conn
-            .query_row(
-                "SELECT review_id FROM comments WHERE id = ?1",
-                params![comment_id],
-                |row| row.get(0),
-            )
-            .optional()?;
-        if let Some(rid) = review_id {
-            Self::touch_review(&conn, &rid)?;
-        }
+        Self::touch_review_for_comment(&conn, comment_id)?;
         Ok(())
     }
 
@@ -462,6 +445,21 @@ impl Store {
             "UPDATE reviews SET updated_at = ?1 WHERE id = ?2",
             params![now_timestamp(), review_id],
         )?;
+        Ok(())
+    }
+
+    /// Look up the parent review for a comment and touch its `updated_at`.
+    fn touch_review_for_comment(conn: &Connection, comment_id: &str) -> Result<(), StoreError> {
+        let review_id: Option<String> = conn
+            .query_row(
+                "SELECT review_id FROM comments WHERE id = ?1",
+                params![comment_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(rid) = review_id {
+            Self::touch_review(conn, &rid)?;
+        }
         Ok(())
     }
 

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -742,9 +742,19 @@ export function updateComment(commentId: string, content: string): Promise<void>
   return invoke('update_comment', { commentId, content });
 }
 
-/** Delete a comment. */
+/** Delete a comment (soft delete). */
 export function deleteComment(commentId: string): Promise<void> {
   return invoke('delete_comment', { commentId });
+}
+
+/** Restore a soft-deleted comment. */
+export function restoreComment(commentId: string): Promise<void> {
+  return invoke('restore_comment', { commentId });
+}
+
+/** Get soft-deleted comments for a review. */
+export function getDeletedComments(reviewId: string): Promise<Comment[]> {
+  return invoke('get_deleted_comments', { reviewId });
 }
 
 /** Add a reference file to a review. */

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -747,6 +747,11 @@ export function deleteComment(commentId: string): Promise<void> {
   return invoke('delete_comment', { commentId });
 }
 
+/** Soft-delete all active comments for a review in one atomic operation. */
+export function deleteAllComments(reviewId: string): Promise<void> {
+  return invoke('delete_all_comments', { reviewId });
+}
+
 /** Restore a soft-deleted comment. */
 export function restoreComment(commentId: string): Promise<void> {
   return invoke('restore_comment', { commentId });

--- a/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
@@ -1,27 +1,42 @@
 <script lang="ts">
-  import { AlertTriangle, Bot, Check, Copy, MessageSquare, Trash2 } from 'lucide-svelte';
+  import {
+    AlertTriangle,
+    Bot,
+    Check,
+    ChevronRight,
+    Copy,
+    MessageSquare,
+    Trash2,
+    Undo2,
+  } from 'lucide-svelte';
   import type { Comment } from '../../types';
   import { formatLineRange, truncateText } from './diffModalHelpers';
 
   interface Props {
     comments: Comment[];
+    deletedComments: Comment[];
     selectedCommentId: string | null;
     copiedFeedback: boolean;
     onSelectComment: (comment: Comment) => void;
     onCopyAll: () => void;
     onDeleteAll: () => void;
     onDeleteComment: (commentId: string) => void;
+    onRestoreComment: (commentId: string) => void;
   }
 
   let {
     comments,
+    deletedComments,
     selectedCommentId,
     copiedFeedback,
     onSelectComment,
     onCopyAll,
     onDeleteAll,
     onDeleteComment,
+    onRestoreComment,
   }: Props = $props();
+
+  let deletedExpanded = $state(false);
 
   function getFileName(path: string): string {
     return path.split('/').pop() || path;
@@ -107,6 +122,63 @@
       </li>
     {/each}
   </ul>
+{/if}
+
+{#if deletedComments.length > 0}
+  <button class="deleted-toggle" onclick={() => (deletedExpanded = !deletedExpanded)}>
+    <span class="deleted-toggle-icon" class:expanded={deletedExpanded}>
+      <ChevronRight size={12} />
+    </span>
+    <span class="deleted-toggle-label">Deleted</span>
+    <span class="count-capsule">{deletedComments.length}</span>
+  </button>
+
+  {#if deletedExpanded}
+    <ul class="tree-section comments-section deleted-comments-section">
+      {#each deletedComments as comment (comment.id)}
+        <li class="tree-item-wrapper">
+          <div class="comment-item-container deleted-comment">
+            <div class="tree-item comment-item" style="padding-left: 8px">
+              <span class="comment-icons">
+                {#if comment.author === 'agent'}
+                  <span class="comment-icon agent-icon">
+                    <Bot size={12} />
+                  </span>
+                {/if}
+                <span
+                  class="comment-icon"
+                  class:comment-icon-warning={comment.commentType === 'warning'}
+                >
+                  {#if comment.commentType === 'warning'}
+                    <AlertTriangle size={12} />
+                  {:else}
+                    <MessageSquare size={12} />
+                  {/if}
+                </span>
+              </span>
+              <span class="comment-details">
+                <span class="comment-location">
+                  <span class="comment-file">{getFileName(comment.path)}</span>
+                  <span class="comment-line">{formatLineRange(comment.span)}</span>
+                </span>
+                <span class="comment-preview">{truncateText(comment.content)}</span>
+              </span>
+            </div>
+            <button
+              class="comment-restore-btn"
+              onclick={(e) => {
+                e.stopPropagation();
+                onRestoreComment(comment.id);
+              }}
+              title="Restore comment"
+            >
+              <Undo2 size={12} />
+            </button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
 {/if}
 
 <style>
@@ -354,5 +426,92 @@
   .delete-all-btn:hover {
     background-color: var(--bg-hover);
     color: var(--status-deleted);
+  }
+
+  /* Deleted comments section */
+
+  .deleted-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 12px;
+    background: none;
+    border: none;
+    color: var(--text-faint);
+    font-size: calc(var(--size-xs) - 1px);
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+    width: 100%;
+    text-align: left;
+    transition:
+      color 0.1s,
+      background-color 0.1s;
+  }
+
+  .deleted-toggle:hover {
+    color: var(--text-muted);
+    background-color: var(--bg-hover);
+  }
+
+  .deleted-toggle-icon {
+    display: flex;
+    align-items: center;
+    transition: transform 0.15s ease;
+  }
+
+  .deleted-toggle-icon.expanded {
+    transform: rotate(90deg);
+  }
+
+  .deleted-toggle-label {
+    text-transform: uppercase;
+  }
+
+  .deleted-comments-section {
+    margin-bottom: 8px;
+  }
+
+  .deleted-comment {
+    opacity: 0.5;
+  }
+
+  .deleted-comment:hover {
+    opacity: 0.8;
+  }
+
+  .deleted-comment .tree-item {
+    cursor: default;
+  }
+
+  .comment-restore-btn {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-faint);
+    cursor: pointer;
+    opacity: 0;
+    transition:
+      opacity 0.1s,
+      color 0.1s,
+      background-color 0.1s;
+    z-index: 1;
+  }
+
+  .comment-item-container:hover .comment-restore-btn {
+    opacity: 1;
+  }
+
+  .comment-restore-btn:hover {
+    color: var(--status-added);
+    background-color: var(--bg-primary);
   }
 </style>

--- a/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
@@ -43,6 +43,30 @@
   }
 </script>
 
+{#snippet commentItemContent(comment: Comment)}
+  <span class="comment-icons">
+    {#if comment.author === 'agent'}
+      <span class="comment-icon agent-icon">
+        <Bot size={12} />
+      </span>
+    {/if}
+    <span class="comment-icon" class:comment-icon-warning={comment.commentType === 'warning'}>
+      {#if comment.commentType === 'warning'}
+        <AlertTriangle size={12} />
+      {:else}
+        <MessageSquare size={12} />
+      {/if}
+    </span>
+  </span>
+  <span class="comment-details">
+    <span class="comment-location">
+      <span class="comment-file">{getFileName(comment.path)}</span>
+      <span class="comment-line">{formatLineRange(comment.span)}</span>
+    </span>
+    <span class="comment-preview">{truncateText(comment.content)}</span>
+  </span>
+{/snippet}
+
 <div class="section-header comments-header">
   <div class="section-left"></div>
   <div class="section-divider">
@@ -83,30 +107,7 @@
             style="padding-left: 8px"
             onclick={() => onSelectComment(comment)}
           >
-            <span class="comment-icons">
-              {#if comment.author === 'agent'}
-                <span class="comment-icon agent-icon">
-                  <Bot size={12} />
-                </span>
-              {/if}
-              <span
-                class="comment-icon"
-                class:comment-icon-warning={comment.commentType === 'warning'}
-              >
-                {#if comment.commentType === 'warning'}
-                  <AlertTriangle size={12} />
-                {:else}
-                  <MessageSquare size={12} />
-                {/if}
-              </span>
-            </span>
-            <span class="comment-details">
-              <span class="comment-location">
-                <span class="comment-file">{getFileName(comment.path)}</span>
-                <span class="comment-line">{formatLineRange(comment.span)}</span>
-              </span>
-              <span class="comment-preview">{truncateText(comment.content)}</span>
-            </span>
+            {@render commentItemContent(comment)}
           </button>
           <button
             class="comment-delete-btn"
@@ -139,30 +140,7 @@
         <li class="tree-item-wrapper">
           <div class="comment-item-container deleted-comment">
             <div class="tree-item comment-item" style="padding-left: 8px">
-              <span class="comment-icons">
-                {#if comment.author === 'agent'}
-                  <span class="comment-icon agent-icon">
-                    <Bot size={12} />
-                  </span>
-                {/if}
-                <span
-                  class="comment-icon"
-                  class:comment-icon-warning={comment.commentType === 'warning'}
-                >
-                  {#if comment.commentType === 'warning'}
-                    <AlertTriangle size={12} />
-                  {:else}
-                    <MessageSquare size={12} />
-                  {/if}
-                </span>
-              </span>
-              <span class="comment-details">
-                <span class="comment-location">
-                  <span class="comment-file">{getFileName(comment.path)}</span>
-                  <span class="comment-line">{formatLineRange(comment.span)}</span>
-                </span>
-                <span class="comment-preview">{truncateText(comment.content)}</span>
-              </span>
+              {@render commentItemContent(comment)}
             </div>
             <button
               class="comment-restore-btn"

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -22,7 +22,6 @@
   import DiffFileTreeSection from './DiffFileTreeSection.svelte';
   import DiffCommitSessionLauncher from './DiffCommitSessionLauncher.svelte';
   import DiffReferenceSection from './DiffReferenceSection.svelte';
-  import ConfirmDialog from '../../shared/ConfirmDialog.svelte';
   import { createDiffViewerState } from './diffViewerState.svelte';
   import { createReviewState } from './reviewState.svelte';
   import { createSearchState } from '@builderbot/diff-viewer/state';
@@ -119,9 +118,7 @@
   let jumpToLine = $state<{ lineIndex: number; token: number } | null>(null);
   let lineJumpToken = 0;
 
-  // Confirmation dialog state
-  let commentToDelete = $state<string | null>(null);
-  let showDeleteAllConfirm = $state(false);
+  // (No confirmation dialogs — soft delete is reversible)
 
   // Annotation reveal state (hold A to reveal)
   let annotationsRevealed = $state(false);
@@ -310,24 +307,16 @@
     return path.split('/').pop() || path;
   }
 
-  function handleDeleteComment(commentId: string) {
-    commentToDelete = commentId;
+  async function handleDeleteComment(commentId: string) {
+    await reviewHandle?.deleteComment(commentId);
   }
 
-  async function confirmDeleteComment() {
-    if (commentToDelete) {
-      await reviewHandle?.deleteComment(commentToDelete);
-      commentToDelete = null;
-    }
-  }
-
-  function handleDeleteAllComments() {
-    showDeleteAllConfirm = true;
-  }
-
-  async function confirmDeleteAllComments() {
+  async function handleDeleteAllComments() {
     await reviewHandle?.deleteAllComments();
-    showDeleteAllConfirm = false;
+  }
+
+  async function handleRestoreComment(commentId: string) {
+    await reviewHandle?.restoreComment(commentId);
   }
 
   async function handleCopyComments() {
@@ -620,12 +609,14 @@
 
                 <DiffCommentsSection
                   comments={currentComments}
+                  deletedComments={reviewHandle?.state.deletedComments ?? []}
                   {selectedCommentId}
                   {copiedFeedback}
                   onSelectComment={handleSelectComment}
                   onCopyAll={handleCopyComments}
                   onDeleteAll={handleDeleteAllComments}
                   onDeleteComment={handleDeleteComment}
+                  onRestoreComment={handleRestoreComment}
                 />
               {/if}
             </div>
@@ -647,30 +638,6 @@
     </div>
   </div>
 </div>
-
-<!-- Delete comment confirmation -->
-{#if commentToDelete}
-  <ConfirmDialog
-    title="Delete Comment"
-    message="Are you sure you want to delete this comment?"
-    confirmLabel="Delete"
-    danger={true}
-    onConfirm={confirmDeleteComment}
-    onCancel={() => (commentToDelete = null)}
-  />
-{/if}
-
-<!-- Delete all comments confirmation -->
-{#if showDeleteAllConfirm}
-  <ConfirmDialog
-    title="Delete All Comments"
-    message="Are you sure you want to delete all comments? This action cannot be undone."
-    confirmLabel="Delete All"
-    danger={true}
-    onConfirm={confirmDeleteAllComments}
-    onCancel={() => (showDeleteAllConfirm = false)}
-  />
-{/if}
 
 <style>
   /* ========================================================================

--- a/packages/diff-viewer/src/lib/state/reviewState.svelte.ts
+++ b/packages/diff-viewer/src/lib/state/reviewState.svelte.ts
@@ -336,17 +336,18 @@ export function createReviewState(
   }
 
   /**
-   * Delete all comments (optimistic, parallel backend calls).
+   * Delete all comments (optimistic, single atomic backend call).
    */
   async function deleteAllComments(): Promise<void> {
+    if (!state.review) return;
+
     const now = Date.now();
     const movedComments = state.comments.map((c) => ({ ...c, deletedAt: now }));
-    const ids = state.comments.map((c) => c.id);
     state.deletedComments = [...movedComments, ...state.deletedComments];
     state.comments = [];
 
     try {
-      await Promise.all(ids.map((id) => commands.deleteComment(id)));
+      await commands.deleteAllComments(state.review.id);
     } catch (e) {
       console.error('Failed to delete all comments:', e);
     }

--- a/packages/diff-viewer/src/lib/state/reviewState.svelte.ts
+++ b/packages/diff-viewer/src/lib/state/reviewState.svelte.ts
@@ -30,6 +30,8 @@ export interface ReviewState {
   review: Review | null;
   /** Local comments list (optimistic, kept in sync with backend). */
   comments: Comment[];
+  /** Soft-deleted comments (recoverable). */
+  deletedComments: Comment[];
   /** Paths marked as reviewed. */
   reviewedPaths: string[];
   /** Reference files pinned for viewing. */
@@ -62,6 +64,7 @@ export function createReviewState(
   const state: ReviewState = $state({
     review: null,
     comments: [],
+    deletedComments: [],
     reviewedPaths: [],
     referenceFiles: [],
     loading: false,
@@ -89,6 +92,9 @@ export function createReviewState(
       if (review.referenceFiles.length > 0) {
         loadReferenceFilesFromPaths(review.referenceFiles);
       }
+
+      // Load deleted comments in background
+      loadDeletedComments(review.id);
 
       return review.id;
     } catch (e) {
@@ -120,6 +126,9 @@ export function createReviewState(
         if (review.referenceFiles.length > 0) {
           loadReferenceFilesFromPaths(review.referenceFiles);
         }
+
+        // Load deleted comments in background
+        loadDeletedComments(review.id);
       }
     } catch (e) {
       console.error('Failed to load existing review:', e);
@@ -166,16 +175,49 @@ export function createReviewState(
   }
 
   /**
-   * Delete a comment (optimistic).
+   * Soft-delete a comment (optimistic — moves to deletedComments).
    */
   async function deleteComment(commentId: string): Promise<void> {
-    // Optimistic removal
+    // Optimistic: move from comments to deletedComments
+    const comment = state.comments.find((c) => c.id === commentId);
     state.comments = state.comments.filter((c) => c.id !== commentId);
+    if (comment) {
+      state.deletedComments = [{ ...comment, deletedAt: Date.now() }, ...state.deletedComments];
+    }
 
     try {
       await commands.deleteComment(commentId);
     } catch (e) {
       console.error('Failed to delete comment:', e);
+    }
+  }
+
+  /**
+   * Restore a soft-deleted comment (optimistic — moves back to comments).
+   */
+  async function restoreComment(commentId: string): Promise<void> {
+    const comment = state.deletedComments.find((c) => c.id === commentId);
+    state.deletedComments = state.deletedComments.filter((c) => c.id !== commentId);
+    if (comment) {
+      state.comments = [...state.comments, { ...comment, deletedAt: null }];
+    }
+
+    try {
+      await commands.restoreComment(commentId);
+    } catch (e) {
+      console.error('Failed to restore comment:', e);
+    }
+  }
+
+  /**
+   * Load soft-deleted comments from backend (fire-and-forget).
+   */
+  async function loadDeletedComments(reviewId: string): Promise<void> {
+    try {
+      const deleted = await commands.getDeletedComments(reviewId);
+      state.deletedComments = deleted;
+    } catch (e) {
+      console.error('Failed to load deleted comments:', e);
     }
   }
 
@@ -297,7 +339,10 @@ export function createReviewState(
    * Delete all comments (optimistic, parallel backend calls).
    */
   async function deleteAllComments(): Promise<void> {
+    const now = Date.now();
+    const movedComments = state.comments.map((c) => ({ ...c, deletedAt: now }));
     const ids = state.comments.map((c) => c.id);
+    state.deletedComments = [...movedComments, ...state.deletedComments];
     state.comments = [];
 
     try {
@@ -312,6 +357,7 @@ export function createReviewState(
     addComment,
     updateComment,
     deleteComment,
+    restoreComment,
     deleteAllComments,
     markReviewed,
     unmarkReviewed,

--- a/packages/diff-viewer/src/lib/types.ts
+++ b/packages/diff-viewer/src/lib/types.ts
@@ -177,6 +177,7 @@ export interface ReviewCommands {
 
   updateComment(commentId: string, content: string): Promise<void>;
   deleteComment(commentId: string): Promise<void>;
+  deleteAllComments(reviewId: string): Promise<void>;
   restoreComment(commentId: string): Promise<void>;
   getDeletedComments(reviewId: string): Promise<Comment[]>;
 

--- a/packages/diff-viewer/src/lib/types.ts
+++ b/packages/diff-viewer/src/lib/types.ts
@@ -79,6 +79,8 @@ export interface Comment {
   /** The type/severity of this comment. Null for user-authored comments. */
   commentType: CommentType | null;
   createdAt: number;
+  /** When the comment was soft-deleted. Null means active. */
+  deletedAt: number | null;
 }
 
 /** A review anchored to a branch + commit + scope. */
@@ -175,6 +177,8 @@ export interface ReviewCommands {
 
   updateComment(commentId: string, content: string): Promise<void>;
   deleteComment(commentId: string): Promise<void>;
+  restoreComment(commentId: string): Promise<void>;
+  getDeletedComments(reviewId: string): Promise<Comment[]>;
 
   markReviewed(reviewId: string, path: string): Promise<void>;
   unmarkReviewed(reviewId: string, path: string): Promise<void>;


### PR DESCRIPTION
## Summary
- Replace hard-delete of review comments with soft-delete (`deleted_at` column) so deletions are reversible
- Add backend commands for `delete_all_comments`, `restore_comment`, and `get_deleted_comments`
- Add collapsible "Deleted" section in the comments sidebar with restore (undo) buttons
- Remove confirmation dialogs for delete actions since soft-delete is inherently safe
- Use optimistic UI updates for delete/restore operations
- Add DB migration (0012) to add `deleted_at` column to comments table

## Test plan
- [ ] Delete a single comment and verify it moves to the "Deleted" section
- [ ] Restore a deleted comment and verify it reappears in the active list
- [ ] Delete all comments and verify they all move to the "Deleted" section
- [ ] Verify deleted comments persist across app restarts
- [ ] Verify the "Deleted" section is hidden when there are no deleted comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)