### PR TITLE
fix: standardize hashtag badge spacing

### DIFF
--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -154,12 +154,13 @@ mark.search-match-current {
 
 /* ── Hashtag badges (shared across all badge contexts) ── */
 .hashtag-badge {
-  display: inline;
+  display: inline-block;
   padding: 3px 6px;
   border-radius: 4px;
   font-size: 0.85em;
   font-weight: 500;
   line-height: 1.35;
+  vertical-align: baseline;
   white-space: nowrap;
 }
 

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -155,7 +155,7 @@ mark.search-match-current {
 /* ── Hashtag badges (shared across all badge contexts) ── */
 .hashtag-badge {
   display: inline;
-  padding: 2px 6px;
+  padding: 3px 6px;
   border-radius: 4px;
   font-size: 0.85em;
   font-weight: 500;

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -152,7 +152,17 @@ mark.search-match-current {
   background-color: rgba(255, 152, 0, 0.6);
 }
 
-/* ── Hashtag badge icon sizing (shared across all badge contexts) ── */
+/* ── Hashtag badges (shared across all badge contexts) ── */
+.hashtag-badge {
+  display: inline;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-weight: 500;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
 .hashtag-badge svg {
   width: 12px;
   height: 12px;

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -517,12 +517,6 @@
 
   /* Inline badge for referenced items */
   .hashtag-editor :global(.hashtag-badge) {
-    display: inline;
-    padding: 1px 6px;
-    border-radius: 4px;
-    font-size: 0.85em;
-    font-weight: 500;
-    white-space: nowrap;
     cursor: default;
     vertical-align: baseline;
     user-select: all;

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -1559,15 +1559,6 @@
     white-space: pre-wrap;
   }
 
-  .human-text :global(.hashtag-badge) {
-    display: inline;
-    padding: 1px 6px;
-    border-radius: 4px;
-    font-size: 0.85em;
-    font-weight: 500;
-    white-space: nowrap;
-  }
-
   .human-bubble .inline-copy {
     position: absolute;
     top: 6px;

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -417,15 +417,6 @@
     line-height: 1.4;
   }
 
-  .timeline-title :global(.hashtag-badge) {
-    display: inline;
-    padding: 1px 6px;
-    border-radius: 4px;
-    font-size: 0.85em;
-    font-weight: 500;
-    white-space: nowrap;
-  }
-
   .skeleton-title {
     color: var(--text-muted);
   }


### PR DESCRIPTION
Centralizes hashtag badge styling in shared CSS, removes duplicate scoped badge rules, and uses inline-block so vertical padding lays out correctly.