### PR TITLE
feat: copy build directories between worktrees

### DIFF
--- a/apps/staged/src-tauri/src/actions/commands.rs
+++ b/apps/staged/src-tauri/src/actions/commands.rs
@@ -313,12 +313,19 @@ pub async fn run_branch_action(
             .map_err(|e| format!("Failed to get workdir: {e}"))?
             .ok_or_else(|| "No worktree found for branch".to_string())?;
 
+        let worktree_root = workdir.path.clone();
         let working_dir = if let Some(subpath) = &subpath {
             let path = std::path::PathBuf::from(&workdir.path).join(subpath);
             path.to_string_lossy().to_string()
         } else {
             workdir.path
         };
+
+        // Track this worktree as the last-run for this repo context so
+        // future worktrees can clone its build directories.
+        if let Err(e) = store.set_last_run_worktree_path(&context.id, &worktree_root) {
+            log::warn!("Failed to update last_run_worktree_path: {e}");
+        }
 
         let wd = working_dir.clone();
         let eid = executor
@@ -615,12 +622,18 @@ pub async fn run_prerun_actions(
         .map_err(|e| format!("Failed to get workdir: {e}"))?
         .ok_or_else(|| "No worktree found for branch".to_string())?;
 
+    let worktree_root = workdir.path.clone();
     let working_dir = if let Some(subpath) = &subpath {
         let path = std::path::PathBuf::from(&workdir.path).join(subpath);
         path.to_string_lossy().to_string()
     } else {
         workdir.path
     };
+
+    // Track this worktree as the last-run for build dir copying.
+    if let Err(e) = store.set_last_run_worktree_path(&context.id, &worktree_root) {
+        log::warn!("Failed to update last_run_worktree_path: {e}");
+    }
 
     // Execute each prerun action sequentially, waiting for each to complete
     // before starting the next one

--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -1057,8 +1057,66 @@ fn create_and_link_worktree(
         }
     }
 
+    // Best-effort: copy build directories from the last-run worktree for
+    // this repo context. Uses APFS cloning on macOS for near-instant,
+    // zero-cost copies.
+    copy_build_dirs_for_branch(store, branch, &worktree_str);
+
     // _guard dropped here, releasing the per-branch lock.
     Ok(worktree_str)
+}
+
+/// Best-effort copy of build directories from the last-run worktree for
+/// this branch's repo context. Failures are logged and swallowed.
+fn copy_build_dirs_for_branch(
+    store: &Arc<Store>,
+    branch: &store::Branch,
+    dest_worktree_path: &str,
+) {
+    // Resolve the repo+subpath for this branch so we can look up the
+    // action context (which stores last_run_worktree_path).
+    let (github_repo, subpath) = match resolve_repo_context_for_branch(store, branch) {
+        Some(ctx) => ctx,
+        None => return,
+    };
+
+    let context =
+        match store.get_action_context_by_repo_and_subpath(&github_repo, subpath.as_deref()) {
+            Ok(Some(ctx)) => ctx,
+            _ => return,
+        };
+
+    if !context.copy_build_dirs_enabled {
+        return;
+    }
+
+    let source_path = match &context.last_run_worktree_path {
+        Some(p) if Path::new(p).is_dir() => p.clone(),
+        _ => return,
+    };
+
+    log::info!(
+        "Copying build dirs from '{}' to '{}'",
+        source_path,
+        dest_worktree_path
+    );
+    crate::build_dir_copy::copy_build_dirs(Path::new(&source_path), Path::new(dest_worktree_path));
+}
+
+/// Resolve (github_repo, subpath) for a branch from its project_repo or
+/// project. Returns `None` on any lookup failure.
+fn resolve_repo_context_for_branch(
+    store: &Arc<Store>,
+    branch: &store::Branch,
+) -> Option<(String, Option<String>)> {
+    if let Some(ref repo_id) = branch.project_repo_id {
+        if let Ok(Some(pr)) = store.get_project_repo(repo_id) {
+            return Some((pr.github_repo, pr.subpath));
+        }
+    }
+    let project = store.get_project(&branch.project_id).ok()??;
+    let repo = project.primary_repo()?.to_string();
+    Some((repo, project.subpath.clone()))
 }
 
 /// Create the git worktree for a local branch and record its workdir.
@@ -1208,6 +1266,23 @@ pub async fn setup_worktree_from_pr(
         .to_str()
         .ok_or("Invalid worktree path")?
         .to_string();
+
+    // Best-effort: copy build dirs from last-run worktree for this repo.
+    if let Ok(Some(ctx)) = store.get_action_context_by_repo_and_subpath(
+        &target_repo.github_repo,
+        target_repo.subpath.as_deref(),
+    ) {
+        if ctx.copy_build_dirs_enabled {
+            if let Some(source) = &ctx.last_run_worktree_path {
+                if Path::new(source).is_dir() {
+                    crate::build_dir_copy::copy_build_dirs(
+                        Path::new(source),
+                        Path::new(&worktree_str),
+                    );
+                }
+            }
+        }
+    }
 
     // Create branch record with PR number
     let branch = store::Branch::new(&project_id, &branch_name, &base_branch)

--- a/apps/staged/src-tauri/src/build_dir_copy.rs
+++ b/apps/staged/src-tauri/src/build_dir_copy.rs
@@ -1,0 +1,207 @@
+//! Copy build directories between worktrees using filesystem cloning.
+//!
+//! On macOS (APFS), `cp -Rc` uses `clonefile()` under the hood so the copy
+//! is instant and shares physical disk blocks until one side diverges (CoW).
+//! On Linux, `cp -R --reflink=auto` achieves the same on Btrfs/XFS and
+//! silently falls back to a regular copy on other filesystems.
+//!
+//! Only directories that are both in the hardcoded whitelist AND ignored by
+//! git are copied, to avoid accidentally duplicating source directories.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Default whitelist of build directory names to copy between worktrees.
+const BUILD_DIR_WHITELIST: &[&str] = &[
+    // JS/TS
+    "node_modules",
+    ".next",
+    ".turbo",
+    ".svelte-kit",
+    // Python
+    "__pycache__",
+    // Xcode
+    "DerivedData",
+    // General
+    "build",
+];
+
+/// Maximum directory depth to walk when searching for build directories.
+const MAX_WALK_DEPTH: usize = 5;
+
+/// Recursively discover and copy whitelisted build directories from `source`
+/// worktree into `dest` worktree.
+///
+/// Walks the entire worktree up to `MAX_WALK_DEPTH`, copying any directory
+/// whose name is in `BUILD_DIR_WHITELIST` and is gitignored. Copied
+/// directories are not recursed into (no need to find nested build dirs
+/// inside build dirs).
+///
+/// This is best-effort: failures are logged but never propagated.
+pub fn copy_build_dirs(source: &Path, dest: &Path) {
+    if !source.is_dir() {
+        log::debug!(
+            "build_dir_copy: source root does not exist: {}",
+            source.display()
+        );
+        return;
+    }
+
+    walk_and_copy(source, dest, source, dest, 0);
+}
+
+/// Recursively walk `current_src` looking for whitelisted build directories.
+///
+/// `source_root` and `dest_root` are the worktree roots, used to compute
+/// relative paths for gitignore checks and destination paths.
+fn walk_and_copy(
+    source_root: &Path,
+    dest_root: &Path,
+    current_src: &Path,
+    current_dest: &Path,
+    depth: usize,
+) {
+    if depth > MAX_WALK_DEPTH {
+        return;
+    }
+
+    let entries = match std::fs::read_dir(current_src) {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::debug!("build_dir_copy: cannot read {}: {e}", current_src.display());
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let name = entry.file_name();
+        let name_str = match name.to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Never descend into .git directories.
+        if name_str == ".git" {
+            continue;
+        }
+
+        let src_dir = current_src.join(name_str);
+        let dest_dir = current_dest.join(name_str);
+
+        if BUILD_DIR_WHITELIST.contains(&name_str) {
+            // Compute path relative to worktree root for gitignore check.
+            let rel_path = match src_dir.strip_prefix(source_root) {
+                Ok(rel) => rel.to_string_lossy().to_string(),
+                Err(_) => continue,
+            };
+
+            if !is_gitignored(dest_root, &rel_path) {
+                log::debug!(
+                    "build_dir_copy: skipping '{}' — not gitignored in dest",
+                    rel_path
+                );
+                continue;
+            }
+
+            if dest_dir.exists() {
+                log::debug!(
+                    "build_dir_copy: skipping '{}' — already exists in dest",
+                    rel_path
+                );
+                continue;
+            }
+
+            log::info!(
+                "build_dir_copy: copying '{}' from {} to {}",
+                rel_path,
+                source_root.display(),
+                dest_root.display()
+            );
+
+            if let Err(e) = clone_directory(&src_dir, &dest_dir) {
+                log::warn!("build_dir_copy: failed to copy '{}': {e}", rel_path);
+            }
+
+            // Don't recurse into copied build dirs.
+        } else {
+            // Not a whitelisted name — recurse deeper.
+            walk_and_copy(source_root, dest_root, &src_dir, &dest_dir, depth + 1);
+        }
+    }
+}
+
+/// Check if a path would be ignored by git in the given working directory.
+fn is_gitignored(working_dir: &Path, rel_path: &str) -> bool {
+    // `git check-ignore` exits 0 if the path is ignored, 1 if not.
+    Command::new("git")
+        .args(["check-ignore", "-q", rel_path])
+        .current_dir(working_dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Clone a directory using the platform-appropriate copy strategy.
+fn clone_directory(src: &Path, dest: &Path) -> Result<(), String> {
+    let output = if cfg!(target_os = "macos") {
+        Command::new("cp").args(["-Rc"]).arg(src).arg(dest).output()
+    } else {
+        // Linux: --reflink=auto gives CoW on Btrfs/XFS, regular copy elsewhere.
+        Command::new("cp")
+            .args(["-R", "--reflink=auto"])
+            .arg(src)
+            .arg(dest)
+            .output()
+    };
+
+    match output {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => Err(String::from_utf8_lossy(&out.stderr).to_string()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_build_dir_whitelist_is_not_empty() {
+        assert!(!BUILD_DIR_WHITELIST.is_empty());
+    }
+
+    #[test]
+    fn test_clone_directory_copies_files() {
+        let tmp = std::env::temp_dir().join(format!("staged-bdc-test-{}", std::process::id()));
+        let src = tmp.join("src");
+        let dest = tmp.join("dest");
+        fs::create_dir_all(src.join("sub")).unwrap();
+        fs::write(src.join("sub/file.txt"), "hello").unwrap();
+
+        let result = clone_directory(&src, &dest);
+        assert!(result.is_ok(), "clone_directory failed: {:?}", result);
+        assert_eq!(
+            fs::read_to_string(dest.join("sub/file.txt")).unwrap(),
+            "hello"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn test_max_walk_depth_is_reasonable() {
+        assert!(MAX_WALK_DEPTH >= 4);
+        assert!(MAX_WALK_DEPTH <= 10);
+    }
+}

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod actions;
 pub mod agent;
 pub mod blox;
 pub mod branches;
+pub mod build_dir_copy;
 pub mod diff_cache;
 pub mod diff_commands;
 pub mod doctor;
@@ -1470,6 +1471,18 @@ fn delete_action_context(
     Ok(())
 }
 
+#[tauri::command(rename_all = "camelCase")]
+fn set_copy_build_dirs_enabled(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    context_id: String,
+    enabled: bool,
+) -> Result<(), String> {
+    let store = get_store(&store)?;
+    store
+        .set_copy_build_dirs_enabled(&context_id, enabled)
+        .map_err(|e| e.to_string())
+}
+
 // =============================================================================
 // Tauri App Setup
 // =============================================================================
@@ -1800,6 +1813,7 @@ pub fn run() {
             create_repo_action,
             delete_all_repo_actions,
             delete_action_context,
+            set_copy_build_dirs_enabled,
             // Timeline
             timeline::get_branch_timeline,
             // Notes

--- a/apps/staged/src-tauri/src/store/actions.rs
+++ b/apps/staged/src-tauri/src/store/actions.rs
@@ -18,14 +18,16 @@ impl Store {
         let context = ActionContext::new(github_repo.to_string(), subpath.map(str::to_string));
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO action_contexts (id, github_repo, subpath, has_detected_actions, detecting_actions, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO action_contexts (id, github_repo, subpath, has_detected_actions, detecting_actions, last_run_worktree_path, copy_build_dirs_enabled, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 context.id,
                 context.github_repo,
                 context.subpath,
                 context.has_detected_actions as i32,
                 context.detecting_actions as i32,
+                context.last_run_worktree_path,
+                context.copy_build_dirs_enabled as i32,
                 context.created_at,
                 context.updated_at,
             ],
@@ -36,7 +38,7 @@ impl Store {
     pub fn list_action_contexts(&self) -> Result<Vec<ActionContext>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, github_repo, subpath, has_detected_actions, detecting_actions, created_at, updated_at
+            "SELECT id, github_repo, subpath, has_detected_actions, detecting_actions, last_run_worktree_path, copy_build_dirs_enabled, created_at, updated_at
              FROM action_contexts
              ORDER BY created_at ASC",
         )?;
@@ -47,7 +49,7 @@ impl Store {
     pub fn get_action_context(&self, id: &str) -> Result<Option<ActionContext>, StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, github_repo, subpath, has_detected_actions, detecting_actions, created_at, updated_at
+            "SELECT id, github_repo, subpath, has_detected_actions, detecting_actions, last_run_worktree_path, copy_build_dirs_enabled, created_at, updated_at
              FROM action_contexts WHERE id = ?1",
             params![id],
             Self::row_to_action_context,
@@ -73,7 +75,7 @@ impl Store {
     ) -> Result<Option<ActionContext>, StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, github_repo, subpath, has_detected_actions, detecting_actions, created_at, updated_at
+            "SELECT id, github_repo, subpath, has_detected_actions, detecting_actions, last_run_worktree_path, copy_build_dirs_enabled, created_at, updated_at
              FROM action_contexts
              WHERE github_repo = ?1 AND subpath IS ?2",
             params![github_repo, subpath],
@@ -94,6 +96,36 @@ impl Store {
              SET detecting_actions = ?1, updated_at = ?2
              WHERE id = ?3",
             params![detecting as i32, now_timestamp(), context_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_last_run_worktree_path(
+        &self,
+        context_id: &str,
+        worktree_path: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE action_contexts
+             SET last_run_worktree_path = ?1, updated_at = ?2
+             WHERE id = ?3",
+            params![worktree_path, now_timestamp(), context_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_copy_build_dirs_enabled(
+        &self,
+        context_id: &str,
+        enabled: bool,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE action_contexts
+             SET copy_build_dirs_enabled = ?1, updated_at = ?2
+             WHERE id = ?3",
+            params![enabled as i32, now_timestamp(), context_id],
         )?;
         Ok(())
     }
@@ -221,14 +253,17 @@ impl Store {
     fn row_to_action_context(row: &rusqlite::Row) -> rusqlite::Result<ActionContext> {
         let has_detected_actions: i32 = row.get(3)?;
         let detecting_actions: i32 = row.get(4)?;
+        let copy_build_dirs_enabled: i32 = row.get(6)?;
         Ok(ActionContext {
             id: row.get(0)?,
             github_repo: row.get(1)?,
             subpath: row.get(2)?,
             has_detected_actions: has_detected_actions != 0,
             detecting_actions: detecting_actions != 0,
-            created_at: row.get(5)?,
-            updated_at: row.get(6)?,
+            last_run_worktree_path: row.get(5)?,
+            copy_build_dirs_enabled: copy_build_dirs_enabled != 0,
+            created_at: row.get(7)?,
+            updated_at: row.get(8)?,
         })
     }
 

--- a/apps/staged/src-tauri/src/store/migration_tests.rs
+++ b/apps/staged/src-tauri/src/store/migration_tests.rs
@@ -145,7 +145,7 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         )
         .unwrap();
 
-    assert_eq!(version, 14);
+    assert_eq!(version, 16);
     assert_eq!(app_version, super::APP_VERSION);
     assert!(table_exists(&conn, "projects"));
     assert!(table_exists(&conn, "project_notes"));
@@ -169,22 +169,14 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
 #[test]
 fn test_store_repairs_github_comment_tracking_user_version() {
     let path = temp_db_path("github-comment-tracking-repair");
-    let conn = Connection::open(&path).unwrap();
+
+    let mut conn = Connection::open(&path).unwrap();
+    migrations::migrate_to(&mut conn, 12).unwrap();
     conn.execute_batch(
         "
-        PRAGMA user_version = 12;
-        CREATE TABLE app_metadata (
-            id          INTEGER PRIMARY KEY CHECK (id = 1),
-            app_version TEXT NOT NULL
-        );
-        INSERT INTO app_metadata (id, app_version) VALUES (1, '0.2.9');
-        CREATE TABLE sessions (id TEXT PRIMARY KEY);
-        CREATE TABLE comments (
-            id                    TEXT PRIMARY KEY,
-            github_comment_id     INTEGER,
-            github_comment_type   TEXT,
-            github_comment_stale  INTEGER NOT NULL DEFAULT 0
-        );
+        ALTER TABLE comments ADD COLUMN github_comment_id INTEGER;
+        ALTER TABLE comments ADD COLUMN github_comment_type TEXT;
+        ALTER TABLE comments ADD COLUMN github_comment_stale INTEGER NOT NULL DEFAULT 0;
         ",
     )
     .unwrap();
@@ -197,8 +189,18 @@ fn test_store_repairs_github_comment_tracking_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 14);
+    assert_eq!(version, 16);
     assert!(column_exists(&conn, "sessions", "pipeline"));
+    assert!(column_exists(
+        &conn,
+        "action_contexts",
+        "last_run_worktree_path"
+    ));
+    assert!(column_exists(
+        &conn,
+        "action_contexts",
+        "copy_build_dirs_enabled"
+    ));
 
     cleanup_db(&path);
 }
@@ -206,20 +208,13 @@ fn test_store_repairs_github_comment_tracking_user_version() {
 #[test]
 fn test_store_repairs_pipeline_user_version() {
     let path = temp_db_path("pipeline-version-repair");
-    let conn = Connection::open(&path).unwrap();
+
+    let mut conn = Connection::open(&path).unwrap();
+    migrations::migrate_to(&mut conn, 12).unwrap();
     conn.execute_batch(
         "
+        ALTER TABLE sessions ADD COLUMN pipeline TEXT;
         PRAGMA user_version = 13;
-        CREATE TABLE app_metadata (
-            id          INTEGER PRIMARY KEY CHECK (id = 1),
-            app_version TEXT NOT NULL
-        );
-        INSERT INTO app_metadata (id, app_version) VALUES (1, '0.2.9');
-        CREATE TABLE sessions (
-            id       TEXT PRIMARY KEY,
-            pipeline TEXT
-        );
-        CREATE TABLE comments (id TEXT PRIMARY KEY);
         ",
     )
     .unwrap();
@@ -232,10 +227,20 @@ fn test_store_repairs_pipeline_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 14);
+    assert_eq!(version, 16);
     assert!(column_exists(&conn, "comments", "github_comment_id"));
     assert!(column_exists(&conn, "comments", "github_comment_type"));
     assert!(column_exists(&conn, "comments", "github_comment_stale"));
+    assert!(column_exists(
+        &conn,
+        "action_contexts",
+        "last_run_worktree_path"
+    ));
+    assert!(column_exists(
+        &conn,
+        "action_contexts",
+        "copy_build_dirs_enabled"
+    ));
 
     cleanup_db(&path);
 }

--- a/apps/staged/src-tauri/src/store/migrations.rs
+++ b/apps/staged/src-tauri/src/store/migrations.rs
@@ -53,6 +53,13 @@ pub(super) fn validate() -> Result<(), StoreError> {
     migrations().validate().map_err(map_migration_error)
 }
 
+#[cfg(test)]
+pub(super) fn migrate_to(conn: &mut Connection, version: usize) -> Result<(), StoreError> {
+    migrations()
+        .to_version(conn, version)
+        .map_err(map_migration_error)
+}
+
 fn migrations() -> &'static Migrations<'static> {
     MIGRATIONS.get_or_init(|| {
         Migrations::from_directory(&MIGRATION_DIR).expect("staged store migrations should be valid")

--- a/apps/staged/src-tauri/src/store/migrations/0015-add-last-run-worktree/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0015-add-last-run-worktree/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE action_contexts ADD COLUMN last_run_worktree_path TEXT;

--- a/apps/staged/src-tauri/src/store/migrations/0016-add-copy-build-dirs-enabled/down.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0016-add-copy-build-dirs-enabled/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE action_contexts DROP COLUMN copy_build_dirs_enabled;

--- a/apps/staged/src-tauri/src/store/migrations/0016-add-copy-build-dirs-enabled/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0016-add-copy-build-dirs-enabled/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE action_contexts ADD COLUMN copy_build_dirs_enabled INTEGER NOT NULL DEFAULT 0;

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -896,6 +896,12 @@ pub struct ActionContext {
     pub subpath: Option<String>,
     pub has_detected_actions: bool,
     pub detecting_actions: bool,
+    /// Path to the most recently run worktree for this repo+subpath context.
+    /// Used to copy build directories (via APFS cloning) into new worktrees.
+    pub last_run_worktree_path: Option<String>,
+    /// Whether to copy build directories from the last-run worktree into new
+    /// worktrees for this repo context. Defaults to off (experimental).
+    pub copy_build_dirs_enabled: bool,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -909,6 +915,8 @@ impl ActionContext {
             subpath,
             has_detected_actions: false,
             detecting_actions: false,
+            last_run_worktree_path: None,
+            copy_build_dirs_enabled: false,
             created_at: now,
             updated_at: now,
         }

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -439,6 +439,7 @@ export interface ActionContext {
   subpath: string | null;
   hasDetectedActions: boolean;
   detectingActions: boolean;
+  copyBuildDirsEnabled: boolean;
   createdAt: number;
   updatedAt: number;
 }
@@ -477,6 +478,10 @@ export function deleteAllRepoActions(contextId: string): Promise<void> {
 
 export function deleteActionContext(contextId: string): Promise<void> {
   return invoke('delete_action_context', { contextId });
+}
+
+export function setCopyBuildDirsEnabled(contextId: string, enabled: boolean): Promise<void> {
+  return invoke('set_copy_build_dirs_enabled', { contextId, enabled });
 }
 
 // =============================================================================

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -643,6 +643,25 @@
           {/if}
 
           {#if selectedContext}
+            <div class="repo-setting-row">
+              <label class="checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={selectedContext.copyBuildDirsEnabled}
+                  onchange={async (e) => {
+                    if (!selectedContext) return;
+                    const enabled = (e.target as HTMLInputElement).checked;
+                    await commands.setCopyBuildDirsEnabled(selectedContext.id, enabled);
+                    contexts = contexts.map((c) =>
+                      c.id === selectedContext!.id ? { ...c, copyBuildDirsEnabled: enabled } : c
+                    );
+                  }}
+                />
+                Copy build dirs to new worktrees
+              </label>
+              <span class="experimental-badge">Experimental</span>
+            </div>
+
             {#if selectedContextAttachments.length > 0}
               <div class="repo-attachments">
                 {#each selectedContextAttachments as attachment (attachment.projectRepoId)}
@@ -1108,6 +1127,27 @@
     font-size: calc(var(--size-xs) - 1px);
     color: var(--text-muted);
     background: var(--bg-primary);
+  }
+
+  .repo-setting-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: var(--size-sm);
+    color: var(--text-primary);
+  }
+
+  .experimental-badge {
+    font-size: calc(var(--size-xs) - 1px);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--ui-warning, #e6a200) 15%, transparent);
+    color: var(--ui-warning, #e6a200);
+    border: 1px solid color-mix(in srgb, var(--ui-warning, #e6a200) 30%, transparent);
+    white-space: nowrap;
   }
 
   .repo-empty-attachments {

--- a/apps/staged/src/lib/features/settings/repoContextSearch.test.ts
+++ b/apps/staged/src/lib/features/settings/repoContextSearch.test.ts
@@ -8,6 +8,7 @@ const context: ActionContext = {
   subpath: 'apps/staged',
   hasDetectedActions: false,
   detectingActions: false,
+  copyBuildDirsEnabled: false,
   createdAt: 0,
   updatedAt: 0,
 };


### PR DESCRIPTION
Adds experimental build directory copying between worktrees with APFS cloning, recursive whitelist discovery, settings UI, and persisted opt-in state.