### PR TITLE
fix: skip stale review delete warning

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -867,10 +867,16 @@
         return;
       }
 
+      // Conservative fallback: if we couldn't load review details, always warn
+      if (!details) {
+        showConfirmDelete();
+        return;
+      }
+
       const shouldWarn = shouldWarnBeforeDeletingReview({
         review: details,
         commits: timeline?.commits ?? [],
-        userCommentCount: details?.userComments,
+        userCommentCount: details.userComments,
       });
       if (shouldWarn) {
         showConfirmDelete();

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -26,6 +26,7 @@
   import * as commands from '../../api/commands';
   import BranchTimeline from '../timeline/BranchTimeline.svelte';
   import ImageViewerModal from '../timeline/ImageViewerModal.svelte';
+  import { countUserComments, shouldWarnBeforeDeletingReview } from '../timeline/reviewState';
   import DiffModal from '../diff/DiffModal.svelte';
   import SessionModal from '../sessions/SessionModal.svelte';
   import NewSessionModal from '../sessions/NewSessionModal.svelte';
@@ -98,12 +99,14 @@
   let error = $state<string | null>(null);
   let showBranchDiff = $state(false);
   let loadedTimelineKey = $state<string | null>(null);
+  type TimelineFullReview = NonNullable<Awaited<ReturnType<typeof commands.getReview>>>;
   type TimelineReviewDetails = {
     commitSha: string;
     scope: 'branch' | 'commit';
     comments: number;
     annotations: number;
     warnings: number;
+    userComments: number;
   };
   let timelineReviewDetailsById = $state<Record<string, TimelineReviewDetails>>({});
 
@@ -649,6 +652,31 @@
     }
   }
 
+  function getTimelineReviewDetails(fullReview: TimelineFullReview): TimelineReviewDetails {
+    let comments = 0;
+    let annotations = 0;
+    let warnings = 0;
+    for (const comment of fullReview.comments) {
+      if (comment.commentType === 'information') {
+        annotations += 1;
+      } else {
+        comments += 1;
+        if (comment.commentType === 'warning') {
+          warnings += 1;
+        }
+      }
+    }
+
+    return {
+      commitSha: fullReview.commitSha,
+      scope: fullReview.scope,
+      comments,
+      annotations,
+      warnings,
+      userComments: countUserComments(fullReview.comments),
+    };
+  }
+
   async function loadTimelineReviewDetails(reviews: BranchTimelineData['reviews']) {
     const loadVersion = ++reviewDetailsLoadVersion;
     if (reviews.length === 0) {
@@ -662,28 +690,7 @@
           const fullReview = await commands.getReview(review.id);
           if (!fullReview) return null;
 
-          let comments = 0;
-          let annotations = 0;
-          let warnings = 0;
-          for (const comment of fullReview.comments) {
-            if (comment.commentType === 'information') {
-              annotations += 1;
-            } else {
-              comments += 1;
-              if (comment.commentType === 'warning') {
-                warnings += 1;
-              }
-            }
-          }
-
-          const details: TimelineReviewDetails = {
-            commitSha: fullReview.commitSha,
-            scope: fullReview.scope,
-            comments,
-            annotations,
-            warnings,
-          };
-          return { id: review.id, details };
+          return { id: review.id, details: getTimelineReviewDetails(fullReview) };
         } catch (e) {
           console.error(`Failed to load review details for ${review.id}:`, e);
           return null;
@@ -835,17 +842,47 @@
         notifyError('Failed to delete review', e);
       }
     };
+    const showConfirmDelete = () => {
+      confirmDelete = {
+        title: 'Delete Review',
+        message:
+          'Are you sure you want to delete this review and all its comments?' +
+          (sessionId ? ' The linked session will also be deleted.' : ''),
+        onConfirm: doDelete,
+      };
+    };
+    const decideDelete = async () => {
+      let details = timelineReviewDetailsById[reviewId] ?? null;
+      try {
+        if (!details) {
+          const review = await commands.getReview(reviewId);
+          if (review) {
+            details = getTimelineReviewDetails(review);
+            timelineReviewDetailsById = { ...timelineReviewDetailsById, [reviewId]: details };
+          }
+        }
+      } catch (e) {
+        console.error('Failed to check review before delete:', e);
+        showConfirmDelete();
+        return;
+      }
+
+      const shouldWarn = shouldWarnBeforeDeletingReview({
+        review: details,
+        commits: timeline?.commits ?? [],
+        userCommentCount: details?.userComments,
+      });
+      if (shouldWarn) {
+        showConfirmDelete();
+      } else {
+        doDelete();
+      }
+    };
     if (opts?.altKey) {
       doDelete();
       return;
     }
-    confirmDelete = {
-      title: 'Delete Review',
-      message:
-        'Are you sure you want to delete this review and all its comments?' +
-        (sessionId ? ' The linked session will also be deleted.' : ''),
-      onConfirm: doDelete,
-    };
+    void decideDelete();
   }
 
   async function handleDeletePendingCommit(commitId: string, sessionId?: string) {

--- a/apps/staged/src/lib/features/timeline/reviewState.test.ts
+++ b/apps/staged/src/lib/features/timeline/reviewState.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { isEmptyFailedReview } from './reviewState';
+import {
+  countUserComments,
+  hasCommitAfterReview,
+  isEmptyFailedReview,
+  shouldWarnBeforeDeletingReview,
+} from './reviewState';
 
 describe('isEmptyFailedReview', () => {
   it('treats a titled review with no comments as successful', () => {
@@ -23,5 +28,85 @@ describe('isEmptyFailedReview', () => {
         totalCount: 0,
       })
     ).toBe(true);
+  });
+});
+
+describe('hasCommitAfterReview', () => {
+  const commits = [
+    { sha: 'first', order: 0 },
+    { sha: 'review-anchor', order: 1 },
+    { sha: 'newer', order: 2 },
+  ];
+
+  it('detects commits after the review anchor', () => {
+    expect(hasCommitAfterReview('review-anchor', commits)).toBe(true);
+  });
+
+  it('does not detect newer commits when the review anchor is missing', () => {
+    expect(hasCommitAfterReview('missing', commits)).toBe(false);
+  });
+});
+
+describe('shouldWarnBeforeDeletingReview', () => {
+  const commits = [
+    { sha: 'review-anchor', order: 0 },
+    { sha: 'newer', order: 1 },
+  ];
+
+  it('skips warning when there is a newer commit and no user comments', () => {
+    expect(
+      shouldWarnBeforeDeletingReview({
+        review: { commitSha: 'review-anchor' },
+        commits,
+        userCommentCount: 0,
+      })
+    ).toBe(false);
+  });
+
+  it('warns when there is no newer commit', () => {
+    expect(
+      shouldWarnBeforeDeletingReview({
+        review: { commitSha: 'newer' },
+        commits,
+        userCommentCount: 0,
+      })
+    ).toBe(true);
+  });
+
+  it('warns when the review has user comments', () => {
+    expect(
+      shouldWarnBeforeDeletingReview({
+        review: { commitSha: 'review-anchor' },
+        commits,
+        userCommentCount: 1,
+      })
+    ).toBe(true);
+  });
+
+  it('warns when the review anchor commit is missing', () => {
+    expect(
+      shouldWarnBeforeDeletingReview({
+        review: { commitSha: 'missing' },
+        commits,
+        userCommentCount: 0,
+      })
+    ).toBe(true);
+  });
+
+  it('treats agent comments and information annotations as non-user comments', () => {
+    const userCommentCount = countUserComments([
+      { author: 'agent', commentType: 'issue' },
+      { author: 'agent', commentType: 'warning' },
+      { author: 'agent', commentType: 'information' },
+    ]);
+
+    expect(userCommentCount).toBe(0);
+    expect(
+      shouldWarnBeforeDeletingReview({
+        review: { commitSha: 'review-anchor' },
+        commits,
+        userCommentCount,
+      })
+    ).toBe(false);
   });
 });

--- a/apps/staged/src/lib/features/timeline/reviewState.ts
+++ b/apps/staged/src/lib/features/timeline/reviewState.ts
@@ -1,3 +1,7 @@
+import type { Comment, CommitTimelineItem, Review } from '../../types';
+
+type ReviewCommit = Pick<CommitTimelineItem, 'order' | 'sha'>;
+
 export function isEmptyFailedReview(params: {
   sessionStatus: string | null;
   sessionId: string | null;
@@ -9,4 +13,33 @@ export function isEmptyFailedReview(params: {
   const isQueued = sessionStatus === 'queued';
   const hasTitle = !!title?.trim();
   return !isRunning && !isQueued && !!sessionId && totalCount === 0 && !hasTitle;
+}
+
+export function hasCommitAfterReview(
+  reviewCommitSha: string,
+  commits: readonly ReviewCommit[]
+): boolean {
+  const reviewCommit = commits.find((commit) => commit.sha === reviewCommitSha);
+  if (!reviewCommit) return false;
+
+  return commits.some((commit) => !!commit.sha && commit.order > reviewCommit.order);
+}
+
+export function countUserComments(
+  comments: readonly Pick<Comment, 'author' | 'commentType'>[]
+): number {
+  return comments.filter((comment) => comment.author === 'user').length;
+}
+
+export function shouldWarnBeforeDeletingReview(params: {
+  review: Pick<Review, 'commitSha'> | null | undefined;
+  commits: readonly ReviewCommit[];
+  userCommentCount: number | null | undefined;
+}): boolean {
+  const { review, commits, userCommentCount } = params;
+
+  if (!review?.commitSha) return true;
+  if (userCommentCount !== 0) return true;
+
+  return !hasCommitAfterReview(review.commitSha, commits);
 }

--- a/apps/staged/src/lib/features/timeline/reviewState.ts
+++ b/apps/staged/src/lib/features/timeline/reviewState.ts
@@ -22,7 +22,7 @@ export function hasCommitAfterReview(
   const reviewCommit = commits.find((commit) => commit.sha === reviewCommitSha);
   if (!reviewCommit) return false;
 
-  return commits.some((commit) => !!commit.sha && commit.order > reviewCommit.order);
+  return commits.some((commit) => commit.order > reviewCommit.order);
 }
 
 export function countUserComments(


### PR DESCRIPTION
🤖 Summary
- Skip the delete confirmation for reviews with no user comments when newer commits exist.
- Preserve warnings for reviews with user comments, missing anchor commits, or no newer commits.
- Add tests for the review deletion warning decision.