### PR TITLE
feat(staged): add timeline row context menu actions

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1208,6 +1208,7 @@
           onNewReview={hasCodeChanges || sessionMgr.hasCommitSessionInProgress
             ? (e) => sessionMgr.openNewSession('review', e)
             : undefined}
+          onNewSessionReferring={(ref) => sessionMgr.openNewSessionReferring(ref)}
           newSessionDisabled={sessionMgr.isNewSessionDisabled}
           {provisioningLabel}
           {provisioningDetail}

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -386,6 +386,18 @@ export default class BranchCardSessionManager {
     this.showNewSession = true;
   }
 
+  openNewSessionReferring(hashtagRef: string) {
+    if (this.showNewSession && this.draftPrompt.trim()) {
+      // Dialog already open with user content — append the reference
+      this.draftPrompt = this.draftPrompt.trimEnd() + '\n' + hashtagRef;
+    } else {
+      // Open fresh dialog with "Re: #type:id\n"
+      this.draftPrompt = `Re: ${hashtagRef}\n`;
+      this.newSessionMode = 'commit';
+      this.showNewSession = true;
+    }
+  }
+
   async startReviewSessionWithoutDialog() {
     this.newSessionMode = 'review';
     this.showNewSession = false;

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -16,6 +16,7 @@ import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
 import { alerts } from '../../shared/alerts.svelte';
 import { projectStateStore } from '../../stores/projectState.svelte';
 import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
+import { buildReferringPrompt } from '../../shared/buildReferringPrompt';
 
 type PendingSessionItemType =
   | 'pending-commit'
@@ -387,12 +388,9 @@ export default class BranchCardSessionManager {
   }
 
   openNewSessionReferring(hashtagRef: string) {
-    if (this.showNewSession && this.draftPrompt.trim()) {
-      // Dialog already open with user content — append the reference
-      this.draftPrompt = this.draftPrompt.trimEnd() + '\n' + hashtagRef;
-    } else {
-      // Open fresh dialog with "Re: #type:id\n"
-      this.draftPrompt = `Re: ${hashtagRef}\n`;
+    const hadContent = this.showNewSession && this.draftPrompt.trim();
+    this.draftPrompt = buildReferringPrompt(this.draftPrompt, hashtagRef);
+    if (!hadContent) {
       this.newSessionMode = 'commit';
       this.showNewSession = true;
     }

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -59,6 +59,7 @@
   import { createImage, createImageFromData, deleteImage, getImageData } from '../../api/commands';
   import { formatRelativeTime, minuteNow } from '../../shared/relativeTime.svelte';
   import { focusAtEnd } from '../../shared/focusAtEnd';
+  import { buildReferringPrompt } from '../../shared/buildReferringPrompt';
   import { createLiveSessionHints } from '../timeline/liveSessionHints';
 
   interface Props {
@@ -727,11 +728,7 @@
 <TimelineContextMenu
   bind:this={projectContextMenuRef}
   onNewSessionReferring={(ref) => {
-    if (promptText.trim()) {
-      promptText = promptText.trimEnd() + '\n' + ref;
-    } else {
-      promptText = `Re: ${ref}\n`;
-    }
+    promptText = buildReferringPrompt(promptText, ref);
     focusAtEnd(promptTextarea);
   }}
 />

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -44,6 +44,7 @@
   import SuggestedRepos from './SuggestedRepos.svelte';
   import type { RepoSelection as RepoPickerSelection } from '../../shared/githubUrl';
   import TimelineRow from '../timeline/TimelineRow.svelte';
+  import TimelineContextMenu from '../timeline/TimelineContextMenu.svelte';
   import NoteModal from '../notes/NoteModal.svelte';
   import SessionModal from '../sessions/SessionModal.svelte';
   import AgentSelector from '../agents/AgentSelector.svelte';
@@ -57,6 +58,7 @@
   } from '../branches/branchCardHelpers';
   import { createImage, createImageFromData, deleteImage, getImageData } from '../../api/commands';
   import { formatRelativeTime, minuteNow } from '../../shared/relativeTime.svelte';
+  import { focusAtEnd } from '../../shared/focusAtEnd';
   import { createLiveSessionHints } from '../timeline/liveSessionHints';
 
   interface Props {
@@ -403,6 +405,7 @@
 
   let openNote = $state<{ title: string; content: string; sessionId?: string } | null>(null);
   let openSessionId = $state<string | null>(null);
+  let projectContextMenuRef: TimelineContextMenu | undefined = $state();
 
   // ── Lifecycle ──────────────────────────────────────────────────────────
 
@@ -647,6 +650,8 @@
               openSessionId = sid;
             }}
             onDeleteClick={() => handleDeleteNote(note.id)}
+            hashtagRef={noteType === 'note' ? `#project-note:${note.id}` : undefined}
+            onContextMenu={(e) => projectContextMenuRef?.open(e)}
           />
         {/each}
       </div>
@@ -718,6 +723,18 @@
     }}
   />
 {/if}
+
+<TimelineContextMenu
+  bind:this={projectContextMenuRef}
+  onNewSessionReferring={(ref) => {
+    if (promptText.trim()) {
+      promptText = promptText.trimEnd() + '\n' + ref;
+    } else {
+      promptText = `Re: ${ref}\n`;
+    }
+    focusAtEnd(promptTextarea);
+  }}
+/>
 
 <style>
   .project-section {

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -23,6 +23,7 @@
   import type { HashtagItem } from '../../types';
   import { FileText, GitCommitVertical, FileSearch, Image as ImageLucide } from 'lucide-svelte';
   import { HASHTAG_TOKEN_RE, hashtagTypeIconSvg, escapeHtml } from './hashtagItems';
+  import { focusAtEndSync } from '../../shared/focusAtEnd';
 
   type DropdownIconComponent = typeof FileText;
 
@@ -121,17 +122,22 @@
     const _items = itemsById;
     if (hasUnresolvedTokens && _items.size > 0 && editorEl) {
       const shouldRestoreSelectAll = selectionCoversContents(editorEl);
+      const sel = window.getSelection();
+      const hadCaret = sel && sel.isCollapsed && editorEl.contains(sel.anchorNode);
 
       renderContent(value);
 
       if (shouldRestoreSelectAll) {
-        const sel = window.getSelection();
         const range = document.createRange();
         range.selectNodeContents(editorEl);
         if (sel) {
           sel.removeAllRanges();
           sel.addRange(range);
         }
+      } else if (hadCaret) {
+        // Restore collapsed cursor to end after re-render.
+        // DOM is already fresh (renderContent just ran), so use the sync variant.
+        focusAtEndSync(editorEl);
       }
     }
   });

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -14,6 +14,7 @@
   import type { BranchTimeline as BranchTimelineData, HashtagItem } from '../../types';
   import TimelineRow from './TimelineRow.svelte';
   import type { TimelineItemType, TimelineBadge } from './TimelineRow.svelte';
+  import TimelineContextMenu from './TimelineContextMenu.svelte';
   import { hasHashtagTokens, renderHashtagTokens } from '../sessions/hashtagItems';
   import {
     formatRelativeTime,
@@ -73,6 +74,7 @@
     onNewNote?: () => void;
     onNewCommit?: () => void;
     onNewReview?: (e: MouseEvent) => void;
+    onNewSessionReferring?: (hashtagRef: string) => void;
     newSessionDisabled?: boolean;
     /** Whether the timeline is being revalidated in the background. */
     revalidating?: boolean;
@@ -112,6 +114,7 @@
     onNewNote,
     onNewCommit,
     onNewReview,
+    onNewSessionReferring,
     newSessionDisabled = false,
     revalidating = false,
     error,
@@ -203,6 +206,8 @@
     /** When set, delete button is shown but disabled with this tooltip. */
     deleteDisabledReason?: string;
     completionReason?: string | null;
+    /** Hashtag reference token for context menu (e.g. "#commit:abc123"). */
+    hashtagRef?: string;
   };
 
   let runningSessionIds = $derived.by(() => collectRunningSessionIds(timeline, pendingItems));
@@ -290,6 +295,7 @@
         commitId: commit.id ?? undefined,
         deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
         completionReason: commit.completionReason,
+        hashtagRef: type === 'commit' ? `#commit:${commit.sha}` : undefined,
       });
     }
 
@@ -332,6 +338,7 @@
         noteContent: note.content,
         deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
         completionReason: note.completionReason,
+        hashtagRef: type === 'note' ? `#note:${note.id}` : undefined,
       });
     }
 
@@ -395,6 +402,7 @@
         reviewId: review.id,
         deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
         completionReason: review.completionReason,
+        hashtagRef: type === 'review' ? `#review:${review.id}` : undefined,
       });
     }
 
@@ -481,6 +489,9 @@
     items.length === 0 && pendingDropNotes.length === 0 && pendingItems.length === 0
   );
 
+  // ── Context menu (single instance for all rows) ───────────────────────
+  let contextMenuRef: TimelineContextMenu | undefined = $state();
+
   // ── Handlers ──────────────────────────────────────────────────────────
 
   function handleItemClick(item: DisplayItem) {
@@ -558,6 +569,9 @@
             !error}
           sessionId={item.sessionId}
           deleteDisabledReason={item.deleteDisabledReason}
+          commitSha={item.commitSha}
+          hashtagRef={item.hashtagRef}
+          onContextMenu={(e) => contextMenuRef?.open(e)}
           {onSessionClick}
           onItemClick={() => handleItemClick(item)}
           onDeleteClick={item.deleteDisabledReason
@@ -681,6 +695,8 @@
     {/if}
   </div>
 {/if}
+
+<TimelineContextMenu bind:this={contextMenuRef} {onNewSessionReferring} />
 
 <style>
   /* ── Timeline ────────────────────────────────────────────────────────── */

--- a/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
@@ -9,20 +9,11 @@
   import { onMount, onDestroy } from 'svelte';
   import { Copy, MessageSquarePlus } from 'lucide-svelte';
   import type { ContextMenuEvent } from './TimelineRow.svelte';
-
-  // ── Module-level close-all signal ─────────────────────────────────────
-  // Multiple TimelineContextMenu instances exist (one per BranchTimeline,
-  // one in ProjectSection). Because TimelineRow stops propagation on
-  // contextmenu events, a right-click in one timeline can't reach the
-  // window handler of another instance's menu. This Set of callbacks lets
-  // any instance broadcast "close" to all others before opening itself.
-  const closeAllListeners = new Set<() => void>();
-
-  function broadcastCloseAll() {
-    for (const fn of closeAllListeners) {
-      fn();
-    }
-  }
+  import {
+    registerCloseListener,
+    unregisterCloseListener,
+    broadcastCloseAll,
+  } from './contextMenuCoordination';
 
   interface Props {
     onNewSessionReferring?: (hashtagRef: string) => void;
@@ -41,11 +32,15 @@
   }
 
   onMount(() => {
-    closeAllListeners.add(handleCloseAll);
+    registerCloseListener(handleCloseAll);
   });
 
   onDestroy(() => {
-    closeAllListeners.delete(handleCloseAll);
+    unregisterCloseListener(handleCloseAll);
+    if (pendingRaf !== null) {
+      cancelAnimationFrame(pendingRaf);
+      pendingRaf = null;
+    }
   });
 
   /** Open the context menu. Called by the parent when a row emits onContextMenu. */

--- a/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
@@ -1,0 +1,186 @@
+<!--
+  TimelineContextMenu.svelte — Shared context menu for timeline rows.
+
+  Rendered once per timeline (not per row) to avoid N window listeners.
+  The parent opens it by calling `open(event)` and provides an
+  `onNewSessionReferring` callback for the hashtag action.
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { Copy, MessageSquarePlus } from 'lucide-svelte';
+  import type { ContextMenuEvent } from './TimelineRow.svelte';
+
+  // ── Module-level close-all signal ─────────────────────────────────────
+  // Multiple TimelineContextMenu instances exist (one per BranchTimeline,
+  // one in ProjectSection). Because TimelineRow stops propagation on
+  // contextmenu events, a right-click in one timeline can't reach the
+  // window handler of another instance's menu. This Set of callbacks lets
+  // any instance broadcast "close" to all others before opening itself.
+  const closeAllListeners = new Set<() => void>();
+
+  function broadcastCloseAll() {
+    for (const fn of closeAllListeners) {
+      fn();
+    }
+  }
+
+  interface Props {
+    onNewSessionReferring?: (hashtagRef: string) => void;
+  }
+
+  let { onNewSessionReferring }: Props = $props();
+
+  /** Menu position and data, or null when closed. */
+  let menu = $state<(ContextMenuEvent & { left: number; top: number }) | null>(null);
+  let menuEl = $state<HTMLDivElement | null>(null);
+  let pendingRaf: number | null = null;
+
+  // Register this instance's close handler in the module-level set.
+  function handleCloseAll() {
+    menu = null;
+  }
+
+  onMount(() => {
+    closeAllListeners.add(handleCloseAll);
+  });
+
+  onDestroy(() => {
+    closeAllListeners.delete(handleCloseAll);
+  });
+
+  /** Open the context menu. Called by the parent when a row emits onContextMenu. */
+  export function open(event: ContextMenuEvent) {
+    // Close any other open context menu instance (cross-timeline).
+    broadcastCloseAll();
+
+    // Cancel any in-flight rAF from a previous open() to avoid stale coordinates clobbering.
+    if (pendingRaf !== null) {
+      cancelAnimationFrame(pendingRaf);
+      pendingRaf = null;
+    }
+
+    // Clamp to viewport after a microtask so the menu element is rendered and measurable.
+    // Use raw position initially; clamp in the next frame.
+    menu = { ...event, left: event.x, top: event.y };
+
+    // Defer clamping until the element is rendered and measurable
+    pendingRaf = requestAnimationFrame(() => {
+      pendingRaf = null;
+      if (!menuEl || !menu) return;
+      const rect = menuEl.getBoundingClientRect();
+      const clampedLeft = Math.min(event.x, window.innerWidth - rect.width - 8);
+      const clampedTop = Math.min(event.y, window.innerHeight - rect.height - 8);
+      menu = { ...menu!, left: Math.max(8, clampedLeft), top: Math.max(8, clampedTop) };
+    });
+  }
+
+  /** Close the context menu. */
+  export function close() {
+    menu = null;
+  }
+
+  function handleCopySha() {
+    if (menu?.commitSha) {
+      navigator.clipboard.writeText(menu.commitSha).catch(() => {});
+    }
+    menu = null;
+  }
+
+  function handleNewSessionReferring() {
+    if (menu?.hashtagRef && onNewSessionReferring) {
+      onNewSessionReferring(menu.hashtagRef);
+    }
+    menu = null;
+  }
+
+  function handleWindowClick() {
+    if (!menu) return;
+    menu = null;
+  }
+
+  function handleWindowContextMenu() {
+    if (!menu) return;
+    // Close when user right-clicks elsewhere (another row or outside)
+    menu = null;
+  }
+
+  function handleWindowKeydown(e: KeyboardEvent) {
+    if (!menu) return;
+    if (e.key === 'Escape') {
+      menu = null;
+      e.stopPropagation();
+    }
+  }
+</script>
+
+<svelte:window
+  onclick={handleWindowClick}
+  oncontextmenu={handleWindowContextMenu}
+  onkeydown={handleWindowKeydown}
+/>
+
+{#if menu}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    bind:this={menuEl}
+    class="context-menu"
+    style="left: {menu.left}px; top: {menu.top}px;"
+    onclick={(e) => e.stopPropagation()}
+    oncontextmenu={(e) => e.stopPropagation()}
+  >
+    {#if menu.commitSha}
+      <button class="context-menu-item" onclick={handleCopySha}>
+        <Copy size={14} />
+        Copy SHA
+      </button>
+    {/if}
+    {#if menu.hashtagRef && onNewSessionReferring}
+      <button class="context-menu-item" onclick={handleNewSessionReferring}>
+        <MessageSquarePlus size={14} />
+        New session referring to this
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .context-menu {
+    position: fixed;
+    z-index: 1000;
+    background-color: var(--bg-elevated);
+    border: 1px solid var(--border-muted);
+    border-radius: 8px;
+    box-shadow:
+      0 4px 12px rgba(0, 0, 0, 0.12),
+      0 1px 4px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    min-width: 140px;
+    padding: 4px 0;
+  }
+
+  .context-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 14px;
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    font-size: var(--size-sm);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  .context-menu-item:hover {
+    background-color: var(--bg-hover);
+  }
+
+  .context-menu-item :global(svg) {
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+</style>

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -40,6 +40,14 @@
     count: number;
   };
 
+  /** Data passed to the parent when the user right-clicks a row with context menu actions. */
+  export type ContextMenuEvent = {
+    x: number;
+    y: number;
+    commitSha?: string;
+    hashtagRef?: string;
+  };
+
   interface Props {
     type: TimelineItemType;
     title: string;
@@ -59,6 +67,12 @@
     onRetryClick?: () => void;
     onStartClick?: () => void;
     onResumeClick?: () => void;
+    /** Full commit SHA for the context menu "Copy SHA" action. */
+    commitSha?: string;
+    /** Hashtag reference token (e.g. "#commit:abc123") for "New session referring to this". */
+    hashtagRef?: string;
+    /** Callback when the user right-clicks and this row has context menu actions. */
+    onContextMenu?: (event: ContextMenuEvent) => void;
   }
 
   let {
@@ -78,6 +92,9 @@
     onRetryClick,
     onStartClick,
     onResumeClick,
+    commitSha,
+    hashtagRef,
+    onContextMenu,
   }: Props = $props();
 
   let isNote = $derived(
@@ -147,6 +164,16 @@
     e.stopPropagation();
     onResumeClick?.();
   }
+
+  // ── Context menu ────────────────────────────────────────────────────
+  let hasContextMenu = $derived(!!commitSha || !!hashtagRef);
+
+  function handleContextMenu(e: MouseEvent) {
+    if (!hasContextMenu || !onContextMenu) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onContextMenu({ x: e.clientX, y: e.clientY, commitSha, hashtagRef });
+  }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -158,6 +185,7 @@
   class:clickable={isClickable}
   class:compact={type === 'revalidating' || type === 'load-error'}
   onclick={handleRowClick}
+  oncontextmenu={handleContextMenu}
 >
   <div class="timeline-marker">
     <div

--- a/apps/staged/src/lib/features/timeline/contextMenuCoordination.ts
+++ b/apps/staged/src/lib/features/timeline/contextMenuCoordination.ts
@@ -1,0 +1,27 @@
+/**
+ * Module-level close-all signal for TimelineContextMenu instances.
+ *
+ * Multiple TimelineContextMenu instances exist (one per BranchTimeline,
+ * one in ProjectSection). Because TimelineRow stops propagation on
+ * contextmenu events, a right-click in one timeline can't reach the
+ * window handler of another instance's menu. This Set of callbacks lets
+ * any instance broadcast "close" to all others before opening itself.
+ *
+ * This must live at module scope (not inside a component function) so that
+ * all instances share the same Set.
+ */
+const closeAllListeners = new Set<() => void>();
+
+export function registerCloseListener(fn: () => void): void {
+  closeAllListeners.add(fn);
+}
+
+export function unregisterCloseListener(fn: () => void): void {
+  closeAllListeners.delete(fn);
+}
+
+export function broadcastCloseAll(): void {
+  for (const fn of closeAllListeners) {
+    fn();
+  }
+}

--- a/apps/staged/src/lib/shared/buildReferringPrompt.ts
+++ b/apps/staged/src/lib/shared/buildReferringPrompt.ts
@@ -1,0 +1,12 @@
+/**
+ * Build a prompt string that references a timeline item via hashtag.
+ *
+ * If there's already user-entered text, appends the reference on a new line.
+ * Otherwise, starts a fresh "Re: #..." prompt.
+ */
+export function buildReferringPrompt(existing: string, ref: string): string {
+  if (existing.trim()) {
+    return existing.trimEnd() + '\n' + ref;
+  }
+  return `Re: ${ref}\n`;
+}

--- a/apps/staged/src/lib/shared/focusAtEnd.ts
+++ b/apps/staged/src/lib/shared/focusAtEnd.ts
@@ -1,0 +1,29 @@
+import { tick } from 'svelte';
+
+/**
+ * Focus a contenteditable element and place the cursor at the end of its content.
+ * Synchronous variant — use when the DOM is already up-to-date (e.g. inside a
+ * Svelte `$effect` that just re-rendered content).
+ */
+export function focusAtEndSync(el: HTMLElement | null): void {
+  if (!el) return;
+  el.focus();
+  const sel = window.getSelection();
+  if (sel) {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+}
+
+/**
+ * Focus a contenteditable element and place the cursor at the end of its content.
+ * Awaits a tick before focusing so that any pending Svelte re-renders complete first.
+ * Use when the DOM may not yet reflect the latest reactive state.
+ */
+export async function focusAtEnd(el: HTMLElement | null): Promise<void> {
+  await tick();
+  focusAtEndSync(el);
+}

--- a/crates/acp-client/src/driver.rs
+++ b/crates/acp-client/src/driver.rs
@@ -943,13 +943,11 @@ impl agent_client_protocol::Client for AcpNotificationHandler {
                             buf.finalize_current();
                             buf.try_match("tool_call")
                         }
-                        SessionUpdate::ToolCallUpdate(update) => {
-                            if update.fields.content.is_some() {
-                                buf.finalize_current();
-                                buf.try_match("tool_result")
-                            } else {
-                                false
-                            }
+                        SessionUpdate::ToolCallUpdate(update)
+                            if update.fields.content.is_some() =>
+                        {
+                            buf.finalize_current();
+                            buf.try_match("tool_result")
                         }
                         SessionUpdate::AgentThoughtChunk(_) => {
                             // Thinking is not persisted — ignore.

--- a/crates/git-diff/src/files.rs
+++ b/crates/git-diff/src/files.rs
@@ -49,7 +49,7 @@ pub fn search_files(
     }
 
     // Sort by match quality
-    matches.sort_by(|a, b| b.1.cmp(&a.1));
+    matches.sort_by_key(|m| std::cmp::Reverse(m.1));
 
     // Return top results
     Ok(matches


### PR DESCRIPTION
## Summary
- Add a shared timeline row context menu with Copy SHA, Revert commit, and New session referring to this actions.
- Wire commit revert through Tauri for local and workspace-backed branches.
- Keep hashtag input focus at the end after inserting references.