### PR TITLE
feat(staged): surface chat updates after linked notes

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -1911,6 +1911,7 @@ pub fn run() {
             session_commands::get_session,
             session_commands::get_session_messages,
             session_commands::get_session_messages_since,
+            session_commands::count_assistant_messages_after,
             session_commands::start_session,
             session_commands::resume_session,
             session_commands::cancel_session,

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -119,6 +119,17 @@ pub fn get_session_messages_since(
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub fn count_assistant_messages_after(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    session_id: String,
+    after_timestamp: i64,
+) -> Result<i64, String> {
+    get_store(&store)?
+        .count_assistant_messages_after(&session_id, after_timestamp)
+        .map_err(|e| e.to_string())
+}
+
 // =============================================================================
 // Lifecycle commands
 // =============================================================================

--- a/apps/staged/src-tauri/src/store/messages.rs
+++ b/apps/staged/src-tauri/src/store/messages.rs
@@ -87,6 +87,22 @@ impl Store {
         Ok(())
     }
 
+    /// Count assistant messages created after a given timestamp.
+    pub fn count_assistant_messages_after(
+        &self,
+        session_id: &str,
+        after_timestamp: i64,
+    ) -> Result<i64, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM session_messages
+             WHERE session_id = ?1 AND role = 'assistant' AND created_at > ?2",
+            params![session_id, after_timestamp],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
     /// Get messages with id >= since_id (inclusive — re-fetches the last known
     /// message so the caller picks up streaming content updates).
     pub fn get_session_messages_since(

--- a/apps/staged/src-tauri/src/store/notes.rs
+++ b/apps/staged/src-tauri/src/store/notes.rs
@@ -86,6 +86,27 @@ impl Store {
         suggested_next_note_step: Option<&str>,
     ) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        // The session runner re-runs note extraction at the end of every turn for sessions
+        // with a linked note, even if the assistant didn't rewrite the note. Without this
+        // short-circuit, `updated_at` would advance on every turn, defeating any freshness
+        // comparison that relies on it.
+        let existing: Option<(String, String, Option<String>, Option<String>)> = conn
+            .query_row(
+                "SELECT title, content, suggested_next_commit_step, suggested_next_note_step
+                 FROM notes WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
+        if let Some((cur_title, cur_content, cur_sncs, cur_snns)) = existing {
+            if cur_title == title
+                && cur_content == content
+                && cur_sncs.as_deref() == suggested_next_commit_step
+                && cur_snns.as_deref() == suggested_next_note_step
+            {
+                return Ok(());
+            }
+        }
         let now = now_timestamp();
         conn.execute(
             "UPDATE notes SET title = ?1, content = ?2, updated_at = ?3, completed_at = COALESCE(completed_at, ?4), suggested_next_commit_step = ?5, suggested_next_note_step = ?6 WHERE id = ?7",

--- a/apps/staged/src-tauri/src/store/project_notes.rs
+++ b/apps/staged/src-tauri/src/store/project_notes.rs
@@ -92,6 +92,27 @@ impl Store {
         suggested_next_note_step: Option<&str>,
     ) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        // The session runner re-runs note extraction at the end of every turn for sessions
+        // with a linked note, even if the assistant didn't rewrite the note. Without this
+        // short-circuit, `updated_at` would advance on every turn, defeating any freshness
+        // comparison that relies on it.
+        let existing: Option<(String, String, Option<String>, Option<String>)> = conn
+            .query_row(
+                "SELECT title, content, suggested_next_commit_step, suggested_next_note_step
+                 FROM project_notes WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
+        if let Some((cur_title, cur_content, cur_sncs, cur_snns)) = existing {
+            if cur_title == title
+                && cur_content == content
+                && cur_sncs.as_deref() == suggested_next_commit_step
+                && cur_snns.as_deref() == suggested_next_note_step
+            {
+                return Ok(());
+            }
+        }
         let now = now_timestamp();
         conn.execute(
             "UPDATE project_notes

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -104,6 +104,57 @@ fn test_project_note_completion_is_write_once() {
 }
 
 #[test]
+fn test_update_project_note_title_and_content_is_noop_when_unchanged() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+
+    let note = ProjectNote::new(&project.id, "", "");
+    store.create_project_note(&note).unwrap();
+
+    store
+        .update_project_note_title_and_content(
+            &note.id,
+            "Title",
+            "Body",
+            Some("commit-step"),
+            Some("note-step"),
+        )
+        .unwrap();
+    let after_first = store.get_project_note(&note.id).unwrap().unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+
+    // Same title/content/steps — must not bump updated_at.
+    store
+        .update_project_note_title_and_content(
+            &note.id,
+            "Title",
+            "Body",
+            Some("commit-step"),
+            Some("note-step"),
+        )
+        .unwrap();
+    let after_second = store.get_project_note(&note.id).unwrap().unwrap();
+    assert_eq!(after_second.updated_at, after_first.updated_at);
+    assert_eq!(after_second.completed_at, after_first.completed_at);
+
+    // A real change still advances updated_at.
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    store
+        .update_project_note_title_and_content(
+            &note.id,
+            "Title",
+            "New body",
+            Some("commit-step"),
+            Some("note-step"),
+        )
+        .unwrap();
+    let after_third = store.get_project_note(&note.id).unwrap().unwrap();
+    assert!(after_third.updated_at > after_first.updated_at);
+}
+
+#[test]
 fn test_list_project_notes_orders_by_completion_time() {
     let store = Store::in_memory().unwrap();
     let project = Project::new("test-owner/test-repo");
@@ -1155,6 +1206,59 @@ fn test_list_notes_for_branch_orders_by_completion_time() {
     let notes = store.list_notes_for_branch(&branch.id).unwrap();
     let ordered_ids: Vec<_> = notes.iter().map(|note| note.id.as_str()).collect();
     assert_eq!(ordered_ids, vec![older.id.as_str(), newer.id.as_str()]);
+}
+
+#[test]
+fn test_update_note_title_and_content_is_noop_when_unchanged() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let branch = Branch::new(&project.id, "feature", "main");
+    store.create_branch(&branch).unwrap();
+
+    let note = Note::new(&branch.id, "", "").with_session("session-1");
+    store.create_note(&note).unwrap();
+
+    store
+        .update_note_title_and_content(
+            &note.id,
+            "Title",
+            "Body",
+            Some("commit-step"),
+            Some("note-step"),
+        )
+        .unwrap();
+    let after_first = store.get_note(&note.id).unwrap().unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+
+    // Same title/content/steps — must not bump updated_at.
+    store
+        .update_note_title_and_content(
+            &note.id,
+            "Title",
+            "Body",
+            Some("commit-step"),
+            Some("note-step"),
+        )
+        .unwrap();
+    let after_second = store.get_note(&note.id).unwrap().unwrap();
+    assert_eq!(after_second.updated_at, after_first.updated_at);
+    assert_eq!(after_second.completed_at, after_first.completed_at);
+
+    // A real change still advances updated_at.
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    store
+        .update_note_title_and_content(
+            &note.id,
+            "Title",
+            "New body",
+            Some("commit-step"),
+            Some("note-step"),
+        )
+        .unwrap();
+    let after_third = store.get_note(&note.id).unwrap().unwrap();
+    assert!(after_third.updated_at > after_first.updated_at);
 }
 
 // =============================================================================

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -623,6 +623,41 @@ fn test_session_messages() {
     assert_eq!(since[1].id, id2);
 }
 
+#[test]
+fn test_count_assistant_messages_after() {
+    let store = Store::in_memory().unwrap();
+
+    let session = Session::new_running("test", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+
+    // Add messages with different roles — timestamps are auto-set via now_timestamp()
+    // so we use a timestamp of 0 to count all assistant messages.
+    store
+        .add_session_message(&session.id, MessageRole::User, "hello")
+        .unwrap();
+    store
+        .add_session_message(&session.id, MessageRole::Assistant, "hi there")
+        .unwrap();
+    store
+        .add_session_message(&session.id, MessageRole::User, "more")
+        .unwrap();
+    store
+        .add_session_message(&session.id, MessageRole::Assistant, "reply")
+        .unwrap();
+
+    // All assistant messages are after timestamp 0
+    let count = store
+        .count_assistant_messages_after(&session.id, 0)
+        .unwrap();
+    assert_eq!(count, 2);
+
+    // No assistant messages after a far-future timestamp
+    let count = store
+        .count_assistant_messages_after(&session.id, i64::MAX)
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
 // =============================================================================
 // Workdirs
 // =============================================================================

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -584,6 +584,13 @@ export function getSessionMessagesSince(
   return invokeCommand('get_session_messages_since', { sessionId, sinceId });
 }
 
+export function countAssistantMessagesAfter(
+  sessionId: string,
+  afterTimestamp: number
+): Promise<number> {
+  return invoke('count_assistant_messages_after', { sessionId, afterTimestamp });
+}
+
 /** Create a session and immediately start the agent. */
 export function startSession(
   prompt: string,

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -588,7 +588,7 @@ export function countAssistantMessagesAfter(
   sessionId: string,
   afterTimestamp: number
 ): Promise<number> {
-  return invoke('count_assistant_messages_after', { sessionId, afterTimestamp });
+  return invokeCommand('count_assistant_messages_after', { sessionId, afterTimestamp });
 }
 
 /** Create a session and immediately start the agent. */

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -65,6 +65,7 @@
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import type { WorktreeChangesPreview } from '../../commands';
+  import type { LinkedNoteContext } from '../sessions/noteFreshness';
 
   interface Props {
     branch: Branch;
@@ -452,6 +453,7 @@
     title: string;
     content: string;
     sessionId?: string;
+    noteUpdatedAt?: number;
     nextSteps?: { commitStep: string | null; noteStep: string | null } | null;
   } | null>(null);
 
@@ -847,20 +849,37 @@
   // =========================================================================
 
   /** Look up note info from timeline data by session ID (for cross-modal navigation). */
-  function findNoteForSession(
-    sessionId: string
-  ): { id: string; title: string; content: string } | null {
-    const note = timeline?.notes.find((n) => n.sessionId === sessionId && n.content?.trim());
+  function findNoteForSession(sessionId: string): LinkedNoteContext | null {
+    const note = timeline?.notes.find((n) => n.sessionId === sessionId);
     if (!note) return null;
-    return { id: note.id, title: note.title, content: note.content };
+    return {
+      id: note.id,
+      title: note.title,
+      content: note.content,
+      updatedAt: note.updatedAt,
+      hasParsedNote: !!note.content.trim(),
+    };
   }
 
   function handleCommitClick(sha: string) {
     commitDiffSha = sha;
   }
 
-  function handleNoteClick(noteId: string, title: string, content: string, sessionId?: string) {
-    openNote = { noteId, title, content, sessionId, nextSteps: computeNoteNextSteps(noteId) };
+  function handleNoteClick(
+    noteId: string,
+    title: string,
+    content: string,
+    sessionId: string | undefined,
+    noteUpdatedAt: number
+  ) {
+    openNote = {
+      noteId,
+      title,
+      content,
+      sessionId,
+      noteUpdatedAt,
+      nextSteps: computeNoteNextSteps(noteId),
+    };
   }
 
   async function handleReviewClick(reviewId: string) {
@@ -1571,6 +1590,7 @@
     title={openNote.title}
     content={openNote.content}
     sessionId={openNote.sessionId}
+    noteUpdatedAt={openNote.noteUpdatedAt}
     nextSteps={openNote.nextSteps}
     onClose={() => (openNote = null)}
     onOpenSession={(sid) => {
@@ -1655,15 +1675,16 @@
     projectId={branch.projectId}
     {repoLabel}
     noteInfo={findNoteForSession(sessionMgr.openSessionId)}
-    onOpenNote={(noteId, title, content) => {
+    onOpenNote={(note) => {
       const sid = sessionMgr.openSessionId;
       sessionMgr.openSessionId = null;
       openNote = {
-        noteId,
-        title,
-        content,
+        noteId: note.id,
+        title: note.title,
+        content: note.content,
         sessionId: sid ?? undefined,
-        nextSteps: computeNoteNextSteps(noteId),
+        noteUpdatedAt: note.updatedAt,
+        nextSteps: computeNoteNextSteps(note.id),
       };
     }}
     onClose={async () => {

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -65,7 +65,7 @@
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import type { WorktreeChangesPreview } from '../../commands';
-  import type { LinkedNoteContext } from '../sessions/noteFreshness';
+  import type { LinkedNoteContext, NoteClickInfo } from '../sessions/noteFreshness';
 
   interface Props {
     branch: Branch;
@@ -865,20 +865,14 @@
     commitDiffSha = sha;
   }
 
-  function handleNoteClick(
-    noteId: string,
-    title: string,
-    content: string,
-    sessionId: string | undefined,
-    noteUpdatedAt: number | undefined
-  ) {
+  function handleNoteClick(note: NoteClickInfo) {
     openNote = {
-      noteId,
-      title,
-      content,
-      sessionId,
-      noteUpdatedAt,
-      nextSteps: computeNoteNextSteps(noteId),
+      noteId: note.noteId,
+      title: note.title,
+      content: note.content,
+      sessionId: note.sessionId,
+      noteUpdatedAt: note.updatedAt,
+      nextSteps: computeNoteNextSteps(note.noteId),
     };
   }
 

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -870,7 +870,7 @@
     title: string,
     content: string,
     sessionId: string | undefined,
-    noteUpdatedAt: number
+    noteUpdatedAt: number | undefined
   ) {
     openNote = {
       noteId,

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -10,12 +10,11 @@
   import { marked } from 'marked';
   import { sanitize } from '../../shared/sanitize';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
-  import { getSessionMessages, handleExternalLinkClick } from '../../api/commands';
+  import { countAssistantMessagesAfter, handleExternalLinkClick } from '../../api/commands';
   import InContentSearch from '../../shared/InContentSearch.svelte';
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
   import { registerSearchShortcutTarget } from '../keyboard/searchTargets';
   import { viewport } from '../../shared/viewport.svelte';
-  import { countAssistantMessagesAfterNote } from '../sessions/noteFreshness';
 
   marked.setOptions({ breaks: true, gfm: true });
 
@@ -85,10 +84,10 @@
     }
 
     let stale = false;
-    getSessionMessages(sid)
-      .then((messages) => {
+    countAssistantMessagesAfter(sid, updatedAt)
+      .then((count) => {
         if (!stale) {
-          assistantMessagesAfterNote = countAssistantMessagesAfterNote(messages, updatedAt);
+          assistantMessagesAfterNote = count;
         }
       })
       .catch(() => {

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -11,6 +11,7 @@
   import { sanitize } from '../../shared/sanitize';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
   import { countAssistantMessagesAfter, handleExternalLinkClick } from '../../api/commands';
+  import { formatChatButtonLabel } from '../sessions/noteFreshness';
   import InContentSearch from '../../shared/InContentSearch.svelte';
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
   import { registerSearchShortcutTarget } from '../keyboard/searchTargets';
@@ -46,13 +47,7 @@
   let copied = $state(false);
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
   let assistantMessagesAfterNote = $state(0);
-  let chatButtonLabel = $derived(
-    assistantMessagesAfterNote === 1
-      ? '1 message after note in chat'
-      : assistantMessagesAfterNote > 1
-        ? `${assistantMessagesAfterNote} messages after note in chat`
-        : 'View chat'
-  );
+  let chatButtonLabel = $derived(formatChatButtonLabel(assistantMessagesAfterNote));
 
   // Search state
   let searchVisible = $state(false);

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -436,20 +436,23 @@
 
   .floating-chat-info {
     position: absolute;
-    left: 24px;
-    right: 24px;
+    left: 50%;
     bottom: 16px;
+    transform: translateX(-50%);
     z-index: 2;
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
+    box-sizing: border-box;
+    width: max-content;
+    max-width: calc(100% - 48px);
     min-height: 44px;
     padding: 10px 14px;
     background: var(--bg-chrome);
     border: 1px solid var(--border-muted);
     border-radius: 8px;
-    box-shadow: var(--shadow-elevated);
+    box-shadow: 0 4px 14px color-mix(in srgb, var(--shadow-overlay) 40%, transparent);
     color: var(--text-primary);
     cursor: pointer;
     font-size: var(--size-sm);
@@ -466,6 +469,7 @@
   }
 
   .floating-chat-info span {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -704,9 +708,8 @@
     }
 
     .floating-chat-info {
-      left: 16px;
-      right: 16px;
       bottom: 12px;
+      max-width: calc(100% - 32px);
     }
 
     .next-steps {

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -6,7 +6,7 @@
 -->
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { X, Copy, Check } from 'lucide-svelte';
+  import { X, Copy, Check, MessageCircle } from 'lucide-svelte';
   import { marked } from 'marked';
   import { sanitize } from '../../shared/sanitize';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
@@ -48,6 +48,9 @@
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
   let assistantMessagesAfterNote = $state(0);
   let chatButtonLabel = $derived(formatChatButtonLabel(assistantMessagesAfterNote));
+  let showFloatingChatInfo = $derived(
+    Boolean(sessionId && onOpenSession && assistantMessagesAfterNote > 0)
+  );
 
   // Search state
   let searchVisible = $state(false);
@@ -233,15 +236,6 @@
             <Copy size={16} />
           {/if}
         </button>
-        {#if sessionId && onOpenSession}
-          <button
-            class="header-btn"
-            onclick={() => onOpenSession?.(sessionId!)}
-            title="Open chat session"
-          >
-            {chatButtonLabel}
-          </button>
-        {/if}
         <button
           class="close-btn"
           onclick={onClose}
@@ -251,14 +245,31 @@
         </button>
       </div>
     </header>
-    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-    <div class="modal-content" bind:this={contentEl} onclick={handleExternalLinkClick}>
-      {#if content.trim()}
-        <div class="markdown-content">
-          {@html renderMarkdown(content)}
-        </div>
-      {:else}
-        <p class="empty-note">This note has no content.</p>
+    <div class="modal-body">
+      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+      <div
+        class:has-floating-chat-info={showFloatingChatInfo}
+        class="modal-content"
+        bind:this={contentEl}
+        onclick={handleExternalLinkClick}
+      >
+        {#if content.trim()}
+          <div class="markdown-content">
+            {@html renderMarkdown(content)}
+          </div>
+        {:else}
+          <p class="empty-note">This note has no content.</p>
+        {/if}
+      </div>
+      {#if showFloatingChatInfo}
+        <button
+          class="floating-chat-info"
+          onclick={() => onOpenSession?.(sessionId!)}
+          title="Open chat session"
+        >
+          <MessageCircle size={16} aria-hidden="true" />
+          <span>{chatButtonLabel}</span>
+        </button>
       {/if}
     </div>
     {#if nextSteps && onStartSession && (nextSteps.noteStep || nextSteps.commitStep)}
@@ -397,11 +408,59 @@
     color: var(--status-added);
   }
 
+  .modal-body {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+  }
+
   .modal-content {
     flex: 1;
     overflow-y: auto;
     padding: 24px;
     min-height: 0;
+  }
+
+  .modal-content.has-floating-chat-info {
+    padding-bottom: 96px;
+  }
+
+  .floating-chat-info {
+    position: absolute;
+    left: 24px;
+    right: 24px;
+    bottom: 16px;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 44px;
+    padding: 10px 14px;
+    background: var(--bg-chrome);
+    border: 1px solid var(--border-muted);
+    border-radius: 8px;
+    box-shadow: var(--shadow-elevated);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: var(--size-sm);
+    font-weight: 500;
+    transition:
+      background-color 0.1s,
+      border-color 0.1s,
+      color 0.1s;
+  }
+
+  .floating-chat-info:hover {
+    background: var(--bg-hover);
+    border-color: var(--text-muted);
+  }
+
+  .floating-chat-info span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .modal-content::-webkit-scrollbar {
@@ -630,6 +689,16 @@
 
     .modal-content {
       padding: 16px;
+    }
+
+    .modal-content.has-floating-chat-info {
+      padding-bottom: 88px;
+    }
+
+    .floating-chat-info {
+      left: 16px;
+      right: 16px;
+      bottom: 12px;
     }
 
     .next-steps {

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -48,9 +48,8 @@
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
   let assistantMessagesAfterNote = $state(0);
   let chatButtonLabel = $derived(formatChatButtonLabel(assistantMessagesAfterNote));
-  let showFloatingChatInfo = $derived(
-    Boolean(sessionId && onOpenSession && assistantMessagesAfterNote > 0)
-  );
+  let canOpenSession = $derived(Boolean(sessionId && onOpenSession));
+  let showFloatingChatInfo = $derived(canOpenSession && assistantMessagesAfterNote > 0);
 
   // Search state
   let searchVisible = $state(false);
@@ -236,6 +235,15 @@
             <Copy size={16} />
           {/if}
         </button>
+        {#if canOpenSession}
+          <button
+            class="header-btn"
+            onclick={() => onOpenSession?.(sessionId!)}
+            title="Open chat session"
+          >
+            View chat
+          </button>
+        {/if}
         <button
           class="close-btn"
           onclick={onClose}

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -10,11 +10,12 @@
   import { marked } from 'marked';
   import { sanitize } from '../../shared/sanitize';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
-  import { handleExternalLinkClick } from '../../api/commands';
+  import { getSessionMessages, handleExternalLinkClick } from '../../api/commands';
   import InContentSearch from '../../shared/InContentSearch.svelte';
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
   import { registerSearchShortcutTarget } from '../keyboard/searchTargets';
   import { viewport } from '../../shared/viewport.svelte';
+  import { countAssistantMessagesAfterNote } from '../sessions/noteFreshness';
 
   marked.setOptions({ breaks: true, gfm: true });
 
@@ -24,6 +25,7 @@
     onClose: () => void;
     /** When set, shows a button to open the associated chat session. */
     sessionId?: string | null;
+    noteUpdatedAt?: number | null;
     onOpenSession?: (sessionId: string) => void;
     /** Suggested next steps to show as action buttons at the bottom. */
     nextSteps?: { commitStep: string | null; noteStep: string | null } | null;
@@ -31,11 +33,27 @@
     onStartSession?: (mode: 'commit' | 'note', prefill: string) => void;
   }
 
-  let { title, content, onClose, sessionId, onOpenSession, nextSteps, onStartSession }: Props =
-    $props();
+  let {
+    title,
+    content,
+    onClose,
+    sessionId,
+    noteUpdatedAt,
+    onOpenSession,
+    nextSteps,
+    onStartSession,
+  }: Props = $props();
 
   let copied = $state(false);
   const backdropDismiss = createBackdropDismissHandlers({ onDismiss: () => onClose() });
+  let assistantMessagesAfterNote = $state(0);
+  let chatButtonLabel = $derived(
+    assistantMessagesAfterNote === 1
+      ? '1 message after note in chat'
+      : assistantMessagesAfterNote > 1
+        ? `${assistantMessagesAfterNote} messages after note in chat`
+        : 'View chat'
+  );
 
   // Search state
   let searchVisible = $state(false);
@@ -56,6 +74,30 @@
 
   onDestroy(() => {
     unregisterSearchTarget?.();
+  });
+
+  $effect(() => {
+    const sid = sessionId;
+    const updatedAt = noteUpdatedAt;
+    if (!sid || typeof updatedAt !== 'number') {
+      assistantMessagesAfterNote = 0;
+      return;
+    }
+
+    let stale = false;
+    getSessionMessages(sid)
+      .then((messages) => {
+        if (!stale) {
+          assistantMessagesAfterNote = countAssistantMessagesAfterNote(messages, updatedAt);
+        }
+      })
+      .catch(() => {
+        if (!stale) assistantMessagesAfterNote = 0;
+      });
+
+    return () => {
+      stale = true;
+    };
   });
 
   function renderMarkdown(text: string): string {
@@ -203,7 +245,7 @@
             onclick={() => onOpenSession?.(sessionId!)}
             title="Open chat session"
           >
-            View chat
+            {chatButtonLabel}
           </button>
         {/if}
         <button

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -63,6 +63,7 @@
   import { focusAtEnd } from '../../shared/focusAtEnd';
   import { buildReferringPrompt } from '../../shared/buildReferringPrompt';
   import { createLiveSessionHints } from '../timeline/liveSessionHints';
+  import type { LinkedNoteContext } from '../sessions/noteFreshness';
 
   interface Props {
     project: Project;
@@ -445,9 +446,25 @@
     })
   );
 
-  let openNote = $state<{ title: string; content: string; sessionId?: string } | null>(null);
+  let openNote = $state<{
+    title: string;
+    content: string;
+    sessionId?: string;
+    noteUpdatedAt?: number;
+  } | null>(null);
   let openSessionId = $state<string | null>(null);
   let projectContextMenuRef: TimelineContextMenu | undefined = $state();
+
+  function linkedNoteContext(note: ProjectNote | undefined): LinkedNoteContext | null {
+    if (!note) return null;
+    return {
+      id: note.id,
+      title: note.title,
+      content: note.content,
+      updatedAt: note.updatedAt,
+      hasParsedNote: !!note.content.trim(),
+    };
+  }
 
   // ── Lifecycle ──────────────────────────────────────────────────────────
 
@@ -700,6 +717,7 @@
                     title: note.title,
                     content: note.content,
                     sessionId: note.sessionId ?? undefined,
+                    noteUpdatedAt: note.updatedAt,
                   };
                 }}
             onSessionClick={(sid) => {
@@ -739,6 +757,7 @@
     title={openNote.title}
     content={openNote.content}
     sessionId={openNote.sessionId}
+    noteUpdatedAt={openNote.noteUpdatedAt}
     onClose={() => (openNote = null)}
     onOpenSession={(sid) => {
       openNote = null;
@@ -748,20 +767,23 @@
 {/if}
 
 {#if openSessionId}
-  {@const noteForSession = projectNotes.find(
-    (n) => n.sessionId === openSessionId && n.content?.trim()
+  {@const noteForSession = linkedNoteContext(
+    projectNotes.find((n) => n.sessionId === openSessionId)
   )}
   <SessionModal
     sessionId={openSessionId}
     repoDir={projectDisplayRootCandidates}
     projectId={project.id}
-    noteInfo={noteForSession
-      ? { id: noteForSession.id, title: noteForSession.title, content: noteForSession.content }
-      : null}
-    onOpenNote={(_noteId, title, content) => {
+    noteInfo={noteForSession}
+    onOpenNote={(note) => {
       const sid = openSessionId;
       openSessionId = null;
-      openNote = { title, content, sessionId: sid ?? undefined };
+      openNote = {
+        title: note.title,
+        content: note.content,
+        sessionId: sid ?? undefined,
+        noteUpdatedAt: note.updatedAt,
+      };
     }}
     onClose={() => {
       openSessionId = null;

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -38,6 +38,7 @@
     ChevronDown,
     Zap,
     GitBranch,
+    FileText,
     Paperclip,
     ImagePlus,
     Plus,
@@ -90,6 +91,11 @@
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
   import { registerSearchShortcutTarget } from '../keyboard/searchTargets';
   import { viewport } from '../../shared/viewport.svelte';
+  import {
+    buildNoteFollowupMessage,
+    getNoteFollowupLabel,
+    type LinkedNoteContext,
+  } from './noteFreshness';
 
   // Configure marked
   marked.setOptions({ breaks: true, gfm: true });
@@ -106,8 +112,8 @@
     /** Repo label for grouping branch-scoped hashtag suggestions. */
     repoLabel?: Pick<ProjectRepo, 'githubRepo' | 'subpath' | 'headRepo'> | null;
     /** When set, shows a button to open the associated note. */
-    noteInfo?: { id: string; title: string; content: string } | null;
-    onOpenNote?: (noteId: string, title: string, content: string) => void;
+    noteInfo?: LinkedNoteContext | null;
+    onOpenNote?: (note: LinkedNoteContext) => void;
   }
 
   let {
@@ -147,6 +153,7 @@
 
   let isLive = $derived(session?.status === 'running');
   let hasQueuedMessages = $derived(messageQueue.length > 0);
+  let noteFollowupLabel = $derived(getNoteFollowupLabel(session, messages, noteInfo));
 
   const SLIDE_DURATION = 150;
 
@@ -523,6 +530,11 @@
     } finally {
       sending = false;
     }
+  }
+
+  function handleNoteFollowupClick() {
+    if (!noteInfo || sending) return;
+    void sendMessage(buildNoteFollowupMessage(noteInfo.hasParsedNote));
   }
 
   /** Process the next queued message when the session becomes idle. */
@@ -1011,12 +1023,8 @@
         onClose={closeSearch}
       />
       <div class="header-actions">
-        {#if noteInfo && onOpenNote}
-          <button
-            class="header-btn"
-            onclick={() => onOpenNote?.(noteInfo!.id, noteInfo!.title, noteInfo!.content)}
-            title="Open note"
-          >
+        {#if noteInfo?.content.trim() && onOpenNote}
+          <button class="header-btn" onclick={() => onOpenNote?.(noteInfo!)} title="Open note">
             View note
           </button>
         {/if}
@@ -1276,6 +1284,23 @@
             <div class="thinking" in:messageSlide>
               <Spinner size={14} />
               <span>Thinking…</span>
+            </div>
+          {/if}
+
+          {#if noteFollowupLabel}
+            <div class="note-followup-row" in:messageSlide>
+              <button
+                class="note-followup-btn"
+                onclick={handleNoteFollowupClick}
+                disabled={sending}
+              >
+                {#if sending}
+                  <Spinner size={13} />
+                {:else}
+                  <FileText size={13} />
+                {/if}
+                <span>{noteFollowupLabel}</span>
+              </button>
             </div>
           {/if}
         </div>
@@ -1952,6 +1977,42 @@
     color: var(--text-muted);
     font-size: var(--size-xs);
     padding: 4px 0;
+  }
+
+  .note-followup-row {
+    display: flex;
+    justify-content: center;
+    padding: 4px 0;
+  }
+
+  .note-followup-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 30px;
+    padding: 6px 12px;
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    background: var(--note-bg);
+    color: var(--note-color);
+    font-size: var(--size-xs);
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background-color 0.1s,
+      border-color 0.1s,
+      color 0.1s;
+  }
+
+  .note-followup-btn:hover:not(:disabled) {
+    border-color: var(--note-color);
+    background: var(--note-bg-emphasis);
+  }
+
+  .note-followup-btn:disabled {
+    cursor: default;
+    opacity: 0.65;
   }
 
   /* Error banner */

--- a/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
@@ -18,6 +18,8 @@ function session(
     id: 'session-1',
     prompt: 'Write a note',
     status,
+    workingDir: '/tmp/test',
+    provider: null,
     agentId: null,
     errorMessage: null,
     completionReason,

--- a/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { Session, SessionMessage, SessionStatus, CompletionReason } from '../../types';
+import {
+  buildNoteFollowupMessage,
+  countAssistantMessagesAfterNote,
+  getNoteFollowupLabel,
+  latestAssistantMessage,
+  type LinkedNoteContext,
+} from './noteFreshness';
+
+function session(
+  status: SessionStatus = 'completed',
+  completionReason: CompletionReason | null = 'turn_complete'
+): Session {
+  return {
+    id: 'session-1',
+    prompt: 'Write a note',
+    status,
+    agentId: null,
+    errorMessage: null,
+    completionReason,
+    createdAt: 1000,
+    updatedAt: 2000,
+  };
+}
+
+function message(
+  id: number,
+  role: SessionMessage['role'],
+  createdAt: number,
+  content = `${role} ${id}`
+): SessionMessage {
+  return {
+    id,
+    sessionId: 'session-1',
+    role,
+    content,
+    createdAt,
+  };
+}
+
+function note(overrides: Partial<LinkedNoteContext> = {}): LinkedNoteContext {
+  return {
+    id: 'note-1',
+    title: 'Note',
+    content: '# Note\n\nBody',
+    updatedAt: 2000,
+    hasParsedNote: true,
+    ...overrides,
+  };
+}
+
+describe('note freshness', () => {
+  it('does not show a note follow-up CTA without a linked note', () => {
+    const messages = [message(1, 'assistant', 3000)];
+
+    expect(getNoteFollowupLabel(session(), messages, null)).toBeNull();
+  });
+
+  it.each([
+    ['queued', null],
+    ['running', null],
+    ['cancelled', 'interrupted'],
+    ['error', 'crashed'],
+    ['completed', 'interrupted'],
+  ] satisfies [SessionStatus, CompletionReason | null][])(
+    'does not show a note follow-up CTA for %s sessions with %s completion',
+    (status, completionReason) => {
+      const messages = [message(1, 'assistant', 3000)];
+
+      expect(getNoteFollowupLabel(session(status, completionReason), messages, note())).toBeNull();
+    }
+  );
+
+  it('asks for a note to be written when an empty linked note has a later assistant message', () => {
+    const messages = [message(1, 'assistant', 3000)];
+    const emptyNote = note({ content: '', hasParsedNote: false });
+
+    expect(getNoteFollowupLabel(session(), messages, emptyNote)).toBe(
+      'Ask for a note to be written'
+    );
+  });
+
+  it('asks for the note to be updated when a parsed linked note has a later assistant message', () => {
+    const messages = [message(1, 'assistant', 3000)];
+
+    expect(getNoteFollowupLabel(session(), messages, note())).toBe(
+      'Ask for the note to be updated'
+    );
+  });
+
+  it('ignores assistant messages before the note updated timestamp', () => {
+    const messages = [
+      message(1, 'assistant', 1500),
+      message(2, 'user', 3000),
+      message(3, 'tool_result', 3500),
+    ];
+
+    expect(countAssistantMessagesAfterNote(messages, 2000)).toBe(0);
+    expect(getNoteFollowupLabel(session(), messages, note())).toBeNull();
+  });
+
+  it('counts multiple assistant messages after the note updated timestamp', () => {
+    const messages = [
+      message(1, 'assistant', 1500),
+      message(2, 'assistant', 2500),
+      message(3, 'user', 3000),
+      message(4, 'assistant', 3500),
+    ];
+
+    expect(countAssistantMessagesAfterNote(messages, 2000)).toBe(2);
+  });
+
+  it('uses the newest assistant message by timestamp and id', () => {
+    const messages = [
+      message(1, 'assistant', 3000),
+      message(2, 'assistant', 2500),
+      message(3, 'assistant', 3000),
+    ];
+
+    expect(latestAssistantMessage(messages)?.id).toBe(3);
+  });
+
+  it('builds a structured follow-up prompt with a readable visible request', () => {
+    const updateMessage = buildNoteFollowupMessage(true);
+    const writeMessage = buildNoteFollowupMessage(false);
+
+    expect(updateMessage.startsWith('<action>')).toBe(true);
+    expect(updateMessage).toContain('```suggested-next-steps');
+    expect(updateMessage).toContain('\n---\n# <Title>');
+    expect(updateMessage).toContain('Please update the note to reflect the latest chat.');
+    expect(writeMessage).toContain('Please write the note for this session.');
+  });
+});

--- a/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
@@ -3,7 +3,9 @@ import type { Session, SessionMessage, SessionStatus, CompletionReason } from '.
 import {
   buildNoteFollowupMessage,
   countAssistantMessagesAfterNote,
+  formatChatButtonLabel,
   getNoteFollowupLabel,
+  hasNoteFollowupBeenSent,
   latestAssistantMessage,
   type LinkedNoteContext,
 } from './noteFreshness';
@@ -130,5 +132,40 @@ describe('note freshness', () => {
     expect(updateMessage).toContain('\n---\n# <Title>');
     expect(updateMessage).toContain('Please update the note to reflect the latest chat.');
     expect(writeMessage).toContain('Please write the note for this session.');
+  });
+
+  it('suppresses note followup CTA when a followup was already sent', () => {
+    const followupContent = buildNoteFollowupMessage(true);
+    const messages = [
+      message(1, 'assistant', 1500),
+      message(2, 'user', 2500, followupContent),
+      message(3, 'assistant', 3000),
+    ];
+
+    expect(hasNoteFollowupBeenSent(messages)).toBe(true);
+    expect(getNoteFollowupLabel(session(), messages, note())).toBeNull();
+  });
+
+  it('does not suppress CTA when no followup has been sent', () => {
+    const messages = [message(1, 'user', 1500, 'Can you help me?'), message(2, 'assistant', 3000)];
+
+    expect(hasNoteFollowupBeenSent(messages)).toBe(false);
+    expect(getNoteFollowupLabel(session(), messages, note())).toBe(
+      'Ask for the note to be updated'
+    );
+  });
+});
+
+describe('formatChatButtonLabel', () => {
+  it('returns singular label for 1 message', () => {
+    expect(formatChatButtonLabel(1)).toBe('1 message after note in chat');
+  });
+
+  it('returns plural label for multiple messages', () => {
+    expect(formatChatButtonLabel(5)).toBe('5 messages after note in chat');
+  });
+
+  it('returns generic label for 0 messages', () => {
+    expect(formatChatButtonLabel(0)).toBe('View chat');
   });
 });

--- a/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
@@ -134,7 +134,7 @@ describe('note freshness', () => {
     expect(writeMessage).toContain('Please write the note for this session.');
   });
 
-  it('suppresses note followup CTA when a followup was already sent', () => {
+  it('suppresses note followup CTA when a followup was already sent after note updatedAt', () => {
     const followupContent = buildNoteFollowupMessage(true);
     const messages = [
       message(1, 'assistant', 1500),
@@ -142,14 +142,30 @@ describe('note freshness', () => {
       message(3, 'assistant', 3000),
     ];
 
-    expect(hasNoteFollowupBeenSent(messages)).toBe(true);
+    expect(hasNoteFollowupBeenSent(messages, 2000)).toBe(true);
     expect(getNoteFollowupLabel(session(), messages, note())).toBeNull();
   });
 
   it('does not suppress CTA when no followup has been sent', () => {
     const messages = [message(1, 'user', 1500, 'Can you help me?'), message(2, 'assistant', 3000)];
 
-    expect(hasNoteFollowupBeenSent(messages)).toBe(false);
+    expect(hasNoteFollowupBeenSent(messages, 2000)).toBe(false);
+    expect(getNoteFollowupLabel(session(), messages, note())).toBe(
+      'Ask for the note to be updated'
+    );
+  });
+
+  it('does not suppress CTA when followup was sent before note was updated', () => {
+    // A followup was sent at t=1500, but the note was updated at t=2000 (after the followup).
+    // New assistant messages at t=3000 should still trigger the CTA.
+    const followupContent = buildNoteFollowupMessage(true);
+    const messages = [
+      message(1, 'assistant', 1000),
+      message(2, 'user', 1500, followupContent),
+      message(3, 'assistant', 3000),
+    ];
+
+    expect(hasNoteFollowupBeenSent(messages, 2000)).toBe(false);
     expect(getNoteFollowupLabel(session(), messages, note())).toBe(
       'Ask for the note to be updated'
     );

--- a/apps/staged/src/lib/features/sessions/noteFreshness.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.ts
@@ -56,11 +56,19 @@ export function latestAssistantMessage(messages: SessionMessage[]): SessionMessa
 const NOTE_FOLLOWUP_MARKER = 'The user is asking you to';
 
 /**
- * Returns true if any user message in the session already contains the
- * note-followup prompt. Used to suppress the CTA after it has been clicked.
+ * Returns true if any user message created after `noteUpdatedAt` contains the
+ * note-followup prompt. Only markers sent after the note was last updated
+ * suppress the CTA, so that a subsequent note update (which advances updatedAt)
+ * re-enables the prompt if new assistant messages arrive.
  */
-export function hasNoteFollowupBeenSent(messages: SessionMessage[]): boolean {
-  return messages.some((m) => m.role === 'user' && m.content.includes(NOTE_FOLLOWUP_MARKER));
+export function hasNoteFollowupBeenSent(
+  messages: SessionMessage[],
+  noteUpdatedAt: number
+): boolean {
+  return messages.some(
+    (m) =>
+      m.role === 'user' && m.createdAt > noteUpdatedAt && m.content.includes(NOTE_FOLLOWUP_MARKER)
+  );
 }
 
 export function shouldAskForNoteUpdate(
@@ -70,7 +78,7 @@ export function shouldAskForNoteUpdate(
 ): boolean {
   if (!session || !noteContext) return false;
   if (session.status !== 'completed' || session.completionReason !== 'turn_complete') return false;
-  if (hasNoteFollowupBeenSent(messages)) return false;
+  if (hasNoteFollowupBeenSent(messages, noteContext.updatedAt)) return false;
 
   const latestAssistant = latestAssistantMessage(messages);
   return !!latestAssistant && latestAssistant.createdAt > noteContext.updatedAt;

--- a/apps/staged/src/lib/features/sessions/noteFreshness.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.ts
@@ -1,0 +1,91 @@
+import type { Session, SessionMessage } from '../../types';
+
+export interface LinkedNoteContext {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+  hasParsedNote: boolean;
+}
+
+export function countAssistantMessagesAfterNote(
+  messages: SessionMessage[],
+  noteUpdatedAt: number | null | undefined
+): number {
+  if (typeof noteUpdatedAt !== 'number') return 0;
+  return messages.filter(
+    (message) => message.role === 'assistant' && message.createdAt > noteUpdatedAt
+  ).length;
+}
+
+export function latestAssistantMessage(messages: SessionMessage[]): SessionMessage | null {
+  let latest: SessionMessage | null = null;
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue;
+    if (
+      !latest ||
+      message.createdAt > latest.createdAt ||
+      (message.createdAt === latest.createdAt && message.id > latest.id)
+    ) {
+      latest = message;
+    }
+  }
+  return latest;
+}
+
+export function shouldAskForNoteUpdate(
+  session: Session | null,
+  messages: SessionMessage[],
+  noteContext: LinkedNoteContext | null | undefined
+): boolean {
+  if (!session || !noteContext) return false;
+  if (session.status !== 'completed' || session.completionReason !== 'turn_complete') return false;
+
+  const latestAssistant = latestAssistantMessage(messages);
+  return !!latestAssistant && latestAssistant.createdAt > noteContext.updatedAt;
+}
+
+export function getNoteFollowupLabel(
+  session: Session | null,
+  messages: SessionMessage[],
+  noteContext: LinkedNoteContext | null | undefined
+): string | null {
+  if (!shouldAskForNoteUpdate(session, messages, noteContext)) return null;
+  return noteContext?.hasParsedNote
+    ? 'Ask for the note to be updated'
+    : 'Ask for a note to be written';
+}
+
+export function buildNoteFollowupMessage(hasParsedNote: boolean): string {
+  const visibleRequest = hasParsedNote
+    ? 'Please update the note to reflect the latest chat.'
+    : 'Please write the note for this session.';
+
+  return `<action>
+The user is asking you to ${hasParsedNote ? 'update the linked note' : 'write the linked note'} from the latest chat history.
+
+Use the existing conversation context. Do not create commits.
+
+Your final response must include a suggested-next-steps fenced block followed by the note content after a horizontal rule:
+
+\`\`\`suggested-next-steps
+{"suggestedNextCommitStep": null, "suggestedNextNoteStep": null}
+\`\`\`
+
+---
+# <Title>
+<Body>
+
+Formatting requirements:
+- The opening fence line for suggested-next-steps must be exactly: \`\`\`suggested-next-steps
+- The closing fence line must be exactly: \`\`\`
+- Put only a JSON object inside the suggested-next-steps block.
+- Include both nullable string fields: suggestedNextCommitStep and suggestedNextNoteStep.
+- Keep suggested next steps concise; use null when there is no clear next action.
+- The \`---\` separator must be on its own line.
+- The note content must start immediately after \`---\` with a markdown H1.
+- Do not wrap the note in code fences.
+</action>
+
+${visibleRequest}`;
+}

--- a/apps/staged/src/lib/features/sessions/noteFreshness.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.ts
@@ -8,6 +8,15 @@ export interface LinkedNoteContext {
   hasParsedNote: boolean;
 }
 
+/** Info passed when a note is clicked in the timeline. */
+export interface NoteClickInfo {
+  noteId: string;
+  title: string;
+  content: string;
+  sessionId?: string;
+  updatedAt?: number;
+}
+
 export function countAssistantMessagesAfterNote(
   messages: SessionMessage[],
   noteUpdatedAt: number | null | undefined
@@ -16,6 +25,16 @@ export function countAssistantMessagesAfterNote(
   return messages.filter(
     (message) => message.role === 'assistant' && message.createdAt > noteUpdatedAt
   ).length;
+}
+
+/**
+ * Formats a label for the "view chat" button in the note modal.
+ * Shows the count of assistant messages after the note was last updated.
+ */
+export function formatChatButtonLabel(messagesAfterNote: number): string {
+  if (messagesAfterNote === 1) return '1 message after note in chat';
+  if (messagesAfterNote > 1) return `${messagesAfterNote} messages after note in chat`;
+  return 'View chat';
 }
 
 export function latestAssistantMessage(messages: SessionMessage[]): SessionMessage | null {
@@ -33,6 +52,17 @@ export function latestAssistantMessage(messages: SessionMessage[]): SessionMessa
   return latest;
 }
 
+/** Marker text embedded in the note followup action block. */
+const NOTE_FOLLOWUP_MARKER = 'The user is asking you to';
+
+/**
+ * Returns true if any user message in the session already contains the
+ * note-followup prompt. Used to suppress the CTA after it has been clicked.
+ */
+export function hasNoteFollowupBeenSent(messages: SessionMessage[]): boolean {
+  return messages.some((m) => m.role === 'user' && m.content.includes(NOTE_FOLLOWUP_MARKER));
+}
+
 export function shouldAskForNoteUpdate(
   session: Session | null,
   messages: SessionMessage[],
@@ -40,6 +70,7 @@ export function shouldAskForNoteUpdate(
 ): boolean {
   if (!session || !noteContext) return false;
   if (session.status !== 'completed' || session.completionReason !== 'turn_complete') return false;
+  if (hasNoteFollowupBeenSent(messages)) return false;
 
   const latestAssistant = latestAssistantMessage(messages);
   return !!latestAssistant && latestAssistant.createdAt > noteContext.updatedAt;

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -58,7 +58,13 @@
     onSessionClick?: (sessionId: string) => void;
     onResumeClick?: (sessionId: string) => void;
     onCommitClick?: (sha: string) => void;
-    onNoteClick?: (noteId: string, title: string, content: string, sessionId?: string) => void;
+    onNoteClick?: (
+      noteId: string,
+      title: string,
+      content: string,
+      sessionId: string | undefined,
+      updatedAt: number
+    ) => void;
     onReviewClick?: (reviewId: string) => void;
     onImageClick?: (imageId: string) => void;
     onDeleteCommit?: (sha: string, sessionId?: string, opts?: { altKey: boolean }) => void;
@@ -235,6 +241,7 @@
     noteId?: string;
     noteTitle?: string;
     noteContent?: string;
+    noteUpdatedAt?: number;
     reviewId?: string;
     imageId?: string;
     imageFilename?: string;
@@ -602,6 +609,7 @@
         noteId: note.id,
         noteTitle: stripXmlTags(note.title),
         noteContent: note.content,
+        noteUpdatedAt: note.updatedAt,
         deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
         completionReason: note.completionReason,
         hashtagRef: type === 'note' ? `#note:${note.id}` : undefined,
@@ -774,7 +782,13 @@
     if (item.type === 'commit' && item.commitSha && onCommitClick) {
       onCommitClick(item.commitSha);
     } else if (item.type === 'note' && item.noteId && onNoteClick) {
-      onNoteClick(item.noteId, item.noteTitle ?? '', item.noteContent ?? '', item.sessionId);
+      onNoteClick(
+        item.noteId,
+        item.noteTitle ?? '',
+        item.noteContent ?? '',
+        item.sessionId,
+        item.noteUpdatedAt ?? 0
+      );
     } else if (item.type === 'review' && item.reviewId && onReviewClick) {
       onReviewClick(item.reviewId);
     } else if (item.type === 'image' && item.imageId && onImageClick) {

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -63,7 +63,7 @@
       title: string,
       content: string,
       sessionId: string | undefined,
-      updatedAt: number
+      updatedAt: number | undefined
     ) => void;
     onReviewClick?: (reviewId: string) => void;
     onImageClick?: (imageId: string) => void;
@@ -787,7 +787,7 @@
         item.noteTitle ?? '',
         item.noteContent ?? '',
         item.sessionId,
-        item.noteUpdatedAt ?? 0
+        item.noteUpdatedAt
       );
     } else if (item.type === 'review' && item.reviewId && onReviewClick) {
       onReviewClick(item.reviewId);

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -17,6 +17,7 @@
     BranchTimeline as BranchTimelineData,
     HashtagItem,
   } from '../../types';
+  import type { NoteClickInfo } from '../sessions/noteFreshness';
   import TimelineRow from './TimelineRow.svelte';
   import type { TimelineItemType, TimelineBadge } from './TimelineRow.svelte';
   import TimelineContextMenu from './TimelineContextMenu.svelte';
@@ -58,13 +59,7 @@
     onSessionClick?: (sessionId: string) => void;
     onResumeClick?: (sessionId: string) => void;
     onCommitClick?: (sha: string) => void;
-    onNoteClick?: (
-      noteId: string,
-      title: string,
-      content: string,
-      sessionId: string | undefined,
-      updatedAt: number | undefined
-    ) => void;
+    onNoteClick?: (note: NoteClickInfo) => void;
     onReviewClick?: (reviewId: string) => void;
     onImageClick?: (imageId: string) => void;
     onDeleteCommit?: (sha: string, sessionId?: string, opts?: { altKey: boolean }) => void;
@@ -782,13 +777,13 @@
     if (item.type === 'commit' && item.commitSha && onCommitClick) {
       onCommitClick(item.commitSha);
     } else if (item.type === 'note' && item.noteId && onNoteClick) {
-      onNoteClick(
-        item.noteId,
-        item.noteTitle ?? '',
-        item.noteContent ?? '',
-        item.sessionId,
-        item.noteUpdatedAt
-      );
+      onNoteClick({
+        noteId: item.noteId,
+        title: item.noteTitle ?? '',
+        content: item.noteContent ?? '',
+        sessionId: item.sessionId,
+        updatedAt: item.noteUpdatedAt,
+      });
     } else if (item.type === 'review' && item.reviewId && onReviewClick) {
       onReviewClick(item.reviewId);
     } else if (item.type === 'image' && item.imageId && onImageClick) {


### PR DESCRIPTION
🤖 Summary:
- Detect whether a session has chat messages sent after a linked note was updated.
- Surface note freshness indicators and follow-up actions across session, branch, project, note, and timeline views.
- Add backend message counting support and focused tests for note freshness behavior.

Tests:
- Push hooks passed: crates-fmt, crates-test, crates-lint, differ-ci, staged-ci