### PR TITLE
feat: add PR button status tooltips with refresh state

### DIFF
--- a/apps/staged/src-tauri/src/git/github.rs
+++ b/apps/staged/src-tauri/src/git/github.rs
@@ -59,6 +59,8 @@ pub struct PrStatus {
     pub checks_summary: ChecksSummary,
     /// The SHA of the PR's head commit on GitHub
     pub head_sha: Option<String>,
+    /// Failed checks from the most recent GitHub status rollup.
+    pub failed_checks: Vec<FailedCheck>,
 }
 
 /// Summary of CI/status checks for a PR
@@ -75,6 +77,15 @@ pub struct ChecksSummary {
     pub pending: u32,
     /// Overall state (SUCCESS, FAILURE, PENDING, or EXPECTED if no checks)
     pub state: String,
+}
+
+/// A failed check from GitHub's PR status rollup.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FailedCheck {
+    pub name: String,
+    pub state: String,
+    pub details_url: Option<String>,
 }
 
 /// A GitHub issue (for display in picker)
@@ -2157,11 +2168,105 @@ struct GhStatusCheck {
     #[serde(rename = "__typename")]
     typename: String,
     #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    context: Option<String>,
+    #[serde(default)]
     state: Option<String>,
     #[serde(default)]
     status: Option<String>,
     #[serde(default)]
     conclusion: Option<String>,
+    #[serde(rename = "detailsUrl", default)]
+    details_url: Option<String>,
+    #[serde(rename = "targetUrl", default)]
+    target_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CheckRollupAnalysis {
+    total: u32,
+    passed: u32,
+    failed: u32,
+    pending: u32,
+    state: String,
+    failed_checks: Vec<FailedCheck>,
+}
+
+fn check_rollup_state(check: &GhStatusCheck) -> Option<String> {
+    let state = if check.typename == "StatusContext" {
+        check.state.as_deref()
+    } else if check.typename == "CheckRun" {
+        check.conclusion.as_deref().or(check.status.as_deref())
+    } else {
+        None
+    };
+
+    state.map(str::to_ascii_uppercase)
+}
+
+fn check_rollup_name(check: &GhStatusCheck) -> String {
+    check
+        .name
+        .as_deref()
+        .or(check.context.as_deref())
+        .unwrap_or("Unnamed check")
+        .to_string()
+}
+
+fn check_rollup_details_url(check: &GhStatusCheck) -> Option<String> {
+    check
+        .details_url
+        .as_ref()
+        .or(check.target_url.as_ref())
+        .cloned()
+}
+
+fn analyze_status_check_rollup(checks: &[GhStatusCheck]) -> CheckRollupAnalysis {
+    let mut total = 0u32;
+    let mut passed = 0u32;
+    let mut failed = 0u32;
+    let mut pending = 0u32;
+    let mut failed_checks = Vec::new();
+
+    for check in checks {
+        total += 1;
+
+        match check_rollup_state(check).as_deref() {
+            Some("SUCCESS") | Some("COMPLETED") => passed += 1,
+            Some(state @ ("FAILURE" | "ERROR" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED")) => {
+                failed += 1;
+                failed_checks.push(FailedCheck {
+                    name: check_rollup_name(check),
+                    state: state.to_string(),
+                    details_url: check_rollup_details_url(check),
+                });
+            }
+            Some("PENDING") | Some("IN_PROGRESS") | Some("QUEUED") | Some("WAITING") => {
+                pending += 1
+            }
+            _ => pending += 1,
+        }
+    }
+
+    let state = if total == 0 {
+        "EXPECTED".to_string()
+    } else if failed > 0 {
+        "FAILURE".to_string()
+    } else if pending > 0 {
+        "PENDING".to_string()
+    } else {
+        "SUCCESS".to_string()
+    };
+
+    CheckRollupAnalysis {
+        total,
+        passed,
+        failed,
+        pending,
+        state,
+        failed_checks,
+    }
 }
 
 /// Fetch detailed status information for a PR by number.
@@ -2180,50 +2285,7 @@ pub fn fetch_pr_status(repo: &Path, pr_number: u64) -> Result<PrStatus, GitError
     let item: GhPrStatusItem =
         serde_json::from_str(&output).map_err(|e| GitError::CommandFailed(e.to_string()))?;
 
-    // Analyze status checks
-    let mut total = 0u32;
-    let mut passed = 0u32;
-    let mut failed = 0u32;
-    let mut pending = 0u32;
-
-    for check in &item.status_check_rollup {
-        total += 1;
-
-        // GitHub status checks have different types and fields
-        // StatusContext uses 'state', CheckRun uses 'status' and 'conclusion'
-        let check_state = if check.typename == "StatusContext" {
-            check.state.as_deref()
-        } else if check.typename == "CheckRun" {
-            // For CheckRun, check conclusion first, then status
-            check.conclusion.as_deref().or(check.status.as_deref())
-        } else {
-            None
-        };
-
-        match check_state {
-            Some("SUCCESS") | Some("COMPLETED") => passed += 1,
-            Some("FAILURE")
-            | Some("ERROR")
-            | Some("CANCELLED")
-            | Some("TIMED_OUT")
-            | Some("ACTION_REQUIRED") => failed += 1,
-            Some("PENDING") | Some("IN_PROGRESS") | Some("QUEUED") | Some("WAITING") => {
-                pending += 1
-            }
-            _ => pending += 1, // Unknown states treated as pending
-        }
-    }
-
-    // Determine overall checks state
-    let checks_state = if total == 0 {
-        "EXPECTED".to_string()
-    } else if failed > 0 {
-        "FAILURE".to_string()
-    } else if pending > 0 {
-        "PENDING".to_string()
-    } else {
-        "SUCCESS".to_string()
-    };
+    let checks = analyze_status_check_rollup(&item.status_check_rollup);
 
     Ok(PrStatus {
         state: item.state.to_uppercase(),
@@ -2231,13 +2293,14 @@ pub fn fetch_pr_status(repo: &Path, pr_number: u64) -> Result<PrStatus, GitError
         mergeable: item.mergeable.to_uppercase(),
         review_decision: item.review_decision,
         checks_summary: ChecksSummary {
-            total,
-            passed,
-            failed,
-            pending,
-            state: checks_state,
+            total: checks.total,
+            passed: checks.passed,
+            failed: checks.failed,
+            pending: checks.pending,
+            state: checks.state,
         },
         head_sha: item.head_ref_oid,
+        failed_checks: checks.failed_checks,
     })
 }
 
@@ -2279,46 +2342,7 @@ pub fn fetch_pr_status_for_repo(github_repo: &str, pr_number: u64) -> Result<PrS
         }
     };
 
-    // Analyze status checks (same logic as fetch_pr_status)
-    let mut total = 0u32;
-    let mut passed = 0u32;
-    let mut failed = 0u32;
-    let mut pending = 0u32;
-
-    for check in &item.status_check_rollup {
-        total += 1;
-
-        let check_state = if check.typename == "StatusContext" {
-            check.state.as_deref()
-        } else if check.typename == "CheckRun" {
-            check.conclusion.as_deref().or(check.status.as_deref())
-        } else {
-            None
-        };
-
-        match check_state {
-            Some("SUCCESS") | Some("COMPLETED") => passed += 1,
-            Some("FAILURE")
-            | Some("ERROR")
-            | Some("CANCELLED")
-            | Some("TIMED_OUT")
-            | Some("ACTION_REQUIRED") => failed += 1,
-            Some("PENDING") | Some("IN_PROGRESS") | Some("QUEUED") | Some("WAITING") => {
-                pending += 1
-            }
-            _ => pending += 1,
-        }
-    }
-
-    let checks_state = if total == 0 {
-        "EXPECTED".to_string()
-    } else if failed > 0 {
-        "FAILURE".to_string()
-    } else if pending > 0 {
-        "PENDING".to_string()
-    } else {
-        "SUCCESS".to_string()
-    };
+    let checks = analyze_status_check_rollup(&item.status_check_rollup);
 
     Ok(PrStatus {
         state: item.state.to_uppercase(),
@@ -2326,13 +2350,14 @@ pub fn fetch_pr_status_for_repo(github_repo: &str, pr_number: u64) -> Result<PrS
         mergeable: item.mergeable.to_uppercase(),
         review_decision: item.review_decision,
         checks_summary: ChecksSummary {
-            total,
-            passed,
-            failed,
-            pending,
-            state: checks_state,
+            total: checks.total,
+            passed: checks.passed,
+            failed: checks.failed,
+            pending: checks.pending,
+            state: checks.state,
         },
         head_sha: item.head_ref_oid,
+        failed_checks: checks.failed_checks,
     })
 }
 
@@ -2736,6 +2761,37 @@ mod tests {
         }
     }
 
+    fn check_run(
+        name: &str,
+        status: &str,
+        conclusion: &str,
+        details_url: Option<&str>,
+    ) -> GhStatusCheck {
+        GhStatusCheck {
+            typename: "CheckRun".to_string(),
+            name: Some(name.to_string()),
+            context: None,
+            state: None,
+            status: Some(status.to_string()),
+            conclusion: Some(conclusion.to_string()),
+            details_url: details_url.map(ToString::to_string),
+            target_url: None,
+        }
+    }
+
+    fn status_context(context: &str, state: &str, target_url: Option<&str>) -> GhStatusCheck {
+        GhStatusCheck {
+            typename: "StatusContext".to_string(),
+            name: None,
+            context: Some(context.to_string()),
+            state: Some(state.to_string()),
+            status: None,
+            conclusion: None,
+            details_url: None,
+            target_url: target_url.map(ToString::to_string),
+        }
+    }
+
     #[test]
     fn test_check_github_auth_returns_status() {
         // This test just verifies the function runs without panicking
@@ -2785,6 +2841,64 @@ mod tests {
 
         drop(lock_map);
         clear_clone_lock_map();
+    }
+
+    #[test]
+    fn test_analyze_status_check_rollup_captures_failed_check_run() {
+        let checks = vec![
+            check_run(
+                "unit-tests",
+                "COMPLETED",
+                "FAILURE",
+                Some("https://github.com/owner/repo/actions/runs/1"),
+            ),
+            check_run(
+                "lint",
+                "COMPLETED",
+                "SUCCESS",
+                Some("https://github.com/owner/repo/actions/runs/2"),
+            ),
+        ];
+
+        let analysis = analyze_status_check_rollup(&checks);
+
+        assert_eq!(analysis.total, 2);
+        assert_eq!(analysis.passed, 1);
+        assert_eq!(analysis.failed, 1);
+        assert_eq!(analysis.pending, 0);
+        assert_eq!(analysis.state, "FAILURE");
+        assert_eq!(
+            analysis.failed_checks,
+            vec![FailedCheck {
+                name: "unit-tests".to_string(),
+                state: "FAILURE".to_string(),
+                details_url: Some("https://github.com/owner/repo/actions/runs/1".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_analyze_status_check_rollup_captures_failed_status_context() {
+        let checks = vec![
+            status_context("lint", "TIMED_OUT", Some("https://ci.example.com/lint/1")),
+            status_context("build", "PENDING", Some("https://ci.example.com/build/1")),
+        ];
+
+        let analysis = analyze_status_check_rollup(&checks);
+
+        assert_eq!(analysis.total, 2);
+        assert_eq!(analysis.passed, 0);
+        assert_eq!(analysis.failed, 1);
+        assert_eq!(analysis.pending, 1);
+        assert_eq!(analysis.state, "FAILURE");
+        assert_eq!(
+            analysis.failed_checks,
+            vec![FailedCheck {
+                name: "lint".to_string(),
+                state: "TIMED_OUT".to_string(),
+                details_url: Some("https://ci.example.com/lint/1".to_string()),
+            }]
+        );
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/git/mod.rs
+++ b/apps/staged/src-tauri/src/git/mod.rs
@@ -23,8 +23,9 @@ pub use github::{
     post_single_comment_to_github, prune_remote_for_repo, push_branch, resolve_default_branch,
     search_github_repos, search_issues, search_pull_requests, sync_review_to_github,
     update_clone_to_remote_head, update_comment_on_github, update_pull_request,
-    validate_subpath_in_repo, ChecksSummary, CreatePrResult, GitHubAuthStatus, GitHubCommentResult,
-    GitHubRepo, GitHubSyncResult, Issue, PrStatus, PullRequest, PullRequestInfo,
+    validate_subpath_in_repo, ChecksSummary, CreatePrResult, FailedCheck, GitHubAuthStatus,
+    GitHubCommentResult, GitHubRepo, GitHubSyncResult, Issue, PrStatus, PullRequest,
+    PullRequestInfo,
 };
 pub use refs::{
     branch_name_without_origin, detect_default_branch, get_current_branch, get_remote_url,

--- a/apps/staged/src-tauri/src/prs.rs
+++ b/apps/staged/src-tauri/src/prs.rs
@@ -42,6 +42,8 @@ struct PrStatusEvent {
     pr_mergeable: bool,
     pr_draft: bool,
     pr_head_sha: Option<String>,
+    pr_fetched_at: i64,
+    failed_checks: Vec<git::FailedCheck>,
 }
 
 // =============================================================================
@@ -703,6 +705,7 @@ pub async fn refresh_pr_status(
         }
     };
     let mergeable = pr_status.mergeable == "MERGEABLE";
+    let pr_fetched_at = store::now_timestamp();
 
     store
         .update_branch_pr_status(
@@ -729,6 +732,8 @@ pub async fn refresh_pr_status(
                 pr_mergeable: mergeable,
                 pr_draft: pr_status.is_draft,
                 pr_head_sha: pr_status.head_sha,
+                pr_fetched_at,
+                failed_checks: pr_status.failed_checks,
             },
         )
         .map_err(|e| format!("Failed to emit event: {}", e))?;
@@ -784,6 +789,7 @@ pub async fn refresh_all_pr_statuses(
         match pr_result {
             Ok(pr_status) => {
                 let mergeable = pr_status.mergeable == "MERGEABLE";
+                let pr_fetched_at = store::now_timestamp();
 
                 if let Err(e) = store.update_branch_pr_status(
                     &branch.id,
@@ -812,6 +818,8 @@ pub async fn refresh_all_pr_statuses(
                         pr_mergeable: mergeable,
                         pr_draft: pr_status.is_draft,
                         pr_head_sha: pr_status.head_sha,
+                        pr_fetched_at,
+                        failed_checks: pr_status.failed_checks,
                     },
                 ) {
                     log::warn!("Failed to emit pr-status-changed event: {}", e);

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -15,8 +15,15 @@
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import ConfirmDialog from '../../shared/ConfirmDialog.svelte';
+  import { minuteNow } from '../../shared/relativeTime.svelte';
   import { listen } from '@tauri-apps/api/event';
-  import type { Branch, BranchTimeline as BranchTimelineData, Session } from '../../types';
+  import type {
+    Branch,
+    BranchTimeline as BranchTimelineData,
+    PrFailedCheck,
+    PrStatusChangedEvent,
+    Session,
+  } from '../../types';
   import * as commands from '../../api/commands';
   import {
     classifyCompletedPushSession,
@@ -25,6 +32,7 @@
     extractPrUrl,
     type CompletedPushOutcome,
   } from './branchCardHelpers';
+  import { buildPrButtonTitle } from './prButtonTooltip';
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { prStateStore, type PrState } from '../../stores/prState.svelte';
@@ -83,9 +91,11 @@
 
   // PR head SHA — updated from events and branch prop
   let prHeadSha = $state<string | null>(null);
+  let prFetchedAt = $state<number | null>(null);
 
   // Stale-data indicator (set by the centralized polling service)
   let prStatusStale = $state(false);
+  let prStatusCleared = $state(false);
 
   // PR status fields (local state, updated via events)
   let prStatusState = $state<string | null>(null);
@@ -93,6 +103,7 @@
   let prStatusReviewDecision = $state<string | null>(null);
   let prStatusMergeable = $state<boolean | null>(null);
   let prStatusDraft = $state<boolean | null>(null);
+  let failedChecks = $state<PrFailedCheck[]>([]);
 
   // Derive hasUnpushed by comparing the latest timeline commit SHA with the PR head SHA.
   // This replaces the old approach of shelling out to `git rev-list`.
@@ -107,13 +118,26 @@
   });
 
   // Sync local PR status state when branch prop changes
+  let syncedBranchId = $state<string | null>(null);
   $effect(() => {
+    if (branch.id !== syncedBranchId) {
+      syncedBranchId = branch.id;
+      failedChecks = [];
+      prStatusCleared = false;
+    }
     prStatusState = branch.prState;
     prStatusChecks = branch.prChecksStatus;
     prStatusReviewDecision = branch.prReviewDecision;
     prStatusMergeable = branch.prMergeable;
     prStatusDraft = branch.prDraft;
     prHeadSha = branch.prHeadSha;
+    prFetchedAt = branch.prFetchedAt;
+    if (branch.prChecksStatus !== 'FAILURE') {
+      failedChecks = [];
+    }
+    if (branch.prChecksStatus) {
+      prStatusCleared = false;
+    }
   });
 
   // =========================================================================
@@ -133,15 +157,7 @@
   $effect(() => {
     const branchId = branch.id;
 
-    const unlistenStatusPromise = listen<{
-      branchId: string;
-      prState: string;
-      prChecksStatus: string;
-      prReviewDecision: string | null;
-      prMergeable: boolean;
-      prDraft: boolean;
-      prHeadSha: string | null;
-    }>('pr-status-changed', (event) => {
+    const unlistenStatusPromise = listen<PrStatusChangedEvent>('pr-status-changed', (event) => {
       const payload = event.payload;
       if (payload.branchId === branchId) {
         prStatusState = payload.prState;
@@ -150,6 +166,9 @@
         prStatusMergeable = payload.prMergeable;
         prStatusDraft = payload.prDraft;
         prHeadSha = payload.prHeadSha;
+        prFetchedAt = payload.prFetchedAt;
+        failedChecks = payload.failedChecks ?? [];
+        prStatusCleared = false;
         // Update the polling service with the new checks status
         prPollingService.updateChecksStatus(
           branchId,
@@ -167,6 +186,10 @@
         prStatusMergeable = null;
         prStatusDraft = null;
         prHeadSha = null;
+        prFetchedAt = null;
+        failedChecks = [];
+        prStatusCleared = true;
+        prPollingService.updateChecksStatus(branchId, branch.projectId, false);
       }
     });
 
@@ -315,6 +338,42 @@
   }
 
   let prStatusIndicator = $derived(getPrStatusIndicator());
+
+  function getPrButtonActionTitle(): string {
+    if (pushState === 'pushing') return 'Pushing… (click to view)';
+    if (pushState === 'error') return 'Push failed — click for details';
+    if (prState === 'created' && hasUnpushed) {
+      return optionHeld ? 'Force push to remote' : 'Push changes to remote';
+    }
+    if (prState === 'created') {
+      if (prStatusState === 'MERGED') return 'Merged';
+      if (prStatusState === 'CLOSED') return 'Closed';
+      if (prStatusDraft) return 'Draft';
+      if (prStatusChecks === 'FAILURE') return 'Checks failing';
+      if (prStatusChecks === 'PENDING') return 'Checks pending';
+      if (prStatusReviewDecision === 'CHANGES_REQUESTED') return 'Changes requested';
+      if (prStatusMergeable === false) return 'Has conflicts';
+      return `View PR${branch.prNumber ? ` #${branch.prNumber}` : ''}`;
+    }
+    if (prState === 'error') return 'PR creation failed — click for details';
+    if (prState === 'creating') return 'Creating PR… (click to view)';
+    return optionHeld ? 'Create draft PR' : 'Create PR';
+  }
+
+  let prButtonTitle = $derived(
+    buildPrButtonTitle({
+      actionTitle: getPrButtonActionTitle(),
+      prNumber: branch.prNumber,
+      prHeadSha,
+      prFetchedAt,
+      checksStatus: prStatusChecks,
+      statusStale: prStatusStale,
+      hasUnpushed: prState === 'created' && hasUnpushed && pushState === 'idle',
+      failedChecks,
+      statusCleared: prStatusCleared,
+      nowMs: minuteNow.now(),
+    })
+  );
 
   // =========================================================================
   // PR creation
@@ -576,23 +635,7 @@
     class:merged={prState === 'created' && prStatusState === 'MERGED'}
     onclick={handlePrButtonClick}
     disabled={showPushErrorDialog || showForcePushDialog || showPrErrorDialog}
-    title={pushState === 'pushing'
-      ? 'Pushing… (click to view)'
-      : pushState === 'error'
-        ? 'Push failed — click for details'
-        : prState === 'created' && hasUnpushed
-          ? optionHeld
-            ? 'Force push to remote'
-            : 'Push changes to remote'
-          : prState === 'created'
-            ? 'View PR'
-            : prState === 'error'
-              ? 'PR creation failed — click for details'
-              : prState === 'creating'
-                ? 'Creating PR… (click to view)'
-                : optionHeld
-                  ? 'Create draft PR'
-                  : 'Create PR'}
+    title={prButtonTitle}
   >
     {#if pushState === 'pushing'}
       <Spinner size={13} />

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -95,6 +95,7 @@
 
   // Stale-data indicator (set by the centralized polling service)
   let prStatusStale = $state(false);
+  let prStatusRefreshing = $state(false);
   let prStatusCleared = $state(false);
 
   // PR status fields (local state, updated via events)
@@ -256,6 +257,19 @@
     return () => unsub();
   });
 
+  // Subscribe to per-project refresh-state notifications so the tooltip can
+  // distinguish "last checked" from "checking right now".
+  $effect(() => {
+    const projectId = branch.projectId;
+    prStatusRefreshing = prPollingService.isRefreshing(projectId);
+    const unsub = prPollingService.onRefreshing((refreshingProjectId, isRefreshing) => {
+      if (refreshingProjectId === projectId) {
+        prStatusRefreshing = isRefreshing;
+      }
+    });
+    return () => unsub();
+  });
+
   onMount(() => {
     window.addEventListener('keydown', handleOptionDown);
     window.addEventListener('keyup', handleOptionUp);
@@ -368,6 +382,7 @@
       prFetchedAt,
       checksStatus: prStatusChecks,
       statusStale: prStatusStale,
+      statusRefreshing: prStatusRefreshing,
       hasUnpushed: prState === 'created' && hasUnpushed && pushState === 'idle',
       failedChecks,
       statusCleared: prStatusCleared,

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -15,7 +15,7 @@
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import ConfirmDialog from '../../shared/ConfirmDialog.svelte';
-  import { minuteNow } from '../../shared/relativeTime.svelte';
+  import { minuteNow, secondNow } from '../../shared/relativeTime.svelte';
   import { listen } from '@tauri-apps/api/event';
   import type {
     Branch,
@@ -374,6 +374,13 @@
     return optionHeld ? 'Create draft PR' : 'Create PR';
   }
 
+  let prButtonTitleNowMs = $derived.by(() => {
+    if (!prFetchedAt) return undefined;
+
+    const nowMs = minuteNow.now();
+    return nowMs - prFetchedAt < 60_000 ? secondNow.now() : nowMs;
+  });
+
   let prButtonTitle = $derived(
     buildPrButtonTitle({
       actionTitle: getPrButtonActionTitle(),
@@ -386,7 +393,7 @@
       hasUnpushed: prState === 'created' && hasUnpushed && pushState === 'idle',
       failedChecks,
       statusCleared: prStatusCleared,
-      nowMs: minuteNow.now(),
+      nowMs: prButtonTitleNowMs,
     })
   );
 

--- a/apps/staged/src/lib/features/branches/prButtonTooltip.test.ts
+++ b/apps/staged/src/lib/features/branches/prButtonTooltip.test.ts
@@ -30,6 +30,18 @@ describe('buildPrButtonTitle', () => {
     );
   });
 
+  it('formats last checked with seconds during the first minute', () => {
+    expect(
+      title({
+        prFetchedAt: NOW - 27_000,
+      })
+    ).toBe(
+      ['View PR #123', 'Latest PR SHA: abcdef1', 'Last checked: 27s ago', 'Checks: succeeded'].join(
+        '\n'
+      )
+    );
+  });
+
   it('formats failed checks with failed check details', () => {
     const failedChecks: PrFailedCheck[] = [
       { name: 'unit-tests', state: 'FAILURE', detailsUrl: 'https://github.com/checks/1' },

--- a/apps/staged/src/lib/features/branches/prButtonTooltip.test.ts
+++ b/apps/staged/src/lib/features/branches/prButtonTooltip.test.ts
@@ -12,6 +12,7 @@ function title(overrides: Partial<Parameters<typeof buildPrButtonTitle>[0]> = {}
     prFetchedAt: NOW - 4 * 60_000,
     checksStatus: 'SUCCESS',
     statusStale: false,
+    statusRefreshing: false,
     hasUnpushed: false,
     failedChecks: [],
     statusCleared: false,
@@ -79,6 +80,22 @@ describe('buildPrButtonTitle', () => {
         'Last checked: 4m ago',
         'Checks: failed',
         'Status refresh may be outdated',
+      ].join('\n')
+    );
+  });
+
+  it('calls out a refresh in progress', () => {
+    expect(
+      title({
+        statusRefreshing: true,
+      })
+    ).toBe(
+      [
+        'View PR #123',
+        'Latest PR SHA: abcdef1',
+        'Last checked: 4m ago',
+        'Status refresh in progress',
+        'Checks: succeeded',
       ].join('\n')
     );
   });

--- a/apps/staged/src/lib/features/branches/prButtonTooltip.test.ts
+++ b/apps/staged/src/lib/features/branches/prButtonTooltip.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { buildPrButtonTitle } from './prButtonTooltip';
+import type { PrFailedCheck } from '../../types';
+
+const NOW = new Date('2026-05-05T12:00:00Z').getTime();
+
+function title(overrides: Partial<Parameters<typeof buildPrButtonTitle>[0]> = {}): string {
+  return buildPrButtonTitle({
+    actionTitle: 'View PR #123',
+    prNumber: 123,
+    prHeadSha: 'abcdef1234567890',
+    prFetchedAt: NOW - 4 * 60_000,
+    checksStatus: 'SUCCESS',
+    statusStale: false,
+    hasUnpushed: false,
+    failedChecks: [],
+    statusCleared: false,
+    nowMs: NOW,
+    ...overrides,
+  });
+}
+
+describe('buildPrButtonTitle', () => {
+  it('formats succeeded checks', () => {
+    expect(title()).toBe(
+      ['View PR #123', 'Latest PR SHA: abcdef1', 'Last checked: 4m ago', 'Checks: succeeded'].join(
+        '\n'
+      )
+    );
+  });
+
+  it('formats failed checks with failed check details', () => {
+    const failedChecks: PrFailedCheck[] = [
+      { name: 'unit-tests', state: 'FAILURE', detailsUrl: 'https://github.com/checks/1' },
+      { name: 'lint', state: 'TIMED_OUT', detailsUrl: null },
+    ];
+
+    expect(
+      title({
+        actionTitle: 'Checks failing',
+        checksStatus: 'FAILURE',
+        failedChecks,
+      })
+    ).toBe(
+      [
+        'Checks failing',
+        'Latest PR SHA: abcdef1',
+        'Last checked: 4m ago',
+        'Checks: failed',
+        'Failed: unit-tests (FAILURE), lint (TIMED_OUT)',
+      ].join('\n')
+    );
+  });
+
+  it('formats pending checks', () => {
+    expect(
+      title({
+        actionTitle: 'Checks pending',
+        checksStatus: 'PENDING',
+      })
+    ).toBe(
+      ['Checks pending', 'Latest PR SHA: abcdef1', 'Last checked: 4m ago', 'Checks: pending'].join(
+        '\n'
+      )
+    );
+  });
+
+  it('calls out stale polling', () => {
+    expect(
+      title({
+        actionTitle: 'Checks failing',
+        checksStatus: 'FAILURE',
+        statusStale: true,
+      })
+    ).toBe(
+      [
+        'Checks failing',
+        'Latest PR SHA: abcdef1',
+        'Last checked: 4m ago',
+        'Checks: failed',
+        'Status refresh may be outdated',
+      ].join('\n')
+    );
+  });
+
+  it('formats unknown status fields', () => {
+    expect(
+      title({
+        prHeadSha: null,
+        prFetchedAt: null,
+        checksStatus: null,
+      })
+    ).toBe(
+      ['View PR #123', 'Latest PR SHA: unknown', 'Last checked: unknown', 'Checks: unknown'].join(
+        '\n'
+      )
+    );
+  });
+
+  it('explains when local commits are newer than the PR', () => {
+    expect(
+      title({
+        actionTitle: 'Push changes to remote',
+        prFetchedAt: NOW - 12 * 60_000,
+        hasUnpushed: true,
+      })
+    ).toBe(
+      [
+        'Push changes to remote',
+        'Latest PR SHA: abcdef1',
+        'Local branch has newer commits than the PR',
+        'Last checked: 12m ago',
+      ].join('\n')
+    );
+  });
+
+  it('explains when previous PR status was cleared after a push', () => {
+    expect(
+      title({
+        prFetchedAt: null,
+        checksStatus: null,
+        failedChecks: [{ name: 'unit-tests', state: 'FAILURE', detailsUrl: null }],
+        statusCleared: true,
+      })
+    ).toBe(
+      [
+        'View PR #123',
+        'Latest PR SHA: abcdef1',
+        'Last checked: unknown',
+        'Previous PR status was cleared; waiting for next GitHub refresh',
+      ].join('\n')
+    );
+  });
+});

--- a/apps/staged/src/lib/features/branches/prButtonTooltip.ts
+++ b/apps/staged/src/lib/features/branches/prButtonTooltip.ts
@@ -8,6 +8,7 @@ export interface PrButtonTooltipInput {
   prFetchedAt: number | null;
   checksStatus: string | null;
   statusStale: boolean;
+  statusRefreshing: boolean;
   hasUnpushed: boolean;
   failedChecks: PrFailedCheck[];
   statusCleared: boolean;
@@ -52,6 +53,9 @@ export function buildPrButtonTitle(input: PrButtonTooltipInput): string {
     } else {
       lines.push('Last checked: unknown');
     }
+    if (input.statusRefreshing) {
+      lines.push('Status refresh in progress');
+    }
     return lines.join('\n');
   }
 
@@ -59,6 +63,10 @@ export function buildPrButtonTitle(input: PrButtonTooltipInput): string {
     lines.push(`Last checked: ${formatRelativeTime(input.prFetchedAt, input.nowMs)}`);
   } else {
     lines.push('Last checked: unknown');
+  }
+
+  if (input.statusRefreshing) {
+    lines.push('Status refresh in progress');
   }
 
   if (input.statusCleared) {

--- a/apps/staged/src/lib/features/branches/prButtonTooltip.ts
+++ b/apps/staged/src/lib/features/branches/prButtonTooltip.ts
@@ -1,5 +1,5 @@
 import type { PrFailedCheck } from '../../types';
-import { formatRelativeTime } from '../../shared/relativeTime';
+import { formatPreciseRelativeTime } from '../../shared/relativeTime';
 
 export interface PrButtonTooltipInput {
   actionTitle: string;
@@ -49,7 +49,7 @@ export function buildPrButtonTitle(input: PrButtonTooltipInput): string {
   if (input.hasUnpushed) {
     lines.push('Local branch has newer commits than the PR');
     if (input.prFetchedAt) {
-      lines.push(`Last checked: ${formatRelativeTime(input.prFetchedAt, input.nowMs)}`);
+      lines.push(`Last checked: ${formatPreciseRelativeTime(input.prFetchedAt, input.nowMs)}`);
     } else {
       lines.push('Last checked: unknown');
     }
@@ -60,7 +60,7 @@ export function buildPrButtonTitle(input: PrButtonTooltipInput): string {
   }
 
   if (input.prFetchedAt) {
-    lines.push(`Last checked: ${formatRelativeTime(input.prFetchedAt, input.nowMs)}`);
+    lines.push(`Last checked: ${formatPreciseRelativeTime(input.prFetchedAt, input.nowMs)}`);
   } else {
     lines.push('Last checked: unknown');
   }

--- a/apps/staged/src/lib/features/branches/prButtonTooltip.ts
+++ b/apps/staged/src/lib/features/branches/prButtonTooltip.ts
@@ -1,0 +1,80 @@
+import type { PrFailedCheck } from '../../types';
+import { formatRelativeTime } from '../../shared/relativeTime';
+
+export interface PrButtonTooltipInput {
+  actionTitle: string;
+  prNumber: number | null;
+  prHeadSha: string | null;
+  prFetchedAt: number | null;
+  checksStatus: string | null;
+  statusStale: boolean;
+  hasUnpushed: boolean;
+  failedChecks: PrFailedCheck[];
+  statusCleared: boolean;
+  nowMs?: number;
+}
+
+function formatSha(sha: string | null): string {
+  return sha ? sha.slice(0, 7) : 'unknown';
+}
+
+function formatChecksStatus(status: string | null): string {
+  switch (status) {
+    case 'SUCCESS':
+      return 'succeeded';
+    case 'FAILURE':
+      return 'failed';
+    case 'PENDING':
+      return 'pending';
+    case 'EXPECTED':
+    case null:
+      return 'unknown';
+    default:
+      return status.toLowerCase();
+  }
+}
+
+function formatFailedChecks(failedChecks: PrFailedCheck[]): string {
+  return failedChecks.map((check) => `${check.name} (${check.state})`).join(', ');
+}
+
+export function buildPrButtonTitle(input: PrButtonTooltipInput): string {
+  const lines = [input.actionTitle];
+
+  if (!input.prNumber) return lines.join('\n');
+
+  lines.push(`Latest PR SHA: ${formatSha(input.prHeadSha)}`);
+
+  if (input.hasUnpushed) {
+    lines.push('Local branch has newer commits than the PR');
+    if (input.prFetchedAt) {
+      lines.push(`Last checked: ${formatRelativeTime(input.prFetchedAt, input.nowMs)}`);
+    } else {
+      lines.push('Last checked: unknown');
+    }
+    return lines.join('\n');
+  }
+
+  if (input.prFetchedAt) {
+    lines.push(`Last checked: ${formatRelativeTime(input.prFetchedAt, input.nowMs)}`);
+  } else {
+    lines.push('Last checked: unknown');
+  }
+
+  if (input.statusCleared) {
+    lines.push('Previous PR status was cleared; waiting for next GitHub refresh');
+    return lines.join('\n');
+  }
+
+  lines.push(`Checks: ${formatChecksStatus(input.checksStatus)}`);
+
+  if (input.failedChecks.length > 0) {
+    lines.push(`Failed: ${formatFailedChecks(input.failedChecks)}`);
+  }
+
+  if (input.statusStale) {
+    lines.push('Status refresh may be outdated');
+  }
+
+  return lines.join('\n');
+}

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -8,7 +8,13 @@
   import { onMount } from 'svelte';
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-  import type { Project, ProjectRepo, Branch, StoreIncompatibility } from '../../types';
+  import type {
+    Project,
+    ProjectRepo,
+    Branch,
+    PrStatusChangedEvent,
+    StoreIncompatibility,
+  } from '../../types';
   import * as commands from '../../api/commands';
   import { listenToRepoActionsDetection } from '../actions/actions';
   import { projectDisplayName } from '../../shared/utils';
@@ -154,15 +160,7 @@
 
     // Listen for PR status changes to update branch state
     let unlistenPrStatus: UnlistenFn | undefined;
-    listen<{
-      branchId: string;
-      prState: string;
-      prChecksStatus: string;
-      prReviewDecision: string | null;
-      prMergeable: boolean;
-      prDraft: boolean;
-      prHeadSha: string | null;
-    }>('pr-status-changed', (event) => {
+    listen<PrStatusChangedEvent>('pr-status-changed', (event) => {
       const payload = event.payload;
       // Find the project that contains this branch and update it
       for (const [projectId, branches] of branchesByProject.entries()) {
@@ -178,6 +176,7 @@
             prMergeable: payload.prMergeable,
             prDraft: payload.prDraft,
             prHeadSha: payload.prHeadSha,
+            prFetchedAt: payload.prFetchedAt,
           };
           branchesByProject = new Map(branchesByProject).set(projectId, updatedBranches);
           break;

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -14,7 +14,13 @@
     GitPullRequestDraft,
     Plus,
   } from 'lucide-svelte';
-  import type { Project, ProjectRepo, Branch, WorkspaceStatus } from '../../types';
+  import type {
+    Project,
+    ProjectRepo,
+    Branch,
+    PrStatusChangedEvent,
+    WorkspaceStatus,
+  } from '../../types';
   import * as commands from '../../api/commands';
   import {
     projectDisplayName,
@@ -287,15 +293,7 @@
 
     // Listen for PR status changes to update branch state
     let unlistenPrStatus: UnlistenFn | undefined;
-    listen<{
-      branchId: string;
-      prState: string;
-      prChecksStatus: string;
-      prReviewDecision: string | null;
-      prMergeable: boolean;
-      prDraft: boolean;
-      prHeadSha: string | null;
-    }>('pr-status-changed', (event) => {
+    listen<PrStatusChangedEvent>('pr-status-changed', (event) => {
       const payload = event.payload;
       // Find the project that contains this branch
       for (const [projectId, branches] of projectBranches.entries()) {
@@ -311,6 +309,7 @@
             prMergeable: payload.prMergeable,
             prDraft: payload.prDraft,
             prHeadSha: payload.prHeadSha,
+            prFetchedAt: payload.prFetchedAt,
           };
           projectBranches = new Map(projectBranches).set(projectId, updatedBranches);
           break;

--- a/apps/staged/src/lib/services/prPollingService.ts
+++ b/apps/staged/src/lib/services/prPollingService.ts
@@ -15,6 +15,7 @@ import { refreshAllPrStatuses } from '../commands';
 // ---------------------------------------------------------------------------
 
 type StaleCallback = (projectId: string, isStale: boolean) => void;
+type RefreshingCallback = (projectId: string, isRefreshing: boolean) => void;
 
 // ---------------------------------------------------------------------------
 // Intervals
@@ -46,6 +47,12 @@ const failures = new Map<string, number>();
 
 /** Registered stale-data callbacks. */
 const staleCallbacks = new Set<StaleCallback>();
+
+/** Registered refresh-state callbacks. */
+const refreshingCallbacks = new Set<RefreshingCallback>();
+
+/** Projects currently being refreshed. */
+const refreshingProjects = new Set<string>();
 
 let timerId: ReturnType<typeof setTimeout> | null = null;
 let refreshInFlight = false;
@@ -98,6 +105,7 @@ async function poll() {
   const due = getProjectsDue();
 
   for (const projectId of due) {
+    setProjectRefreshing(projectId, true);
     try {
       await refreshAllPrStatuses(projectId);
       lastPolledAt.set(projectId, Date.now());
@@ -117,6 +125,8 @@ async function poll() {
       if (count === MAX_CONSECUTIVE_FAILURES) {
         notifyStale(projectId, true);
       }
+    } finally {
+      setProjectRefreshing(projectId, false);
     }
   }
 
@@ -156,6 +166,28 @@ function notifyStale(projectId: string, isStale: boolean) {
     } catch {
       // ignore callback errors
     }
+  }
+}
+
+function notifyRefreshing(projectId: string, isRefreshing: boolean) {
+  for (const cb of refreshingCallbacks) {
+    try {
+      cb(projectId, isRefreshing);
+    } catch {
+      // ignore callback errors
+    }
+  }
+}
+
+function setProjectRefreshing(projectId: string, isRefreshing: boolean) {
+  const wasRefreshing = refreshingProjects.has(projectId);
+  if (isRefreshing) {
+    refreshingProjects.add(projectId);
+  } else {
+    refreshingProjects.delete(projectId);
+  }
+  if (wasRefreshing !== isRefreshing) {
+    notifyRefreshing(projectId, isRefreshing);
   }
 }
 
@@ -206,6 +238,7 @@ export function setProjects(projectIds: string[]): void {
       allProjectIds.delete(id);
       lastPolledAt.delete(id);
       failures.delete(id);
+      setProjectRefreshing(id, false);
     }
   }
 
@@ -229,6 +262,9 @@ export function setProjects(projectIds: string[]): void {
     stopTimer();
     removeWindowListeners();
     failures.clear();
+    for (const projectId of [...refreshingProjects]) {
+      setProjectRefreshing(projectId, false);
+    }
   }
 }
 
@@ -267,6 +303,19 @@ export function onStale(callback: StaleCallback): () => void {
   return () => staleCallbacks.delete(callback);
 }
 
+/** Register a callback for PR refresh-state notifications. Returns an unsubscribe function. */
+export function onRefreshing(callback: RefreshingCallback): () => void {
+  refreshingCallbacks.add(callback);
+  for (const projectId of refreshingProjects) {
+    callback(projectId, true);
+  }
+  return () => refreshingCallbacks.delete(callback);
+}
+
+export function isRefreshing(projectId: string): boolean {
+  return refreshingProjects.has(projectId);
+}
+
 // ---------------------------------------------------------------------------
 // PR recovery coordination
 // ---------------------------------------------------------------------------
@@ -303,6 +352,7 @@ export function refreshNow(projectId: string): void {
     return;
   }
   refreshInFlight = true;
+  setProjectRefreshing(projectId, true);
   refreshAllPrStatuses(projectId)
     .then(() => {
       lastPolledAt.set(projectId, Date.now());
@@ -317,6 +367,7 @@ export function refreshNow(projectId: string): void {
       console.error(`[PrPollingService] immediate refresh failed for project=${projectId}:`, e)
     )
     .finally(() => {
+      setProjectRefreshing(projectId, false);
       refreshInFlight = false;
       // Drain queued immediate-refresh requests one at a time.
       if (pendingRefreshProjectIds.size > 0) {

--- a/apps/staged/src/lib/shared/relativeTime.svelte.ts
+++ b/apps/staged/src/lib/shared/relativeTime.svelte.ts
@@ -1,3 +1,8 @@
+import {
+  formatRelativeTime as formatRelativeTimeBase,
+  formatRelativeTimeSeconds as formatRelativeTimeSecondsBase,
+} from './relativeTime';
+
 class MinuteNowStore {
   private value = $state(Date.now());
 
@@ -27,22 +32,12 @@ class MinuteNowStore {
 export const minuteNow = new MinuteNowStore();
 
 export function formatRelativeTime(timestampMs: number, nowMs = minuteNow.now()): string {
-  const date = new Date(timestampMs);
-  const diffMs = nowMs - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMins / 60);
-  const diffDays = Math.floor(diffHours / 24);
-
-  if (diffMins < 1) return 'just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
+  return formatRelativeTimeBase(timestampMs, nowMs);
 }
 
 export function formatRelativeTimeSeconds(
   timestampSeconds: number,
   nowMs = minuteNow.now()
 ): string {
-  return formatRelativeTime(timestampSeconds * 1000, nowMs);
+  return formatRelativeTimeSecondsBase(timestampSeconds, nowMs);
 }

--- a/apps/staged/src/lib/shared/relativeTime.svelte.ts
+++ b/apps/staged/src/lib/shared/relativeTime.svelte.ts
@@ -29,7 +29,30 @@ class MinuteNowStore {
   }
 }
 
+class SecondNowStore {
+  private value = $state(Date.now());
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      this.start();
+    }
+  }
+
+  now(): number {
+    return this.value;
+  }
+
+  private start(): void {
+    this.value = Date.now();
+
+    setInterval(() => {
+      this.value = Date.now();
+    }, 1000);
+  }
+}
+
 export const minuteNow = new MinuteNowStore();
+export const secondNow = new SecondNowStore();
 
 export function formatRelativeTime(timestampMs: number, nowMs = minuteNow.now()): string {
   return formatRelativeTimeBase(timestampMs, nowMs);

--- a/apps/staged/src/lib/shared/relativeTime.ts
+++ b/apps/staged/src/lib/shared/relativeTime.ts
@@ -1,11 +1,28 @@
-export function formatRelativeTime(timestampMs: number, nowMs = Date.now()): string {
+function relativeParts(timestampMs: number, nowMs: number) {
   const date = new Date(timestampMs);
-  const diffMs = nowMs - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
+  const diffMs = Math.max(0, nowMs - date.getTime());
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
   const diffHours = Math.floor(diffMins / 60);
   const diffDays = Math.floor(diffHours / 24);
 
+  return { date, diffSecs, diffMins, diffHours, diffDays };
+}
+
+export function formatRelativeTime(timestampMs: number, nowMs = Date.now()): string {
+  const { date, diffMins, diffHours, diffDays } = relativeParts(timestampMs, nowMs);
+
   if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+export function formatPreciseRelativeTime(timestampMs: number, nowMs = Date.now()): string {
+  const { date, diffSecs, diffMins, diffHours, diffDays } = relativeParts(timestampMs, nowMs);
+
+  if (diffSecs < 60) return `${diffSecs}s ago`;
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;

--- a/apps/staged/src/lib/shared/relativeTime.ts
+++ b/apps/staged/src/lib/shared/relativeTime.ts
@@ -1,0 +1,17 @@
+export function formatRelativeTime(timestampMs: number, nowMs = Date.now()): string {
+  const date = new Date(timestampMs);
+  const diffMs = nowMs - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+export function formatRelativeTimeSeconds(timestampSeconds: number, nowMs = Date.now()): string {
+  return formatRelativeTime(timestampSeconds * 1000, nowMs);
+}

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -94,6 +94,26 @@ export interface PrStatus {
     pending: number;
     state: string; // "SUCCESS", "FAILURE", "PENDING", "EXPECTED"
   };
+  headSha: string | null;
+  failedChecks: PrFailedCheck[];
+}
+
+export interface PrFailedCheck {
+  name: string;
+  state: string;
+  detailsUrl: string | null;
+}
+
+export interface PrStatusChangedEvent {
+  branchId: string;
+  prState: string;
+  prChecksStatus: string;
+  prReviewDecision: string | null;
+  prMergeable: boolean;
+  prDraft: boolean;
+  prHeadSha: string | null;
+  prFetchedAt: number | null;
+  failedChecks: PrFailedCheck[];
 }
 
 export interface CommitTimelineItem {


### PR DESCRIPTION
## Summary

- Add informative tooltips to PR buttons showing check status, review state, and last refresh time
- Track PR polling state (refreshing/last refreshed) in a new `prPollingService` and surface it in the UI
- Parse failed checks from GitHub's status rollup and display them in tooltips
- Add relative time formatting with seconds-level granularity for recent refreshes
- Include unit tests for tooltip text generation

## Test plan

- [x] CI passes (crates-fmt, crates-lint, crates-test, staged-ci, differ-ci)
- [ ] Verify tooltips appear on hover over PR buttons with correct status info
- [ ] Confirm refresh state updates in real-time as PRs are polled
- [ ] Check that failed check names are listed in tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)