### PR TITLE
feat: add project context menu actions

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectContextMenu.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectContextMenu.svelte
@@ -32,6 +32,8 @@
       Math.min(y, window.innerHeight - rect.height - viewportPadding)
     );
     positioned = true;
+    await tick();
+    focusItem(0);
   }
 
   function handlePointerDown(event: PointerEvent) {
@@ -39,10 +41,54 @@
     onClose();
   }
 
+  function getMenuItems(): HTMLButtonElement[] {
+    if (!menuEl) return [];
+    return Array.from(menuEl.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+  }
+
+  function focusItem(index: number) {
+    const items = getMenuItems();
+    if (items.length === 0) return;
+    const clamped = Math.max(0, Math.min(index, items.length - 1));
+    items[clamped].focus();
+  }
+
   function handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
       event.preventDefault();
       onClose();
+      return;
+    }
+
+    const items = getMenuItems();
+    if (items.length === 0) return;
+    const active = document.activeElement as HTMLElement;
+    const currentIndex = items.indexOf(active as HTMLButtonElement);
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        focusItem(currentIndex < 0 ? 0 : (currentIndex + 1) % items.length);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        focusItem(
+          currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length
+        );
+        break;
+      case 'Home':
+        event.preventDefault();
+        focusItem(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        focusItem(items.length - 1);
+        break;
+      case 'Tab':
+        // Trap focus within menu; close instead of tabbing out
+        event.preventDefault();
+        onClose();
+        break;
     }
   }
 
@@ -87,11 +133,23 @@
   style:opacity={positioned ? '1' : '0'}
   bind:this={menuEl}
 >
-  <button type="button" class="menu-item" role="menuitem" onclick={handleMarkAsUnread}>
+  <button
+    type="button"
+    class="menu-item"
+    role="menuitem"
+    tabindex="-1"
+    onclick={handleMarkAsUnread}
+  >
     <Mail size={14} />
     Mark as Unread
   </button>
-  <button type="button" class="menu-item danger" role="menuitem" onclick={handleRemoveProject}>
+  <button
+    type="button"
+    class="menu-item danger"
+    role="menuitem"
+    tabindex="-1"
+    onclick={handleRemoveProject}
+  >
     <Trash2 size={14} />
     Remove Project
   </button>

--- a/apps/staged/src/lib/features/projects/ProjectContextMenu.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectContextMenu.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { Mail, Trash2 } from 'lucide-svelte';
+
+  interface Props {
+    x: number;
+    y: number;
+    onMarkAsUnread: () => void;
+    onRemoveProject: () => void;
+    onClose: () => void;
+  }
+
+  let { x, y, onMarkAsUnread, onRemoveProject, onClose }: Props = $props();
+
+  let menuEl = $state<HTMLDivElement | null>(null);
+  let left = $state(0);
+  let top = $state(0);
+  let positioned = $state(false);
+  const viewportPadding = 8;
+
+  async function placeMenu() {
+    positioned = false;
+    left = x;
+    top = y;
+    await tick();
+    if (!menuEl) return;
+
+    const rect = menuEl.getBoundingClientRect();
+    left = Math.max(viewportPadding, Math.min(x, window.innerWidth - rect.width - viewportPadding));
+    top = Math.max(
+      viewportPadding,
+      Math.min(y, window.innerHeight - rect.height - viewportPadding)
+    );
+    positioned = true;
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (menuEl?.contains(event.target as Node)) return;
+    onClose();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  }
+
+  function handleMarkAsUnread() {
+    onMarkAsUnread();
+    onClose();
+  }
+
+  function handleRemoveProject() {
+    onRemoveProject();
+    onClose();
+  }
+
+  onMount(() => {
+    void placeMenu();
+    window.addEventListener('pointerdown', handlePointerDown, true);
+    window.addEventListener('keydown', handleKeydown, true);
+    window.addEventListener('scroll', onClose, true);
+    window.addEventListener('resize', onClose);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown, true);
+      window.removeEventListener('keydown', handleKeydown, true);
+      window.removeEventListener('scroll', onClose, true);
+      window.removeEventListener('resize', onClose);
+    };
+  });
+
+  $effect(() => {
+    x;
+    y;
+    void placeMenu();
+  });
+</script>
+
+<div
+  class="project-context-menu"
+  role="menu"
+  aria-label="Project actions"
+  style:left={`${left}px`}
+  style:top={`${top}px`}
+  style:opacity={positioned ? '1' : '0'}
+  bind:this={menuEl}
+>
+  <button type="button" class="menu-item" role="menuitem" onclick={handleMarkAsUnread}>
+    <Mail size={14} />
+    Mark as Unread
+  </button>
+  <button type="button" class="menu-item danger" role="menuitem" onclick={handleRemoveProject}>
+    <Trash2 size={14} />
+    Remove Project
+  </button>
+</div>
+
+<style>
+  .project-context-menu {
+    position: fixed;
+    z-index: 1100;
+    min-width: 172px;
+    padding: 4px;
+    border: 1px solid var(--border-muted);
+    border-radius: 8px;
+    background: var(--bg-elevated);
+    box-shadow: var(--shadow-elevated);
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-height: 30px;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: var(--size-sm);
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .menu-item:hover,
+  .menu-item:focus-visible {
+    background: var(--bg-hover);
+    outline: none;
+  }
+
+  .menu-item :global(svg) {
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .menu-item.danger {
+    color: var(--ui-danger);
+  }
+
+  .menu-item.danger :global(svg) {
+    color: var(--ui-danger);
+  }
+
+  .menu-item.danger:hover,
+  .menu-item.danger:focus-visible {
+    background: var(--ui-danger-bg);
+  }
+</style>

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -24,6 +24,8 @@
   import { workspaceLifecycle } from './workspaceLifecycle.svelte';
   import { projectRunActionsStore } from '../../stores/projectRunActions.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
+  import { projectStateStore } from '../../stores/projectState.svelte';
+  import { canDeleteProjectWithoutConfirmation } from './projectDeleteSafety';
 
   /**
    * Merge incoming branches with existing ones, preserving worktreePath when
@@ -376,29 +378,14 @@
           continue;
         }
 
-        // Check if all branches have merged PRs and no unpushed changes.
-        // Skip the expensive hasUnpushedCommits check for remote branches —
-        // their commits live on the workspace and the SSH round-trip (~5s)
-        // blocks the UI. Treat merged remote branches as safe.
-        if (branches.length > 0) {
-          const allSafe = await Promise.all(
-            branches.map(async (branch) => {
-              const isMerged = branch.prState === 'MERGED';
-              if (!isMerged) return false;
-              if (branch.branchType === 'remote') return true;
+        const safe = await canDeleteProjectWithoutConfirmation({
+          branches,
+          repoCount,
+          hasUnpushedCommits: commands.hasUnpushedCommits,
+        });
 
-              try {
-                const hasUnpushed = await commands.hasUnpushedCommits(branch.id);
-                return !hasUnpushed;
-              } catch (e) {
-                return false;
-              }
-            })
-          );
-
-          if (allSafe.every((safe) => safe)) {
-            nextSafe.add(project.id);
-          }
+        if (safe) {
+          nextSafe.add(project.id);
         }
       }
 
@@ -418,6 +405,11 @@
 
   function handleNewProject() {
     showNewProjectModal = true;
+  }
+
+  function handleMarkProjectUnread(project: Project) {
+    if (deletingProjectNames.has(project.id)) return;
+    projectStateStore.markAsUnread(project.id);
   }
 
   async function handleProjectCreated(project: Project) {
@@ -444,35 +436,12 @@
     const branches = branchesByProject.get(project.id) || [];
     const repoCount = repoCountsByProject.get(project.id) || 0;
 
-    // If no repos, safe to delete without confirmation
-    if (repoCount === 0) {
-      projectToDelete = project;
-      // Immediately confirm since it's safe
-      await confirmDeleteProject();
-      return;
-    }
-
-    // Check if all branches have merged PRs and no unpushed changes.
-    // Skip the expensive hasUnpushedCommits check for remote branches —
-    // their commits live on the workspace and the SSH round-trip blocks the UI.
-    const allSafe = await Promise.all(
-      branches.map(async (branch) => {
-        const isMerged = branch.prState === 'MERGED';
-        if (!isMerged) return false;
-        if (branch.branchType === 'remote') return true;
-
-        // Check for unpushed commits
-        try {
-          const hasUnpushed = await commands.hasUnpushedCommits(branch.id);
-          return !hasUnpushed;
-        } catch (e) {
-          console.error('Failed to check unpushed commits:', e);
-          return false;
-        }
-      })
-    );
-
-    const isSafeToDelete = branches.length > 0 && allSafe.every((safe) => safe);
+    const isSafeToDelete = await canDeleteProjectWithoutConfirmation({
+      branches,
+      repoCount,
+      hasUnpushedCommits: commands.hasUnpushedCommits,
+      onCheckError: (e) => console.error('Failed to check unpushed commits:', e),
+    });
 
     if (isSafeToDelete) {
       // Safe to delete without confirmation
@@ -690,6 +659,8 @@
     {reposByProject}
     projectBranches={branchesByProject}
     showAllProjectsRow={true}
+    onMarkProjectUnread={handleMarkProjectUnread}
+    onRemoveProject={handleDeleteProjectRequest}
   />
 
   <div class="main-panel" class:no-pad={!loading && !hasContent}>

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -480,6 +480,7 @@
 
     try {
       await commands.deleteProject(id);
+      projectStateStore.markAsRead(id);
       projects = projects.filter((p) => p.id !== id);
       setProjects(projects);
       const nextBranches = new Map(branchesByProject);

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -462,6 +462,7 @@
 
     try {
       await commands.deleteProject(id);
+      projectStateStore.markAsRead(id);
       commands.invalidateProjectBranchTimelines(branchesToClear.map((branch) => branch.id));
       await loadProjects();
     } catch (e) {

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -26,11 +26,14 @@
   import { selectProject } from '../layout/navigation.svelte';
   import NewProjectModal from './NewProjectModal.svelte';
   import ProjectsSidebar from './ProjectsSidebar.svelte';
+  import ProjectContextMenu from './ProjectContextMenu.svelte';
   import { getProjectStatus } from './projectStatus';
   import SplashScreen from './SplashScreen.svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import SineWave from '../../shared/SineWave.svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
+  import ConfirmDialog from '../../shared/ConfirmDialog.svelte';
+  import { alerts } from '../../shared/alerts.svelte';
 
   import { setProjects } from './projectsSidebarState.svelte';
   import {
@@ -41,6 +44,7 @@
   import { darkMode } from '../../stores/isDark.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { badgeBg, badgeFg, badgeBgHover } from '../../shared/badgeColors';
+  import { canDeleteProjectWithoutConfirmation } from './projectDeleteSafety';
 
   type FilterKind = 'unread' | 'running' | { repo: string; subpath: string };
 
@@ -51,6 +55,8 @@
   let showNewProjectModal = $state(false);
   let isCommandKeyHeld = $state(false);
   let deletingProjectNames = $state<Map<string, string>>(new Map());
+  let projectToDelete = $state<Project | null>(null);
+  let projectMenu = $state<{ project: Project; x: number; y: number } | null>(null);
   let reposByProject = $state<Map<string, ProjectRepo[]>>(new Map());
   let reposHydrating = $state(false);
   let mainPanelEl = $state<HTMLDivElement | null>(null);
@@ -399,11 +405,78 @@
   }
 
   function openProject(projectId: string) {
+    closeProjectMenu();
     if (isProjectDeleting(projectId)) return;
     if (mainPanelEl) {
       setProjectsListScrollTop(mainPanelEl.scrollTop);
     }
     selectProject(projectId);
+  }
+
+  function closeProjectMenu() {
+    projectMenu = null;
+  }
+
+  function openProjectMenu(event: MouseEvent, project: Project, deleting: boolean) {
+    if (deleting) return;
+    event.preventDefault();
+    event.stopPropagation();
+    projectMenu = { project, x: event.clientX, y: event.clientY };
+  }
+
+  function handleMarkProjectUnread(project: Project) {
+    if (isProjectDeleting(project.id)) return;
+    projectStateStore.markAsUnread(project.id);
+  }
+
+  async function handleRemoveProject(project: Project) {
+    if (isProjectDeleting(project.id)) return;
+
+    const deleteImmediately = await canDeleteProjectWithoutConfirmation({
+      branches: projectBranches.get(project.id) || [],
+      repoCount: repoCountsByProject.get(project.id) ?? (project.githubRepo ? 1 : 0),
+      hasUnpushedCommits: commands.hasUnpushedCommits,
+      onCheckError: (e) => console.error('Failed to check unpushed commits:', e),
+    });
+
+    if (deleteImmediately) {
+      await deleteProject(project);
+    } else {
+      projectToDelete = project;
+    }
+  }
+
+  async function confirmDeleteProject() {
+    if (!projectToDelete) return;
+    await deleteProject(projectToDelete);
+  }
+
+  async function deleteProject(project: Project) {
+    if (isProjectDeleting(project.id)) return;
+
+    const id = project.id;
+    const name = projectDisplayName(project);
+    const branchesToClear = projectBranches.get(id) || [];
+    projectToDelete = null;
+    deletingProjectNames = new Map(deletingProjectNames).set(id, name);
+
+    try {
+      await commands.deleteProject(id);
+      commands.invalidateProjectBranchTimelines(branchesToClear.map((branch) => branch.id));
+      await loadProjects();
+    } catch (e) {
+      console.error('Failed to delete project:', e);
+      const message = e instanceof Error ? e.message : String(e);
+      alerts.show({
+        tone: 'error',
+        title: 'Unable to delete project',
+        message,
+      });
+    } finally {
+      const next = new Map(deletingProjectNames);
+      next.delete(id);
+      deletingProjectNames = next;
+    }
   }
 
   function getProjectPrStatus(
@@ -504,6 +577,8 @@
     {reposByProject}
     {projectBranches}
     showAllProjectsRow={true}
+    onMarkProjectUnread={handleMarkProjectUnread}
+    onRemoveProject={handleRemoveProject}
   />
 
   <div class="main-panel" bind:this={mainPanelEl} onscroll={handleMainPanelScroll}>
@@ -582,6 +657,8 @@
                 class="project-card"
                 class:deleting={status.kind === 'deleting'}
                 onclick={() => openProject(project.id)}
+                oncontextmenu={(event: MouseEvent) =>
+                  openProjectMenu(event, project, status.kind === 'deleting')}
                 disabled={status.kind === 'deleting'}
                 title={status.kind === 'deleting' ? 'Project deletion in progress' : undefined}
               >
@@ -703,6 +780,28 @@
 
 {#if showNewProjectModal && projects.length > 0}
   <NewProjectModal onCreated={handleProjectCreated} onClose={() => (showNewProjectModal = false)} />
+{/if}
+
+{#if projectMenu}
+  {@const menuProject = projectMenu.project}
+  <ProjectContextMenu
+    x={projectMenu.x}
+    y={projectMenu.y}
+    onMarkAsUnread={() => handleMarkProjectUnread(menuProject)}
+    onRemoveProject={() => handleRemoveProject(menuProject)}
+    onClose={closeProjectMenu}
+  />
+{/if}
+
+{#if projectToDelete}
+  <ConfirmDialog
+    title="Remove Project"
+    message={`Remove "${projectDisplayName(projectToDelete)}" from Staged? There are unmerged changes in this project's branches. Deleting this project will lose any changes not pushed to GitHub.`}
+    confirmLabel="Remove"
+    danger={true}
+    onConfirm={confirmDeleteProject}
+    onCancel={() => (projectToDelete = null)}
+  />
 {/if}
 
 <style>

--- a/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
@@ -35,6 +35,7 @@
     SIDEBAR_MIN_WIDTH,
   } from './projectsSidebarState.svelte';
   import { viewport, watchViewport } from '../../shared/viewport.svelte';
+  import ProjectContextMenu from './ProjectContextMenu.svelte';
 
   const devBranch = import.meta.env.VITE_DEV_BRANCH as string | undefined;
 
@@ -47,6 +48,8 @@
     reposByProject?: Map<string, ProjectRepo[]>;
     showAllProjectsRow?: boolean;
     projectBranches?: Map<string, Branch[]>;
+    onMarkProjectUnread?: (project: Project) => void;
+    onRemoveProject?: (project: Project) => void | Promise<void>;
   }
 
   let {
@@ -58,9 +61,15 @@
     reposByProject = new Map(),
     showAllProjectsRow = true,
     projectBranches = new Map(),
+    onMarkProjectUnread,
+    onRemoveProject,
   }: Props = $props();
 
+  let projectMenu = $state<{ project: Project; x: number; y: number } | null>(null);
+  let lastNavigationKey = `${navigation.activeView}:${navigation.selectedProjectId ?? ''}`;
+
   function openProject(projectId: string) {
+    closeProjectMenu();
     const status = getProjectStatus(
       projectId,
       deletingProjectNames,
@@ -71,11 +80,24 @@
   }
 
   function openAllProjects() {
+    closeProjectMenu();
     goHome();
   }
 
   function openNewProject() {
+    closeProjectMenu();
     window.dispatchEvent(new CustomEvent('staged:new-project'));
+  }
+
+  function closeProjectMenu() {
+    projectMenu = null;
+  }
+
+  function openProjectMenu(event: MouseEvent, project: Project, deleting: boolean) {
+    if (deleting || !onMarkProjectUnread || !onRemoveProject) return;
+    event.preventDefault();
+    event.stopPropagation();
+    projectMenu = { project, x: event.clientX, y: event.clientY };
   }
 
   function scrollIfActive(node: HTMLElement, active: boolean) {
@@ -205,6 +227,14 @@
       setProjectsSidebarWidth(SIDEBAR_MAX_WIDTH);
     }
   }
+
+  $effect(() => {
+    const nextNavigationKey = `${navigation.activeView}:${navigation.selectedProjectId ?? ''}`;
+    if (nextNavigationKey !== lastNavigationKey) {
+      closeProjectMenu();
+      lastNavigationKey = nextNavigationKey;
+    }
+  });
 </script>
 
 {#if sidebarVisible}
@@ -268,6 +298,8 @@
                 class:active={navigation.selectedProjectId === project.id}
                 class:deleting={status.kind === 'deleting'}
                 onclick={() => openProject(project.id)}
+                oncontextmenu={(event: MouseEvent) =>
+                  openProjectMenu(event, project, status.kind === 'deleting')}
                 disabled={status.kind === 'deleting'}
                 title={status.kind === 'deleting' ? 'Project deletion in progress' : undefined}
               >
@@ -373,6 +405,17 @@
       onkeydown={handleResizeHandleKeydown}
     ></button>
   </aside>
+{/if}
+
+{#if projectMenu && onMarkProjectUnread && onRemoveProject}
+  {@const menuProject = projectMenu.project}
+  <ProjectContextMenu
+    x={projectMenu.x}
+    y={projectMenu.y}
+    onMarkAsUnread={() => onMarkProjectUnread(menuProject)}
+    onRemoveProject={() => onRemoveProject(menuProject)}
+    onClose={closeProjectMenu}
+  />
 {/if}
 
 <style>

--- a/apps/staged/src/lib/features/projects/projectDeleteSafety.test.ts
+++ b/apps/staged/src/lib/features/projects/projectDeleteSafety.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Branch } from '../../types';
+import { canDeleteProjectWithoutConfirmation } from './projectDeleteSafety';
+
+function branch(overrides: Partial<Branch> = {}): Branch {
+  return {
+    id: 'branch-1',
+    projectId: 'project-1',
+    projectRepoId: 'repo-1',
+    branchName: 'feature',
+    baseBranch: 'main',
+    prNumber: 123,
+    branchType: 'local',
+    workspaceName: null,
+    workstationId: null,
+    workspaceStatus: null,
+    setupComplete: true,
+    worktreePath: '/tmp/repo',
+    createdAt: 0,
+    updatedAt: 0,
+    prState: 'MERGED',
+    prChecksStatus: 'SUCCESS',
+    prReviewDecision: 'APPROVED',
+    prMergeable: true,
+    prDraft: false,
+    prUrl: null,
+    prUpdatedAt: null,
+    prFetchedAt: null,
+    prHeadSha: null,
+    ...overrides,
+  };
+}
+
+describe('canDeleteProjectWithoutConfirmation', () => {
+  it('allows projects with no repos to delete immediately', async () => {
+    const hasUnpushedCommits = vi.fn();
+
+    await expect(
+      canDeleteProjectWithoutConfirmation({
+        branches: [],
+        repoCount: 0,
+        hasUnpushedCommits,
+      })
+    ).resolves.toBe(true);
+    expect(hasUnpushedCommits).not.toHaveBeenCalled();
+  });
+
+  it('allows merged remote branches without checking unpushed commits', async () => {
+    const hasUnpushedCommits = vi.fn();
+
+    await expect(
+      canDeleteProjectWithoutConfirmation({
+        branches: [branch({ branchType: 'remote', id: 'remote-branch' })],
+        repoCount: 1,
+        hasUnpushedCommits,
+      })
+    ).resolves.toBe(true);
+    expect(hasUnpushedCommits).not.toHaveBeenCalled();
+  });
+
+  it('allows merged local branches without unpushed commits', async () => {
+    const hasUnpushedCommits = vi.fn().mockResolvedValue(false);
+
+    await expect(
+      canDeleteProjectWithoutConfirmation({
+        branches: [branch({ id: 'local-branch' })],
+        repoCount: 1,
+        hasUnpushedCommits,
+      })
+    ).resolves.toBe(true);
+    expect(hasUnpushedCommits).toHaveBeenCalledWith('local-branch');
+  });
+
+  it('requires confirmation for merged local branches with unpushed commits', async () => {
+    const hasUnpushedCommits = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      canDeleteProjectWithoutConfirmation({
+        branches: [branch()],
+        repoCount: 1,
+        hasUnpushedCommits,
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('requires confirmation for unmerged branches', async () => {
+    const hasUnpushedCommits = vi.fn();
+
+    await expect(
+      canDeleteProjectWithoutConfirmation({
+        branches: [branch({ prState: 'OPEN' })],
+        repoCount: 1,
+        hasUnpushedCommits,
+      })
+    ).resolves.toBe(false);
+    expect(hasUnpushedCommits).not.toHaveBeenCalled();
+  });
+
+  it('requires confirmation when the unpushed commits check fails', async () => {
+    const error = new Error('git failed');
+    const hasUnpushedCommits = vi.fn().mockRejectedValue(error);
+    const onCheckError = vi.fn();
+    const checkedBranch = branch();
+
+    await expect(
+      canDeleteProjectWithoutConfirmation({
+        branches: [checkedBranch],
+        repoCount: 1,
+        hasUnpushedCommits,
+        onCheckError,
+      })
+    ).resolves.toBe(false);
+    expect(onCheckError).toHaveBeenCalledWith(error, checkedBranch);
+  });
+});

--- a/apps/staged/src/lib/features/projects/projectDeleteSafety.ts
+++ b/apps/staged/src/lib/features/projects/projectDeleteSafety.ts
@@ -1,0 +1,34 @@
+import type { Branch } from '../../types';
+
+export interface ProjectDeleteSafetyOptions {
+  branches: Branch[];
+  repoCount: number;
+  hasUnpushedCommits: (branchId: string) => Promise<boolean>;
+  onCheckError?: (error: unknown, branch: Branch) => void;
+}
+
+export async function canDeleteProjectWithoutConfirmation({
+  branches,
+  repoCount,
+  hasUnpushedCommits,
+  onCheckError,
+}: ProjectDeleteSafetyOptions): Promise<boolean> {
+  if (repoCount === 0) return true;
+  if (branches.length === 0) return false;
+
+  const branchSafety = await Promise.all(
+    branches.map(async (branch) => {
+      if (branch.prState !== 'MERGED') return false;
+      if (branch.branchType === 'remote') return true;
+
+      try {
+        return !(await hasUnpushedCommits(branch.id));
+      } catch (error) {
+        onCheckError?.(error, branch);
+        return false;
+      }
+    })
+  );
+
+  return branchSafety.every(Boolean);
+}


### PR DESCRIPTION
🤖 Summary
- Add right-click project actions for marking projects unread and removing projects from the list/sidebar.
- Share delete-safety logic across project views and clear unread state after deletion.
- Add unit coverage for project delete confirmation rules.

Tests
- pre-push hooks: crates-fmt, crates-test, crates-lint, differ-ci, staged-ci