### PR TITLE
feat(ui): add Open In dropdown for diff files

### DIFF
--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -4,42 +4,60 @@ use crate::blox;
 use serde::Serialize;
 use std::path::Path;
 
-/// An application that can open directories.
+/// An application that can open directories or files.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenerApp {
     id: String,
     name: String,
+    kind: OpenerKind,
 }
 
-/// Known applications with their bundle IDs (macOS).
+/// The kind of opener application.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OpenerKind {
+    Editor,
+    Terminal,
+    FileBrowser,
+}
+
+/// Known applications with their bundle IDs and kinds (macOS).
 #[cfg(target_os = "macos")]
-const KNOWN_OPENERS: &[(&str, &str)] = &[
+const KNOWN_OPENERS: &[(&str, &str, OpenerKind)] = &[
     // Terminals
-    ("terminal", "com.apple.Terminal"),
-    ("warp", "dev.warp.Warp-Stable"),
-    ("iterm", "com.googlecode.iterm2"),
-    ("hyper", "co.zeit.hyper"),
-    ("kitty", "net.kovidgoyal.kitty"),
-    ("alacritty", "org.alacritty"),
+    ("terminal", "com.apple.Terminal", OpenerKind::Terminal),
+    ("warp", "dev.warp.Warp-Stable", OpenerKind::Terminal),
+    ("iterm", "com.googlecode.iterm2", OpenerKind::Terminal),
+    ("hyper", "co.zeit.hyper", OpenerKind::Terminal),
+    ("kitty", "net.kovidgoyal.kitty", OpenerKind::Terminal),
+    ("alacritty", "org.alacritty", OpenerKind::Terminal),
     // Editors
-    ("vscode", "com.microsoft.VSCode"),
-    ("vscode-insiders", "com.microsoft.VSCodeInsiders"),
-    ("cursor", "com.todesktop.230313mzl4w4u92"),
-    ("sublime", "com.sublimetext.4"),
-    ("atom", "com.github.atom"),
-    ("textmate", "com.macromates.TextMate"),
-    ("nova", "com.panic.Nova"),
-    ("bbedit", "com.barebones.bbedit"),
-    ("intellij", "com.jetbrains.intellij"),
-    ("webstorm", "com.jetbrains.WebStorm"),
-    ("pycharm", "com.jetbrains.pycharm"),
-    ("rubymine", "com.jetbrains.rubymine"),
-    ("goland", "com.jetbrains.goland"),
-    ("fleet", "fleet.app"),
-    ("zed", "dev.zed.Zed"),
+    ("vscode", "com.microsoft.VSCode", OpenerKind::Editor),
+    (
+        "vscode-insiders",
+        "com.microsoft.VSCodeInsiders",
+        OpenerKind::Editor,
+    ),
+    (
+        "cursor",
+        "com.todesktop.230313mzl4w4u92",
+        OpenerKind::Editor,
+    ),
+    ("sublime", "com.sublimetext.4", OpenerKind::Editor),
+    ("atom", "com.github.atom", OpenerKind::Editor),
+    ("textmate", "com.macromates.TextMate", OpenerKind::Editor),
+    ("nova", "com.panic.Nova", OpenerKind::Editor),
+    ("bbedit", "com.barebones.bbedit", OpenerKind::Editor),
+    ("intellij", "com.jetbrains.intellij", OpenerKind::Editor),
+    ("webstorm", "com.jetbrains.WebStorm", OpenerKind::Editor),
+    ("pycharm", "com.jetbrains.pycharm", OpenerKind::Editor),
+    ("rubymine", "com.jetbrains.rubymine", OpenerKind::Editor),
+    ("goland", "com.jetbrains.goland", OpenerKind::Editor),
+    ("fleet", "fleet.app", OpenerKind::Editor),
+    ("zed", "dev.zed.Zed", OpenerKind::Editor),
     // File browsers
-    ("finder", "com.apple.finder"),
+    ("finder", "com.apple.finder", OpenerKind::FileBrowser),
 ];
 
 /// Open a URL in the user's default browser.
@@ -115,7 +133,7 @@ pub async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
 
         let mut available = Vec::new();
 
-        for (id, bundle_id) in KNOWN_OPENERS {
+        for (id, bundle_id, kind) in KNOWN_OPENERS {
             let output = Command::new("mdfind")
                 .arg(format!("kMDItemCFBundleIdentifier == '{bundle_id}'"))
                 .output()
@@ -127,6 +145,7 @@ pub async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
                     available.push(OpenerApp {
                         id: id.to_string(),
                         name: prettify_app_name(id),
+                        kind: kind.clone(),
                     });
                 }
             }
@@ -187,8 +206,8 @@ pub async fn open_in_app(path: String, app_id: String) -> Result<(), String> {
         // Find the bundle ID for this app
         let bundle_id = KNOWN_OPENERS
             .iter()
-            .find(|(id, _)| *id == app_id)
-            .map(|(_, bundle)| *bundle)
+            .find(|(id, _, _)| *id == app_id)
+            .map(|(_, bundle, _)| *bundle)
             .ok_or_else(|| format!("Unknown app ID: {app_id}"))?;
 
         let status = Command::new("open")

--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -192,13 +192,24 @@ fn prettify_app_name(id: &str) -> String {
     .to_string()
 }
 
-/// Open a directory in a specific application.
+/// Editors that support `--args <project> <file>` for project-aware opening.
+#[cfg(target_os = "macos")]
+const PROJECT_AWARE_OPENERS: &[&str] = &["vscode", "vscode-insiders", "cursor", "zed"];
+
+/// Open a file or directory in a specific application.
 ///
 /// On macOS, uses the `open -b` command with the app's bundle ID.
+/// When `project_path` is provided and the app supports it, passes
+/// `--args <project_path> <file_path>` so the editor opens with
+/// the project as the workspace context.
 /// On other platforms, returns an error.
-#[tauri::command]
+#[tauri::command(rename_all = "camelCase")]
 #[allow(unused_variables)]
-pub async fn open_in_app(path: String, app_id: String) -> Result<(), String> {
+pub async fn open_in_app(
+    path: String,
+    app_id: String,
+    project_path: Option<String>,
+) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         use std::process::Command;
@@ -210,12 +221,30 @@ pub async fn open_in_app(path: String, app_id: String) -> Result<(), String> {
             .map(|(_, bundle, _)| *bundle)
             .ok_or_else(|| format!("Unknown app ID: {app_id}"))?;
 
-        let status = Command::new("open")
-            .arg("-b")
-            .arg(bundle_id)
-            .arg(&path)
-            .status()
-            .map_err(|e| format!("Failed to run open command: {e}"))?;
+        let status = if let Some(ref project) = project_path {
+            if PROJECT_AWARE_OPENERS.contains(&app_id.as_str()) {
+                Command::new("open")
+                    .arg("-b")
+                    .arg(bundle_id)
+                    .arg("--args")
+                    .arg(project)
+                    .arg(&path)
+                    .status()
+            } else {
+                Command::new("open")
+                    .arg("-b")
+                    .arg(bundle_id)
+                    .arg(&path)
+                    .status()
+            }
+        } else {
+            Command::new("open")
+                .arg("-b")
+                .arg(bundle_id)
+                .arg(&path)
+                .status()
+        }
+        .map_err(|e| format!("Failed to run open command: {e}"))?;
 
         if status.success() {
             Ok(())

--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -192,16 +192,22 @@ fn prettify_app_name(id: &str) -> String {
     .to_string()
 }
 
-/// Editors that support `--args <project> <file>` for project-aware opening.
+/// Mapping from app ID to CLI command name for editors that have dedicated
+/// CLI tools. These CLIs handle window reuse, IPC, and workspace resolution
+/// properly — unlike `open -b` which just launches the Electron binary.
 #[cfg(target_os = "macos")]
-const PROJECT_AWARE_OPENERS: &[&str] = &["vscode", "vscode-insiders", "cursor", "zed"];
+const CLI_OPENERS: &[(&str, &str)] = &[
+    ("vscode", "code"),
+    ("vscode-insiders", "code-insiders"),
+    ("cursor", "cursor"),
+    ("zed", "zed"),
+];
 
 /// Open a file or directory in a specific application.
 ///
-/// On macOS, uses the `open -b` command with the app's bundle ID.
-/// When `project_path` is provided and the app supports it, passes
-/// `--args <project_path> <file_path>` so the editor opens with
-/// the project as the workspace context.
+/// For editors with dedicated CLI tools (VS Code, Cursor, Zed), uses the CLI
+/// to open with proper project context. Falls back to `open -b <bundle_id>`
+/// when the CLI is not available or for other apps.
 /// On other platforms, returns an error.
 #[tauri::command(rename_all = "camelCase")]
 #[allow(unused_variables)]
@@ -221,30 +227,44 @@ pub async fn open_in_app(
             .map(|(_, bundle, _)| *bundle)
             .ok_or_else(|| format!("Unknown app ID: {app_id}"))?;
 
-        let status = if let Some(ref project) = project_path {
-            if PROJECT_AWARE_OPENERS.contains(&app_id.as_str()) {
-                Command::new("open")
-                    .arg("-b")
-                    .arg(bundle_id)
-                    .arg("--args")
-                    .arg(project)
-                    .arg(&path)
+        // Try CLI tool first for supported editors
+        if let Some(cli_cmd) = CLI_OPENERS
+            .iter()
+            .find(|(id, _)| *id == app_id)
+            .map(|(_, cmd)| *cmd)
+        {
+            // Check if the CLI is available
+            let has_cli = Command::new("which")
+                .arg(cli_cmd)
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+
+            if has_cli {
+                let mut cmd = Command::new(cli_cmd);
+                if let Some(ref project) = project_path {
+                    cmd.arg(project);
+                }
+                cmd.arg(&path);
+
+                let status = cmd
                     .status()
-            } else {
-                Command::new("open")
-                    .arg("-b")
-                    .arg(bundle_id)
-                    .arg(&path)
-                    .status()
+                    .map_err(|e| format!("Failed to run {cli_cmd}: {e}"))?;
+
+                if status.success() {
+                    return Ok(());
+                }
+                // CLI failed — fall through to open -b
             }
-        } else {
-            Command::new("open")
-                .arg("-b")
-                .arg(bundle_id)
-                .arg(&path)
-                .status()
         }
-        .map_err(|e| format!("Failed to run open command: {e}"))?;
+
+        // Fallback: open via bundle ID (no --args)
+        let status = Command::new("open")
+            .arg("-b")
+            .arg(bundle_id)
+            .arg(&path)
+            .status()
+            .map_err(|e| format!("Failed to run open command: {e}"))?;
 
         if status.success() {
             Ok(())

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1189,6 +1189,7 @@
     commits={timeline?.commits}
     baseBranchLabel={formatBaseBranch(branch.baseBranch)}
     branchLabel={branch.branchName}
+    worktreePath={branch.worktreePath}
     {projectName}
     githubRepo={repoLabel?.headRepo ?? repoLabel?.githubRepo}
     subpath={repoLabel?.subpath}
@@ -1211,6 +1212,7 @@
     commits={timeline?.commits}
     baseBranchLabel={formatBaseBranch(branch.baseBranch)}
     branchLabel={branch.branchName}
+    worktreePath={branch.worktreePath}
     {projectName}
     githubRepo={repoLabel?.headRepo ?? repoLabel?.githubRepo}
     subpath={repoLabel?.subpath}

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -429,7 +429,7 @@
     showMoreMenu = false;
     showOpenInSubmenu = false;
     if (branch.worktreePath) {
-      await openInApp(branch.worktreePath, appId);
+      await openInApp(branch.worktreePath, appId, branch.worktreePath);
     }
   }
 

--- a/apps/staged/src/lib/features/branches/branch.ts
+++ b/apps/staged/src/lib/features/branches/branch.ts
@@ -25,10 +25,13 @@ export async function getAvailableOpeners(): Promise<OpenerApp[]> {
 }
 
 /**
- * Open a directory in a specific application.
+ * Open a file or directory in a specific application.
+ *
+ * When `projectPath` is provided, editors that support it (VS Code, Cursor,
+ * Zed) will open the file within the project workspace context.
  */
-export async function openInApp(path: string, appId: string): Promise<void> {
-  return invoke<void>('open_in_app', { path, appId });
+export async function openInApp(path: string, appId: string, projectPath?: string): Promise<void> {
+  return invoke<void>('open_in_app', { path, appId, projectPath: projectPath ?? null });
 }
 
 /**

--- a/apps/staged/src/lib/features/branches/branch.ts
+++ b/apps/staged/src/lib/features/branches/branch.ts
@@ -1,10 +1,14 @@
 import { invoke } from '@tauri-apps/api/core';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 
-/** An application that can open a directory */
+/** The kind of opener application. */
+export type OpenerKind = 'editor' | 'terminal' | 'file-browser';
+
+/** An application that can open a directory or file. */
 export interface OpenerApp {
   id: string;
   name: string;
+  kind: OpenerKind;
 }
 
 // Cache for performance

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -24,6 +24,7 @@
   import DiffCommitSessionLauncher from './DiffCommitSessionLauncher.svelte';
   import DiffReferenceSection from './DiffReferenceSection.svelte';
   import ConfirmDialog from '../../shared/ConfirmDialog.svelte';
+  import OpenInDropdown from './OpenInDropdown.svelte';
   import { createDiffViewerState } from './diffViewerState.svelte';
   import { createReviewState } from './reviewState.svelte';
   import { createSearchState } from '@builderbot/diff-viewer/state';
@@ -71,6 +72,8 @@
     baseBranchLabel?: string;
     /** Branch name for label display when switching to branch scope. */
     branchLabel?: string;
+    /** Worktree path for "Open In" file actions. */
+    worktreePath?: string | null;
     /** Project name to display in title bar. */
     projectName?: string;
     /** GitHub repo (e.g., "owner/repo") to display in title bar. */
@@ -92,6 +95,7 @@
     commits,
     baseBranchLabel,
     branchLabel,
+    worktreePath = null,
     projectName,
     githubRepo,
     subpath,
@@ -769,6 +773,11 @@
     <div class="modal-body">
       <!-- Diff viewer -->
       <div class="diff-viewer-container">
+        {#snippet openInSnippet(afterPath: string | null)}
+          {#if worktreePath && afterPath}
+            <OpenInDropdown filePath="{worktreePath}/{afterPath}" />
+          {/if}
+        {/snippet}
         <DiffViewer
           diff={currentDiff}
           comments={readonly ? [] : currentComments}
@@ -780,6 +789,7 @@
           annotations={revealedAnnotations}
           {annotationsRevealed}
           searchState={searchState.state}
+          afterHeaderExtra={worktreePath ? openInSnippet : undefined}
           onAddComment={readonly ? undefined : handleAddComment}
           onUpdateComment={readonly ? undefined : handleUpdateComment}
           onDeleteComment={readonly ? undefined : handleDeleteCommentFromViewer}

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -775,7 +775,7 @@
       <div class="diff-viewer-container">
         {#snippet openInSnippet(afterPath: string | null)}
           {#if worktreePath && afterPath}
-            <OpenInDropdown filePath="{worktreePath}/{afterPath}" />
+            <OpenInDropdown filePath="{worktreePath}/{afterPath}" projectPath={worktreePath} />
           {/if}
         {/snippet}
         <DiffViewer

--- a/apps/staged/src/lib/features/diff/OpenInDropdown.svelte
+++ b/apps/staged/src/lib/features/diff/OpenInDropdown.svelte
@@ -15,9 +15,11 @@
   interface Props {
     /** Full absolute path to the file to open. */
     filePath: string | null;
+    /** Optional project/worktree path for project-aware editor opening. */
+    projectPath?: string | null;
   }
 
-  let { filePath }: Props = $props();
+  let { filePath, projectPath }: Props = $props();
 
   let fileOpenerApps = $state<OpenerApp[]>([]);
   let showDropdown = $state(false);
@@ -42,7 +44,7 @@
 
   function handleOpenIn(appId: string) {
     if (filePath) {
-      openInApp(filePath, appId);
+      openInApp(filePath, appId, projectPath ?? undefined);
     }
     showDropdown = false;
   }

--- a/apps/staged/src/lib/features/diff/OpenInDropdown.svelte
+++ b/apps/staged/src/lib/features/diff/OpenInDropdown.svelte
@@ -1,0 +1,169 @@
+<!--
+  OpenInDropdown.svelte — "Open In" dropdown for diff pane headers.
+  Shows available editors that can open the current file.
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { ExternalLink, ChevronDown, Copy } from 'lucide-svelte';
+  import {
+    getAvailableOpeners,
+    openInApp,
+    copyPathToClipboard,
+    type OpenerApp,
+  } from '../branches/branch';
+
+  interface Props {
+    /** Full absolute path to the file to open. */
+    filePath: string | null;
+  }
+
+  let { filePath }: Props = $props();
+
+  /** Apps that can open files (editors only, not terminals/finder). */
+  const DIRECTORY_ONLY_IDS = new Set([
+    'terminal',
+    'warp',
+    'iterm',
+    'hyper',
+    'kitty',
+    'alacritty',
+    'finder',
+  ]);
+
+  let fileOpenerApps = $state<OpenerApp[]>([]);
+  let showDropdown = $state(false);
+
+  onMount(() => {
+    getAvailableOpeners().then((apps) => {
+      fileOpenerApps = apps.filter((app) => !DIRECTORY_ONLY_IDS.has(app.id));
+    });
+  });
+
+  function handleOpenIn(appId: string) {
+    if (filePath) {
+      openInApp(filePath, appId);
+    }
+    showDropdown = false;
+  }
+
+  function handleCopyPath() {
+    if (filePath) {
+      copyPathToClipboard(filePath);
+    }
+    showDropdown = false;
+  }
+
+  function handleToggle(e: MouseEvent) {
+    e.stopPropagation();
+    showDropdown = !showDropdown;
+  }
+
+  function handleClickOutside(e: MouseEvent) {
+    if (showDropdown) {
+      showDropdown = false;
+    }
+  }
+</script>
+
+<svelte:window onclick={handleClickOutside} />
+
+{#if filePath && fileOpenerApps.length > 0}
+  <div class="open-in-dropdown">
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <button class="open-in-trigger" onclick={handleToggle} title="Open in...">
+      <ExternalLink size={12} />
+      <span>Open In</span>
+      <ChevronDown size={10} />
+    </button>
+
+    {#if showDropdown}
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="open-in-menu" onclick={(e) => e.stopPropagation()}>
+        {#each fileOpenerApps as app (app.id)}
+          <button class="open-in-item" onclick={() => handleOpenIn(app.id)}>
+            {app.name}
+          </button>
+        {/each}
+        <div class="menu-separator"></div>
+        <button class="open-in-item" onclick={handleCopyPath}>
+          <Copy size={12} />
+          Copy Path
+        </button>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .open-in-dropdown {
+    position: relative;
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+
+  .open-in-trigger {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    background: none;
+    border: 1px solid var(--border-default);
+    border-radius: 4px;
+    color: var(--text-muted);
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: var(--size-xs);
+    cursor: pointer;
+    transition:
+      color 0.1s,
+      background-color 0.1s,
+      border-color 0.1s;
+    white-space: nowrap;
+  }
+
+  .open-in-trigger:hover {
+    color: var(--text-primary);
+    background-color: var(--bg-hover);
+    border-color: var(--border-hover);
+  }
+
+  .open-in-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    min-width: 160px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-default);
+    border-radius: 8px;
+    padding: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+  }
+
+  .open-in-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 6px 8px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-primary);
+    font-size: var(--size-sm);
+    cursor: pointer;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  .open-in-item:hover {
+    background-color: var(--bg-hover);
+  }
+
+  .menu-separator {
+    height: 1px;
+    background: var(--border-default);
+    margin: 4px 0;
+  }
+</style>

--- a/apps/staged/src/lib/features/diff/OpenInDropdown.svelte
+++ b/apps/staged/src/lib/features/diff/OpenInDropdown.svelte
@@ -19,25 +19,26 @@
 
   let { filePath }: Props = $props();
 
-  /** Apps that can open files (editors only, not terminals/finder). */
-  const DIRECTORY_ONLY_IDS = new Set([
-    'terminal',
-    'warp',
-    'iterm',
-    'hyper',
-    'kitty',
-    'alacritty',
-    'finder',
-  ]);
-
   let fileOpenerApps = $state<OpenerApp[]>([]);
   let showDropdown = $state(false);
+  let triggerEl: HTMLButtonElement | undefined = $state();
+  let menuStyle = $state('');
 
   onMount(() => {
-    getAvailableOpeners().then((apps) => {
-      fileOpenerApps = apps.filter((app) => !DIRECTORY_ONLY_IDS.has(app.id));
-    });
+    getAvailableOpeners()
+      .then((apps) => {
+        fileOpenerApps = apps.filter((app) => app.kind === 'editor');
+      })
+      .catch((err) => {
+        console.warn('Failed to fetch available openers:', err);
+      });
   });
+
+  function positionMenu() {
+    if (!triggerEl) return;
+    const rect = triggerEl.getBoundingClientRect();
+    menuStyle = `position: fixed; top: ${rect.bottom + 4}px; left: ${rect.right}px; transform: translateX(-100%);`;
+  }
 
   function handleOpenIn(appId: string) {
     if (filePath) {
@@ -56,6 +57,9 @@
   function handleToggle(e: MouseEvent) {
     e.stopPropagation();
     showDropdown = !showDropdown;
+    if (showDropdown) {
+      positionMenu();
+    }
   }
 
   function handleClickOutside(e: MouseEvent) {
@@ -71,7 +75,7 @@
   <div class="open-in-dropdown">
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <button class="open-in-trigger" onclick={handleToggle} title="Open in...">
+    <button class="open-in-trigger" bind:this={triggerEl} onclick={handleToggle} title="Open in...">
       <ExternalLink size={12} />
       <span>Open In</span>
       <ChevronDown size={10} />
@@ -80,7 +84,7 @@
     {#if showDropdown}
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div class="open-in-menu" onclick={(e) => e.stopPropagation()}>
+      <div class="open-in-menu" style={menuStyle} onclick={(e) => e.stopPropagation()}>
         {#each fileOpenerApps as app (app.id)}
           <button class="open-in-item" onclick={() => handleOpenIn(app.id)}>
             {app.name}
@@ -129,9 +133,6 @@
   }
 
   .open-in-menu {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
     min-width: 160px;
     background: var(--bg-primary);
     border: 1px solid var(--border-default);

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -15,7 +15,7 @@
   rather than pulling from global stores.
 -->
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, type Snippet } from 'svelte';
   import { MessageSquarePlus, MessageSquare, X, FileText, Code } from 'lucide-svelte';
   import { marked } from 'marked';
   import { sanitize } from '../utils/sanitize';
@@ -105,6 +105,9 @@
     /** Search state for highlighting matches in the diff content. */
     searchState?: SearchState;
 
+    /** Optional snippet rendered in the after-pane header (e.g. "Open In" dropdown). Receives the after path. */
+    afterHeaderExtra?: Snippet<[string | null]>;
+
     // -- Comment callbacks (all optional; without them commenting is disabled) --
     onAddComment?: (path: string, span: Span, content: string) => Promise<void>;
     onUpdateComment?: (commentId: string, content: string) => Promise<void>;
@@ -124,6 +127,7 @@
     annotations = [],
     annotationsRevealed = false,
     searchState,
+    afterHeaderExtra,
     onAddComment,
     onUpdateComment,
     onDeleteComment,
@@ -2027,6 +2031,9 @@
                 {#if markdownPreview}<Code size={14} />{:else}<FileText size={14} />{/if}
               </button>
             {/if}
+            {#if afterHeaderExtra}
+              {@render afterHeaderExtra(afterPath)}
+            {/if}
           </div>
           <div
             class="code-area"
@@ -2133,6 +2140,9 @@
           <div class="pane-header">
             <span class="pane-label">{afterLabel}</span>
             <span class="pane-path" title={afterPath}>{afterPath ?? 'No file'}</span>
+            {#if afterHeaderExtra}
+              {@render afterHeaderExtra(afterPath)}
+            {/if}
           </div>
           <div class="code-area" onwheel={handleAfterWheel}>
             <div class="code-container" bind:this={afterPane}>


### PR DESCRIPTION
🤖 Summary:
- Add an editor-only Open In dropdown to diff file headers.
- Open files with project context for VS Code, Cursor, and Zed via their CLI tools.
- Preserve existing branch Open In behavior by passing the worktree as project context.