### PR TITLE
fix(staged): improve rebase and squash agent prompts with explicit git commands

### DIFF
--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -724,13 +724,6 @@ pub async fn start_branch_session(
         (worktree_path, ctx)
     };
 
-    // Enrich squash/rebase prompts with merge-base info for local branches.
-    let prompt = if !is_remote {
-        enrich_prompt_with_merge_base(&prompt, &working_dir, &branch.base_branch)
-    } else {
-        prompt
-    };
-
     // Build the full prompt with action instructions + project information + branch context.
     let project_information = build_project_context(&store, &project, &branch);
     let full_prompt = build_full_prompt(
@@ -2355,47 +2348,6 @@ fn image_timeline_entries(store: &Arc<Store>, branch_id: &str) -> Vec<TimelineEn
             }
         })
         .collect()
-}
-
-/// Enrich squash/rebase prompts with merge-base info so the agent knows the
-/// exact branch-off point and doesn't rely on a potentially stale local ref.
-fn enrich_prompt_with_merge_base(prompt: &str, worktree: &Path, base_branch: &str) -> String {
-    if prompt == "Squash this branch's commits" {
-        match git::merge_base(worktree, base_branch, "HEAD") {
-            Ok(merge_base_sha) => {
-                let commit_count = git::get_commits_since_base(worktree, base_branch)
-                    .map(|c| c.len())
-                    .unwrap_or(0);
-                format!(
-                    "Squash this branch's commits into a single commit.\n\
-                     The branch has {commit_count} commits since its branch-off point (merge-base: {merge_base_sha}).\n\
-                     Only squash the commits listed in the branch history above.\n\
-                     Use `git reset --soft {merge_base_sha}` followed by `git commit` to squash.\n\
-                     Do not squash any commits beyond the branch-off point."
-                )
-            }
-            Err(e) => {
-                log::warn!("Failed to compute merge-base for squash prompt: {e}");
-                prompt.to_string()
-            }
-        }
-    } else if prompt == "Rebase this branch. Do not push the branch." {
-        match git::merge_base(worktree, base_branch, "HEAD") {
-            Ok(merge_base_sha) => {
-                format!(
-                    "Rebase this branch. Do not push the branch.\n\
-                     The branch-off point is {merge_base_sha} (base branch: {base_branch}).\n\
-                     Use `git rebase {base_branch}` to rebase."
-                )
-            }
-            Err(e) => {
-                log::warn!("Failed to compute merge-base for rebase prompt: {e}");
-                prompt.to_string()
-            }
-        }
-    } else {
-        prompt.to_string()
-    }
 }
 
 /// Assemble the full prompt from action instructions + branch context + user prompt.

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -724,6 +724,13 @@ pub async fn start_branch_session(
         (worktree_path, ctx)
     };
 
+    // Enrich squash/rebase prompts with merge-base info for local branches.
+    let prompt = if !is_remote {
+        enrich_prompt_with_merge_base(&prompt, &working_dir, &branch.base_branch)
+    } else {
+        prompt
+    };
+
     // Build the full prompt with action instructions + project information + branch context.
     let project_information = build_project_context(&store, &project, &branch);
     let full_prompt = build_full_prompt(
@@ -2348,6 +2355,47 @@ fn image_timeline_entries(store: &Arc<Store>, branch_id: &str) -> Vec<TimelineEn
             }
         })
         .collect()
+}
+
+/// Enrich squash/rebase prompts with merge-base info so the agent knows the
+/// exact branch-off point and doesn't rely on a potentially stale local ref.
+fn enrich_prompt_with_merge_base(prompt: &str, worktree: &Path, base_branch: &str) -> String {
+    if prompt == "Squash this branch's commits" {
+        match git::merge_base(worktree, base_branch, "HEAD") {
+            Ok(merge_base_sha) => {
+                let commit_count = git::get_commits_since_base(worktree, base_branch)
+                    .map(|c| c.len())
+                    .unwrap_or(0);
+                format!(
+                    "Squash this branch's commits into a single commit.\n\
+                     The branch has {commit_count} commits since its branch-off point (merge-base: {merge_base_sha}).\n\
+                     Only squash the commits listed in the branch history above.\n\
+                     Use `git reset --soft {merge_base_sha}` followed by `git commit` to squash.\n\
+                     Do not squash any commits beyond the branch-off point."
+                )
+            }
+            Err(e) => {
+                log::warn!("Failed to compute merge-base for squash prompt: {e}");
+                prompt.to_string()
+            }
+        }
+    } else if prompt == "Rebase this branch. Do not push the branch." {
+        match git::merge_base(worktree, base_branch, "HEAD") {
+            Ok(merge_base_sha) => {
+                format!(
+                    "Rebase this branch. Do not push the branch.\n\
+                     The branch-off point is {merge_base_sha} (base branch: {base_branch}).\n\
+                     Use `git rebase {base_branch}` to rebase."
+                )
+            }
+            Err(e) => {
+                log::warn!("Failed to compute merge-base for rebase prompt: {e}");
+                prompt.to_string()
+            }
+        }
+    } else {
+        prompt.to_string()
+    }
 }
 
 /// Assemble the full prompt from action instructions + branch context + user prompt.

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1061,9 +1061,15 @@
           {onRename}
           onNoteCreated={() => loadTimeline()}
           onRebaseBranch={() =>
-            sessionMgr.startOrQueueSession('commit', 'Rebase this branch. Do not push the branch.')}
+            sessionMgr.startOrQueueSession(
+              'commit',
+              `Rebase this branch onto ${branch.baseBranch} using git merge-base to find the fork point. Do not push.`
+            )}
           onSquashCommits={() =>
-            sessionMgr.startOrQueueSession('commit', "Squash this branch's commits")}
+            sessionMgr.startOrQueueSession(
+              'commit',
+              `Squash this branch's commits. Run git merge-base ${branch.baseBranch} HEAD to find the branch-off point, then git reset --soft <result> && git commit to squash. Do not squash beyond the merge-base.`
+            )}
           newCommitDisabled={sessionMgr.isNewSessionDisabled}
           {commitCount}
         />

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1068,7 +1068,7 @@
           onSquashCommits={() =>
             sessionMgr.startOrQueueSession(
               'commit',
-              `Squash this branch's commits. Run git merge-base ${branch.baseBranch} HEAD to find the branch-off point, then git reset --soft <result> && git commit to squash. Do not squash beyond the merge-base.`
+              `Squash this branch's commits. Run \`git merge-base ${branch.baseBranch} HEAD\` to find the branch-off point, then \`git reset --soft <result> && git commit\` to squash. Do not squash beyond the merge-base.`
             )}
           newCommitDisabled={sessionMgr.isNewSessionDisabled}
           {commitCount}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1063,7 +1063,7 @@
           onRebaseBranch={() =>
             sessionMgr.startOrQueueSession(
               'commit',
-              `Rebase this branch onto ${branch.baseBranch} using git merge-base to find the fork point. Do not push.`
+              `Rebase this branch onto ${branch.baseBranch}. Run \`git fetch origin\` first, then \`git merge-base ${branch.baseBranch} HEAD\` to find the fork point, then \`git rebase --onto ${branch.baseBranch} <merge-base> HEAD\`. Do not push.`
             )}
           onSquashCommits={() =>
             sessionMgr.startOrQueueSession(


### PR DESCRIPTION
## Summary
- Enrich the rebase prompt to fetch origin first, compute the merge-base fork point, and use `git rebase --onto` for correctness
- Enrich the squash prompt to compute the merge-base and use `git reset --soft <merge-base> && git commit` to avoid squashing beyond the branch point
- Use consistent backtick escaping and multi-line formatting for readability

## Test plan
- [ ] Verify rebase action sends the improved prompt with fetch, merge-base, and --onto commands
- [ ] Verify squash action sends the improved prompt with merge-base and reset --soft commands
- [ ] Confirm both prompts correctly interpolate `branch.baseBranch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)