### PR TITLE
fix: remove commit SHAs from hashtag labels

### DIFF
--- a/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { BranchTimeline } from '../../types';
+import { timelineToHashtagItems } from './hashtagItems';
+
+describe('timelineToHashtagItems', () => {
+  it('uses only the commit subject for commit hashtag titles', () => {
+    const timeline: BranchTimeline = {
+      notes: [],
+      commits: [
+        {
+          id: 'commit-id',
+          sha: 'abcdef1234567890',
+          shortSha: 'abcdef1',
+          subject: 'Add branch picker filtering',
+          author: 'Test User',
+          timestamp: 1,
+          order: 0,
+          sessionId: null,
+          sessionStatus: null,
+          completionReason: null,
+        },
+      ],
+      reviews: [],
+      images: [],
+    };
+
+    expect(timelineToHashtagItems(timeline)).toContainEqual(
+      expect.objectContaining({
+        type: 'commit',
+        id: 'abcdef1234567890',
+        title: 'Add branch picker filtering',
+      })
+    );
+  });
+});

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -108,7 +108,7 @@ export function timelineToHashtagItems(
     items.push({
       type: 'commit',
       id: commit.sha,
-      title: `${commit.shortSha} ${commit.subject}`,
+      title: commit.subject,
       color: '--commit-color',
       bgColor: '--commit-bg',
       branchName,


### PR DESCRIPTION
🤖 Removes commit SHA text from generated hashtag labels and adds focused tests for hashtag item formatting.