### PR TITLE
fix: prevent mobile viewport zoom

### DIFF
--- a/apps/staged/index.html
+++ b/apps/staged/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>Staged</title>
     <!-- The window starts hidden and is shown by App.svelte after the
          theme is applied, so no inline style hacks are needed here. -->

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -231,7 +231,7 @@
     border: 1px solid var(--border-muted);
     border-radius: 6px;
     color: var(--text-primary);
-    font-size: var(--size-sm);
+    font-size: var(--size-md);
     font-family: inherit;
     line-height: 1.5;
     resize: none;

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -1050,7 +1050,7 @@
     border: none;
     background: none;
     color: var(--text-primary);
-    font-size: var(--size-sm);
+    font-size: var(--size-md);
     font-family: inherit;
     line-height: 1.5;
     resize: none;
@@ -1345,6 +1345,8 @@
       height: auto;
       max-height: 120px;
       padding: 4px 2px;
+      min-height: 40px;
+      font-size: var(--size-md);
       overflow-y: auto;
       white-space: pre-wrap;
     }

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -699,7 +699,7 @@
     border: 1px solid var(--border-muted);
     border-radius: 6px;
     color: var(--text-primary);
-    font-size: var(--size-sm);
+    font-size: var(--size-md);
     font-family: inherit;
     line-height: 1.5;
     flex: 1;

--- a/apps/staged/src/lib/features/sessions/SessionLauncher.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionLauncher.svelte
@@ -285,7 +285,7 @@
     border: 1px solid var(--border-muted);
     border-radius: 6px;
     color: var(--text-primary);
-    font-size: var(--size-xs);
+    font-size: var(--size-md);
   }
 
   .create-input::placeholder {

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -2183,7 +2183,7 @@
     border: 1px solid var(--border-muted);
     border-radius: 10px;
     color: var(--text-primary);
-    font-size: var(--size-sm);
+    font-size: var(--size-md);
     font-family: inherit;
     line-height: 1.5;
     resize: none;

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -904,7 +904,7 @@
     min-width: 0;
     min-height: 36px;
     padding: 8px 12px;
-    font-size: var(--size-sm);
+    font-size: var(--size-md);
   }
 
   .context-list {
@@ -1035,7 +1035,7 @@
     background: var(--bg-chrome);
     color: var(--text-primary);
     font-family: 'SF Mono', Menlo, Consolas, monospace;
-    font-size: var(--size-xs);
+    font-size: var(--size-md);
   }
 
   .badge-input-error {

--- a/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
@@ -228,7 +228,7 @@
     border: 1px solid var(--border-muted);
     border-radius: 5px;
     color: var(--text-primary);
-    font-size: var(--size-xs);
+    font-size: var(--size-md);
     cursor: pointer;
     transition:
       border-color 0.1s,

--- a/apps/staged/src/lib/features/settings/ThemeSelectorModal.svelte
+++ b/apps/staged/src/lib/features/settings/ThemeSelectorModal.svelte
@@ -165,7 +165,7 @@
     border: 1px solid var(--border-muted);
     border-radius: 5px;
     color: var(--text-primary);
-    font-size: var(--size-xs);
+    font-size: var(--size-md);
     box-sizing: border-box;
     transition:
       border-color 0.1s,

--- a/apps/staged/src/lib/shared/InContentSearch.svelte
+++ b/apps/staged/src/lib/shared/InContentSearch.svelte
@@ -113,7 +113,7 @@
     background: transparent;
     border: none;
     outline: none;
-    font-size: var(--size-sm);
+    font-size: var(--size-md);
     color: var(--text-primary);
     width: 200px;
     font-family: inherit;


### PR DESCRIPTION
🤖

## Summary
- Disable viewport scaling for Staged on mobile.
- Use the base font size for editable fields to avoid input auto-zoom.

## Tests
- Push hooks passed: crates-fmt, crates-lint, crates-test, differ-ci, staged-ci.