### PR TITLE
fix: reload timelines after branch setup

### DIFF
--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -329,6 +329,7 @@ const inFlightTimelines = new Map<string, Promise<BranchTimeline>>();
 
 export function invalidateBranchTimeline(branchId: string): void {
   timelineCache.delete(branchId);
+  inFlightTimelines.delete(branchId);
   window.dispatchEvent(
     new CustomEvent('timeline-invalidated', { detail: { branchIds: [branchId] } })
   );
@@ -347,16 +348,18 @@ export function getBranchTimeline(
     if (cached) {
       return Promise.resolve(cached.timeline);
     }
-  }
 
-  const existing = inFlightTimelines.get(branchId);
-  if (existing) {
-    return existing;
+    const existing = inFlightTimelines.get(branchId);
+    if (existing) {
+      return existing;
+    }
   }
 
   const request = invoke<BranchTimeline>('get_branch_timeline', { branchId })
     .then((timeline) => {
-      timelineCache.set(branchId, { timeline, fetchedAt: Date.now() });
+      if (inFlightTimelines.get(branchId) === request) {
+        timelineCache.set(branchId, { timeline, fetchedAt: Date.now() });
+      }
       return timeline;
     })
     .finally(() => {
@@ -384,6 +387,7 @@ export function getBranchTimelineWithRevalidation(branchId: string): {
 export function invalidateProjectBranchTimelines(branchIds: string[]): void {
   for (const id of branchIds) {
     timelineCache.delete(id);
+    inFlightTimelines.delete(id);
   }
   window.dispatchEvent(new CustomEvent('timeline-invalidated', { detail: { branchIds } }));
 }

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -45,6 +45,7 @@
   import ReasonBanner from './ReasonBanner.svelte';
   import RemoteWorkspaceStatusBadge from './RemoteWorkspaceStatusBadge.svelte';
   import RemoteWorkspaceStatusView from './RemoteWorkspaceStatusView.svelte';
+  import { branchTimelineReadyKey } from './branchTimelineReady';
   import { alerts } from '../../shared/alerts.svelte';
   import { timelineToHashtagItems, projectNotesToHashtagItems } from '../sessions/hashtagItems';
   import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
@@ -450,26 +451,12 @@
     getTimeline: () => timeline,
   });
 
+  let requestedTimelineKey: string | null = null;
+  let timelineLoadVersion = 0;
   let revalidationVersion = 0;
 
-  /**
-   * Compute the timeline cache key for a branch, or null if the branch is
-   * not yet ready for timeline loading.
-   *
-   * Shared between the synchronous hydration block and the $effect that
-   * triggers loadTimeline(), so the readiness conditions and key format
-   * stay in sync.
-   */
-  function getTimelineKey(
-    branchId: string,
-    isLocalVal: boolean,
-    isRemoteVal: boolean,
-    worktreePath: string | undefined | null,
-    remoteStatus: string | null | undefined
-  ): string | null {
-    if (isLocalVal && !worktreePath) return null;
-    if (!isLocalVal && (!isRemoteVal || remoteStatus !== 'running')) return null;
-    return isRemoteVal ? `${branchId}:<remote>` : `${branchId}:${worktreePath}`;
+  function isCurrentTimelineLoad(loadVersion: number, timelineKey: string): boolean {
+    return loadVersion === timelineLoadVersion && branchTimelineReadyKey(branch) === timelineKey;
   }
 
   /**
@@ -482,9 +469,11 @@
    */
   function applyCachedTimeline(
     cached: BranchTimelineData,
-    fresh: Promise<BranchTimelineData> | null
+    fresh: Promise<BranchTimelineData> | null,
+    timelineKey: string
   ) {
     timeline = cached;
+    loadedTimelineKey = timelineKey;
     loading = false;
     prunedSessionIds = sessionMgr.prunePendingSessionItems(cached);
     if (fresh) {
@@ -492,18 +481,25 @@
       const version = ++revalidationVersion;
       fresh
         .then((next) => {
-          if (version !== revalidationVersion) return;
+          if (version !== revalidationVersion || branchTimelineReadyKey(branch) !== timelineKey) {
+            return;
+          }
           error = null;
           timeline = next;
+          loadedTimelineKey = timelineKey;
           prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
           void loadTimelineReviewDetails(next.reviews);
         })
         .catch((e) => {
-          if (version !== revalidationVersion) return;
+          if (version !== revalidationVersion || branchTimelineReadyKey(branch) !== timelineKey) {
+            return;
+          }
           error = e instanceof Error ? e.message : String(e);
         })
         .finally(() => {
-          if (version !== revalidationVersion) return;
+          if (version !== revalidationVersion || branchTimelineReadyKey(branch) !== timelineKey) {
+            return;
+          }
           revalidating = false;
         });
     } else {
@@ -516,26 +512,13 @@
   // flash and the slide-in animation for already-cached rows.
   {
     // svelte-ignore state_referenced_locally
-    const initIsLocal = isLocal;
-    // svelte-ignore state_referenced_locally
-    const initIsRemote = isRemote;
-    // svelte-ignore state_referenced_locally
     const initBranch = branch;
-    // svelte-ignore state_referenced_locally
-    const initRemoteWorkspaceStatus = remoteWorkspaceStatus;
     untrack(() => {
-      const key = getTimelineKey(
-        initBranch.id,
-        initIsLocal,
-        initIsRemote,
-        initBranch.worktreePath,
-        initRemoteWorkspaceStatus
-      );
+      const key = branchTimelineReadyKey(initBranch);
       if (key) {
         const { cached, fresh } = commands.getBranchTimelineWithRevalidation(initBranch.id);
         if (cached) {
-          loadedTimelineKey = key;
-          applyCachedTimeline(cached, fresh);
+          applyCachedTimeline(cached, fresh, key);
         }
       }
     });
@@ -617,56 +600,74 @@
 
   // Load timeline when a branch becomes timeline-ready
   $effect(() => {
-    const timelineKey = getTimelineKey(
-      branch.id,
-      isLocal,
-      isRemote,
-      branch.worktreePath,
-      remoteWorkspaceStatus
-    );
-    if (!timelineKey || timelineKey === loadedTimelineKey) return;
+    const timelineKey = branchTimelineReadyKey(branch);
+    if (!timelineKey) return;
+    if (timelineKey === loadedTimelineKey || timelineKey === requestedTimelineKey) return;
 
-    loadedTimelineKey = timelineKey;
-    void loadTimeline();
+    void loadTimeline({ timelineKey });
   });
 
   // Re-fetch timeline when the cache is invalidated (e.g. after project-setup-progress)
   $effect(() => {
     const handler = (e: Event) => {
       const { branchIds } = (e as CustomEvent<{ branchIds: string[] }>).detail;
-      if (branchIds.includes(branch.id) && (branch.worktreePath || isRemote)) {
-        void loadTimeline();
+      const timelineKey = branchTimelineReadyKey(branch);
+      if (branchIds.includes(branch.id) && timelineKey) {
+        loadedTimelineKey = null;
+        void loadTimeline({ timelineKey, force: true });
       }
     };
     window.addEventListener('timeline-invalidated', handler);
     return () => window.removeEventListener('timeline-invalidated', handler);
   });
 
-  async function loadTimeline() {
-    const isInitialLoad = !timeline;
+  async function loadTimeline({
+    timelineKey = branchTimelineReadyKey(branch),
+    force = false,
+  }: { timelineKey?: string | null; force?: boolean } = {}) {
+    if (!timelineKey) return;
+
+    const loadVersion = ++timelineLoadVersion;
+    requestedTimelineKey = timelineKey;
+    const isInitialLoad = !timeline || loadedTimelineKey !== timelineKey;
     error = null;
     // Cancel any in-flight revalidation so it can't overwrite fresher data
     revalidationVersion++;
-
-    if (isInitialLoad) {
-      const { cached, fresh } = commands.getBranchTimelineWithRevalidation(branch.id);
-      if (cached) {
-        applyCachedTimeline(cached, fresh);
-        return;
-      }
-      // No cache — show loading spinner as before
-      loading = true;
-    }
+    revalidating = false;
 
     try {
-      const nextTimeline = await commands.getBranchTimeline(branch.id, { force: !isInitialLoad });
+      if (isInitialLoad) {
+        if (!force) {
+          const { cached, fresh } = commands.getBranchTimelineWithRevalidation(branch.id);
+          if (cached) {
+            if (isCurrentTimelineLoad(loadVersion, timelineKey)) {
+              applyCachedTimeline(cached, fresh, timelineKey);
+            }
+            return;
+          }
+        }
+        // No cache — show loading spinner as before
+        loading = true;
+      }
+
+      const nextTimeline = await commands.getBranchTimeline(branch.id, {
+        force: force || !isInitialLoad,
+      });
+      if (!isCurrentTimelineLoad(loadVersion, timelineKey)) return;
       timeline = nextTimeline;
+      loadedTimelineKey = timelineKey;
       prunedSessionIds = sessionMgr.prunePendingSessionItems(nextTimeline);
       void loadTimelineReviewDetails(nextTimeline.reviews);
     } catch (e) {
+      if (!isCurrentTimelineLoad(loadVersion, timelineKey)) return;
       error = e instanceof Error ? e.message : String(e);
     } finally {
-      loading = false;
+      if (requestedTimelineKey === timelineKey) {
+        requestedTimelineKey = null;
+      }
+      if (isCurrentTimelineLoad(loadVersion, timelineKey)) {
+        loading = false;
+      }
     }
   }
 

--- a/apps/staged/src/lib/features/branches/branchTimelineReady.test.ts
+++ b/apps/staged/src/lib/features/branches/branchTimelineReady.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { Branch } from '../../types';
+import { branchTimelineReadyKey } from './branchTimelineReady';
+
+function branch(overrides: Partial<Branch> = {}): Branch {
+  return {
+    id: 'branch-1',
+    projectId: 'project-1',
+    projectRepoId: null,
+    branchName: 'feature',
+    baseBranch: 'main',
+    prNumber: null,
+    branchType: 'local',
+    workspaceName: null,
+    workstationId: null,
+    workspaceStatus: null,
+    setupComplete: false,
+    worktreePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+    prState: null,
+    prChecksStatus: null,
+    prReviewDecision: null,
+    prMergeable: null,
+    prDraft: null,
+    prUrl: null,
+    prUpdatedAt: null,
+    prFetchedAt: null,
+    prHeadSha: null,
+    ...overrides,
+  };
+}
+
+describe('branchTimelineReadyKey', () => {
+  it('waits for local branches to have a worktree path', () => {
+    expect(branchTimelineReadyKey(branch())).toBeNull();
+    expect(branchTimelineReadyKey(branch({ worktreePath: '/tmp/repo' }))).toBe(
+      'branch-1:/tmp/repo'
+    );
+  });
+
+  it('waits for remote branches to be running', () => {
+    expect(
+      branchTimelineReadyKey(
+        branch({
+          branchType: 'remote',
+          workspaceStatus: 'starting',
+        })
+      )
+    ).toBeNull();
+
+    expect(
+      branchTimelineReadyKey(
+        branch({
+          branchType: 'remote',
+          workspaceStatus: 'running',
+        })
+      )
+    ).toBe('branch-1:<remote>');
+  });
+});

--- a/apps/staged/src/lib/features/branches/branchTimelineReady.ts
+++ b/apps/staged/src/lib/features/branches/branchTimelineReady.ts
@@ -1,0 +1,19 @@
+import type { Branch } from '../../types';
+
+type TimelineReadyBranch = Pick<Branch, 'id' | 'branchType' | 'worktreePath' | 'workspaceStatus'>;
+
+/**
+ * Returns the stable timeline readiness key for a branch, or null while the
+ * branch cannot load a timeline yet.
+ */
+export function branchTimelineReadyKey(branch: TimelineReadyBranch): string | null {
+  if (branch.branchType === 'local') {
+    return branch.worktreePath ? `${branch.id}:${branch.worktreePath}` : null;
+  }
+
+  if (branch.branchType === 'remote') {
+    return branch.workspaceStatus === 'running' ? `${branch.id}:<remote>` : null;
+  }
+
+  return null;
+}

--- a/apps/staged/src/lib/features/projects/workspaceLifecycle.svelte.ts
+++ b/apps/staged/src/lib/features/projects/workspaceLifecycle.svelte.ts
@@ -514,6 +514,7 @@ class WorkspaceLifecycleController {
           )
         );
       }
+      commands.invalidateBranchTimeline(branchId);
 
       // NOTE: prerun actions are only triggered here when opts.runPrerun
       // is set (e.g. the retry path). The normal creation paths run them

--- a/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
@@ -1,11 +1,63 @@
-import { describe, expect, it } from 'vitest';
-import type { BranchTimeline } from '../../types';
-import { timelineToHashtagItems } from './hashtagItems';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Branch, BranchTimeline, ProjectNote } from '../../types';
+import { getBranchTimeline, listProjectNotes } from '../../commands';
+import { buildProjectHashtagItems, timelineToHashtagItems } from './hashtagItems';
+
+vi.mock('../../commands', () => ({
+  getBranchTimeline: vi.fn(),
+  listProjectNotes: vi.fn(),
+}));
+
+function branch(overrides: Partial<Branch> = {}): Branch {
+  return {
+    id: 'branch-1',
+    projectId: 'project-1',
+    projectRepoId: null,
+    branchName: 'feature',
+    baseBranch: 'main',
+    prNumber: null,
+    branchType: 'local',
+    workspaceName: null,
+    workstationId: null,
+    workspaceStatus: null,
+    setupComplete: false,
+    worktreePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+    prState: null,
+    prChecksStatus: null,
+    prReviewDecision: null,
+    prMergeable: null,
+    prDraft: null,
+    prUrl: null,
+    prUpdatedAt: null,
+    prFetchedAt: null,
+    prHeadSha: null,
+    ...overrides,
+  };
+}
+
+function emptyTimeline(overrides: Partial<BranchTimeline> = {}): BranchTimeline {
+  return {
+    notes: [],
+    commits: [],
+    reviews: [],
+    images: [],
+    ...overrides,
+  };
+}
+
+const projectNotes: ProjectNote[] = [];
+
+beforeEach(() => {
+  vi.mocked(getBranchTimeline).mockReset();
+  vi.mocked(listProjectNotes).mockReset();
+  vi.mocked(listProjectNotes).mockResolvedValue(projectNotes);
+});
 
 describe('timelineToHashtagItems', () => {
   it('uses only the commit subject for commit hashtag titles', () => {
-    const timeline: BranchTimeline = {
-      notes: [],
+    const timeline: BranchTimeline = emptyTimeline({
       commits: [
         {
           id: 'commit-id',
@@ -20,9 +72,7 @@ describe('timelineToHashtagItems', () => {
           completionReason: null,
         },
       ],
-      reviews: [],
-      images: [],
-    };
+    });
 
     expect(timelineToHashtagItems(timeline)).toContainEqual(
       expect.objectContaining({
@@ -31,5 +81,22 @@ describe('timelineToHashtagItems', () => {
         title: 'Add branch picker filtering',
       })
     );
+  });
+});
+
+describe('buildProjectHashtagItems', () => {
+  it('does not load timelines for branches that are not timeline-ready', async () => {
+    vi.mocked(getBranchTimeline).mockResolvedValue(emptyTimeline());
+
+    await buildProjectHashtagItems('project-1', [
+      branch({ id: 'local-unready', branchType: 'local', worktreePath: null }),
+      branch({ id: 'local-ready', branchType: 'local', worktreePath: '/tmp/repo' }),
+      branch({ id: 'remote-starting', branchType: 'remote', workspaceStatus: 'starting' }),
+      branch({ id: 'remote-ready', branchType: 'remote', workspaceStatus: 'running' }),
+    ]);
+
+    expect(getBranchTimeline).toHaveBeenCalledTimes(2);
+    expect(getBranchTimeline).toHaveBeenNthCalledWith(1, 'local-ready');
+    expect(getBranchTimeline).toHaveBeenNthCalledWith(2, 'remote-ready');
   });
 });

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -1,5 +1,6 @@
 import type { BranchTimeline, HashtagItem, ProjectNote, Branch, ProjectRepo } from '../../types';
 import { getBranchTimeline, listProjectNotes } from '../../commands';
+import { branchTimelineReadyKey } from '../branches/branchTimelineReady';
 
 /** Regex matching `#type:id` hashtag tokens in plain text. Use with `new RegExp(source, 'g')` for stateful iteration. */
 export const HASHTAG_TOKEN_RE = /#(note|commit|review|project-note|image):([^\s]+)/g;
@@ -63,10 +64,11 @@ export async function buildProjectHashtagItems(
   reposById?: Map<string, ProjectRepo>
 ): Promise<HashtagItem[]> {
   const items: HashtagItem[] = [];
+  const readyBranches = branches.filter((branch) => branchTimelineReadyKey(branch) !== null);
 
   const [timelines, projectNotes] = await Promise.all([
     Promise.all(
-      branches.map((b) => getBranchTimeline(b.id).then((t) => ({ branch: b, timeline: t })))
+      readyBranches.map((b) => getBranchTimeline(b.id).then((t) => ({ branch: b, timeline: t })))
     ),
     listProjectNotes(projectId),
   ]);


### PR DESCRIPTION
🤖 Summary:
- Invalidate branch timeline caches and in-flight timeline loads after branch setup.
- Gate timeline loads on a shared readiness key for local and remote branches.
- Skip hashtag timeline loading for branches that are not timeline-ready and add coverage.