### PR TITLE
fix(staged): filter incomplete items from hashtag options

### DIFF
--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -77,6 +77,7 @@ export function timelineToHashtagItems(
 
   for (const note of timeline.notes) {
     if (!note.title.trim()) continue;
+    if (note.completedAt == null) continue;
     items.push({
       type: 'note',
       id: note.id,
@@ -89,6 +90,7 @@ export function timelineToHashtagItems(
   }
 
   for (const commit of timeline.commits) {
+    if (!commit.sha) continue;
     items.push({
       type: 'commit',
       id: commit.sha,
@@ -102,6 +104,7 @@ export function timelineToHashtagItems(
 
   for (const review of timeline.reviews) {
     if (review.isAuto) continue;
+    if (review.completedAt == null) continue;
     const title = review.title || review.commitSha.slice(0, 7);
     items.push({
       type: 'review',


### PR DESCRIPTION
## Summary
- Filter out incomplete notes (no `completedAt`) from hashtag options so in-progress sessions don't appear
- Skip commits without a SHA from hashtag options
- Filter out incomplete reviews (no `completedAt`) from hashtag options

## Test plan
- [x] Verify hashtag autocomplete no longer shows uncommitted/incomplete session items
- [x] Verify completed notes, commits with SHAs, and completed reviews still appear in hashtag options

🤖 Generated with [Claude Code](https://claude.com/claude-code)