### PR TITLE
feat(diff): show relative file change indicators

### DIFF
--- a/apps/staged/src-tauri/src/diff_cache.rs
+++ b/apps/staged/src-tauri/src/diff_cache.rs
@@ -487,6 +487,41 @@ fn decode_file(b64: &str, path: &str) -> git_diff::File {
     }
 }
 
+fn supports_line_stats(file: &Option<git_diff::File>) -> bool {
+    match file {
+        Some(git_diff::File {
+            content: git_diff::FileContent::Binary | git_diff::FileContent::ImageBase64 { .. },
+            ..
+        }) => false,
+        _ => true,
+    }
+}
+
+fn line_stats_from_patch(
+    patch: &str,
+    before: &Option<git_diff::File>,
+    after: &Option<git_diff::File>,
+) -> (Option<u32>, Option<u32>) {
+    if !supports_line_stats(before) || !supports_line_stats(after) {
+        return (None, None);
+    }
+
+    let mut added = 0;
+    let mut deleted = 0;
+    for line in patch.lines() {
+        if line.starts_with("+++") || line.starts_with("---") {
+            continue;
+        }
+        if line.starts_with('+') {
+            added += 1;
+        } else if line.starts_with('-') {
+            deleted += 1;
+        }
+    }
+
+    (Some(added), Some(deleted))
+}
+
 /// Parse file entries from the collection script into summaries and full diffs.
 fn parse_script_files(
     entries: &[CollectScriptFile],
@@ -511,11 +546,6 @@ fn parse_script_files(
             Some(entry.after_path.clone())
         };
 
-        files.push(git_diff::FileDiffSummary {
-            before: before_path.as_deref().map(PathBuf::from),
-            after: after_path.as_deref().map(PathBuf::from),
-        });
-
         let canonical_path = after_path.as_deref().or(before_path.as_deref());
         let canonical_path = match canonical_path {
             Some(p) if !p.is_empty() => p,
@@ -530,6 +560,14 @@ fn parse_script_files(
         let after = entry.after_content_b64.as_deref().map(|b64| {
             let path = after_path.as_deref().unwrap_or(canonical_path);
             decode_file(b64, path)
+        });
+
+        let (added_lines, deleted_lines) = line_stats_from_patch(&entry.patch, &before, &after);
+        files.push(git_diff::FileDiffSummary {
+            before: before_path.as_deref().map(PathBuf::from),
+            after: after_path.as_deref().map(PathBuf::from),
+            added_lines,
+            deleted_lines,
         });
 
         let hunks = parse_unified_hunks(&entry.patch);
@@ -763,4 +801,62 @@ fn cache_branch_diff_background(
     )?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_branch_index_deserializes_summaries_without_line_stats() {
+        let json = r#"{
+            "branch_id": "branch-1",
+            "base_sha": "base",
+            "head_sha": "head",
+            "files": [
+                { "before": "src/old.ts", "after": "src/new.ts" }
+            ],
+            "cached_at": 0
+        }"#;
+
+        let index: CachedBranchIndex = serde_json::from_str(json).unwrap();
+        assert_eq!(index.files.len(), 1);
+        assert_eq!(index.files[0].added_lines, None);
+        assert_eq!(index.files[0].deleted_lines, None);
+    }
+
+    #[test]
+    fn line_stats_from_patch_counts_text_changes() {
+        let patch = "\
+diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,3 @@
+-old
++new
++added
+ unchanged";
+
+        let before = Some(git_diff::File {
+            path: "file.txt".to_string(),
+            content: git_diff::FileContent::Text { lines: vec![] },
+        });
+        let after = before.clone();
+
+        assert_eq!(
+            line_stats_from_patch(patch, &before, &after),
+            (Some(2), Some(1))
+        );
+    }
+
+    #[test]
+    fn line_stats_from_patch_skips_binary_content() {
+        let before = Some(git_diff::File {
+            path: "image.png".to_string(),
+            content: git_diff::FileContent::Binary,
+        });
+        let after = before.clone();
+
+        assert_eq!(line_stats_from_patch("", &before, &after), (None, None));
+    }
 }

--- a/apps/staged/src-tauri/src/diff_cache.rs
+++ b/apps/staged/src-tauri/src/diff_cache.rs
@@ -488,13 +488,13 @@ fn decode_file(b64: &str, path: &str) -> git_diff::File {
 }
 
 fn supports_line_stats(file: &Option<git_diff::File>) -> bool {
-    match file {
+    !matches!(
+        file,
         Some(git_diff::File {
             content: git_diff::FileContent::Binary | git_diff::FileContent::ImageBase64 { .. },
             ..
-        }) => false,
-        _ => true,
-    }
+        })
+    )
 }
 
 fn line_stats_from_patch(
@@ -509,7 +509,7 @@ fn line_stats_from_patch(
     let mut added = 0;
     let mut deleted = 0;
     for line in patch.lines() {
-        if line.starts_with("+++") || line.starts_with("---") {
+        if line.starts_with("+++ ") || line.starts_with("--- ") {
             continue;
         }
         if line.starts_with('+') {

--- a/apps/staged/src/lib/features/diff/DiffFileTreeSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffFileTreeSection.svelte
@@ -105,8 +105,8 @@
     return `+${added} / -${deleted}`;
   }
 
-  function changeIndicatorWidth(total: number): number {
-    return Math.round(4 + fileChangeScale(total, maxFileChangeTotal) * 14);
+  function changeIndicatorHeight(total: number): number {
+    return Math.round(4 + fileChangeScale(total, maxFileChangeTotal) * 12);
   }
 
   // Helper to get snippet for a search result
@@ -192,21 +192,22 @@
   {@const deleted = lineCount(file.deletedLines)}
   <span
     class="change-indicator"
+    class:change-indicator-visible={total !== null}
     title={total !== null && total > 0 ? changeIndicatorTitle(added, deleted) : undefined}
     aria-hidden="true"
   >
     {#if total !== null && total > 0}
-      <span class="change-indicator-fill" style:width={`${changeIndicatorWidth(total)}px`}>
+      <span class="change-indicator-fill" style:height={`${changeIndicatorHeight(total)}px`}>
         {#if added > 0}
           <span
             class="change-segment change-segment-added"
-            style:width={`${(added / total) * 100}%`}
+            style:height={`${(added / total) * 100}%`}
           ></span>
         {/if}
         {#if deleted > 0}
           <span
             class="change-segment change-segment-deleted"
-            style:width={`${(deleted / total) * 100}%`}
+            style:height={`${(deleted / total) * 100}%`}
           ></span>
         {/if}
       </span>
@@ -581,23 +582,29 @@
 
   .change-indicator {
     display: inline-flex;
-    align-items: center;
-    justify-content: flex-start;
+    align-items: flex-end;
+    justify-content: center;
     flex-shrink: 0;
-    width: 18px;
-    height: 12px;
+    width: 8px;
+    height: 16px;
+    overflow: hidden;
+    border-radius: 2px;
+  }
+
+  .change-indicator-visible {
+    background: color-mix(in srgb, var(--border-muted) 35%, transparent);
   }
 
   .change-indicator-fill {
     display: flex;
-    height: 6px;
+    flex-direction: column;
+    width: 100%;
     overflow: hidden;
-    border-radius: 2px;
-    background: var(--border-muted);
+    border-radius: inherit;
   }
 
   .change-segment {
-    height: 100%;
+    width: 100%;
   }
 
   .change-segment-added {

--- a/apps/staged/src/lib/features/diff/DiffFileTreeSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffFileTreeSection.svelte
@@ -13,7 +13,12 @@
   } from 'lucide-svelte';
   import { FileSearchResults } from '@builderbot/diff-viewer/components';
   import { getMatchSnippet, getTextLines, type SearchMatch } from '@builderbot/diff-viewer/utils';
-  import type { FileEntry, TreeNode } from './diffModalHelpers';
+  import {
+    fileChangeScale,
+    fileChangeTotal,
+    type FileEntry,
+    type TreeNode,
+  } from './diffModalHelpers';
   import type { FileDiff, FileDiffSummary } from '@builderbot/diff-viewer/types';
   import type { FileSearchResult } from '@builderbot/diff-viewer/state';
   import '@builderbot/diff-viewer/components/search.css';
@@ -83,8 +88,26 @@
     fileEntries.map((entry) => ({
       before: entry.status === 'added' ? null : entry.path,
       after: entry.status === 'deleted' ? null : entry.path,
+      addedLines: entry.addedLines,
+      deletedLines: entry.deletedLines,
     }))
   );
+
+  const maxFileChangeTotal = $derived(
+    fileEntries.reduce((max, entry) => Math.max(max, fileChangeTotal(entry) ?? 0), 0)
+  );
+
+  function lineCount(value: number | null | undefined): number {
+    return typeof value === 'number' ? Math.max(0, value) : 0;
+  }
+
+  function changeIndicatorTitle(added: number, deleted: number): string {
+    return `+${added} / -${deleted}`;
+  }
+
+  function changeIndicatorWidth(total: number): number {
+    return Math.round(4 + fileChangeScale(total, maxFileChangeTotal) * 14);
+  }
 
   // Helper to get snippet for a search result
   function getSnippet(match: SearchMatch, filePath: string): string {
@@ -163,6 +186,34 @@
   {/if}
 {/snippet}
 
+{#snippet changeIndicator(file: FileEntry)}
+  {@const total = fileChangeTotal(file)}
+  {@const added = lineCount(file.addedLines)}
+  {@const deleted = lineCount(file.deletedLines)}
+  <span
+    class="change-indicator"
+    title={total !== null && total > 0 ? changeIndicatorTitle(added, deleted) : undefined}
+    aria-hidden="true"
+  >
+    {#if total !== null && total > 0}
+      <span class="change-indicator-fill" style:width={`${changeIndicatorWidth(total)}px`}>
+        {#if added > 0}
+          <span
+            class="change-segment change-segment-added"
+            style:width={`${(added / total) * 100}%`}
+          ></span>
+        {/if}
+        {#if deleted > 0}
+          <span
+            class="change-segment change-segment-deleted"
+            style:width={`${(deleted / total) * 100}%`}
+          ></span>
+        {/if}
+      </span>
+    {/if}
+  </span>
+{/snippet}
+
 {#snippet treeNodes(nodes: TreeNode[], depth: number, showReviewedSection: boolean)}
   {#each nodes as node (node.path)}
     {#if node.isDir}
@@ -227,6 +278,7 @@
             {/if}
           {/if}
           {@render fileIcon(node.file, showReviewedSection)}
+          {@render changeIndicator(node.file)}
           <span class="file-name">{node.name}</span>
           {#if node.file.commentCount > 0}
             <span
@@ -525,6 +577,35 @@
 
   .icon-hover-unreview {
     color: var(--text-muted);
+  }
+
+  .change-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex-shrink: 0;
+    width: 18px;
+    height: 12px;
+  }
+
+  .change-indicator-fill {
+    display: flex;
+    height: 6px;
+    overflow: hidden;
+    border-radius: 2px;
+    background: var(--border-muted);
+  }
+
+  .change-segment {
+    height: 100%;
+  }
+
+  .change-segment-added {
+    background: var(--status-added);
+  }
+
+  .change-segment-deleted {
+    background: var(--status-deleted);
   }
 
   .comment-indicator {

--- a/apps/staged/src/lib/features/diff/DiffFileTreeSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffFileTreeSection.svelte
@@ -7,9 +7,9 @@
     ChevronDown,
     Folder,
     MessageSquare,
-    CirclePlus,
-    CircleMinus,
-    CircleArrowUp,
+    MoveRight,
+    Plus,
+    X,
   } from 'lucide-svelte';
   import { FileSearchResults } from '@builderbot/diff-viewer/components';
   import { getMatchSnippet, getTextLines, type SearchMatch } from '@builderbot/diff-viewer/utils';
@@ -109,6 +109,10 @@
     return Math.round(4 + fileChangeScale(total, maxFileChangeTotal) * 12);
   }
 
+  function hasLineChanges(file: FileEntry): boolean {
+    return (fileChangeTotal(file) ?? 0) > 0;
+  }
+
   // Helper to get snippet for a search result
   function getSnippet(match: SearchMatch, filePath: string): string {
     if (!diffViewerState) return '';
@@ -146,20 +150,24 @@
 
 {#snippet fileIcon(file: FileEntry, showReviewedSection: boolean)}
   {#if isReadonly}
-    <span class="status-icon status-icon-static">
+    <span
+      class="status-icon status-icon-static"
+      class:status-icon-added={file.status === 'added'}
+      class:status-icon-deleted={file.status === 'deleted'}
+      class:status-icon-renamed={file.status === 'renamed' && !hasLineChanges(file)}
+      class:status-icon-renamed-modified={file.status === 'renamed' && hasLineChanges(file)}
+    >
       <span class="icon-default">
-        {#if file.status === 'added'}
-          <CirclePlus size={16} />
-        {:else if file.status === 'deleted'}
-          <CircleMinus size={16} />
-        {:else}
-          <CircleArrowUp size={16} />
-        {/if}
+        {@render fileStatusVisual(file)}
       </span>
     </span>
   {:else}
     <span
       class="status-icon"
+      class:status-icon-added={file.status === 'added'}
+      class:status-icon-deleted={file.status === 'deleted'}
+      class:status-icon-renamed={file.status === 'renamed' && !hasLineChanges(file)}
+      class:status-icon-renamed-modified={file.status === 'renamed' && hasLineChanges(file)}
       onclick={(e) => onToggleReviewed(e, file)}
       onkeydown={(e) => e.key === 'Enter' && onToggleReviewed(e, file)}
       role="button"
@@ -167,13 +175,7 @@
       title={showReviewedSection ? 'Mark as needs review' : 'Mark as reviewed'}
     >
       <span class="icon-default">
-        {#if file.status === 'added'}
-          <CirclePlus size={16} />
-        {:else if file.status === 'deleted'}
-          <CircleMinus size={16} />
-        {:else}
-          <CircleArrowUp size={16} />
-        {/if}
+        {@render fileStatusVisual(file)}
       </span>
       <span class="icon-hover" class:icon-hover-unreview={showReviewedSection}>
         {#if showReviewedSection}
@@ -183,6 +185,18 @@
         {/if}
       </span>
     </span>
+  {/if}
+{/snippet}
+
+{#snippet fileStatusVisual(file: FileEntry)}
+  {#if file.status === 'added'}
+    <Plus size={16} />
+  {:else if file.status === 'deleted'}
+    <X size={16} />
+  {:else if file.status === 'renamed'}
+    <MoveRight size={16} />
+  {:else}
+    {@render changeIndicator(file)}
   {/if}
 {/snippet}
 
@@ -211,6 +225,8 @@
           ></span>
         {/if}
       </span>
+    {:else}
+      <span class="change-indicator-empty"></span>
     {/if}
   </span>
 {/snippet}
@@ -279,7 +295,6 @@
             {/if}
           {/if}
           {@render fileIcon(node.file, showReviewedSection)}
-          {@render changeIndicator(node.file)}
           <span class="file-name">{node.name}</span>
           {#if node.file.commentCount > 0}
             <span
@@ -543,9 +558,28 @@
     cursor: pointer;
     color: var(--text-muted);
     border-radius: 3px;
+    box-sizing: border-box;
+    width: 20px;
+    height: 20px;
     transition:
       color 0.1s,
       background-color 0.1s;
+  }
+
+  .status-icon-added {
+    color: var(--status-added);
+  }
+
+  .status-icon-deleted {
+    color: var(--status-deleted);
+  }
+
+  .status-icon-renamed {
+    color: var(--status-renamed);
+  }
+
+  .status-icon-renamed-modified {
+    color: var(--status-modified);
   }
 
   .status-icon:not(.status-icon-static):hover {
@@ -585,7 +619,7 @@
     align-items: flex-end;
     justify-content: center;
     flex-shrink: 0;
-    width: 8px;
+    width: 4px;
     height: 16px;
     overflow: hidden;
     border-radius: 2px;
@@ -601,6 +635,13 @@
     width: 100%;
     overflow: hidden;
     border-radius: inherit;
+  }
+
+  .change-indicator-empty {
+    width: 100%;
+    height: 6px;
+    border-radius: inherit;
+    background: var(--status-modified);
   }
 
   .change-segment {

--- a/apps/staged/src/lib/features/diff/diffModalHelpers.ts
+++ b/apps/staged/src/lib/features/diff/diffModalHelpers.ts
@@ -3,6 +3,8 @@ export {
   buildFileEntries,
   buildTree,
   compactTree,
+  fileChangeScale,
+  fileChangeTotal,
   formatLineRange,
   pathsMatch,
   truncateText,

--- a/crates/git-diff/src/diff.rs
+++ b/crates/git-diff/src/diff.rs
@@ -3,6 +3,7 @@ use crate::refs;
 use crate::types::*;
 use git2::{DiffOptions, Repository};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::Path;
 
 /// Resolve a GitRef, converting MergeBase/MergeBaseOf to a concrete SHA.
@@ -100,13 +101,25 @@ pub fn list_diff_files(repo: &Path, spec: &DiffSpec) -> Result<Vec<FileDiffSumma
             // Staged changes: diff between a rev and the index
             let args = ["diff", "--cached", "--name-status", "-z", base.as_str()];
             let output = cli::run(repo, &args)?;
-            parse_name_status(&output)
+            let mut files = parse_name_status(&output)?;
+            enrich_with_numstat(
+                repo,
+                &["diff", "--cached", "--numstat", "-z", base.as_str()],
+                &mut files,
+            );
+            Ok(files)
         }
         (GitRef::Rev(base), GitRef::Rev(head)) => {
             // Commit range - use git diff
             let args = ["diff", "--name-status", "-z", base.as_str(), head.as_str()];
             let output = cli::run(repo, &args)?;
-            parse_name_status(&output)
+            let mut files = parse_name_status(&output)?;
+            enrich_with_numstat(
+                repo,
+                &["diff", "--numstat", "-z", base.as_str(), head.as_str()],
+                &mut files,
+            );
+            Ok(files)
         }
         (GitRef::WorkingTree, _) | (GitRef::Index, _) => Err(GitError::CommandFailed(
             "Cannot use working tree or index as base".to_string(),
@@ -130,6 +143,8 @@ fn list_working_tree_changes(repo: &Path, base: &str) -> Result<Vec<FileDiffSumm
 
     // If base is HEAD, status gives us exactly what we need
     if base == "HEAD" {
+        let mut status_files = status_files;
+        enrich_with_numstat(repo, &["diff", "--numstat", "-z", base], &mut status_files);
         return Ok(status_files);
     }
 
@@ -154,7 +169,75 @@ fn list_working_tree_changes(repo: &Path, base: &str) -> Result<Vec<FileDiffSumm
         result_map.insert(path, file);
     }
 
-    Ok(result_map.into_values().collect())
+    let mut files: Vec<_> = result_map.into_values().collect();
+    enrich_with_numstat(repo, &["diff", "--numstat", "-z", base], &mut files);
+    Ok(files)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LineStats {
+    added: Option<u32>,
+    deleted: Option<u32>,
+}
+
+fn enrich_with_numstat(repo: &Path, args: &[&str], files: &mut [FileDiffSummary]) {
+    match cli::run(repo, args) {
+        Ok(output) => apply_numstat_output(files, &output),
+        Err(e) => log::warn!("git-diff: failed to enrich file list with numstat: {e}"),
+    }
+}
+
+fn parse_numstat_count(value: &str) -> Option<u32> {
+    if value == "-" {
+        None
+    } else {
+        value.parse().ok()
+    }
+}
+
+fn parse_numstat(output: &str) -> HashMap<std::path::PathBuf, LineStats> {
+    let mut stats = HashMap::new();
+    let mut parts = output.split('\0').peekable();
+
+    while let Some(record) = parts.next() {
+        if record.is_empty() {
+            continue;
+        }
+
+        let mut columns = record.split('\t');
+        let added = match columns.next() {
+            Some(value) => parse_numstat_count(value),
+            None => continue,
+        };
+        let deleted = match columns.next() {
+            Some(value) => parse_numstat_count(value),
+            None => continue,
+        };
+        let path_field = columns.next().unwrap_or_default();
+
+        let path = if path_field.is_empty() {
+            let _old = parts.next();
+            parts.next()
+        } else {
+            Some(path_field)
+        };
+
+        if let Some(path) = path.filter(|p| !p.is_empty()) {
+            stats.insert(path.into(), LineStats { added, deleted });
+        }
+    }
+
+    stats
+}
+
+fn apply_numstat_output(files: &mut [FileDiffSummary], output: &str) {
+    let stats = parse_numstat(output);
+    for file in files {
+        if let Some(line_stats) = stats.get(file.path()) {
+            file.added_lines = line_stats.added;
+            file.deleted_lines = line_stats.deleted;
+        }
+    }
 }
 
 /// Parse `git status --porcelain -z` output.
@@ -202,42 +285,30 @@ fn parse_porcelain_status(repo: &Path, output: &str) -> Result<Vec<FileDiffSumma
                         // It's a directory - expand into individual files
                         let files = expand_untracked_dir(repo, p)?;
                         for file in files {
-                            results.push(FileDiffSummary {
-                                before: None,
-                                after: Some(file.into()),
-                            });
+                            results.push(FileDiffSummary::new(None, Some(file.into())));
                         }
                     } else {
-                        results.push(FileDiffSummary {
-                            before: None,
-                            after: Some(p.clone().into()),
-                        });
+                        results.push(FileDiffSummary::new(None, Some(p.clone().into())));
                     }
                 }
             }
             ('A', _) | (_, 'A') => {
-                results.push(FileDiffSummary {
-                    before: None,
-                    after: new_path.map(Into::into),
-                });
+                results.push(FileDiffSummary::new(None, new_path.map(Into::into)));
             }
             ('D', _) | (_, 'D') => {
-                results.push(FileDiffSummary {
-                    before: new_path.map(Into::into),
-                    after: None,
-                });
+                results.push(FileDiffSummary::new(new_path.map(Into::into), None));
             }
             ('R', _) | ('C', _) => {
-                results.push(FileDiffSummary {
-                    before: old_path.map(Into::into),
-                    after: new_path.map(Into::into),
-                });
+                results.push(FileDiffSummary::new(
+                    old_path.map(Into::into),
+                    new_path.map(Into::into),
+                ));
             }
             _ => {
-                results.push(FileDiffSummary {
-                    before: new_path.clone().map(Into::into),
-                    after: new_path.map(Into::into),
-                });
+                results.push(FileDiffSummary::new(
+                    new_path.clone().map(Into::into),
+                    new_path.map(Into::into),
+                ));
             }
         };
     }
@@ -277,38 +348,26 @@ pub fn parse_name_status(output: &str) -> Result<Vec<FileDiffSummary>, GitError>
             'A' => {
                 // Added: just one path
                 if let Some(path) = parts.next() {
-                    results.push(FileDiffSummary {
-                        before: None,
-                        after: Some(path.into()),
-                    });
+                    results.push(FileDiffSummary::new(None, Some(path.into())));
                 }
             }
             'D' => {
                 // Deleted: just one path
                 if let Some(path) = parts.next() {
-                    results.push(FileDiffSummary {
-                        before: Some(path.into()),
-                        after: None,
-                    });
+                    results.push(FileDiffSummary::new(Some(path.into()), None));
                 }
             }
             'M' | 'T' => {
                 // Modified or Type changed: just one path
                 if let Some(path) = parts.next() {
-                    results.push(FileDiffSummary {
-                        before: Some(path.into()),
-                        after: Some(path.into()),
-                    });
+                    results.push(FileDiffSummary::new(Some(path.into()), Some(path.into())));
                 }
             }
             'R' | 'C' => {
                 // Renamed or Copied: two paths (old, new)
                 // Status might include similarity percentage like R100
                 if let (Some(old), Some(new)) = (parts.next(), parts.next()) {
-                    results.push(FileDiffSummary {
-                        before: Some(old.into()),
-                        after: Some(new.into()),
-                    });
+                    results.push(FileDiffSummary::new(Some(old.into()), Some(new.into())));
                 }
             }
             _ => {
@@ -753,6 +812,46 @@ mod tests {
         let output = "A\0added.txt\0M\0modified.txt\0D\0deleted.txt\0";
         let result = parse_name_status(output).unwrap();
         assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_apply_numstat_added() {
+        let mut result = parse_name_status("A\0new_file.txt\0").unwrap();
+        apply_numstat_output(&mut result, "12\t0\tnew_file.txt\0");
+        assert_eq!(result[0].added_lines, Some(12));
+        assert_eq!(result[0].deleted_lines, Some(0));
+    }
+
+    #[test]
+    fn test_apply_numstat_deleted() {
+        let mut result = parse_name_status("D\0old_file.txt\0").unwrap();
+        apply_numstat_output(&mut result, "0\t8\told_file.txt\0");
+        assert_eq!(result[0].added_lines, Some(0));
+        assert_eq!(result[0].deleted_lines, Some(8));
+    }
+
+    #[test]
+    fn test_apply_numstat_modified() {
+        let mut result = parse_name_status("M\0changed.txt\0").unwrap();
+        apply_numstat_output(&mut result, "3\t2\tchanged.txt\0");
+        assert_eq!(result[0].added_lines, Some(3));
+        assert_eq!(result[0].deleted_lines, Some(2));
+    }
+
+    #[test]
+    fn test_apply_numstat_renamed() {
+        let mut result = parse_name_status("R100\0old_name.txt\0new_name.txt\0").unwrap();
+        apply_numstat_output(&mut result, "4\t1\t\0old_name.txt\0new_name.txt\0");
+        assert_eq!(result[0].added_lines, Some(4));
+        assert_eq!(result[0].deleted_lines, Some(1));
+    }
+
+    #[test]
+    fn test_apply_numstat_binary() {
+        let mut result = parse_name_status("M\0image.png\0").unwrap();
+        apply_numstat_output(&mut result, "-\t-\timage.png\0");
+        assert_eq!(result[0].added_lines, None);
+        assert_eq!(result[0].deleted_lines, None);
     }
 
     #[test]

--- a/crates/git-diff/src/types.rs
+++ b/crates/git-diff/src/types.rs
@@ -137,12 +137,26 @@ pub struct File {
 /// Status inferred: Added (before=None), Deleted (after=None),
 /// Renamed (both Some, different paths), Modified (both Some, same path)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FileDiffSummary {
     pub before: Option<PathBuf>,
     pub after: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub added_lines: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_lines: Option<u32>,
 }
 
 impl FileDiffSummary {
+    pub fn new(before: Option<PathBuf>, after: Option<PathBuf>) -> Self {
+        Self {
+            before,
+            after,
+            added_lines: None,
+            deleted_lines: None,
+        }
+    }
+
     /// The primary path to use for this file (after if exists, else before)
     pub fn path(&self) -> &PathBuf {
         self.after.as_ref().or(self.before.as_ref()).unwrap()

--- a/packages/diff-viewer/src/lib/types.ts
+++ b/packages/diff-viewer/src/lib/types.ts
@@ -31,6 +31,8 @@ export interface File {
 export interface FileDiffSummary {
   before: string | null;
   after: string | null;
+  addedLines?: number | null;
+  deletedLines?: number | null;
 }
 
 /** Maps a region in the before file to a region in the after file. */

--- a/packages/diff-viewer/src/lib/utils/diffModalHelpers.test.ts
+++ b/packages/diff-viewer/src/lib/utils/diffModalHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { pathsMatch } from './diffModalHelpers';
+import { buildFileEntries, fileChangeScale, fileChangeTotal, pathsMatch } from './diffModalHelpers';
 
 describe('pathsMatch', () => {
   it('returns true for identical paths', () => {
@@ -43,5 +43,55 @@ describe('pathsMatch', () => {
 
   it('returns true when both paths are empty', () => {
     expect(pathsMatch('', '')).toBe(true);
+  });
+});
+
+describe('fileChangeTotal', () => {
+  it('returns null when a summary has no line stats', () => {
+    expect(fileChangeTotal({ before: 'a.ts', after: 'a.ts' })).toBeNull();
+  });
+
+  it('adds available added and deleted counts', () => {
+    expect(fileChangeTotal({ before: 'a.ts', after: 'a.ts', addedLines: 5, deletedLines: 2 })).toBe(
+      7
+    );
+  });
+});
+
+describe('fileChangeScale', () => {
+  it('returns 0 when totals are missing or empty', () => {
+    expect(fileChangeScale(null, 10)).toBe(0);
+    expect(fileChangeScale(0, 10)).toBe(0);
+    expect(fileChangeScale(10, 0)).toBe(0);
+  });
+
+  it('uses logarithmic scaling against the largest file total', () => {
+    expect(fileChangeScale(9, 99)).toBeCloseTo(Math.log1p(9) / Math.log1p(99));
+    expect(fileChangeScale(99, 99)).toBe(1);
+  });
+});
+
+describe('buildFileEntries', () => {
+  it('propagates optional line stats to file entries', () => {
+    const entries = buildFileEntries(
+      [{ before: 'src/file.ts', after: 'src/file.ts', addedLines: 3, deletedLines: 1 }],
+      [],
+      []
+    );
+
+    expect(entries[0]).toMatchObject({
+      path: 'src/file.ts',
+      addedLines: 3,
+      deletedLines: 1,
+    });
+  });
+
+  it('keeps missing line stats as null for older cached summaries', () => {
+    const entries = buildFileEntries([{ before: 'src/file.ts', after: 'src/file.ts' }], [], []);
+
+    expect(entries[0]).toMatchObject({
+      addedLines: null,
+      deletedLines: null,
+    });
   });
 });

--- a/packages/diff-viewer/src/lib/utils/diffModalHelpers.ts
+++ b/packages/diff-viewer/src/lib/utils/diffModalHelpers.ts
@@ -4,6 +4,8 @@ import { fileSummaryPath } from '../state/diffViewerState.svelte';
 export interface FileEntry {
   path: string;
   status: 'added' | 'deleted' | 'modified' | 'renamed';
+  addedLines?: number | null;
+  deletedLines?: number | null;
   isReviewed: boolean;
   commentCount: number;
   /** The distinct comment types present on this file (e.g. 'warning', 'suggestion'). */
@@ -32,6 +34,23 @@ export function fileStatus(summary: FileDiffSummary): 'added' | 'deleted' | 'mod
   if (!summary.after) return 'deleted';
   if (summary.before !== summary.after) return 'renamed';
   return 'modified';
+}
+
+export function fileChangeTotal(
+  file: Pick<FileDiffSummary | FileEntry, 'addedLines' | 'deletedLines'>
+): number | null {
+  const added = file.addedLines;
+  const deleted = file.deletedLines;
+  if (typeof added !== 'number' && typeof deleted !== 'number') return null;
+  return Math.max(0, added ?? 0) + Math.max(0, deleted ?? 0);
+}
+
+export function fileChangeScale(
+  fileTotal: number | null | undefined,
+  maxTotalInDiff: number
+): number {
+  if (!fileTotal || fileTotal <= 0 || maxTotalInDiff <= 0) return 0;
+  return Math.min(1, Math.log1p(fileTotal) / Math.log1p(maxTotalInDiff));
 }
 
 /** Aggregate comment count and distinct types for a single path. */
@@ -102,6 +121,8 @@ export function buildFileEntries(
     return {
       path,
       status: fileStatus(summary),
+      addedLines: summary.addedLines ?? null,
+      deletedLines: summary.deletedLines ?? null,
       isReviewed: reviewedSet.has(path),
       commentCount,
       commentTypes: [...commentTypes],

--- a/packages/diff-viewer/src/lib/utils/index.ts
+++ b/packages/diff-viewer/src/lib/utils/index.ts
@@ -13,6 +13,8 @@ export {
   buildFileEntries,
   buildTree,
   compactTree,
+  fileChangeScale,
+  fileChangeTotal,
   formatLineRange,
   pathsMatch,
   truncateText,


### PR DESCRIPTION
🤖 Summary
- Show relative file change indicators in the diff file tree.
- Parse, cache, and expose per-file relative change counts for diff consumers.
- Add helper coverage for relative diff modal behavior.

Tests
- Push hooks passed: crates-fmt, crates-test, crates-lint, staged-ci, differ-ci.