### PR TITLE
fix(staged): prevent long PR titles from overflowing project dialog

### DIFF
--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -364,6 +364,8 @@
 <style>
   .repo-fields-stack {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    min-width: 0;
   }
 
   .repo-fields-stack > * {

--- a/apps/staged/src/lib/shared/FormInput.svelte
+++ b/apps/staged/src/lib/shared/FormInput.svelte
@@ -17,6 +17,7 @@
 
 <style>
   .form-input {
+    width: 100%;
     min-height: 42px;
     border: 1.5px solid var(--border-muted);
     background: transparent;
@@ -27,6 +28,7 @@
     font-family: inherit;
     outline: none;
     transition: border-color 0.15s ease;
+    box-sizing: border-box;
   }
 
   .form-input:focus {


### PR DESCRIPTION
## Summary
- Add CSS constraints to prevent long PR titles from causing the new project dialog to overflow its container
- Set `grid-template-columns: minmax(0, 1fr)` and `min-width: 0` on the repo fields grid to constrain child content
- Set `width: 100%` and `box-sizing: border-box` on form inputs to keep them within bounds

## Test plan
- [ ] Open the new project dialog with a repo that has long PR titles
- [ ] Verify the dialog does not overflow or expand beyond its expected width
- [ ] Verify form inputs remain properly sized within the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)