### PR TITLE
fix(diff): close deleted comments

### DIFF
--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -394,6 +394,15 @@
   // Split AI "information" comments into annotations; everything else stays as comments
   let currentComments = $derived(allComments.filter((c) => c.commentType !== 'information'));
 
+  $effect(() => {
+    if (selectedCommentId && !currentComments.some((c) => c.id === selectedCommentId)) {
+      clearCommentNavigation(selectedCommentId);
+    }
+    if (jumpToComment && !currentComments.some((c) => c.id === jumpToComment?.id)) {
+      jumpToComment = null;
+    }
+  });
+
   /** Convert "information" comments to SmartDiffAnnotation for the overlay system.
    *  Merges annotations from both the user's review and the latest auto review. */
   let currentAnnotations = $derived<SmartDiffAnnotation[]>([
@@ -486,11 +495,22 @@
     return path.split('/').pop() || path;
   }
 
+  function clearCommentNavigation(commentId?: string) {
+    if (!commentId || selectedCommentId === commentId) {
+      selectedCommentId = null;
+    }
+    if (!commentId || jumpToComment?.id === commentId) {
+      jumpToComment = null;
+    }
+  }
+
   async function handleDeleteComment(commentId: string) {
+    clearCommentNavigation(commentId);
     await reviewHandle?.deleteComment(commentId);
   }
 
   async function handleDeleteAllComments() {
+    clearCommentNavigation();
     await reviewHandle?.deleteAllComments();
   }
 
@@ -567,6 +587,7 @@
   }
 
   async function handleDeleteCommentFromViewer(commentId: string): Promise<void> {
+    clearCommentNavigation(commentId);
     await reviewHandle?.deleteComment(commentId);
   }
 

--- a/apps/staged/src/lib/features/diff/diffViewerCommentState.test.ts
+++ b/apps/staged/src/lib/features/diff/diffViewerCommentState.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTrackedComment } from '@builderbot/diff-viewer/utils';
+import type { Comment } from '../../types';
+
+function createComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: 'comment-1',
+    path: 'src/app.ts',
+    span: { start: 2, end: 3 },
+    content: 'Check this line',
+    author: 'user',
+    commentType: 'suggestion',
+    createdAt: 1,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('resolveTrackedComment', () => {
+  it('uses the latest comments prop for a jump-opened comment', () => {
+    const openedComment = createComment({ content: 'Old content' });
+    const latestComment = createComment({ content: 'Updated content' });
+
+    expect(resolveTrackedComment([latestComment], openedComment, null)).toEqual({
+      commentId: 'comment-1',
+      existingComment: latestComment,
+      missing: false,
+    });
+  });
+
+  it('marks a jump-opened comment as missing after rerender removes it', () => {
+    const openedComment = createComment();
+
+    expect(resolveTrackedComment([], openedComment, null)).toEqual({
+      commentId: 'comment-1',
+      existingComment: null,
+      missing: true,
+    });
+  });
+
+  it('keeps a new comment editor open when there is no tracked comment id', () => {
+    expect(resolveTrackedComment([], null, null)).toEqual({
+      commentId: null,
+      existingComment: null,
+      missing: false,
+    });
+  });
+});

--- a/apps/staged/src/lib/features/diff/diffViewerCommentState.test.ts
+++ b/apps/staged/src/lib/features/diff/diffViewerCommentState.test.ts
@@ -45,4 +45,22 @@ describe('resolveTrackedComment', () => {
       missing: false,
     });
   });
+
+  it('falls back to editingCommentId when activeComment is null (range-comment scenario)', () => {
+    const comment = createComment({ id: 'range-comment-1' });
+
+    expect(resolveTrackedComment([comment], null, 'range-comment-1')).toEqual({
+      commentId: 'range-comment-1',
+      existingComment: comment,
+      missing: false,
+    });
+  });
+
+  it('marks a range comment as missing when editingCommentId is set but comment is deleted', () => {
+    expect(resolveTrackedComment([], null, 'range-comment-1')).toEqual({
+      commentId: 'range-comment-1',
+      existingComment: null,
+      missing: true,
+    });
+  });
 });

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -49,6 +49,7 @@
     buildBeforeMarkers,
     buildLineToAlignmentMap,
     findCommentById,
+    resolveTrackedComment,
     getCommentsForAlignment,
     getTokensForLine,
     isLineInChangedAlignment as helperIsLineInChangedAlignment,
@@ -329,7 +330,13 @@
 
   // Comments for the current file (suffix-match to handle path prefix mismatches)
   let currentFileComments = $derived(
-    comments.filter((c) => currentFilePath !== null && pathsMatch(c.path, currentFilePath)),
+    comments.filter((c) => currentFilePath !== null && pathsMatch(c.path, currentFilePath))
+  );
+  let activeLineCommentState = $derived(
+    resolveTrackedComment(currentFileComments, activeLineComment, editingCommentId)
+  );
+  let activeRangeCommentState = $derived(
+    resolveTrackedComment(currentFileComments, null, editingRangeCommentId)
   );
 
   // ==========================================================================
@@ -508,6 +515,22 @@
       lineCommentReadOnly = false;
       commentingOnRange = null;
       commentEditorStyle = null;
+    }
+  });
+
+  // Keep editor state tied to the latest comments prop. When an opened comment
+  // is deleted upstream, close the editor instead of showing a stale or blank one.
+  $effect(() => {
+    if (activeLineCommentState.missing) {
+      clearLineSelection();
+    }
+  });
+
+  $effect(() => {
+    if (activeRangeCommentState.missing) {
+      commentingOnRange = null;
+      commentEditorStyle = null;
+      editingRangeCommentId = null;
     }
   });
 
@@ -2226,10 +2249,8 @@
     {/if}
 
     <!-- Range comment editor (two-pane mode only) -->
-    {#if commentingOnRange !== null && commentEditorStyle}
-      {@const existingComment = editingRangeCommentId
-        ? findCommentById(comments, editingRangeCommentId)
-        : null}
+    {#if commentingOnRange !== null && commentEditorStyle && !activeRangeCommentState.missing}
+      {@const existingComment = activeRangeCommentState.existingComment}
       <CommentEditor
         top={commentEditorStyle.top}
         left={commentEditorStyle.left}
@@ -2280,10 +2301,8 @@
     {/if}
 
     <!-- Line comment editor -->
-    {#if commentingOnLines && lineCommentEditorStyle}
-      {@const existingComment =
-        activeLineComment ??
-        (editingCommentId ? findCommentById(comments, editingCommentId) : null)}
+    {#if commentingOnLines && lineCommentEditorStyle && !activeLineCommentState.missing}
+      {@const existingComment = activeLineCommentState.existingComment}
       <CommentEditor
         top={lineCommentEditorStyle.top}
         left={lineCommentEditorStyle.left}

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -506,15 +506,8 @@
       hoveredRangeIndex = null;
       rangeToolbarStyle = null;
       focusedHunkIndex = null;
-      lineSelection = null;
-      commentingOnLines = null;
-      lineCommentEditorStyle = null;
-      lineCommentPositionPreference = 'below';
-      editingCommentId = null;
-      activeLineComment = null;
-      lineCommentReadOnly = false;
-      commentingOnRange = null;
-      commentEditorStyle = null;
+      clearLineSelection();
+      clearRangeSelection();
     }
   });
 
@@ -528,9 +521,7 @@
 
   $effect(() => {
     if (activeRangeCommentState.missing) {
-      commentingOnRange = null;
-      commentEditorStyle = null;
-      editingRangeCommentId = null;
+      clearRangeSelection();
     }
   });
 
@@ -1373,13 +1364,11 @@
     const span: Span = { start: alignment.after.start, end: alignment.after.end };
 
     await onAddComment(currentFilePath, span, content);
-    commentingOnRange = null;
-    commentEditorStyle = null;
+    clearRangeSelection();
   }
 
   function handleCommentCancel() {
-    commentingOnRange = null;
-    commentEditorStyle = null;
+    clearRangeSelection();
   }
 
   async function handleCommentEdit(id: string, content: string) {
@@ -1453,6 +1442,12 @@
     editingCommentId = null;
     activeLineComment = null;
     lineCommentReadOnly = false;
+  }
+
+  function clearRangeSelection() {
+    commentingOnRange = null;
+    commentEditorStyle = null;
+    editingRangeCommentId = null;
   }
 
   // Store the initial left position for line selection toolbar
@@ -1661,8 +1656,7 @@
       if (commentingOnRange !== null) {
         event.preventDefault();
         event.stopPropagation();
-        commentingOnRange = null;
-        commentEditorStyle = null;
+        clearRangeSelection();
         return;
       }
       if (selectedLineRange) {

--- a/packages/diff-viewer/src/lib/utils/diffViewerHelpers.ts
+++ b/packages/diff-viewer/src/lib/utils/diffViewerHelpers.ts
@@ -171,6 +171,20 @@ export function findCommentById(comments: Comment[], id: string): Comment | null
   return comments.find((c) => c.id === id) ?? null;
 }
 
+export function resolveTrackedComment(
+  comments: Comment[],
+  activeComment: Comment | null,
+  editingCommentId: string | null
+): { commentId: string | null; existingComment: Comment | null; missing: boolean } {
+  const commentId = activeComment?.id ?? editingCommentId;
+  if (!commentId) {
+    return { commentId: null, existingComment: null, missing: false };
+  }
+
+  const existingComment = findCommentById(comments, commentId);
+  return { commentId, existingComment, missing: existingComment === null };
+}
+
 export function getCommentsForAlignment(
   alignmentIndex: number,
   changedAlignments: ChangedAlignmentEntry[],

--- a/packages/diff-viewer/src/lib/utils/index.ts
+++ b/packages/diff-viewer/src/lib/utils/index.ts
@@ -25,6 +25,7 @@ export {
   buildBeforeMarkers,
   buildAfterMarkers,
   findCommentById,
+  resolveTrackedComment,
   getCommentsForAlignment,
   getTokensForLine,
   isLineInChangedAlignment,


### PR DESCRIPTION
Summary:
- Close comment navigation and editor state when deleted comments disappear.
- Resolve tracked line and range comments from the latest comments prop and cover deleted-comment behavior with tests.