### PR TITLE
fix(staged): hide remote project option without sq

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -366,7 +366,13 @@ fn create_project(
     // re-validation here removes a ~500ms-2s GitHub API round-trip.
 
     let project_location = match location.as_deref() {
-        Some("remote") => store::ProjectLocation::Remote,
+        Some("remote") if blox::is_sq_available() => store::ProjectLocation::Remote,
+        Some("remote") => {
+            log::warn!(
+                "[create_project] remote project requested but sq CLI is unavailable; creating a local project instead"
+            );
+            store::ProjectLocation::Local
+        }
         _ => store::ProjectLocation::Local,
     };
     let inferred_branch_name = branch_name

--- a/apps/staged/src/App.svelte
+++ b/apps/staged/src/App.svelte
@@ -24,7 +24,7 @@
     resetSize,
   } from './lib/features/settings/preferences.svelte';
   import { refreshProviders } from './lib/features/agents/agent.svelte';
-  import { refreshSqAvailability } from './lib/features/settings/sq.svelte';
+  import { ensureSqAvailabilityLoaded } from './lib/features/settings/sq.svelte';
   import {
     navigation,
     initNavigation,
@@ -382,8 +382,8 @@
       setAiAgent(providers[0].id);
     }
 
-    // Check for `sq` CLI in the background (non-blocking).
-    refreshSqAvailability();
+    // Check for `sq` CLI in the background if preferences did not need it.
+    ensureSqAvailabilityLoaded();
 
     // Window was created hidden — show it now that the theme is applied
     await getCurrentWindow().show();

--- a/apps/staged/src/lib/features/projects/NewProjectForm.svelte
+++ b/apps/staged/src/lib/features/projects/NewProjectForm.svelte
@@ -64,7 +64,7 @@
   let effectiveLocation = $derived(remoteProjectsAvailable ? location : 'local');
 
   $effect(() => {
-    if (!remoteProjectsAvailable && location === 'remote') {
+    if (sqState.loaded && !sqState.available && location === 'remote') {
       location = 'local';
     }
   });

--- a/apps/staged/src/lib/features/projects/NewProjectForm.svelte
+++ b/apps/staged/src/lib/features/projects/NewProjectForm.svelte
@@ -18,6 +18,7 @@
   import { parseGitHubUrl } from '../../shared/githubUrl';
   import type { RepoSelection } from '../../shared/githubUrl';
   import type { PullRequest } from '../../types';
+  import { sqState } from '../settings/sq.svelte';
 
   interface Props {
     onCreated: (project: Project) => void;
@@ -59,7 +60,16 @@
     error = null;
   });
 
-  let repoMissing = $derived(location === 'remote' && !selectedRepo);
+  let remoteProjectsAvailable = $derived(sqState.loaded && sqState.available);
+  let effectiveLocation = $derived(remoteProjectsAvailable ? location : 'local');
+
+  $effect(() => {
+    if (!remoteProjectsAvailable && location === 'remote') {
+      location = 'local';
+    }
+  });
+
+  let repoMissing = $derived(effectiveLocation === 'remote' && !selectedRepo);
   let canCreate = $derived(!!name.trim() && !saving && !repoMissing);
 
   async function handleCreate() {
@@ -88,7 +98,7 @@
 
       const project = await commands.createProject(
         name.trim(),
-        location,
+        effectiveLocation,
         selectedRepo ?? undefined,
         normalizedSubpath,
         normalizedBranch,
@@ -168,27 +178,29 @@
     />
   </div>
 
-  <div class="form-group">
-    <div class="field-label">Location</div>
-    <FormToggle
-      bind:value={location}
-      options={[
-        {
-          value: 'local',
-          label: 'Local',
-          description: 'Run agents on your machine',
-          icon: Monitor,
-        },
-        {
-          value: 'remote',
-          label: 'Remote',
-          description: 'Run agents in the cloud',
-          icon: Cloud,
-        },
-      ]}
-      disabled={saving}
-    />
-  </div>
+  {#if remoteProjectsAvailable}
+    <div class="form-group">
+      <div class="field-label">Location</div>
+      <FormToggle
+        bind:value={location}
+        options={[
+          {
+            value: 'local',
+            label: 'Local',
+            description: 'Run agents on your machine',
+            icon: Monitor,
+          },
+          {
+            value: 'remote',
+            label: 'Remote',
+            description: 'Run agents in the cloud',
+            icon: Cloud,
+          },
+        ]}
+        disabled={saving}
+      />
+    </div>
+  {/if}
 
   <RepoConfigForm
     bind:selectedRepo
@@ -200,7 +212,7 @@
     bind:defaultBranch
     bind:api={repoConfigApi}
     disabled={saving}
-    repoRequired={location === 'remote'}
+    repoRequired={effectiveLocation === 'remote'}
     onBranchSelected={handleBranchSelected}
   />
 

--- a/apps/staged/src/lib/features/settings/preferences.svelte.ts
+++ b/apps/staged/src/lib/features/settings/preferences.svelte.ts
@@ -20,7 +20,6 @@ import {
 } from '../diff/highlighter';
 import { initPersistentStore, getStoreValue, setStoreValue } from '../../shared/persistentStore';
 import { createAdaptiveTheme, themeToVarMap } from '../../theme';
-import { ensureSqAvailabilityLoaded } from './sq.svelte';
 
 // Re-export for convenience
 export { isLightTheme, loadAllThemePreviewColors, type ThemePreviewColors };
@@ -107,6 +106,12 @@ function applyAdaptiveTheme() {
   }
 }
 
+async function loadSqAvailabilityForDefault(): Promise<boolean> {
+  // Keep preferences from taking a static dependency on the sq state module.
+  const { ensureSqAvailabilityLoaded } = await import('./sq.svelte');
+  return ensureSqAvailabilityLoaded();
+}
+
 // =============================================================================
 // Initialization
 // =============================================================================
@@ -157,7 +162,7 @@ export async function initPreferences(): Promise<void> {
   if (savedAutoReview === 'never' || savedAutoReview === 'after-changes') {
     preferences.autoReviewMode = savedAutoReview;
   } else {
-    preferences.autoReviewMode = (await ensureSqAvailabilityLoaded()) ? 'after-changes' : 'never';
+    preferences.autoReviewMode = (await loadSqAvailabilityForDefault()) ? 'after-changes' : 'never';
   }
 
   preferences.loaded = true;

--- a/apps/staged/src/lib/features/settings/preferences.svelte.ts
+++ b/apps/staged/src/lib/features/settings/preferences.svelte.ts
@@ -20,6 +20,7 @@ import {
 } from '../diff/highlighter';
 import { initPersistentStore, getStoreValue, setStoreValue } from '../../shared/persistentStore';
 import { createAdaptiveTheme, themeToVarMap } from '../../theme';
+import { ensureSqAvailabilityLoaded } from './sq.svelte';
 
 // Re-export for convenience
 export { isLightTheme, loadAllThemePreviewColors, type ThemePreviewColors };
@@ -156,8 +157,7 @@ export async function initPreferences(): Promise<void> {
   if (savedAutoReview === 'never' || savedAutoReview === 'after-changes') {
     preferences.autoReviewMode = savedAutoReview;
   } else {
-    const { isSqAvailable } = await import('../../commands');
-    preferences.autoReviewMode = (await isSqAvailable()) ? 'after-changes' : 'never';
+    preferences.autoReviewMode = (await ensureSqAvailabilityLoaded()) ? 'after-changes' : 'never';
   }
 
   preferences.loaded = true;

--- a/apps/staged/src/lib/features/settings/sq.svelte.ts
+++ b/apps/staged/src/lib/features/settings/sq.svelte.ts
@@ -13,12 +13,9 @@ export const sqState = $state({
   loaded: false,
 });
 
-/**
- * Detect whether the `sq` CLI is present and update the cache.
- *
- * Called once at startup from App.svelte. Safe to call again if needed.
- */
-export async function refreshSqAvailability(): Promise<boolean> {
+let sqAvailabilityPromise: Promise<boolean> | null = null;
+
+async function loadSqAvailability(): Promise<boolean> {
   try {
     const available = await isSqAvailable();
     sqState.available = available;
@@ -28,5 +25,28 @@ export async function refreshSqAvailability(): Promise<boolean> {
     sqState.available = false;
     sqState.loaded = true;
     return false;
+  } finally {
+    sqAvailabilityPromise = null;
   }
+}
+
+/**
+ * Detect whether the `sq` CLI is present and update the cache.
+ *
+ * Safe to call again if a caller needs to refresh the app-level state.
+ */
+export async function refreshSqAvailability(): Promise<boolean> {
+  sqAvailabilityPromise ??= loadSqAvailability();
+  return sqAvailabilityPromise;
+}
+
+/**
+ * Return cached `sq` availability, loading it once if needed.
+ */
+export function ensureSqAvailabilityLoaded(): Promise<boolean> {
+  if (sqState.loaded) {
+    return Promise.resolve(sqState.available);
+  }
+
+  return refreshSqAvailability();
 }


### PR DESCRIPTION
Hides the remote project option when sq is unavailable, centralizes cached sq availability loading, and defensively falls back to local project creation if remote is requested without sq.