### PR TITLE
feat: surface branch git state in timeline with actionable rows

### DIFF
--- a/apps/staged/justfile
+++ b/apps/staged/justfile
@@ -148,7 +148,7 @@ lint:
 
 # Run Rust unit tests
 test:
-    cd src-tauri && cargo test
+    cd src-tauri && cargo test --lib --bins --tests
 
 # Run frontend unit tests
 test-frontend:

--- a/apps/staged/src-tauri/src/blox.rs
+++ b/apps/staged/src-tauri/src/blox.rs
@@ -5,7 +5,7 @@
 
 use std::sync::OnceLock;
 
-pub use blox_cli::{BloxError, WorkspaceCommand, WorkspaceInfo, WorkspaceListEntry};
+pub use blox_cli::{BloxError, WorkspaceCommand, WorkspaceInfo, WorkspaceListEntry, WsExecOutput};
 
 static SQ_AVAILABLE: OnceLock<bool> = OnceLock::new();
 
@@ -66,6 +66,12 @@ pub fn ws_exec(name: &str, args: &[&str]) -> Result<String, BloxError> {
 /// Use this when the command may produce binary output (e.g. `git show` on image files).
 pub fn ws_exec_bytes(name: &str, args: &[&str]) -> Result<Vec<u8>, BloxError> {
     blox_cli::ws_exec_bytes(name, args)
+}
+
+/// Execute a command inside a Blox workspace, returning full output regardless
+/// of exit code. Infrastructure errors still return `Err`.
+pub fn ws_exec_output(name: &str, args: &[&str]) -> Result<WsExecOutput, BloxError> {
+    blox_cli::ws_exec_output(name, args)
 }
 
 /// Quick authentication check — runs `sq blox ws list` and inspects the result.

--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -213,6 +213,26 @@ pub(crate) fn run_workspace_git(
     blox::ws_exec(workspace_name, &borrowed)
 }
 
+/// Execute a shell script inside a Blox workspace via `sh -c`.
+///
+/// Positional arguments are passed as `$1`, `$2`, etc. This allows batching
+/// multiple git commands into a single `ws_exec` round-trip.
+pub(crate) fn run_workspace_shell(
+    workspace_name: &str,
+    script: &str,
+    args: &[&str],
+) -> Result<String, blox::BloxError> {
+    let mut owned = Vec::<String>::with_capacity(3 + args.len());
+    owned.push("sh".to_string());
+    owned.push("-c".to_string());
+    owned.push(script.to_string());
+    // $0 placeholder (conventional for sh -c)
+    owned.push("_".to_string());
+    owned.extend(args.iter().map(|arg| (*arg).to_string()));
+    let borrowed = owned.iter().map(String::as_str).collect::<Vec<_>>();
+    blox::ws_exec(workspace_name, &borrowed)
+}
+
 pub(crate) fn run_workspace_git_bytes(
     workspace_name: &str,
     repo_subpath: Option<&str>,

--- a/apps/staged/src-tauri/src/diff_commands.rs
+++ b/apps/staged/src-tauri/src/diff_commands.rs
@@ -4,8 +4,11 @@ use crate::branches;
 use crate::git;
 use crate::store::Store;
 use serde::Serialize;
-use std::path::Path;
+use std::path::{Component, Path};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
+
+const WORKTREE_TEXT_PREVIEW_MAX_BYTES: u64 = 1024 * 1024;
 
 /// Context needed to compute diffs for a branch.
 pub(crate) struct BranchDiffContext {
@@ -108,6 +111,10 @@ fn build_diff_spec(
             };
             Ok((spec, sha.to_string()))
         }
+        "worktree" => {
+            let resolved_sha = git::get_head_sha(worktree).map_err(|e| e.to_string())?;
+            Ok((git::DiffSpec::uncommitted(), resolved_sha))
+        }
         _ => {
             let resolved_sha = match commit_sha {
                 Some(sha) => sha.to_string(),
@@ -186,6 +193,81 @@ pub(crate) fn file_content_from_bytes(bytes: &[u8], path: &str) -> git::FileCont
     git::FileContent::Text {
         lines: text.lines().map(|line| line.to_string()).collect(),
     }
+}
+
+fn file_content_from_bytes_with_text_limit(bytes: &[u8], path: &str) -> git::FileContent {
+    let check_len = bytes.len().min(8192);
+    if bytes[..check_len].contains(&0) {
+        return file_content_binary_or_image(bytes, path);
+    }
+    if bytes.len() as u64 > WORKTREE_TEXT_PREVIEW_MAX_BYTES {
+        return git::FileContent::Binary;
+    }
+    let text = String::from_utf8_lossy(bytes);
+    git::FileContent::Text {
+        lines: text.lines().map(|line| line.to_string()).collect(),
+    }
+}
+
+fn validate_relative_diff_path(path: &str) -> Result<(), String> {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        return Err("Diff path must be relative".to_string());
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            _ => return Err("Diff path contains an invalid segment".to_string()),
+        }
+    }
+    Ok(())
+}
+
+fn file_exists_at_head(worktree: &Path, path: &str) -> Result<bool, String> {
+    let spec = format!("HEAD:{path}");
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(worktree)
+        .args(["cat-file", "-e", &spec]);
+    git::strip_git_env(&mut command);
+    let output = command.output().map_err(|e| e.to_string())?;
+    Ok(output.status.success())
+}
+
+fn large_added_worktree_file_diff(
+    worktree: &Path,
+    path: &str,
+) -> Result<Option<git::FileDiff>, String> {
+    validate_relative_diff_path(path)?;
+    if file_exists_at_head(worktree, path)? {
+        return Ok(None);
+    }
+
+    let full_path = worktree.join(path);
+    let Ok(metadata) = std::fs::metadata(&full_path) else {
+        return Ok(None);
+    };
+    if !metadata.is_file() || metadata.len() <= WORKTREE_TEXT_PREVIEW_MAX_BYTES {
+        return Ok(None);
+    }
+
+    let content = if metadata.len() <= git::IMAGE_PREVIEW_MAX_BYTES as u64 {
+        let bytes = std::fs::read(&full_path)
+            .map_err(|e| format!("Cannot read worktree file {path}: {e}"))?;
+        file_content_from_bytes_with_text_limit(&bytes, path)
+    } else {
+        git::FileContent::Binary
+    };
+
+    Ok(Some(git::FileDiff {
+        before: None,
+        after: Some(git::File {
+            path: path.to_string(),
+            content,
+        }),
+        alignments: Vec::new(),
+    }))
 }
 
 /// For binary content in the remote path, try to produce an ImageBase64 variant.
@@ -436,6 +518,10 @@ pub async fn get_diff_files(
         });
     }
 
+    if scope == "worktree" {
+        return Err("Worktree diff is only available for local branches".to_string());
+    }
+
     // Remote branch — check cache, then collect on miss.
     let latest_sha = store
         .list_commits_for_branch(&branch_id)
@@ -515,6 +601,11 @@ pub async fn get_file_diff(
         let worktree = Path::new(worktree_path);
         let (spec, _) = build_diff_spec(worktree, &ctx.base_branch, Some(&commit_sha), &scope)?;
         let file_path = Path::new(&path);
+        if scope == "worktree" {
+            if let Some(diff) = large_added_worktree_file_diff(worktree, &path)? {
+                return Ok(diff);
+            }
+        }
         let result = git::get_file_diff(worktree, &spec, file_path).map_err(|e| e.to_string())?;
         fn file_stats(f: &Option<git::File>) -> (usize, usize) {
             match f {
@@ -536,6 +627,10 @@ pub async fn get_file_diff(
             result.alignments.len()
         );
         return Ok(result);
+    }
+
+    if scope == "worktree" {
+        return Err("Worktree diff is only available for local branches".to_string());
     }
 
     // Check cache for branch-scope diffs.

--- a/apps/staged/src-tauri/src/git/mod.rs
+++ b/apps/staged/src-tauri/src/git/mod.rs
@@ -37,9 +37,11 @@ pub use refs::{
     resolve_ref, BranchRef,
 };
 pub use state::{
-    compute_branch_git_state, compute_branch_git_state_batched, compute_local_branch_git_state,
-    ensure_fast_forward_pullable, fast_forward_to_ref, BaseGitState, BranchGitState, FetchGitState,
-    FetchMode, FetchStatus, UpstreamGitState, UpstreamRelation, WorktreeGitState,
+    complete_local_git_state, compute_branch_git_state, compute_branch_git_state_batched,
+    compute_fast_git_state_batched, compute_fast_local_git_state, compute_local_branch_git_state,
+    ensure_fast_forward_pullable, fast_forward_to_ref, local_git_state_cache_key, needs_fetch,
+    BaseGitState, BranchGitState, FastGitState, FetchGitState, FetchMode, FetchStatus,
+    UpstreamGitState, UpstreamRelation, WorktreeGitState,
 };
 pub use types::*;
 pub use worktree::{

--- a/apps/staged/src-tauri/src/git/mod.rs
+++ b/apps/staged/src-tauri/src/git/mod.rs
@@ -8,6 +8,7 @@ mod refs;
 mod state;
 #[cfg(test)]
 mod state_tests;
+mod status_parse;
 mod types;
 mod worktree;
 

--- a/apps/staged/src-tauri/src/git/mod.rs
+++ b/apps/staged/src-tauri/src/git/mod.rs
@@ -37,9 +37,9 @@ pub use refs::{
     resolve_ref, BranchRef,
 };
 pub use state::{
-    compute_branch_git_state, compute_local_branch_git_state, ensure_fast_forward_pullable,
-    fast_forward_to_ref, BaseGitState, BranchGitState, FetchGitState, FetchMode, FetchStatus,
-    UpstreamGitState, UpstreamRelation, WorktreeGitState,
+    compute_branch_git_state, compute_branch_git_state_batched, compute_local_branch_git_state,
+    ensure_fast_forward_pullable, fast_forward_to_ref, BaseGitState, BranchGitState, FetchGitState,
+    FetchMode, FetchStatus, UpstreamGitState, UpstreamRelation, WorktreeGitState,
 };
 pub use types::*;
 pub use worktree::{

--- a/apps/staged/src-tauri/src/git/mod.rs
+++ b/apps/staged/src-tauri/src/git/mod.rs
@@ -5,6 +5,9 @@ mod env;
 mod files;
 pub mod github;
 mod refs;
+mod state;
+#[cfg(test)]
+mod state_tests;
 mod types;
 mod worktree;
 
@@ -32,13 +35,19 @@ pub use refs::{
     get_repo_root, list_branches, list_refs, merge_base, origin_ref_for_branch, prune_remote,
     resolve_ref, BranchRef,
 };
+pub use state::{
+    compute_branch_git_state, compute_local_branch_git_state, ensure_fast_forward_pullable,
+    fast_forward_to_ref, BaseGitState, BranchGitState, FetchGitState, FetchMode, FetchStatus,
+    UpstreamGitState, UpstreamRelation, WorktreeGitState,
+};
 pub use types::*;
 pub use worktree::{
     branch_exists, create_worktree, create_worktree_at_path, create_worktree_for_existing_branch,
     create_worktree_for_existing_branch_at_path, create_worktree_from_pr,
-    create_worktree_from_pr_at_path, fetch_pr_head_sha, get_commits_since_base,
-    get_full_commit_log, get_head_sha, get_parent_commit, has_unpushed_commits, list_worktrees,
+    create_worktree_from_pr_at_path, discard_worktree_changes, fetch_pr_head_sha,
+    get_commits_since_base, get_full_commit_log, get_head_sha, get_parent_commit,
+    has_unpushed_commits, list_worktree_change_paths, list_worktrees, parse_worktree_status_paths,
     project_worktree_path_for, project_worktree_root_for, remote_branch_exists, remove_worktree,
     reset_to_commit, set_upstream_to_origin, switch_branch, update_branch_from_pr,
-    worktree_path_for, CommitInfo, UpdateFromPrResult,
+    worktree_path_for, CommitInfo, UpdateFromPrResult, WorktreeChangePaths,
 };

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -512,6 +512,7 @@ const BATCH_FETCH_SCRIPT: &str = concat!(
     "echo STATUS_END\n",
     "[ -n \"$upstream_missing\" ] && echo 'UPSTREAM_MISSING=true'\n",
     "[ -n \"$fetch_err\" ] && printf 'FETCH_ERR=%s\\n' \"$fetch_err\"\n",
+    "exit 0\n",
 );
 
 /// Shell script that computes upstream and base ref state in one round-trip.

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -491,6 +491,473 @@ pub fn compute_local_branch_git_state(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Batched computation for remote projects
+// ---------------------------------------------------------------------------
+//
+// Instead of N separate round-trips (each `run_git` call is a `ws_exec`),
+// we batch multiple git commands into two shell scripts:
+//
+// Script 1 (fetch + local state): fetch, rev-parse HEAD, branch name, status
+// Script 2 (post-fetch ref state): upstream SHA/counts/merge-base, base SHA/merge-base/count
+//
+// The fetch TTL cache still controls whether Script 1 is needed at all.
+
+/// Shell script that performs fetch and collects local state in one round-trip.
+/// Arguments: $1=repo_path  $2=base_refspec  $3=branch_refspec (empty if same as base)
+const BATCH_FETCH_SCRIPT: &str = concat!(
+    "cd \"$1\" || exit 1\n",
+    // Fetch — capture stderr for missing-ref detection
+    "fetch_err=''\n",
+    "upstream_missing=''\n",
+    "if [ -n \"$3\" ]; then\n",
+    "  if ! git fetch --prune origin \"$2\" \"$3\" 2>/tmp/_staged_fetch_err; then\n",
+    "    if grep -qi 'could.not.find.remote.ref\\|couldn.t.find.remote.ref' /tmp/_staged_fetch_err; then\n",
+    "      if ! git fetch --prune origin \"$2\" 2>/tmp/_staged_fetch_err2; then\n",
+    "        fetch_err=$(cat /tmp/_staged_fetch_err2)\n",
+    "      else\n",
+    "        upstream_missing=true\n",
+    "      fi\n",
+    "    else\n",
+    "      fetch_err=$(cat /tmp/_staged_fetch_err)\n",
+    "    fi\n",
+    "  fi\n",
+    "else\n",
+    "  if ! git fetch --prune origin \"$2\" 2>/tmp/_staged_fetch_err; then\n",
+    "    fetch_err=$(cat /tmp/_staged_fetch_err)\n",
+    "  fi\n",
+    "fi\n",
+    // Local state (unaffected by fetch)
+    "printf 'HEAD=%s\\n' \"$(git rev-parse HEAD 2>/dev/null || true)\"\n",
+    "printf 'BRANCH=%s\\n' \"$(git branch --show-current 2>/dev/null || true)\"\n",
+    "echo STATUS_START\n",
+    "git status --porcelain=1 --untracked-files=all 2>/dev/null || true\n",
+    "echo STATUS_END\n",
+    "[ -n \"$upstream_missing\" ] && echo 'UPSTREAM_MISSING=true'\n",
+    "[ -n \"$fetch_err\" ] && printf 'FETCH_ERR=%s\\n' \"$fetch_err\"\n",
+);
+
+/// Shell script that computes upstream and base ref state in one round-trip.
+/// Arguments: $1=repo_path  $2=upstream_ref  $3=head_ref(HEAD)  $4=base_ref
+const BATCH_REFS_SCRIPT: &str = concat!(
+    "cd \"$1\" || exit 1\n",
+    // Upstream state
+    "up_sha=$(git rev-parse --verify \"$2\" 2>/dev/null || true)\n",
+    "printf 'UP_SHA=%s\\n' \"$up_sha\"\n",
+    "if [ -n \"$up_sha\" ] && [ -n \"$3\" ]; then\n",
+    "  printf 'UP_COUNTS=%s\\n' \"$(git rev-list --left-right --count \"$3\"...\"$2\" 2>/dev/null || echo '0 0')\"\n",
+    "  printf 'UP_MB=%s\\n' \"$(git merge-base \"$3\" \"$2\" 2>/dev/null || true)\"\n",
+    "fi\n",
+    // Base state
+    "base_sha=$(git rev-parse --verify \"$4\" 2>/dev/null || true)\n",
+    "printf 'BASE_SHA=%s\\n' \"$base_sha\"\n",
+    "if [ -n \"$base_sha\" ] && [ -n \"$3\" ]; then\n",
+    "  mb=$(git merge-base \"$3\" \"$4\" 2>/dev/null || true)\n",
+    "  printf 'BASE_MB=%s\\n' \"$mb\"\n",
+    "  if [ -n \"$mb\" ]; then\n",
+    "    printf 'BASE_BEHIND=%s\\n' \"$(git rev-list --count \"$mb\"..\"$4\" 2>/dev/null || echo 0)\"\n",
+    "  fi\n",
+    "fi\n",
+);
+
+/// Parsed output from the fetch + local state script.
+struct BatchFetchOutput {
+    head_sha: Option<String>,
+    branch: Option<String>,
+    status_lines: String,
+    upstream_missing: bool,
+    fetch_error: Option<String>,
+}
+
+fn parse_batch_fetch_output(raw: &str) -> BatchFetchOutput {
+    let mut head_sha = None;
+    let mut branch = None;
+    let mut upstream_missing = false;
+    let mut fetch_error = None;
+    let mut status_lines = String::new();
+    let mut in_status = false;
+
+    for line in raw.lines() {
+        if line == "STATUS_START" {
+            in_status = true;
+            continue;
+        }
+        if line == "STATUS_END" {
+            in_status = false;
+            continue;
+        }
+        if in_status {
+            if !status_lines.is_empty() {
+                status_lines.push('\n');
+            }
+            status_lines.push_str(line);
+            continue;
+        }
+        if let Some(val) = line.strip_prefix("HEAD=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                head_sha = Some(v.to_string());
+            }
+        } else if let Some(val) = line.strip_prefix("BRANCH=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                branch = Some(v.to_string());
+            }
+        } else if line.starts_with("UPSTREAM_MISSING=") {
+            upstream_missing = true;
+        } else if let Some(val) = line.strip_prefix("FETCH_ERR=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                fetch_error = Some(v.to_string());
+            }
+        }
+    }
+
+    BatchFetchOutput {
+        head_sha,
+        branch,
+        status_lines,
+        upstream_missing,
+        fetch_error,
+    }
+}
+
+/// Parsed output from the refs state script.
+struct BatchRefsOutput {
+    up_sha: Option<String>,
+    up_ahead: u32,
+    up_behind: u32,
+    up_merge_base: Option<String>,
+    base_sha: Option<String>,
+    base_behind: u32,
+}
+
+fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
+    let mut up_sha = None;
+    let mut up_ahead = 0u32;
+    let mut up_behind = 0u32;
+    let mut up_merge_base = None;
+    let mut base_sha = None;
+    let mut base_behind = 0u32;
+
+    for line in raw.lines() {
+        if let Some(val) = line.strip_prefix("UP_SHA=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                up_sha = Some(v.to_string());
+            }
+        } else if let Some(val) = line.strip_prefix("UP_COUNTS=") {
+            let mut parts = val.split_whitespace();
+            up_ahead = parse_u32(parts.next());
+            up_behind = parse_u32(parts.next());
+        } else if let Some(val) = line.strip_prefix("UP_MB=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                up_merge_base = Some(v.to_string());
+            }
+        } else if let Some(val) = line.strip_prefix("BASE_SHA=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                base_sha = Some(v.to_string());
+            }
+        } else if line.starts_with("BASE_MB=") {
+            // Parsed by the script internally to compute BASE_BEHIND; not
+            // needed in the Rust-side output struct.
+        } else if let Some(val) = line.strip_prefix("BASE_BEHIND=") {
+            base_behind = parse_u32(Some(val.trim()));
+        }
+    }
+
+    BatchRefsOutput {
+        up_sha,
+        up_ahead,
+        up_behind,
+        up_merge_base,
+        base_sha,
+        base_behind,
+    }
+}
+
+fn parse_worktree_from_status(status_output: &str) -> WorktreeGitState {
+    let mut state = WorktreeGitState {
+        dirty: false,
+        staged: 0,
+        unstaged: 0,
+        untracked: 0,
+        conflicted: 0,
+    };
+
+    for line in status_output.lines() {
+        let mut chars = line.chars();
+        let x = chars.next().unwrap_or(' ');
+        let y = chars.next().unwrap_or(' ');
+
+        if x == '?' && y == '?' {
+            state.untracked += 1;
+            continue;
+        }
+        if is_conflicted_status(x, y) {
+            state.conflicted += 1;
+            continue;
+        }
+        if x != ' ' {
+            state.staged += 1;
+        }
+        if y != ' ' {
+            state.unstaged += 1;
+        }
+    }
+
+    state.dirty =
+        state.staged > 0 || state.unstaged > 0 || state.untracked > 0 || state.conflicted > 0;
+    state
+}
+
+/// Compute branch git state using batched shell scripts.
+///
+/// This is the remote-optimised counterpart of `compute_branch_git_state`.
+/// Instead of many individual `run_git` calls (each a separate `ws_exec`
+/// round-trip), it bundles commands into at most two shell scripts:
+///
+/// - Script 1 (fetch + local state): 1 round-trip instead of 4-5
+/// - Script 2 (post-fetch ref state): 1 round-trip instead of 6
+///
+/// When the fetch TTL cache says "skip fetch", only Script 2 runs
+/// (with a simpler local-only preamble), giving **1 round-trip total**.
+pub fn compute_branch_git_state_batched<F>(
+    cache_key: &str,
+    run_script: F,
+    repo_path: &str,
+    branch_name: &str,
+    base_branch: &str,
+    fetch_mode: FetchMode,
+) -> BranchGitState
+where
+    F: Fn(&str, &[&str]) -> Result<String, String>,
+{
+    let base_refspec = refspec_for(base_branch);
+    let branch_refspec = refspec_for(branch_name);
+    let upstream_ref = origin_ref_for_branch(branch_name);
+    let base_ref = origin_ref_for_branch(base_branch);
+    let expected_branch = branch_name_without_origin(branch_name);
+
+    // Check fetch cache to decide whether we need Script 1 at all.
+    let now = now_ms();
+    let previous = fetch_cache()
+        .lock()
+        .ok()
+        .and_then(|cache| cache.get(cache_key).cloned());
+
+    let should_fetch = match (fetch_mode, &previous) {
+        (FetchMode::Never, _) => false,
+        (FetchMode::Force, _) => true,
+        (FetchMode::Ttl, Some(entry)) => now.saturating_sub(entry.fetched_at) > FETCH_TTL_MS,
+        (FetchMode::Ttl, None) => true,
+    };
+
+    // Phase 1: fetch + local state (or just local state if cache is fresh)
+    let (fetch_state, head_sha, branch, worktree, upstream_known_missing) = if should_fetch {
+        // Full fetch + local state script
+        let branch_arg = if branch_refspec != base_refspec {
+            branch_refspec.as_str()
+        } else {
+            ""
+        };
+        let raw = run_script(BATCH_FETCH_SCRIPT, &[repo_path, &base_refspec, branch_arg]);
+
+        match raw {
+            Ok(output) => {
+                let parsed = parse_batch_fetch_output(&output);
+                let fetch = if let Some(ref err) = parsed.fetch_error {
+                    FetchGitState {
+                        status: FetchStatus::Failed,
+                        fetched_at: previous.as_ref().map(|e| e.fetched_at),
+                        error: Some(err.clone()),
+                    }
+                } else {
+                    // Update cache on successful fetch
+                    if let Ok(mut cache) = fetch_cache().lock() {
+                        cache.insert(
+                            cache_key.to_string(),
+                            FetchCacheEntry {
+                                fetched_at: now,
+                                upstream_known_missing: parsed.upstream_missing,
+                            },
+                        );
+                    }
+                    FetchGitState {
+                        status: FetchStatus::Fresh,
+                        fetched_at: Some(now),
+                        error: None,
+                    }
+                };
+                let worktree = parse_worktree_from_status(&parsed.status_lines);
+                (
+                    fetch,
+                    parsed.head_sha,
+                    parsed.branch,
+                    worktree,
+                    parsed.upstream_missing,
+                )
+            }
+            Err(err) => {
+                // Script execution itself failed — treat as fetch failure
+                let fetch = FetchGitState {
+                    status: FetchStatus::Failed,
+                    fetched_at: previous.as_ref().map(|e| e.fetched_at),
+                    error: Some(err),
+                };
+                let worktree = WorktreeGitState {
+                    dirty: false,
+                    staged: 0,
+                    unstaged: 0,
+                    untracked: 0,
+                    conflicted: 0,
+                };
+                (fetch, None, None, worktree, false)
+            }
+        }
+    } else {
+        // Cache says skip fetch — just get local state with a minimal script
+        let local_script = concat!(
+            "cd \"$1\" || exit 1\n",
+            "printf 'HEAD=%s\\n' \"$(git rev-parse HEAD 2>/dev/null || true)\"\n",
+            "printf 'BRANCH=%s\\n' \"$(git branch --show-current 2>/dev/null || true)\"\n",
+            "echo STATUS_START\n",
+            "git status --porcelain=1 --untracked-files=all 2>/dev/null || true\n",
+            "echo STATUS_END\n",
+        );
+        let fetched_at = previous.as_ref().map(|entry| entry.fetched_at);
+        let upstream_known_missing = previous
+            .as_ref()
+            .map(|e| e.upstream_known_missing)
+            .unwrap_or(false);
+
+        match run_script(local_script, &[repo_path]) {
+            Ok(output) => {
+                let parsed = parse_batch_fetch_output(&output);
+                let fetch = FetchGitState {
+                    status: if fetched_at.is_some() {
+                        FetchStatus::Fresh
+                    } else {
+                        FetchStatus::Stale
+                    },
+                    fetched_at,
+                    error: None,
+                };
+                let worktree = parse_worktree_from_status(&parsed.status_lines);
+                (
+                    fetch,
+                    parsed.head_sha,
+                    parsed.branch,
+                    worktree,
+                    upstream_known_missing,
+                )
+            }
+            Err(_) => {
+                let fetch = FetchGitState {
+                    status: if fetched_at.is_some() {
+                        FetchStatus::Fresh
+                    } else {
+                        FetchStatus::Stale
+                    },
+                    fetched_at,
+                    error: None,
+                };
+                let worktree = WorktreeGitState {
+                    dirty: false,
+                    staged: 0,
+                    unstaged: 0,
+                    untracked: 0,
+                    conflicted: 0,
+                };
+                (fetch, None, None, worktree, upstream_known_missing)
+            }
+        }
+    };
+
+    let detached_head = head_sha.is_some() && branch.is_none();
+    let expected_branch_matches = branch
+        .as_deref()
+        .map(|current| current == expected_branch)
+        .unwrap_or(false);
+
+    // Phase 2: upstream + base ref state (single round-trip)
+    let head_arg = head_sha.as_deref().unwrap_or("");
+    let up_ref_arg = if upstream_known_missing {
+        "" // Skip upstream resolution when we know it's missing
+    } else {
+        upstream_ref.as_str()
+    };
+
+    let (upstream, base) = match run_script(
+        BATCH_REFS_SCRIPT,
+        &[repo_path, up_ref_arg, head_arg, &base_ref],
+    ) {
+        Ok(output) => {
+            let refs = parse_batch_refs_output(&output);
+
+            let up_exists = refs.up_sha.is_some();
+            let relation = if !up_exists || head_sha.is_none() {
+                UpstreamRelation::Missing
+            } else {
+                match (refs.up_ahead, refs.up_behind) {
+                    (0, 0) => UpstreamRelation::InSync,
+                    (_, 0) => UpstreamRelation::LocalAhead,
+                    (0, _) => UpstreamRelation::OriginAhead,
+                    _ => UpstreamRelation::Diverged,
+                }
+            };
+
+            let upstream = UpstreamGitState {
+                r#ref: upstream_ref,
+                exists: up_exists,
+                sha: refs.up_sha,
+                relation,
+                ahead: refs.up_ahead,
+                behind: refs.up_behind,
+                merge_base_sha: refs.up_merge_base,
+            };
+
+            let base = BaseGitState {
+                r#ref: base_ref,
+                sha: refs.base_sha,
+                commits_since_fork: refs.base_behind,
+            };
+
+            (upstream, base)
+        }
+        Err(_) => {
+            let upstream = UpstreamGitState {
+                r#ref: upstream_ref,
+                exists: false,
+                sha: None,
+                relation: UpstreamRelation::Missing,
+                ahead: 0,
+                behind: 0,
+                merge_base_sha: None,
+            };
+            let base = BaseGitState {
+                r#ref: base_ref,
+                sha: None,
+                commits_since_fork: 0,
+            };
+            (upstream, base)
+        }
+    };
+
+    BranchGitState {
+        upstream,
+        base,
+        worktree,
+        fetch: fetch_state,
+        head_sha,
+        current_branch: branch,
+        detached_head,
+        expected_branch_matches,
+    }
+}
+
 pub fn fast_forward_to_ref(repo: &Path, reference: &str) -> Result<(), GitError> {
     cli::run(repo, &["merge", "--ff-only", reference])?;
     Ok(())

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -1,5 +1,6 @@
 use super::cli::{self, GitError};
 use super::refs::{branch_name_without_origin, origin_ref_for_branch};
+use super::status_parse::is_conflicted_status;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -170,24 +171,36 @@ where
     }
 
     let base_refspec = refspec_for(base_branch);
-    if let Err(error) = run_git(&["fetch", "--prune", "origin", base_refspec.as_str()]) {
-        return RefreshOutcome {
-            fetch: FetchGitState {
-                status: FetchStatus::Failed,
-                fetched_at: previous.map(|entry| entry.fetched_at),
-                error: Some(error.trim().to_string()),
-            },
-            upstream_known_missing: false,
-        };
-    }
-
-    let mut upstream_known_missing = false;
     let branch_refspec = refspec_for(branch_name);
+    let mut upstream_known_missing = false;
+
+    // Fetch both refspecs in a single network call when they differ.
     if branch_refspec != base_refspec {
-        if let Err(error) = run_git(&["fetch", "--prune", "origin", branch_refspec.as_str()]) {
-            if is_missing_remote_ref(&error) {
+        match run_git(&[
+            "fetch",
+            "--prune",
+            "origin",
+            base_refspec.as_str(),
+            branch_refspec.as_str(),
+        ]) {
+            Err(error) if is_missing_remote_ref(&error) => {
+                // The branch refspec is missing on the remote. Re-fetch with
+                // just the base refspec so we still get base branch updates.
+                if let Err(base_err) =
+                    run_git(&["fetch", "--prune", "origin", base_refspec.as_str()])
+                {
+                    return RefreshOutcome {
+                        fetch: FetchGitState {
+                            status: FetchStatus::Failed,
+                            fetched_at: previous.map(|entry| entry.fetched_at),
+                            error: Some(base_err.trim().to_string()),
+                        },
+                        upstream_known_missing: false,
+                    };
+                }
                 upstream_known_missing = true;
-            } else {
+            }
+            Err(error) => {
                 return RefreshOutcome {
                     fetch: FetchGitState {
                         status: FetchStatus::Failed,
@@ -197,7 +210,17 @@ where
                     upstream_known_missing: false,
                 };
             }
+            Ok(_) => {}
         }
+    } else if let Err(error) = run_git(&["fetch", "--prune", "origin", base_refspec.as_str()]) {
+        return RefreshOutcome {
+            fetch: FetchGitState {
+                status: FetchStatus::Failed,
+                fetched_at: previous.map(|entry| entry.fetched_at),
+                error: Some(error.trim().to_string()),
+            },
+            upstream_known_missing: false,
+        };
     }
 
     if let Ok(mut cache) = fetch_cache().lock() {
@@ -335,13 +358,6 @@ where
         sha,
         commits_since_fork,
     }
-}
-
-fn is_conflicted_status(x: char, y: char) -> bool {
-    matches!(
-        (x, y),
-        ('D', 'D') | ('A', 'U') | ('U', 'D') | ('U', 'A') | ('D', 'U') | ('A', 'A') | ('U', 'U')
-    )
 }
 
 fn compute_worktree_state<F>(run_git: &F) -> WorktreeGitState

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -410,34 +410,66 @@ pub fn compute_branch_git_state<F>(
     fetch_mode: FetchMode,
 ) -> BranchGitState
 where
-    F: Fn(&[&str]) -> Result<String, String>,
+    F: Fn(&[&str]) -> Result<String, String> + Sync,
 {
-    let refresh = refresh_refs_if_needed(cache_key, &run_git, branch_name, base_branch, fetch_mode);
-    let head_sha = run_git(&["rev-parse", "HEAD"])
-        .ok()
-        .and_then(trim_non_empty);
-    let current_branch = current_branch(&run_git);
-    let detached_head = head_sha.is_some() && current_branch.is_none();
+    // Phase 1: Fetch runs in parallel with local-only commands (HEAD, branch
+    // name, worktree status) since those read local state unaffected by fetch.
+    let (refresh, head_sha, branch, worktree) = std::thread::scope(|s| {
+        let fetch_handle = s.spawn(|| {
+            refresh_refs_if_needed(cache_key, &run_git, branch_name, base_branch, fetch_mode)
+        });
+        let head_handle = s.spawn(|| {
+            run_git(&["rev-parse", "HEAD"])
+                .ok()
+                .and_then(trim_non_empty)
+        });
+        let branch_handle = s.spawn(|| current_branch(&run_git));
+        let worktree_handle = s.spawn(|| compute_worktree_state(&run_git));
+
+        (
+            fetch_handle.join().expect("fetch thread panicked"),
+            head_handle.join().expect("head thread panicked"),
+            branch_handle.join().expect("branch thread panicked"),
+            worktree_handle.join().expect("worktree thread panicked"),
+        )
+    });
+
+    let detached_head = head_sha.is_some() && branch.is_none();
     let expected_branch = branch_name_without_origin(branch_name);
-    let expected_branch_matches = current_branch
+    let expected_branch_matches = branch
         .as_deref()
         .map(|current| current == expected_branch)
         .unwrap_or(false);
     let upstream_ref = origin_ref_for_branch(branch_name);
     let base_ref = origin_ref_for_branch(base_branch);
 
+    // Phase 2: Upstream and base state computations are independent of each
+    // other but both need fetch to have completed (for up-to-date remote refs)
+    // and head_sha.
+    let (upstream, base) = std::thread::scope(|s| {
+        let upstream_handle = s.spawn(|| {
+            compute_upstream_state(
+                &run_git,
+                upstream_ref,
+                head_sha.as_deref(),
+                refresh.upstream_known_missing,
+            )
+        });
+        let base_handle = s.spawn(|| compute_base_state(&run_git, base_ref, head_sha.as_deref()));
+
+        (
+            upstream_handle.join().expect("upstream thread panicked"),
+            base_handle.join().expect("base thread panicked"),
+        )
+    });
+
     BranchGitState {
-        upstream: compute_upstream_state(
-            &run_git,
-            upstream_ref,
-            head_sha.as_deref(),
-            refresh.upstream_known_missing,
-        ),
-        base: compute_base_state(&run_git, base_ref, head_sha.as_deref()),
-        worktree: compute_worktree_state(&run_git),
+        upstream,
+        base,
+        worktree,
         fetch: refresh.fetch,
         head_sha,
-        current_branch,
+        current_branch: branch,
         detached_head,
         expected_branch_matches,
     }

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -316,9 +316,9 @@ where
     let counts_range = format!("HEAD...{upstream_ref}");
     let (ahead, behind) = run_git(&["rev-list", "--left-right", "--count", counts_range.as_str()])
         .ok()
-        .and_then(|output| {
+        .map(|output| {
             let mut parts = output.split_whitespace();
-            Some((parse_u32(parts.next()), parse_u32(parts.next())))
+            (parse_u32(parts.next()), parse_u32(parts.next()))
         })
         .unwrap_or((0, 0));
     let relation = match (ahead, behind) {
@@ -507,24 +507,26 @@ pub fn compute_local_branch_git_state(
 /// Arguments: $1=repo_path  $2=base_refspec  $3=branch_refspec (empty if same as base)
 const BATCH_FETCH_SCRIPT: &str = concat!(
     "cd \"$1\" || exit 1\n",
-    // Fetch — capture stderr for missing-ref detection
+    // Fetch — capture stderr for missing-ref detection using unique temp files
     "fetch_err=''\n",
     "upstream_missing=''\n",
+    "_ferr=$(mktemp) || exit 1\n",
+    "trap 'rm -f \"$_ferr\"' EXIT\n",
     "if [ -n \"$3\" ]; then\n",
-    "  if ! git fetch --prune origin \"$2\" \"$3\" 2>/tmp/_staged_fetch_err; then\n",
-    "    if grep -qi 'could.not.find.remote.ref\\|couldn.t.find.remote.ref' /tmp/_staged_fetch_err; then\n",
-    "      if ! git fetch --prune origin \"$2\" 2>/tmp/_staged_fetch_err2; then\n",
-    "        fetch_err=$(cat /tmp/_staged_fetch_err2)\n",
+    "  if ! git fetch --prune origin \"$2\" \"$3\" 2>\"$_ferr\"; then\n",
+    "    if grep -qi 'could.not.find.remote.ref\\|couldn.t.find.remote.ref' \"$_ferr\"; then\n",
+    "      if ! git fetch --prune origin \"$2\" 2>\"$_ferr\"; then\n",
+    "        fetch_err=$(cat \"$_ferr\")\n",
     "      else\n",
     "        upstream_missing=true\n",
     "      fi\n",
     "    else\n",
-    "      fetch_err=$(cat /tmp/_staged_fetch_err)\n",
+    "      fetch_err=$(cat \"$_ferr\")\n",
     "    fi\n",
     "  fi\n",
     "else\n",
-    "  if ! git fetch --prune origin \"$2\" 2>/tmp/_staged_fetch_err; then\n",
-    "    fetch_err=$(cat /tmp/_staged_fetch_err)\n",
+    "  if ! git fetch --prune origin \"$2\" 2>\"$_ferr\"; then\n",
+    "    fetch_err=$(cat \"$_ferr\")\n",
     "  fi\n",
     "fi\n",
     // Local state (unaffected by fetch)

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -364,42 +364,17 @@ fn compute_worktree_state<F>(run_git: &F) -> WorktreeGitState
 where
     F: Fn(&[&str]) -> Result<String, String>,
 {
-    let mut state = WorktreeGitState {
-        dirty: false,
-        staged: 0,
-        unstaged: 0,
-        untracked: 0,
-        conflicted: 0,
-    };
-
     let Ok(output) = run_git(&["status", "--porcelain=1", "--untracked-files=all"]) else {
-        return state;
+        return WorktreeGitState {
+            dirty: false,
+            staged: 0,
+            unstaged: 0,
+            untracked: 0,
+            conflicted: 0,
+        };
     };
 
-    for line in output.lines() {
-        let mut chars = line.chars();
-        let x = chars.next().unwrap_or(' ');
-        let y = chars.next().unwrap_or(' ');
-
-        if x == '?' && y == '?' {
-            state.untracked += 1;
-            continue;
-        }
-        if is_conflicted_status(x, y) {
-            state.conflicted += 1;
-            continue;
-        }
-        if x != ' ' {
-            state.staged += 1;
-        }
-        if y != ' ' {
-            state.unstaged += 1;
-        }
-    }
-
-    state.dirty =
-        state.staged > 0 || state.unstaged > 0 || state.untracked > 0 || state.conflicted > 0;
-    state
+    parse_worktree_from_status(&output)
 }
 
 pub fn compute_branch_git_state<F>(

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const FETCH_TTL_MS: i64 = 30_000;
 
@@ -438,18 +438,11 @@ pub fn compute_branch_git_state<F>(
 where
     F: Fn(&[&str]) -> Result<String, String> + Sync,
 {
-    let t_total = Instant::now();
-
     // Phase 1: Fetch runs in parallel with local-only commands (HEAD, branch
     // name, worktree status) since those read local state unaffected by fetch.
-    let t_phase1 = Instant::now();
     let (refresh, head_sha, branch, worktree) = std::thread::scope(|s| {
         let fetch_handle = s.spawn(|| {
-            let t = Instant::now();
-            let r =
-                refresh_refs_if_needed(cache_key, &run_git, branch_name, base_branch, fetch_mode);
-            log::info!("[git-state] fetch: {:?} key={}", t.elapsed(), cache_key);
-            r
+            refresh_refs_if_needed(cache_key, &run_git, branch_name, base_branch, fetch_mode)
         });
         let head_handle = s.spawn(|| {
             run_git(&["rev-parse", "HEAD"])
@@ -466,11 +459,6 @@ where
             worktree_handle.join().expect("worktree thread panicked"),
         )
     });
-    log::info!(
-        "[git-state] phase1 (fetch+local): {:?} key={}",
-        t_phase1.elapsed(),
-        cache_key
-    );
 
     let detached_head = head_sha.is_some() && branch.is_none();
     let expected_branch = branch_name_without_origin(branch_name);
@@ -484,7 +472,6 @@ where
     // Phase 2: Upstream and base state computations are independent of each
     // other but both need fetch to have completed (for up-to-date remote refs)
     // and head_sha.
-    let t_phase2 = Instant::now();
     let (upstream, base) = std::thread::scope(|s| {
         let upstream_handle = s.spawn(|| {
             compute_upstream_state(
@@ -501,16 +488,6 @@ where
             base_handle.join().expect("base thread panicked"),
         )
     });
-    log::info!(
-        "[git-state] phase2 (upstream+base): {:?} key={}",
-        t_phase2.elapsed(),
-        cache_key
-    );
-    log::info!(
-        "[git-state] total: {:?} key={}",
-        t_total.elapsed(),
-        cache_key
-    );
 
     BranchGitState {
         upstream,
@@ -662,7 +639,6 @@ pub fn local_git_state_cache_key(repo: &Path, branch_name: &str, base_branch: &s
 ///   $6 = "skip_fetch" to skip the fetch phase (cache fresh)
 const BATCH_GIT_STATE_SCRIPT: &str = concat!(
     "cd \"$1\" || exit 1\n",
-    "_t0=$(date +%s%3N 2>/dev/null || echo 0)\n",
     // --- Fetch phase (conditional) ---
     "fetch_err=''\n",
     "upstream_missing=''\n",
@@ -687,7 +663,6 @@ const BATCH_GIT_STATE_SCRIPT: &str = concat!(
     "    fi\n",
     "  fi\n",
     "fi\n",
-    "_t1=$(date +%s%3N 2>/dev/null || echo 0)\n",
     // --- Local state ---
     "head_sha=$(git rev-parse HEAD 2>/dev/null || true)\n",
     "printf 'HEAD=%s\\n' \"$head_sha\"\n",
@@ -695,7 +670,6 @@ const BATCH_GIT_STATE_SCRIPT: &str = concat!(
     "echo STATUS_START\n",
     "git status --porcelain=1 --untracked-files=all 2>/dev/null || true\n",
     "echo STATUS_END\n",
-    "_t2=$(date +%s%3N 2>/dev/null || echo 0)\n",
     "[ -n \"$upstream_missing\" ] && echo 'UPSTREAM_MISSING=true'\n",
     "[ -n \"$fetch_err\" ] && printf 'FETCH_ERR=%s\\n' \"$fetch_err\"\n",
     // --- Upstream state (skip if $4 is empty) ---
@@ -709,7 +683,6 @@ const BATCH_GIT_STATE_SCRIPT: &str = concat!(
     "  printf 'UP_COUNTS=%s\\n' \"$(git rev-list --left-right --count \"$head_sha\"...\"$4\" 2>/dev/null || echo '0 0')\"\n",
     "  printf 'UP_MB=%s\\n' \"$(git merge-base \"$head_sha\" \"$4\" 2>/dev/null || true)\"\n",
     "fi\n",
-    "_t3=$(date +%s%3N 2>/dev/null || echo 0)\n",
     // --- Base state ---
     "base_sha=$(git rev-parse --verify \"$5\" 2>/dev/null || true)\n",
     "printf 'BASE_SHA=%s\\n' \"$base_sha\"\n",
@@ -720,11 +693,6 @@ const BATCH_GIT_STATE_SCRIPT: &str = concat!(
     "    printf 'BASE_BEHIND=%s\\n' \"$(git rev-list --count \"$mb\"..\"$5\" 2>/dev/null || echo 0)\"\n",
     "  fi\n",
     "fi\n",
-    "_t4=$(date +%s%3N 2>/dev/null || echo 0)\n",
-    "printf 'TIMING_FETCH=%s\\n' \"$((_t1 - _t0))\"\n",
-    "printf 'TIMING_LOCAL=%s\\n' \"$((_t2 - _t1))\"\n",
-    "printf 'TIMING_UPSTREAM=%s\\n' \"$((_t3 - _t2))\"\n",
-    "printf 'TIMING_BASE=%s\\n' \"$((_t4 - _t3))\"\n",
     "exit 0\n",
 );
 
@@ -741,10 +709,6 @@ struct BatchGitStateOutput {
     up_merge_base: Option<String>,
     base_sha: Option<String>,
     base_behind: u32,
-    timing_fetch_ms: Option<i64>,
-    timing_local_ms: Option<i64>,
-    timing_upstream_ms: Option<i64>,
-    timing_base_ms: Option<i64>,
 }
 
 fn parse_batch_git_state_output(raw: &str) -> BatchGitStateOutput {
@@ -760,10 +724,6 @@ fn parse_batch_git_state_output(raw: &str) -> BatchGitStateOutput {
     let mut up_merge_base = None;
     let mut base_sha = None;
     let mut base_behind = 0u32;
-    let mut timing_fetch_ms = None;
-    let mut timing_local_ms = None;
-    let mut timing_upstream_ms = None;
-    let mut timing_base_ms = None;
 
     for line in raw.lines() {
         if line == "STATUS_START" {
@@ -821,14 +781,6 @@ fn parse_batch_git_state_output(raw: &str) -> BatchGitStateOutput {
             // Used internally by the script to compute BASE_BEHIND.
         } else if let Some(val) = line.strip_prefix("BASE_BEHIND=") {
             base_behind = parse_u32(Some(val.trim()));
-        } else if let Some(val) = line.strip_prefix("TIMING_FETCH=") {
-            timing_fetch_ms = val.trim().parse().ok();
-        } else if let Some(val) = line.strip_prefix("TIMING_LOCAL=") {
-            timing_local_ms = val.trim().parse().ok();
-        } else if let Some(val) = line.strip_prefix("TIMING_UPSTREAM=") {
-            timing_upstream_ms = val.trim().parse().ok();
-        } else if let Some(val) = line.strip_prefix("TIMING_BASE=") {
-            timing_base_ms = val.trim().parse().ok();
         }
     }
 
@@ -844,10 +796,6 @@ fn parse_batch_git_state_output(raw: &str) -> BatchGitStateOutput {
         up_merge_base,
         base_sha,
         base_behind,
-        timing_fetch_ms,
-        timing_local_ms,
-        timing_upstream_ms,
-        timing_base_ms,
     }
 }
 
@@ -1042,7 +990,6 @@ pub fn compute_branch_git_state_batched<F>(
 where
     F: Fn(&str, &[&str]) -> Result<String, String>,
 {
-    let t_total = Instant::now();
     let base_refspec = refspec_for(base_branch);
     let branch_refspec = refspec_for(branch_name);
     let upstream_ref = origin_ref_for_branch(branch_name);
@@ -1097,15 +1044,6 @@ where
     match raw {
         Ok(output) => {
             let parsed = parse_batch_git_state_output(&output);
-            log::info!(
-                "[git-state-remote] fetch={}ms local={}ms upstream={}ms base={}ms round-trip={:?} key={}",
-                parsed.timing_fetch_ms.unwrap_or(-1),
-                parsed.timing_local_ms.unwrap_or(-1),
-                parsed.timing_upstream_ms.unwrap_or(-1),
-                parsed.timing_base_ms.unwrap_or(-1),
-                t_total.elapsed(),
-                cache_key,
-            );
 
             let upstream_known_missing = if should_fetch {
                 parsed.upstream_missing

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -1,0 +1,469 @@
+use super::cli::{self, GitError};
+use super::refs::{branch_name_without_origin, origin_ref_for_branch};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const FETCH_TTL_MS: i64 = 30_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchMode {
+    Ttl,
+    Force,
+    Never,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BranchGitState {
+    pub head_sha: Option<String>,
+    pub current_branch: Option<String>,
+    pub detached_head: bool,
+    pub expected_branch_matches: bool,
+    pub upstream: UpstreamGitState,
+    pub base: BaseGitState,
+    pub worktree: WorktreeGitState,
+    pub fetch: FetchGitState,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpstreamGitState {
+    pub r#ref: String,
+    pub exists: bool,
+    pub sha: Option<String>,
+    pub relation: UpstreamRelation,
+    pub ahead: u32,
+    pub behind: u32,
+    pub merge_base_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum UpstreamRelation {
+    Missing,
+    InSync,
+    LocalAhead,
+    OriginAhead,
+    Diverged,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseGitState {
+    pub r#ref: String,
+    pub sha: Option<String>,
+    pub commits_since_fork: u32,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeGitState {
+    pub dirty: bool,
+    pub staged: u32,
+    pub unstaged: u32,
+    pub untracked: u32,
+    pub conflicted: u32,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchGitState {
+    pub status: FetchStatus,
+    pub fetched_at: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum FetchStatus {
+    Fresh,
+    Stale,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+struct FetchCacheEntry {
+    fetched_at: i64,
+    upstream_known_missing: bool,
+}
+
+#[derive(Debug, Clone)]
+struct RefreshOutcome {
+    fetch: FetchGitState,
+    upstream_known_missing: bool,
+}
+
+fn fetch_cache() -> &'static Mutex<HashMap<String, FetchCacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, FetchCacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+fn trim_non_empty(output: String) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn is_missing_remote_ref(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("couldn't find remote ref") || lower.contains("could not find remote ref")
+}
+
+fn refspec_for(remote_branch: &str) -> String {
+    let branch = branch_name_without_origin(remote_branch);
+    format!("+refs/heads/{branch}:refs/remotes/origin/{branch}")
+}
+
+fn refresh_refs_if_needed<F>(
+    cache_key: &str,
+    run_git: &F,
+    branch_name: &str,
+    base_branch: &str,
+    fetch_mode: FetchMode,
+) -> RefreshOutcome
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    let now = now_ms();
+    let previous = fetch_cache()
+        .lock()
+        .ok()
+        .and_then(|cache| cache.get(cache_key).cloned());
+
+    let should_fetch = match (fetch_mode, &previous) {
+        (FetchMode::Never, _) => false,
+        (FetchMode::Force, _) => true,
+        (FetchMode::Ttl, Some(entry)) => now.saturating_sub(entry.fetched_at) > FETCH_TTL_MS,
+        (FetchMode::Ttl, None) => true,
+    };
+
+    if !should_fetch {
+        let fetched_at = previous.as_ref().map(|entry| entry.fetched_at);
+        return RefreshOutcome {
+            fetch: FetchGitState {
+                status: if fetched_at.is_some() {
+                    FetchStatus::Fresh
+                } else {
+                    FetchStatus::Stale
+                },
+                fetched_at,
+                error: None,
+            },
+            upstream_known_missing: previous
+                .as_ref()
+                .map(|entry| entry.upstream_known_missing)
+                .unwrap_or(false),
+        };
+    }
+
+    let base_refspec = refspec_for(base_branch);
+    if let Err(error) = run_git(&["fetch", "--prune", "origin", base_refspec.as_str()]) {
+        return RefreshOutcome {
+            fetch: FetchGitState {
+                status: FetchStatus::Failed,
+                fetched_at: previous.map(|entry| entry.fetched_at),
+                error: Some(error.trim().to_string()),
+            },
+            upstream_known_missing: false,
+        };
+    }
+
+    let mut upstream_known_missing = false;
+    let branch_refspec = refspec_for(branch_name);
+    if branch_refspec != base_refspec {
+        if let Err(error) = run_git(&["fetch", "--prune", "origin", branch_refspec.as_str()]) {
+            if is_missing_remote_ref(&error) {
+                upstream_known_missing = true;
+            } else {
+                return RefreshOutcome {
+                    fetch: FetchGitState {
+                        status: FetchStatus::Failed,
+                        fetched_at: previous.map(|entry| entry.fetched_at),
+                        error: Some(error.trim().to_string()),
+                    },
+                    upstream_known_missing: false,
+                };
+            }
+        }
+    }
+
+    if let Ok(mut cache) = fetch_cache().lock() {
+        cache.insert(
+            cache_key.to_string(),
+            FetchCacheEntry {
+                fetched_at: now,
+                upstream_known_missing,
+            },
+        );
+    }
+
+    RefreshOutcome {
+        fetch: FetchGitState {
+            status: FetchStatus::Fresh,
+            fetched_at: Some(now),
+            error: None,
+        },
+        upstream_known_missing,
+    }
+}
+
+fn parse_u32(raw: Option<&str>) -> u32 {
+    raw.and_then(|s| s.parse::<u32>().ok()).unwrap_or(0)
+}
+
+fn rev_count<F>(run_git: &F, range: &str) -> u32
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    run_git(&["rev-list", "--count", range])
+        .ok()
+        .and_then(trim_non_empty)
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(0)
+}
+
+fn current_branch<F>(run_git: &F) -> Option<String>
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    run_git(&["branch", "--show-current"])
+        .ok()
+        .and_then(trim_non_empty)
+}
+
+fn resolve_ref<F>(run_git: &F, reference: &str) -> Option<String>
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    run_git(&["rev-parse", "--verify", reference])
+        .ok()
+        .and_then(trim_non_empty)
+}
+
+fn merge_base<F>(run_git: &F, left: &str, right: &str) -> Option<String>
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    run_git(&["merge-base", left, right])
+        .ok()
+        .and_then(trim_non_empty)
+}
+
+fn compute_upstream_state<F>(
+    run_git: &F,
+    upstream_ref: String,
+    head_sha: Option<&str>,
+    upstream_known_missing: bool,
+) -> UpstreamGitState
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    let sha = if upstream_known_missing {
+        None
+    } else {
+        resolve_ref(run_git, &upstream_ref)
+    };
+    let exists = sha.is_some();
+
+    if !exists || head_sha.is_none() {
+        return UpstreamGitState {
+            r#ref: upstream_ref,
+            exists,
+            sha,
+            relation: UpstreamRelation::Missing,
+            ahead: 0,
+            behind: 0,
+            merge_base_sha: None,
+        };
+    }
+
+    let counts_range = format!("HEAD...{upstream_ref}");
+    let (ahead, behind) = run_git(&["rev-list", "--left-right", "--count", counts_range.as_str()])
+        .ok()
+        .and_then(|output| {
+            let mut parts = output.split_whitespace();
+            Some((parse_u32(parts.next()), parse_u32(parts.next())))
+        })
+        .unwrap_or((0, 0));
+    let relation = match (ahead, behind) {
+        (0, 0) => UpstreamRelation::InSync,
+        (_, 0) => UpstreamRelation::LocalAhead,
+        (0, _) => UpstreamRelation::OriginAhead,
+        _ => UpstreamRelation::Diverged,
+    };
+    let merge_base_sha = merge_base(run_git, "HEAD", &upstream_ref);
+
+    UpstreamGitState {
+        r#ref: upstream_ref,
+        exists,
+        sha,
+        relation,
+        ahead,
+        behind,
+        merge_base_sha,
+    }
+}
+
+fn compute_base_state<F>(run_git: &F, base_ref: String, head_sha: Option<&str>) -> BaseGitState
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    let sha = resolve_ref(run_git, &base_ref);
+    let commits_since_fork = if sha.is_some() && head_sha.is_some() {
+        merge_base(run_git, "HEAD", &base_ref)
+            .map(|base| rev_count(run_git, &format!("{base}..{base_ref}")))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    BaseGitState {
+        r#ref: base_ref,
+        sha,
+        commits_since_fork,
+    }
+}
+
+fn is_conflicted_status(x: char, y: char) -> bool {
+    matches!(
+        (x, y),
+        ('D', 'D') | ('A', 'U') | ('U', 'D') | ('U', 'A') | ('D', 'U') | ('A', 'A') | ('U', 'U')
+    )
+}
+
+fn compute_worktree_state<F>(run_git: &F) -> WorktreeGitState
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    let mut state = WorktreeGitState {
+        dirty: false,
+        staged: 0,
+        unstaged: 0,
+        untracked: 0,
+        conflicted: 0,
+    };
+
+    let Ok(output) = run_git(&["status", "--porcelain=1", "--untracked-files=all"]) else {
+        return state;
+    };
+
+    for line in output.lines() {
+        let mut chars = line.chars();
+        let x = chars.next().unwrap_or(' ');
+        let y = chars.next().unwrap_or(' ');
+
+        if x == '?' && y == '?' {
+            state.untracked += 1;
+            continue;
+        }
+        if is_conflicted_status(x, y) {
+            state.conflicted += 1;
+            continue;
+        }
+        if x != ' ' {
+            state.staged += 1;
+        }
+        if y != ' ' {
+            state.unstaged += 1;
+        }
+    }
+
+    state.dirty =
+        state.staged > 0 || state.unstaged > 0 || state.untracked > 0 || state.conflicted > 0;
+    state
+}
+
+pub fn compute_branch_git_state<F>(
+    cache_key: &str,
+    run_git: F,
+    branch_name: &str,
+    base_branch: &str,
+    fetch_mode: FetchMode,
+) -> BranchGitState
+where
+    F: Fn(&[&str]) -> Result<String, String>,
+{
+    let refresh = refresh_refs_if_needed(cache_key, &run_git, branch_name, base_branch, fetch_mode);
+    let head_sha = run_git(&["rev-parse", "HEAD"])
+        .ok()
+        .and_then(trim_non_empty);
+    let current_branch = current_branch(&run_git);
+    let detached_head = head_sha.is_some() && current_branch.is_none();
+    let expected_branch = branch_name_without_origin(branch_name);
+    let expected_branch_matches = current_branch
+        .as_deref()
+        .map(|current| current == expected_branch)
+        .unwrap_or(false);
+    let upstream_ref = origin_ref_for_branch(branch_name);
+    let base_ref = origin_ref_for_branch(base_branch);
+
+    BranchGitState {
+        upstream: compute_upstream_state(
+            &run_git,
+            upstream_ref,
+            head_sha.as_deref(),
+            refresh.upstream_known_missing,
+        ),
+        base: compute_base_state(&run_git, base_ref, head_sha.as_deref()),
+        worktree: compute_worktree_state(&run_git),
+        fetch: refresh.fetch,
+        head_sha,
+        current_branch,
+        detached_head,
+        expected_branch_matches,
+    }
+}
+
+pub fn compute_local_branch_git_state(
+    repo: &Path,
+    branch_name: &str,
+    base_branch: &str,
+    fetch_mode: FetchMode,
+) -> BranchGitState {
+    let cache_key = format!("local:{}:{}:{}", repo.display(), branch_name, base_branch);
+    compute_branch_git_state(
+        &cache_key,
+        |args| cli::run(repo, args).map_err(|e| e.to_string()),
+        branch_name,
+        base_branch,
+        fetch_mode,
+    )
+}
+
+pub fn fast_forward_to_ref(repo: &Path, reference: &str) -> Result<(), GitError> {
+    cli::run(repo, &["merge", "--ff-only", reference])?;
+    Ok(())
+}
+
+pub fn ensure_fast_forward_pullable(state: &BranchGitState) -> Result<(), String> {
+    if state.detached_head {
+        return Err("Cannot pull while HEAD is detached".to_string());
+    }
+    if !state.expected_branch_matches {
+        let current = state
+            .current_branch
+            .as_deref()
+            .unwrap_or("an unknown branch");
+        return Err(format!("Cannot pull while checked out on {current}"));
+    }
+    if state.worktree.dirty {
+        return Err("Cannot pull with uncommitted changes".to_string());
+    }
+    if state.upstream.relation != UpstreamRelation::OriginAhead {
+        return Err("Branch is not behind origin, or cannot be fast-forwarded".to_string());
+    }
+    Ok(())
+}

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 const FETCH_TTL_MS: i64 = 30_000;
 
@@ -387,11 +387,18 @@ pub fn compute_branch_git_state<F>(
 where
     F: Fn(&[&str]) -> Result<String, String> + Sync,
 {
+    let t_total = Instant::now();
+
     // Phase 1: Fetch runs in parallel with local-only commands (HEAD, branch
     // name, worktree status) since those read local state unaffected by fetch.
+    let t_phase1 = Instant::now();
     let (refresh, head_sha, branch, worktree) = std::thread::scope(|s| {
         let fetch_handle = s.spawn(|| {
-            refresh_refs_if_needed(cache_key, &run_git, branch_name, base_branch, fetch_mode)
+            let t = Instant::now();
+            let r =
+                refresh_refs_if_needed(cache_key, &run_git, branch_name, base_branch, fetch_mode);
+            log::info!("[git-state] fetch: {:?} key={}", t.elapsed(), cache_key);
+            r
         });
         let head_handle = s.spawn(|| {
             run_git(&["rev-parse", "HEAD"])
@@ -408,6 +415,11 @@ where
             worktree_handle.join().expect("worktree thread panicked"),
         )
     });
+    log::info!(
+        "[git-state] phase1 (fetch+local): {:?} key={}",
+        t_phase1.elapsed(),
+        cache_key
+    );
 
     let detached_head = head_sha.is_some() && branch.is_none();
     let expected_branch = branch_name_without_origin(branch_name);
@@ -421,6 +433,7 @@ where
     // Phase 2: Upstream and base state computations are independent of each
     // other but both need fetch to have completed (for up-to-date remote refs)
     // and head_sha.
+    let t_phase2 = Instant::now();
     let (upstream, base) = std::thread::scope(|s| {
         let upstream_handle = s.spawn(|| {
             compute_upstream_state(
@@ -437,6 +450,16 @@ where
             base_handle.join().expect("base thread panicked"),
         )
     });
+    log::info!(
+        "[git-state] phase2 (upstream+base): {:?} key={}",
+        t_phase2.elapsed(),
+        cache_key
+    );
+    log::info!(
+        "[git-state] total: {:?} key={}",
+        t_total.elapsed(),
+        cache_key
+    );
 
     BranchGitState {
         upstream,
@@ -482,6 +505,7 @@ pub fn compute_local_branch_git_state(
 /// Arguments: $1=repo_path  $2=base_refspec  $3=branch_refspec (empty if same as base)
 const BATCH_FETCH_SCRIPT: &str = concat!(
     "cd \"$1\" || exit 1\n",
+    "_t0=$(date +%s%3N 2>/dev/null || echo 0)\n",
     // Fetch — capture stderr for missing-ref detection using unique temp files
     "fetch_err=''\n",
     "upstream_missing=''\n",
@@ -504,14 +528,18 @@ const BATCH_FETCH_SCRIPT: &str = concat!(
     "    fetch_err=$(cat \"$_ferr\")\n",
     "  fi\n",
     "fi\n",
+    "_t1=$(date +%s%3N 2>/dev/null || echo 0)\n",
     // Local state (unaffected by fetch)
     "printf 'HEAD=%s\\n' \"$(git rev-parse HEAD 2>/dev/null || true)\"\n",
     "printf 'BRANCH=%s\\n' \"$(git branch --show-current 2>/dev/null || true)\"\n",
     "echo STATUS_START\n",
     "git status --porcelain=1 --untracked-files=all 2>/dev/null || true\n",
     "echo STATUS_END\n",
+    "_t2=$(date +%s%3N 2>/dev/null || echo 0)\n",
     "[ -n \"$upstream_missing\" ] && echo 'UPSTREAM_MISSING=true'\n",
     "[ -n \"$fetch_err\" ] && printf 'FETCH_ERR=%s\\n' \"$fetch_err\"\n",
+    "printf 'TIMING_FETCH=%s\\n' \"$((_t1 - _t0))\"\n",
+    "printf 'TIMING_LOCAL=%s\\n' \"$((_t2 - _t1))\"\n",
     "exit 0\n",
 );
 
@@ -519,6 +547,7 @@ const BATCH_FETCH_SCRIPT: &str = concat!(
 /// Arguments: $1=repo_path  $2=upstream_ref  $3=head_ref(HEAD)  $4=base_ref
 const BATCH_REFS_SCRIPT: &str = concat!(
     "cd \"$1\" || exit 1\n",
+    "_t0=$(date +%s%3N 2>/dev/null || echo 0)\n",
     // Upstream state
     "up_sha=$(git rev-parse --verify \"$2\" 2>/dev/null || true)\n",
     "printf 'UP_SHA=%s\\n' \"$up_sha\"\n",
@@ -526,6 +555,7 @@ const BATCH_REFS_SCRIPT: &str = concat!(
     "  printf 'UP_COUNTS=%s\\n' \"$(git rev-list --left-right --count \"$3\"...\"$2\" 2>/dev/null || echo '0 0')\"\n",
     "  printf 'UP_MB=%s\\n' \"$(git merge-base \"$3\" \"$2\" 2>/dev/null || true)\"\n",
     "fi\n",
+    "_t1=$(date +%s%3N 2>/dev/null || echo 0)\n",
     // Base state
     "base_sha=$(git rev-parse --verify \"$4\" 2>/dev/null || true)\n",
     "printf 'BASE_SHA=%s\\n' \"$base_sha\"\n",
@@ -536,6 +566,9 @@ const BATCH_REFS_SCRIPT: &str = concat!(
     "    printf 'BASE_BEHIND=%s\\n' \"$(git rev-list --count \"$mb\"..\"$4\" 2>/dev/null || echo 0)\"\n",
     "  fi\n",
     "fi\n",
+    "_t2=$(date +%s%3N 2>/dev/null || echo 0)\n",
+    "printf 'TIMING_UPSTREAM=%s\\n' \"$((_t1 - _t0))\"\n",
+    "printf 'TIMING_BASE=%s\\n' \"$((_t2 - _t1))\"\n",
 );
 
 /// Parsed output from the fetch + local state script.
@@ -545,6 +578,8 @@ struct BatchFetchOutput {
     status_lines: String,
     upstream_missing: bool,
     fetch_error: Option<String>,
+    timing_fetch_ms: Option<i64>,
+    timing_local_ms: Option<i64>,
 }
 
 fn parse_batch_fetch_output(raw: &str) -> BatchFetchOutput {
@@ -554,6 +589,8 @@ fn parse_batch_fetch_output(raw: &str) -> BatchFetchOutput {
     let mut fetch_error = None;
     let mut status_lines = String::new();
     let mut in_status = false;
+    let mut timing_fetch_ms = None;
+    let mut timing_local_ms = None;
 
     for line in raw.lines() {
         if line == "STATUS_START" {
@@ -588,6 +625,10 @@ fn parse_batch_fetch_output(raw: &str) -> BatchFetchOutput {
             if !v.is_empty() {
                 fetch_error = Some(v.to_string());
             }
+        } else if let Some(val) = line.strip_prefix("TIMING_FETCH=") {
+            timing_fetch_ms = val.trim().parse().ok();
+        } else if let Some(val) = line.strip_prefix("TIMING_LOCAL=") {
+            timing_local_ms = val.trim().parse().ok();
         }
     }
 
@@ -597,6 +638,8 @@ fn parse_batch_fetch_output(raw: &str) -> BatchFetchOutput {
         status_lines,
         upstream_missing,
         fetch_error,
+        timing_fetch_ms,
+        timing_local_ms,
     }
 }
 
@@ -608,6 +651,8 @@ struct BatchRefsOutput {
     up_merge_base: Option<String>,
     base_sha: Option<String>,
     base_behind: u32,
+    timing_upstream_ms: Option<i64>,
+    timing_base_ms: Option<i64>,
 }
 
 fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
@@ -617,6 +662,8 @@ fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
     let mut up_merge_base = None;
     let mut base_sha = None;
     let mut base_behind = 0u32;
+    let mut timing_upstream_ms = None;
+    let mut timing_base_ms = None;
 
     for line in raw.lines() {
         if let Some(val) = line.strip_prefix("UP_SHA=") {
@@ -643,6 +690,10 @@ fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
             // needed in the Rust-side output struct.
         } else if let Some(val) = line.strip_prefix("BASE_BEHIND=") {
             base_behind = parse_u32(Some(val.trim()));
+        } else if let Some(val) = line.strip_prefix("TIMING_UPSTREAM=") {
+            timing_upstream_ms = val.trim().parse().ok();
+        } else if let Some(val) = line.strip_prefix("TIMING_BASE=") {
+            timing_base_ms = val.trim().parse().ok();
         }
     }
 
@@ -653,6 +704,8 @@ fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
         up_merge_base,
         base_sha,
         base_behind,
+        timing_upstream_ms,
+        timing_base_ms,
     }
 }
 
@@ -713,6 +766,7 @@ pub fn compute_branch_git_state_batched<F>(
 where
     F: Fn(&str, &[&str]) -> Result<String, String>,
 {
+    let t_total = Instant::now();
     let base_refspec = refspec_for(base_branch);
     let branch_refspec = refspec_for(branch_name);
     let upstream_ref = origin_ref_for_branch(branch_name);
@@ -734,6 +788,7 @@ where
     };
 
     // Phase 1: fetch + local state (or just local state if cache is fresh)
+    let t_phase1 = Instant::now();
     let (fetch_state, head_sha, branch, worktree, upstream_known_missing) = if should_fetch {
         // Full fetch + local state script
         let branch_arg = if branch_refspec != base_refspec {
@@ -746,6 +801,13 @@ where
         match raw {
             Ok(output) => {
                 let parsed = parse_batch_fetch_output(&output);
+                log::info!(
+                    "[git-state-remote] script1 fetch={}ms local={}ms round-trip={:?} key={}",
+                    parsed.timing_fetch_ms.unwrap_or(-1),
+                    parsed.timing_local_ms.unwrap_or(-1),
+                    t_phase1.elapsed(),
+                    cache_key,
+                );
                 let fetch = if let Some(ref err) = parsed.fetch_error {
                     FetchGitState {
                         status: FetchStatus::Failed,
@@ -814,6 +876,11 @@ where
         match run_script(local_script, &[repo_path]) {
             Ok(output) => {
                 let parsed = parse_batch_fetch_output(&output);
+                log::info!(
+                    "[git-state-remote] local-only script round-trip={:?} key={}",
+                    t_phase1.elapsed(),
+                    cache_key,
+                );
                 let fetch = FetchGitState {
                     status: if fetched_at.is_some() {
                         FetchStatus::Fresh
@@ -868,12 +935,20 @@ where
         upstream_ref.as_str()
     };
 
+    let t_phase2 = Instant::now();
     let (upstream, base) = match run_script(
         BATCH_REFS_SCRIPT,
         &[repo_path, up_ref_arg, head_arg, &base_ref],
     ) {
         Ok(output) => {
             let refs = parse_batch_refs_output(&output);
+            log::info!(
+                "[git-state-remote] script2 upstream={}ms base={}ms round-trip={:?} key={}",
+                refs.timing_upstream_ms.unwrap_or(-1),
+                refs.timing_base_ms.unwrap_or(-1),
+                t_phase2.elapsed(),
+                cache_key,
+            );
 
             let up_exists = refs.up_sha.is_some();
             let relation = if !up_exists || head_sha.is_none() {
@@ -923,6 +998,12 @@ where
             (upstream, base)
         }
     };
+
+    log::info!(
+        "[git-state-remote] total={:?} key={}",
+        t_total.elapsed(),
+        cache_key
+    );
 
     BranchGitState {
         upstream,

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -85,6 +85,57 @@ pub enum FetchStatus {
     Failed,
 }
 
+/// Fast (local-only) git state — no fetch, no ref comparisons.
+/// Used for the fast stream of the two-stream timeline split.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FastGitState {
+    pub head_sha: Option<String>,
+    pub current_branch: Option<String>,
+    pub detached_head: bool,
+    pub expected_branch_matches: bool,
+    pub worktree: WorktreeGitState,
+}
+
+impl FastGitState {
+    /// Convert to a full BranchGitState with placeholder upstream/base/fetch fields.
+    /// Used to build the partial timeline before the slow stream (fetch + refs) completes.
+    pub fn into_placeholder_git_state(
+        self,
+        branch_name: &str,
+        base_branch: &str,
+    ) -> BranchGitState {
+        let upstream_ref = origin_ref_for_branch(branch_name);
+        let base_ref = origin_ref_for_branch(base_branch);
+        BranchGitState {
+            head_sha: self.head_sha,
+            current_branch: self.current_branch,
+            detached_head: self.detached_head,
+            expected_branch_matches: self.expected_branch_matches,
+            worktree: self.worktree,
+            upstream: UpstreamGitState {
+                r#ref: upstream_ref,
+                exists: false,
+                sha: None,
+                relation: UpstreamRelation::Missing,
+                ahead: 0,
+                behind: 0,
+                merge_base_sha: None,
+            },
+            base: BaseGitState {
+                r#ref: base_ref,
+                sha: None,
+                commits_since_fork: 0,
+            },
+            fetch: FetchGitState {
+                status: FetchStatus::Stale,
+                fetched_at: None,
+                error: None,
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct FetchCacheEntry {
     fetched_at: i64,
@@ -489,6 +540,105 @@ pub fn compute_local_branch_git_state(
     )
 }
 
+/// Check whether a fetch is needed for the given cache key and mode.
+/// Used by timeline to decide whether to use the two-stream path.
+pub fn needs_fetch(cache_key: &str, fetch_mode: FetchMode) -> bool {
+    let now = now_ms();
+    let previous = fetch_cache()
+        .lock()
+        .ok()
+        .and_then(|cache| cache.get(cache_key).cloned());
+
+    match (fetch_mode, &previous) {
+        (FetchMode::Never, _) => false,
+        (FetchMode::Force, _) => true,
+        (FetchMode::Ttl, Some(entry)) => now.saturating_sub(entry.fetched_at) > FETCH_TTL_MS,
+        (FetchMode::Ttl, None) => true,
+    }
+}
+
+/// Compute fast (local-only) git state for a local branch.
+/// Returns HEAD, branch name, and worktree status without any fetch.
+pub fn compute_fast_local_git_state(repo: &Path, branch_name: &str) -> FastGitState {
+    let run_git = |args: &[&str]| -> Result<String, String> {
+        cli::run(repo, args).map_err(|e| e.to_string())
+    };
+    let (head_sha, branch, worktree) = std::thread::scope(|s| {
+        let h = s.spawn(|| {
+            run_git(&["rev-parse", "HEAD"])
+                .ok()
+                .and_then(trim_non_empty)
+        });
+        let b = s.spawn(|| current_branch(&run_git));
+        let w = s.spawn(|| compute_worktree_state(&run_git));
+        (
+            h.join().expect("head thread panicked"),
+            b.join().expect("branch thread panicked"),
+            w.join().expect("worktree thread panicked"),
+        )
+    });
+    let expected = branch_name_without_origin(branch_name);
+    FastGitState {
+        detached_head: head_sha.is_some() && branch.is_none(),
+        expected_branch_matches: branch.as_deref().map(|c| c == expected).unwrap_or(false),
+        head_sha,
+        current_branch: branch,
+        worktree,
+    }
+}
+
+/// Complete a local branch git state: runs fetch + ref comparisons, combining
+/// with a pre-computed `FastGitState`. Used by the slow stream after the
+/// partial timeline has been emitted.
+pub fn complete_local_git_state(
+    repo: &Path,
+    fast: &FastGitState,
+    branch_name: &str,
+    base_branch: &str,
+    fetch_mode: FetchMode,
+) -> BranchGitState {
+    let cache_key = format!("local:{}:{}:{}", repo.display(), branch_name, base_branch);
+    let run_git = |args: &[&str]| -> Result<String, String> {
+        cli::run(repo, args).map_err(|e| e.to_string())
+    };
+
+    let refresh =
+        refresh_refs_if_needed(&cache_key, &run_git, branch_name, base_branch, fetch_mode);
+    let upstream_ref = origin_ref_for_branch(branch_name);
+    let base_ref = origin_ref_for_branch(base_branch);
+
+    let (upstream, base) = std::thread::scope(|s| {
+        let u = s.spawn(|| {
+            compute_upstream_state(
+                &run_git,
+                upstream_ref,
+                fast.head_sha.as_deref(),
+                refresh.upstream_known_missing,
+            )
+        });
+        let b = s.spawn(|| compute_base_state(&run_git, base_ref, fast.head_sha.as_deref()));
+        (
+            u.join().expect("upstream thread panicked"),
+            b.join().expect("base thread panicked"),
+        )
+    });
+
+    BranchGitState {
+        head_sha: fast.head_sha.clone(),
+        current_branch: fast.current_branch.clone(),
+        detached_head: fast.detached_head,
+        expected_branch_matches: fast.expected_branch_matches,
+        worktree: fast.worktree.clone(),
+        fetch: refresh.fetch,
+        upstream,
+        base,
+    }
+}
+
+pub fn local_git_state_cache_key(repo: &Path, branch_name: &str, base_branch: &str) -> String {
+    format!("local:{}:{}:{}", repo.display(), branch_name, base_branch)
+}
+
 // ---------------------------------------------------------------------------
 // Batched computation for remote projects
 // ---------------------------------------------------------------------------
@@ -734,6 +884,144 @@ fn parse_worktree_from_status(status_output: &str) -> WorktreeGitState {
     state.dirty =
         state.staged > 0 || state.unstaged > 0 || state.untracked > 0 || state.conflicted > 0;
     state
+}
+
+// ---------------------------------------------------------------------------
+// Fast script for remote two-stream split
+// ---------------------------------------------------------------------------
+//
+// When a fetch is needed, the timeline uses two concurrent round-trips:
+//   1. BATCH_FAST_SCRIPT — local state + commits (no fetch, returns immediately)
+//   2. BATCH_GIT_STATE_SCRIPT — fetch + full ref comparisons (blocks on fetch)
+//
+// The fast script's output is used to emit a partial timeline event so
+// commits + worktree rows appear before the slow stream completes.
+
+/// Fast local-only script for remote projects.
+///
+/// Arguments:
+///   $1 = repo_path
+///   $2 = base_ref (e.g., "origin/main") — used for merge-base + git log
+const BATCH_FAST_SCRIPT: &str = concat!(
+    "cd \"$1\" || exit 1\n",
+    "head_sha=$(git rev-parse HEAD 2>/dev/null || true)\n",
+    "printf 'HEAD=%s\\n' \"$head_sha\"\n",
+    "printf 'BRANCH=%s\\n' \"$(git branch --show-current 2>/dev/null || true)\"\n",
+    "echo STATUS_START\n",
+    "git status --porcelain=1 --untracked-files=all 2>/dev/null || true\n",
+    "echo STATUS_END\n",
+    // Commits using locally-cached refs
+    "mb=$(git merge-base \"$2\" HEAD 2>/dev/null || true)\n",
+    "if [ -n \"$mb\" ]; then\n",
+    "  range=\"${mb}..HEAD\"\n",
+    "else\n",
+    "  range=\"$2..HEAD\"\n",
+    "fi\n",
+    "echo COMMITS_START\n",
+    "git log --format='%H|%h|%s|%an|%ct' \"$range\" 2>/dev/null || true\n",
+    "echo COMMITS_END\n",
+    "exit 0\n",
+);
+
+/// Parsed output from the fast local-only script.
+pub struct BatchFastOutput {
+    pub head_sha: Option<String>,
+    pub branch: Option<String>,
+    pub status_lines: String,
+    pub commit_lines: Vec<String>,
+}
+
+pub fn parse_batch_fast_output(raw: &str) -> BatchFastOutput {
+    let mut head_sha = None;
+    let mut branch = None;
+    let mut status_lines = String::new();
+    let mut commit_lines = Vec::new();
+    let mut in_status = false;
+    let mut in_commits = false;
+
+    for line in raw.lines() {
+        if line == "STATUS_START" {
+            in_status = true;
+            continue;
+        }
+        if line == "STATUS_END" {
+            in_status = false;
+            continue;
+        }
+        if line == "COMMITS_START" {
+            in_commits = true;
+            continue;
+        }
+        if line == "COMMITS_END" {
+            in_commits = false;
+            continue;
+        }
+        if in_status {
+            if !status_lines.is_empty() {
+                status_lines.push('\n');
+            }
+            status_lines.push_str(line);
+            continue;
+        }
+        if in_commits {
+            if !line.is_empty() {
+                commit_lines.push(line.to_string());
+            }
+            continue;
+        }
+        if let Some(val) = line.strip_prefix("HEAD=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                head_sha = Some(v.to_string());
+            }
+        } else if let Some(val) = line.strip_prefix("BRANCH=") {
+            let v = val.trim();
+            if !v.is_empty() {
+                branch = Some(v.to_string());
+            }
+        }
+    }
+
+    BatchFastOutput {
+        head_sha,
+        branch,
+        status_lines,
+        commit_lines,
+    }
+}
+
+impl BatchFastOutput {
+    /// Convert to FastGitState.
+    pub fn into_fast_git_state(self, branch_name: &str) -> (FastGitState, Vec<String>) {
+        let worktree = parse_worktree_from_status(&self.status_lines);
+        let expected = branch_name_without_origin(branch_name);
+        let fast = FastGitState {
+            detached_head: self.head_sha.is_some() && self.branch.is_none(),
+            expected_branch_matches: self
+                .branch
+                .as_deref()
+                .map(|c| c == expected)
+                .unwrap_or(false),
+            head_sha: self.head_sha,
+            current_branch: self.branch,
+            worktree,
+        };
+        (fast, self.commit_lines)
+    }
+}
+
+/// Run the fast local-only script on a remote workspace and return parsed output.
+pub fn compute_fast_git_state_batched<F>(
+    run_script: &F,
+    repo_path: &str,
+    base_branch: &str,
+) -> Result<BatchFastOutput, String>
+where
+    F: Fn(&str, &[&str]) -> Result<String, String>,
+{
+    let base_ref = origin_ref_for_branch(base_branch);
+    let raw = run_script(BATCH_FAST_SCRIPT, &[repo_path, &base_ref])?;
+    Ok(parse_batch_fast_output(&raw))
 }
 
 /// Compute branch git state using a single batched shell script.

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -494,43 +494,53 @@ pub fn compute_local_branch_git_state(
 // ---------------------------------------------------------------------------
 //
 // Instead of N separate round-trips (each `run_git` call is a `ws_exec`),
-// we batch multiple git commands into two shell scripts:
+// we batch all git commands into a single shell script that performs fetch
+// (when needed), local state collection, and ref comparisons in one call.
 //
-// Script 1 (fetch + local state): fetch, rev-parse HEAD, branch name, status
-// Script 2 (post-fetch ref state): upstream SHA/counts/merge-base, base SHA/merge-base/count
-//
-// The fetch TTL cache still controls whether Script 1 is needed at all.
+// The fetch TTL cache controls whether the fetch phase runs within the
+// script (via a "skip_fetch" flag argument).
 
-/// Shell script that performs fetch and collects local state in one round-trip.
-/// Arguments: $1=repo_path  $2=base_refspec  $3=branch_refspec (empty if same as base)
-const BATCH_FETCH_SCRIPT: &str = concat!(
+/// Combined shell script that performs fetch, collects local state, and computes
+/// upstream + base ref state in a single round-trip.
+///
+/// Arguments:
+///   $1 = repo_path
+///   $2 = base_refspec
+///   $3 = branch_refspec (empty if same as base)
+///   $4 = upstream_ref (empty to skip upstream resolution)
+///   $5 = base_ref
+///   $6 = "skip_fetch" to skip the fetch phase (cache fresh)
+const BATCH_GIT_STATE_SCRIPT: &str = concat!(
     "cd \"$1\" || exit 1\n",
     "_t0=$(date +%s%3N 2>/dev/null || echo 0)\n",
-    // Fetch — capture stderr for missing-ref detection using unique temp files
+    // --- Fetch phase (conditional) ---
     "fetch_err=''\n",
     "upstream_missing=''\n",
-    "_ferr=$(mktemp) || exit 1\n",
-    "trap 'rm -f \"$_ferr\"' EXIT\n",
-    "if [ -n \"$3\" ]; then\n",
-    "  if ! git fetch --prune origin \"$2\" \"$3\" 2>\"$_ferr\"; then\n",
-    "    if grep -qi 'could.not.find.remote.ref\\|couldn.t.find.remote.ref' \"$_ferr\"; then\n",
-    "      if ! git fetch --prune origin \"$2\" 2>\"$_ferr\"; then\n",
-    "        fetch_err=$(cat \"$_ferr\")\n",
+    "if [ \"$6\" != 'skip_fetch' ]; then\n",
+    "  _ferr=$(mktemp) || exit 1\n",
+    "  trap 'rm -f \"$_ferr\"' EXIT\n",
+    "  if [ -n \"$3\" ]; then\n",
+    "    if ! git fetch --prune origin \"$2\" \"$3\" 2>\"$_ferr\"; then\n",
+    "      if grep -qi 'could.not.find.remote.ref\\|couldn.t.find.remote.ref' \"$_ferr\"; then\n",
+    "        if ! git fetch --prune origin \"$2\" 2>\"$_ferr\"; then\n",
+    "          fetch_err=$(cat \"$_ferr\")\n",
+    "        else\n",
+    "          upstream_missing=true\n",
+    "        fi\n",
     "      else\n",
-    "        upstream_missing=true\n",
+    "        fetch_err=$(cat \"$_ferr\")\n",
     "      fi\n",
-    "    else\n",
+    "    fi\n",
+    "  else\n",
+    "    if ! git fetch --prune origin \"$2\" 2>\"$_ferr\"; then\n",
     "      fetch_err=$(cat \"$_ferr\")\n",
     "    fi\n",
     "  fi\n",
-    "else\n",
-    "  if ! git fetch --prune origin \"$2\" 2>\"$_ferr\"; then\n",
-    "    fetch_err=$(cat \"$_ferr\")\n",
-    "  fi\n",
     "fi\n",
     "_t1=$(date +%s%3N 2>/dev/null || echo 0)\n",
-    // Local state (unaffected by fetch)
-    "printf 'HEAD=%s\\n' \"$(git rev-parse HEAD 2>/dev/null || true)\"\n",
+    // --- Local state ---
+    "head_sha=$(git rev-parse HEAD 2>/dev/null || true)\n",
+    "printf 'HEAD=%s\\n' \"$head_sha\"\n",
     "printf 'BRANCH=%s\\n' \"$(git branch --show-current 2>/dev/null || true)\"\n",
     "echo STATUS_START\n",
     "git status --porcelain=1 --untracked-files=all 2>/dev/null || true\n",
@@ -538,59 +548,72 @@ const BATCH_FETCH_SCRIPT: &str = concat!(
     "_t2=$(date +%s%3N 2>/dev/null || echo 0)\n",
     "[ -n \"$upstream_missing\" ] && echo 'UPSTREAM_MISSING=true'\n",
     "[ -n \"$fetch_err\" ] && printf 'FETCH_ERR=%s\\n' \"$fetch_err\"\n",
+    // --- Upstream state (skip if $4 is empty) ---
+    "if [ -n \"$4\" ] && [ -z \"$upstream_missing\" ]; then\n",
+    "  up_sha=$(git rev-parse --verify \"$4\" 2>/dev/null || true)\n",
+    "else\n",
+    "  up_sha=''\n",
+    "fi\n",
+    "printf 'UP_SHA=%s\\n' \"$up_sha\"\n",
+    "if [ -n \"$up_sha\" ] && [ -n \"$head_sha\" ]; then\n",
+    "  printf 'UP_COUNTS=%s\\n' \"$(git rev-list --left-right --count \"$head_sha\"...\"$4\" 2>/dev/null || echo '0 0')\"\n",
+    "  printf 'UP_MB=%s\\n' \"$(git merge-base \"$head_sha\" \"$4\" 2>/dev/null || true)\"\n",
+    "fi\n",
+    "_t3=$(date +%s%3N 2>/dev/null || echo 0)\n",
+    // --- Base state ---
+    "base_sha=$(git rev-parse --verify \"$5\" 2>/dev/null || true)\n",
+    "printf 'BASE_SHA=%s\\n' \"$base_sha\"\n",
+    "if [ -n \"$base_sha\" ] && [ -n \"$head_sha\" ]; then\n",
+    "  mb=$(git merge-base \"$head_sha\" \"$5\" 2>/dev/null || true)\n",
+    "  printf 'BASE_MB=%s\\n' \"$mb\"\n",
+    "  if [ -n \"$mb\" ]; then\n",
+    "    printf 'BASE_BEHIND=%s\\n' \"$(git rev-list --count \"$mb\"..\"$5\" 2>/dev/null || echo 0)\"\n",
+    "  fi\n",
+    "fi\n",
+    "_t4=$(date +%s%3N 2>/dev/null || echo 0)\n",
     "printf 'TIMING_FETCH=%s\\n' \"$((_t1 - _t0))\"\n",
     "printf 'TIMING_LOCAL=%s\\n' \"$((_t2 - _t1))\"\n",
+    "printf 'TIMING_UPSTREAM=%s\\n' \"$((_t3 - _t2))\"\n",
+    "printf 'TIMING_BASE=%s\\n' \"$((_t4 - _t3))\"\n",
     "exit 0\n",
 );
 
-/// Shell script that computes upstream and base ref state in one round-trip.
-/// Arguments: $1=repo_path  $2=upstream_ref  $3=head_ref(HEAD)  $4=base_ref
-const BATCH_REFS_SCRIPT: &str = concat!(
-    "cd \"$1\" || exit 1\n",
-    "_t0=$(date +%s%3N 2>/dev/null || echo 0)\n",
-    // Upstream state
-    "up_sha=$(git rev-parse --verify \"$2\" 2>/dev/null || true)\n",
-    "printf 'UP_SHA=%s\\n' \"$up_sha\"\n",
-    "if [ -n \"$up_sha\" ] && [ -n \"$3\" ]; then\n",
-    "  printf 'UP_COUNTS=%s\\n' \"$(git rev-list --left-right --count \"$3\"...\"$2\" 2>/dev/null || echo '0 0')\"\n",
-    "  printf 'UP_MB=%s\\n' \"$(git merge-base \"$3\" \"$2\" 2>/dev/null || true)\"\n",
-    "fi\n",
-    "_t1=$(date +%s%3N 2>/dev/null || echo 0)\n",
-    // Base state
-    "base_sha=$(git rev-parse --verify \"$4\" 2>/dev/null || true)\n",
-    "printf 'BASE_SHA=%s\\n' \"$base_sha\"\n",
-    "if [ -n \"$base_sha\" ] && [ -n \"$3\" ]; then\n",
-    "  mb=$(git merge-base \"$3\" \"$4\" 2>/dev/null || true)\n",
-    "  printf 'BASE_MB=%s\\n' \"$mb\"\n",
-    "  if [ -n \"$mb\" ]; then\n",
-    "    printf 'BASE_BEHIND=%s\\n' \"$(git rev-list --count \"$mb\"..\"$4\" 2>/dev/null || echo 0)\"\n",
-    "  fi\n",
-    "fi\n",
-    "_t2=$(date +%s%3N 2>/dev/null || echo 0)\n",
-    "printf 'TIMING_UPSTREAM=%s\\n' \"$((_t1 - _t0))\"\n",
-    "printf 'TIMING_BASE=%s\\n' \"$((_t2 - _t1))\"\n",
-);
-
-/// Parsed output from the fetch + local state script.
-struct BatchFetchOutput {
+/// Parsed output from the combined git state script.
+struct BatchGitStateOutput {
     head_sha: Option<String>,
     branch: Option<String>,
     status_lines: String,
     upstream_missing: bool,
     fetch_error: Option<String>,
+    up_sha: Option<String>,
+    up_ahead: u32,
+    up_behind: u32,
+    up_merge_base: Option<String>,
+    base_sha: Option<String>,
+    base_behind: u32,
     timing_fetch_ms: Option<i64>,
     timing_local_ms: Option<i64>,
+    timing_upstream_ms: Option<i64>,
+    timing_base_ms: Option<i64>,
 }
 
-fn parse_batch_fetch_output(raw: &str) -> BatchFetchOutput {
+fn parse_batch_git_state_output(raw: &str) -> BatchGitStateOutput {
     let mut head_sha = None;
     let mut branch = None;
     let mut upstream_missing = false;
     let mut fetch_error = None;
     let mut status_lines = String::new();
     let mut in_status = false;
+    let mut up_sha = None;
+    let mut up_ahead = 0u32;
+    let mut up_behind = 0u32;
+    let mut up_merge_base = None;
+    let mut base_sha = None;
+    let mut base_behind = 0u32;
     let mut timing_fetch_ms = None;
     let mut timing_local_ms = None;
+    let mut timing_upstream_ms = None;
+    let mut timing_base_ms = None;
 
     for line in raw.lines() {
         if line == "STATUS_START" {
@@ -625,48 +648,7 @@ fn parse_batch_fetch_output(raw: &str) -> BatchFetchOutput {
             if !v.is_empty() {
                 fetch_error = Some(v.to_string());
             }
-        } else if let Some(val) = line.strip_prefix("TIMING_FETCH=") {
-            timing_fetch_ms = val.trim().parse().ok();
-        } else if let Some(val) = line.strip_prefix("TIMING_LOCAL=") {
-            timing_local_ms = val.trim().parse().ok();
-        }
-    }
-
-    BatchFetchOutput {
-        head_sha,
-        branch,
-        status_lines,
-        upstream_missing,
-        fetch_error,
-        timing_fetch_ms,
-        timing_local_ms,
-    }
-}
-
-/// Parsed output from the refs state script.
-struct BatchRefsOutput {
-    up_sha: Option<String>,
-    up_ahead: u32,
-    up_behind: u32,
-    up_merge_base: Option<String>,
-    base_sha: Option<String>,
-    base_behind: u32,
-    timing_upstream_ms: Option<i64>,
-    timing_base_ms: Option<i64>,
-}
-
-fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
-    let mut up_sha = None;
-    let mut up_ahead = 0u32;
-    let mut up_behind = 0u32;
-    let mut up_merge_base = None;
-    let mut base_sha = None;
-    let mut base_behind = 0u32;
-    let mut timing_upstream_ms = None;
-    let mut timing_base_ms = None;
-
-    for line in raw.lines() {
-        if let Some(val) = line.strip_prefix("UP_SHA=") {
+        } else if let Some(val) = line.strip_prefix("UP_SHA=") {
             let v = val.trim();
             if !v.is_empty() {
                 up_sha = Some(v.to_string());
@@ -686,10 +668,13 @@ fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
                 base_sha = Some(v.to_string());
             }
         } else if line.starts_with("BASE_MB=") {
-            // Parsed by the script internally to compute BASE_BEHIND; not
-            // needed in the Rust-side output struct.
+            // Used internally by the script to compute BASE_BEHIND.
         } else if let Some(val) = line.strip_prefix("BASE_BEHIND=") {
             base_behind = parse_u32(Some(val.trim()));
+        } else if let Some(val) = line.strip_prefix("TIMING_FETCH=") {
+            timing_fetch_ms = val.trim().parse().ok();
+        } else if let Some(val) = line.strip_prefix("TIMING_LOCAL=") {
+            timing_local_ms = val.trim().parse().ok();
         } else if let Some(val) = line.strip_prefix("TIMING_UPSTREAM=") {
             timing_upstream_ms = val.trim().parse().ok();
         } else if let Some(val) = line.strip_prefix("TIMING_BASE=") {
@@ -697,13 +682,20 @@ fn parse_batch_refs_output(raw: &str) -> BatchRefsOutput {
         }
     }
 
-    BatchRefsOutput {
+    BatchGitStateOutput {
+        head_sha,
+        branch,
+        status_lines,
+        upstream_missing,
+        fetch_error,
         up_sha,
         up_ahead,
         up_behind,
         up_merge_base,
         base_sha,
         base_behind,
+        timing_fetch_ms,
+        timing_local_ms,
         timing_upstream_ms,
         timing_base_ms,
     }
@@ -744,17 +736,13 @@ fn parse_worktree_from_status(status_output: &str) -> WorktreeGitState {
     state
 }
 
-/// Compute branch git state using batched shell scripts.
+/// Compute branch git state using a single batched shell script.
 ///
 /// This is the remote-optimised counterpart of `compute_branch_git_state`.
 /// Instead of many individual `run_git` calls (each a separate `ws_exec`
-/// round-trip), it bundles commands into at most two shell scripts:
-///
-/// - Script 1 (fetch + local state): 1 round-trip instead of 4-5
-/// - Script 2 (post-fetch ref state): 1 round-trip instead of 6
-///
-/// When the fetch TTL cache says "skip fetch", only Script 2 runs
-/// (with a simpler local-only preamble), giving **1 round-trip total**.
+/// round-trip), it bundles all commands into one shell script that performs
+/// fetch (when needed), local state collection, and ref comparisons — giving
+/// **1 round-trip total** regardless of whether fetch is cached or not.
 pub fn compute_branch_git_state_batched<F>(
     cache_key: &str,
     run_script: F,
@@ -773,7 +761,7 @@ where
     let base_ref = origin_ref_for_branch(base_branch);
     let expected_branch = branch_name_without_origin(branch_name);
 
-    // Check fetch cache to decide whether we need Script 1 at all.
+    // Check fetch cache to decide whether we need the fetch phase.
     let now = now_ms();
     let previous = fetch_cache()
         .lock()
@@ -787,41 +775,71 @@ where
         (FetchMode::Ttl, None) => true,
     };
 
-    // Phase 1: fetch + local state (or just local state if cache is fresh)
-    let t_phase1 = Instant::now();
-    let (fetch_state, head_sha, branch, worktree, upstream_known_missing) = if should_fetch {
-        // Full fetch + local state script
-        let branch_arg = if branch_refspec != base_refspec {
-            branch_refspec.as_str()
-        } else {
-            ""
-        };
-        let raw = run_script(BATCH_FETCH_SCRIPT, &[repo_path, &base_refspec, branch_arg]);
+    let branch_arg = if branch_refspec != base_refspec {
+        branch_refspec.as_str()
+    } else {
+        ""
+    };
 
-        match raw {
-            Ok(output) => {
-                let parsed = parse_batch_fetch_output(&output);
-                log::info!(
-                    "[git-state-remote] script1 fetch={}ms local={}ms round-trip={:?} key={}",
-                    parsed.timing_fetch_ms.unwrap_or(-1),
-                    parsed.timing_local_ms.unwrap_or(-1),
-                    t_phase1.elapsed(),
-                    cache_key,
-                );
-                let fetch = if let Some(ref err) = parsed.fetch_error {
+    // When cache says upstream is missing, pass empty upstream_ref so the
+    // script skips upstream resolution.
+    let cached_upstream_missing = previous
+        .as_ref()
+        .map(|e| e.upstream_known_missing)
+        .unwrap_or(false);
+    let up_ref_arg = if !should_fetch && cached_upstream_missing {
+        ""
+    } else {
+        upstream_ref.as_str()
+    };
+    let skip_fetch_arg = if should_fetch { "" } else { "skip_fetch" };
+
+    let raw = run_script(
+        BATCH_GIT_STATE_SCRIPT,
+        &[
+            repo_path,
+            &base_refspec,
+            branch_arg,
+            up_ref_arg,
+            &base_ref,
+            skip_fetch_arg,
+        ],
+    );
+
+    match raw {
+        Ok(output) => {
+            let parsed = parse_batch_git_state_output(&output);
+            log::info!(
+                "[git-state-remote] fetch={}ms local={}ms upstream={}ms base={}ms round-trip={:?} key={}",
+                parsed.timing_fetch_ms.unwrap_or(-1),
+                parsed.timing_local_ms.unwrap_or(-1),
+                parsed.timing_upstream_ms.unwrap_or(-1),
+                parsed.timing_base_ms.unwrap_or(-1),
+                t_total.elapsed(),
+                cache_key,
+            );
+
+            let upstream_known_missing = if should_fetch {
+                parsed.upstream_missing
+            } else {
+                cached_upstream_missing
+            };
+
+            // Build fetch state
+            let fetch_state = if should_fetch {
+                if let Some(ref err) = parsed.fetch_error {
                     FetchGitState {
                         status: FetchStatus::Failed,
                         fetched_at: previous.as_ref().map(|e| e.fetched_at),
                         error: Some(err.clone()),
                     }
                 } else {
-                    // Update cache on successful fetch
                     if let Ok(mut cache) = fetch_cache().lock() {
                         cache.insert(
                             cache_key.to_string(),
                             FetchCacheEntry {
                                 fetched_at: now,
-                                upstream_known_missing: parsed.upstream_missing,
+                                upstream_known_missing,
                             },
                         );
                     }
@@ -830,58 +848,10 @@ where
                         fetched_at: Some(now),
                         error: None,
                     }
-                };
-                let worktree = parse_worktree_from_status(&parsed.status_lines);
-                (
-                    fetch,
-                    parsed.head_sha,
-                    parsed.branch,
-                    worktree,
-                    parsed.upstream_missing,
-                )
-            }
-            Err(err) => {
-                // Script execution itself failed — treat as fetch failure
-                let fetch = FetchGitState {
-                    status: FetchStatus::Failed,
-                    fetched_at: previous.as_ref().map(|e| e.fetched_at),
-                    error: Some(err),
-                };
-                let worktree = WorktreeGitState {
-                    dirty: false,
-                    staged: 0,
-                    unstaged: 0,
-                    untracked: 0,
-                    conflicted: 0,
-                };
-                (fetch, None, None, worktree, false)
-            }
-        }
-    } else {
-        // Cache says skip fetch — just get local state with a minimal script
-        let local_script = concat!(
-            "cd \"$1\" || exit 1\n",
-            "printf 'HEAD=%s\\n' \"$(git rev-parse HEAD 2>/dev/null || true)\"\n",
-            "printf 'BRANCH=%s\\n' \"$(git branch --show-current 2>/dev/null || true)\"\n",
-            "echo STATUS_START\n",
-            "git status --porcelain=1 --untracked-files=all 2>/dev/null || true\n",
-            "echo STATUS_END\n",
-        );
-        let fetched_at = previous.as_ref().map(|entry| entry.fetched_at);
-        let upstream_known_missing = previous
-            .as_ref()
-            .map(|e| e.upstream_known_missing)
-            .unwrap_or(false);
-
-        match run_script(local_script, &[repo_path]) {
-            Ok(output) => {
-                let parsed = parse_batch_fetch_output(&output);
-                log::info!(
-                    "[git-state-remote] local-only script round-trip={:?} key={}",
-                    t_phase1.elapsed(),
-                    cache_key,
-                );
-                let fetch = FetchGitState {
+                }
+            } else {
+                let fetched_at = previous.as_ref().map(|e| e.fetched_at);
+                FetchGitState {
                     status: if fetched_at.is_some() {
                         FetchStatus::Fresh
                     } else {
@@ -889,72 +859,23 @@ where
                     },
                     fetched_at,
                     error: None,
-                };
-                let worktree = parse_worktree_from_status(&parsed.status_lines);
-                (
-                    fetch,
-                    parsed.head_sha,
-                    parsed.branch,
-                    worktree,
-                    upstream_known_missing,
-                )
-            }
-            Err(_) => {
-                let fetch = FetchGitState {
-                    status: if fetched_at.is_some() {
-                        FetchStatus::Fresh
-                    } else {
-                        FetchStatus::Stale
-                    },
-                    fetched_at,
-                    error: None,
-                };
-                let worktree = WorktreeGitState {
-                    dirty: false,
-                    staged: 0,
-                    unstaged: 0,
-                    untracked: 0,
-                    conflicted: 0,
-                };
-                (fetch, None, None, worktree, upstream_known_missing)
-            }
-        }
-    };
+                }
+            };
 
-    let detached_head = head_sha.is_some() && branch.is_none();
-    let expected_branch_matches = branch
-        .as_deref()
-        .map(|current| current == expected_branch)
-        .unwrap_or(false);
+            let worktree = parse_worktree_from_status(&parsed.status_lines);
+            let detached_head = parsed.head_sha.is_some() && parsed.branch.is_none();
+            let expected_branch_matches = parsed
+                .branch
+                .as_deref()
+                .map(|current| current == expected_branch)
+                .unwrap_or(false);
 
-    // Phase 2: upstream + base ref state (single round-trip)
-    let head_arg = head_sha.as_deref().unwrap_or("");
-    let up_ref_arg = if upstream_known_missing {
-        "" // Skip upstream resolution when we know it's missing
-    } else {
-        upstream_ref.as_str()
-    };
-
-    let t_phase2 = Instant::now();
-    let (upstream, base) = match run_script(
-        BATCH_REFS_SCRIPT,
-        &[repo_path, up_ref_arg, head_arg, &base_ref],
-    ) {
-        Ok(output) => {
-            let refs = parse_batch_refs_output(&output);
-            log::info!(
-                "[git-state-remote] script2 upstream={}ms base={}ms round-trip={:?} key={}",
-                refs.timing_upstream_ms.unwrap_or(-1),
-                refs.timing_base_ms.unwrap_or(-1),
-                t_phase2.elapsed(),
-                cache_key,
-            );
-
-            let up_exists = refs.up_sha.is_some();
-            let relation = if !up_exists || head_sha.is_none() {
+            // Build upstream state from parsed output
+            let up_exists = parsed.up_sha.is_some();
+            let relation = if !up_exists || parsed.head_sha.is_none() {
                 UpstreamRelation::Missing
             } else {
-                match (refs.up_ahead, refs.up_behind) {
+                match (parsed.up_ahead, parsed.up_behind) {
                     (0, 0) => UpstreamRelation::InSync,
                     (_, 0) => UpstreamRelation::LocalAhead,
                     (0, _) => UpstreamRelation::OriginAhead,
@@ -965,55 +886,78 @@ where
             let upstream = UpstreamGitState {
                 r#ref: upstream_ref,
                 exists: up_exists,
-                sha: refs.up_sha,
+                sha: parsed.up_sha,
                 relation,
-                ahead: refs.up_ahead,
-                behind: refs.up_behind,
-                merge_base_sha: refs.up_merge_base,
+                ahead: parsed.up_ahead,
+                behind: parsed.up_behind,
+                merge_base_sha: parsed.up_merge_base,
             };
 
             let base = BaseGitState {
                 r#ref: base_ref,
-                sha: refs.base_sha,
-                commits_since_fork: refs.base_behind,
+                sha: parsed.base_sha,
+                commits_since_fork: parsed.base_behind,
             };
 
-            (upstream, base)
+            BranchGitState {
+                upstream,
+                base,
+                worktree,
+                fetch: fetch_state,
+                head_sha: parsed.head_sha,
+                current_branch: parsed.branch,
+                detached_head,
+                expected_branch_matches,
+            }
         }
-        Err(_) => {
-            let upstream = UpstreamGitState {
-                r#ref: upstream_ref,
-                exists: false,
-                sha: None,
-                relation: UpstreamRelation::Missing,
-                ahead: 0,
-                behind: 0,
-                merge_base_sha: None,
-            };
-            let base = BaseGitState {
-                r#ref: base_ref,
-                sha: None,
-                commits_since_fork: 0,
-            };
-            (upstream, base)
+        Err(err) => {
+            // Script execution itself failed
+            let fetched_at = previous.as_ref().map(|e| e.fetched_at);
+            BranchGitState {
+                upstream: UpstreamGitState {
+                    r#ref: upstream_ref,
+                    exists: false,
+                    sha: None,
+                    relation: UpstreamRelation::Missing,
+                    ahead: 0,
+                    behind: 0,
+                    merge_base_sha: None,
+                },
+                base: BaseGitState {
+                    r#ref: base_ref,
+                    sha: None,
+                    commits_since_fork: 0,
+                },
+                worktree: WorktreeGitState {
+                    dirty: false,
+                    staged: 0,
+                    unstaged: 0,
+                    untracked: 0,
+                    conflicted: 0,
+                },
+                fetch: if should_fetch {
+                    FetchGitState {
+                        status: FetchStatus::Failed,
+                        fetched_at,
+                        error: Some(err),
+                    }
+                } else {
+                    FetchGitState {
+                        status: if fetched_at.is_some() {
+                            FetchStatus::Fresh
+                        } else {
+                            FetchStatus::Stale
+                        },
+                        fetched_at,
+                        error: None,
+                    }
+                },
+                head_sha: None,
+                current_branch: None,
+                detached_head: false,
+                expected_branch_matches: false,
+            }
         }
-    };
-
-    log::info!(
-        "[git-state-remote] total={:?} key={}",
-        t_total.elapsed(),
-        cache_key
-    );
-
-    BranchGitState {
-        upstream,
-        base,
-        worktree,
-        fetch: fetch_state,
-        head_sha,
-        current_branch: branch,
-        detached_head,
-        expected_branch_matches,
     }
 }
 

--- a/apps/staged/src-tauri/src/git/state_tests.rs
+++ b/apps/staged/src-tauri/src/git/state_tests.rs
@@ -1,0 +1,243 @@
+use super::state::{compute_local_branch_git_state, BranchGitState, FetchMode, UpstreamRelation};
+use super::strip_git_env;
+use crate::test_utils::TempGitRepo;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use uuid::Uuid;
+
+struct TempPath {
+    path: PathBuf,
+}
+
+impl TempPath {
+    fn new(label: &str) -> Self {
+        let path = std::env::temp_dir().join(format!("staged-{label}-{}", Uuid::new_v4()));
+        fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+}
+
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> String {
+    let mut command = Command::new("git");
+    command
+        .arg("-c")
+        .arg("core.hooksPath=/dev/null")
+        .arg("-C")
+        .arg(repo)
+        .args(args);
+    strip_git_env(&mut command);
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn clone_repo(origin: &TempGitRepo) -> TempPath {
+    let clone_dir = TempPath::new("clone");
+    let mut command = Command::new("git");
+    command.arg("clone").arg(origin.path()).arg(&clone_dir.path);
+    strip_git_env(&mut command);
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "git clone failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    run_git(
+        &clone_dir.path,
+        &["config", "user.email", "test@example.com"],
+    );
+    run_git(&clone_dir.path, &["config", "user.name", "Test"]);
+    clone_dir
+}
+
+fn remote_backed_feature() -> (TempGitRepo, TempPath) {
+    let origin = TempGitRepo::new();
+    origin.write_file("file.txt", "base\n");
+    origin.commit("base");
+
+    let clone = clone_repo(&origin);
+    run_git(&clone.path, &["checkout", "-b", "feature"]);
+    fs::write(clone.path.join("file.txt"), "base\nfeature\n").unwrap();
+    run_git(&clone.path, &["add", "."]);
+    run_git(&clone.path, &["commit", "-m", "feature"]);
+    run_git(&clone.path, &["push", "origin", "feature:feature"]);
+    run_git(&clone.path, &["fetch", "origin", "main", "feature"]);
+    (origin, clone)
+}
+
+fn state(repo: &Path, fetch_mode: FetchMode) -> BranchGitState {
+    compute_local_branch_git_state(repo, "feature", "main", fetch_mode)
+}
+
+#[test]
+fn detects_in_sync_branch() {
+    let (_origin, clone) = remote_backed_feature();
+    let state = state(&clone.path, FetchMode::Force);
+
+    assert_eq!(state.upstream.relation, UpstreamRelation::InSync);
+    assert_eq!(state.upstream.ahead, 0);
+    assert_eq!(state.upstream.behind, 0);
+    assert!(state.expected_branch_matches);
+    assert!(!state.worktree.dirty);
+}
+
+#[test]
+fn detects_local_ahead_branch() {
+    let (_origin, clone) = remote_backed_feature();
+    fs::write(clone.path.join("local.txt"), "local\n").unwrap();
+    run_git(&clone.path, &["add", "."]);
+    run_git(&clone.path, &["commit", "-m", "local"]);
+
+    let state = state(&clone.path, FetchMode::Force);
+
+    assert_eq!(state.upstream.relation, UpstreamRelation::LocalAhead);
+    assert_eq!(state.upstream.ahead, 1);
+    assert_eq!(state.upstream.behind, 0);
+}
+
+#[test]
+fn detects_origin_ahead_branch() {
+    let (origin, clone) = remote_backed_feature();
+    origin.run_git(&["checkout", "feature"]);
+    origin.write_file("origin.txt", "origin\n");
+    origin.commit("origin");
+
+    let state = state(&clone.path, FetchMode::Force);
+
+    assert_eq!(state.upstream.relation, UpstreamRelation::OriginAhead);
+    assert_eq!(state.upstream.ahead, 0);
+    assert_eq!(state.upstream.behind, 1);
+}
+
+#[test]
+fn detects_diverged_branch() {
+    let (origin, clone) = remote_backed_feature();
+    fs::write(clone.path.join("local.txt"), "local\n").unwrap();
+    run_git(&clone.path, &["add", "."]);
+    run_git(&clone.path, &["commit", "-m", "local"]);
+
+    origin.run_git(&["checkout", "feature"]);
+    origin.write_file("origin.txt", "origin\n");
+    origin.commit("origin");
+
+    let state = state(&clone.path, FetchMode::Force);
+
+    assert_eq!(state.upstream.relation, UpstreamRelation::Diverged);
+    assert_eq!(state.upstream.ahead, 1);
+    assert_eq!(state.upstream.behind, 1);
+    assert!(state.upstream.merge_base_sha.is_some());
+}
+
+#[test]
+fn detects_missing_upstream_branch() {
+    let origin = TempGitRepo::new();
+    origin.write_file("file.txt", "base\n");
+    origin.commit("base");
+    let clone = clone_repo(&origin);
+    run_git(&clone.path, &["checkout", "-b", "feature"]);
+    fs::write(clone.path.join("file.txt"), "base\nlocal\n").unwrap();
+    run_git(&clone.path, &["add", "."]);
+    run_git(&clone.path, &["commit", "-m", "feature"]);
+
+    let state = state(&clone.path, FetchMode::Force);
+
+    assert_eq!(state.upstream.relation, UpstreamRelation::Missing);
+    assert!(!state.upstream.exists);
+}
+
+#[test]
+fn detects_dirty_worktree_counts() {
+    let (_origin, clone) = remote_backed_feature();
+    fs::write(clone.path.join("staged.txt"), "staged\n").unwrap();
+    run_git(&clone.path, &["add", "staged.txt"]);
+    fs::write(clone.path.join("file.txt"), "base\nfeature\nunstaged\n").unwrap();
+    fs::write(clone.path.join("untracked.txt"), "untracked\n").unwrap();
+
+    let state = state(&clone.path, FetchMode::Never);
+
+    assert!(state.worktree.dirty);
+    assert_eq!(state.worktree.staged, 1);
+    assert_eq!(state.worktree.unstaged, 1);
+    assert_eq!(state.worktree.untracked, 1);
+}
+
+#[test]
+fn detects_conflicted_worktree() {
+    let repo = TempGitRepo::new();
+    repo.write_file("file.txt", "base\n");
+    repo.commit("base");
+    repo.run_git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    repo.run_git(&["checkout", "-b", "feature"]);
+    repo.write_file("file.txt", "feature\n");
+    repo.commit("feature");
+    repo.run_git(&["checkout", "main"]);
+    repo.write_file("file.txt", "main\n");
+    repo.commit("main");
+    repo.run_git(&["checkout", "feature"]);
+
+    let mut command = Command::new("git");
+    command
+        .arg("-c")
+        .arg("core.hooksPath=/dev/null")
+        .arg("-C")
+        .arg(repo.path())
+        .args(["merge", "main"]);
+    strip_git_env(&mut command);
+    let output = command.output().unwrap();
+    assert!(!output.status.success());
+
+    let state = compute_local_branch_git_state(repo.path(), "feature", "main", FetchMode::Never);
+
+    assert!(state.worktree.dirty);
+    assert_eq!(state.worktree.conflicted, 1);
+}
+
+#[test]
+fn detects_detached_head() {
+    let (_origin, clone) = remote_backed_feature();
+    let head = run_git(&clone.path, &["rev-parse", "HEAD"]);
+    run_git(&clone.path, &["checkout", "--detach", head.trim()]);
+
+    let state = state(&clone.path, FetchMode::Never);
+
+    assert!(state.detached_head);
+    assert!(state.current_branch.is_none());
+    assert!(!state.expected_branch_matches);
+}
+
+#[test]
+fn detects_wrong_checked_out_branch() {
+    let (_origin, clone) = remote_backed_feature();
+    run_git(&clone.path, &["checkout", "-b", "other"]);
+
+    let state = state(&clone.path, FetchMode::Never);
+
+    assert_eq!(state.current_branch.as_deref(), Some("other"));
+    assert!(!state.detached_head);
+    assert!(!state.expected_branch_matches);
+}
+
+#[test]
+fn detects_base_branch_moved() {
+    let (origin, clone) = remote_backed_feature();
+    origin.run_git(&["checkout", "main"]);
+    origin.write_file("base.txt", "new base\n");
+    origin.commit("base moved");
+
+    let state = state(&clone.path, FetchMode::Force);
+
+    assert_eq!(state.base.commits_since_fork, 1);
+}

--- a/apps/staged/src-tauri/src/git/status_parse.rs
+++ b/apps/staged/src-tauri/src/git/status_parse.rs
@@ -1,0 +1,8 @@
+/// Returns true if the given porcelain status codes (X, Y) represent a
+/// merge conflict state per `git status --porcelain` documentation.
+pub fn is_conflicted_status(x: char, y: char) -> bool {
+    matches!(
+        (x, y),
+        ('D', 'D') | ('A', 'U') | ('U', 'D') | ('U', 'A') | ('D', 'U') | ('A', 'A') | ('U', 'U')
+    )
+}

--- a/apps/staged/src-tauri/src/git/worktree.rs
+++ b/apps/staged/src-tauri/src/git/worktree.rs
@@ -463,6 +463,119 @@ pub fn reset_to_commit(worktree: &Path, commit_sha: &str) -> Result<(), GitError
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeChangePaths {
+    pub revert_paths: Vec<String>,
+    pub remove_paths: Vec<String>,
+    pub conflicted_paths: Vec<String>,
+    pub reset_required: bool,
+}
+
+impl WorktreeChangePaths {
+    pub fn is_empty(&self) -> bool {
+        self.revert_paths.is_empty()
+            && self.remove_paths.is_empty()
+            && self.conflicted_paths.is_empty()
+    }
+}
+
+fn is_conflicted_status(x: char, y: char) -> bool {
+    matches!(
+        (x, y),
+        ('D', 'D') | ('A', 'U') | ('U', 'D') | ('U', 'A') | ('D', 'U') | ('A', 'A') | ('U', 'U')
+    )
+}
+
+fn literal_pathspec(path: &str) -> String {
+    format!(":(literal){path}")
+}
+
+/// Parse `git status --porcelain=1 -z --untracked-files=all` into paths that
+/// will be reverted by reset and paths that must be removed with clean.
+pub fn parse_worktree_status_paths(output: &str) -> WorktreeChangePaths {
+    let mut revert_paths = Vec::new();
+    let mut remove_paths = Vec::new();
+    let mut conflicted_paths = Vec::new();
+    let mut reset_required = false;
+
+    let mut parts = output.split('\0').filter(|part| !part.is_empty());
+    while let Some(record) = parts.next() {
+        let mut chars = record.chars();
+        let x = chars.next().unwrap_or(' ');
+        let y = chars.next().unwrap_or(' ');
+        let path = record.get(3..).unwrap_or("").to_string();
+        if path.is_empty() {
+            continue;
+        }
+
+        let original_path = if matches!(x, 'R' | 'C') || matches!(y, 'R' | 'C') {
+            parts.next().map(str::to_string)
+        } else {
+            None
+        };
+
+        if x == '?' && y == '?' {
+            remove_paths.push(path);
+            continue;
+        }
+
+        if is_conflicted_status(x, y) {
+            conflicted_paths.push(path);
+            continue;
+        }
+
+        reset_required = true;
+        if matches!(x, 'A' | 'C') || matches!(y, 'A' | 'C') {
+            remove_paths.push(path);
+        } else if let Some(original) = original_path {
+            revert_paths.push(format!("{original} -> {path}"));
+        } else {
+            revert_paths.push(path);
+        }
+    }
+
+    revert_paths.sort();
+    remove_paths.sort();
+    conflicted_paths.sort();
+
+    WorktreeChangePaths {
+        revert_paths,
+        remove_paths,
+        conflicted_paths,
+        reset_required,
+    }
+}
+
+pub fn list_worktree_change_paths(worktree: &Path) -> Result<WorktreeChangePaths, GitError> {
+    let output = cli::run(
+        worktree,
+        &["status", "--porcelain=1", "-z", "--untracked-files=all"],
+    )?;
+    Ok(parse_worktree_status_paths(&output))
+}
+
+pub fn discard_worktree_changes(
+    worktree: &Path,
+    changes: &WorktreeChangePaths,
+) -> Result<(), GitError> {
+    if changes.reset_required {
+        cli::run(worktree, &["reset", "--hard", "HEAD"])?;
+    }
+
+    if !changes.remove_paths.is_empty() {
+        let pathspecs = changes
+            .remove_paths
+            .iter()
+            .map(|path| literal_pathspec(path))
+            .collect::<Vec<_>>();
+        let mut args = vec!["clean", "-fd", "--"];
+        args.extend(pathspecs.iter().map(String::as_str));
+        cli::run(worktree, &args)?;
+    }
+
+    Ok(())
+}
+
 /// Get the parent commit SHA of a given commit.
 /// Returns None if the commit has no parent (initial commit).
 pub fn get_parent_commit(worktree: &Path, commit_sha: &str) -> Result<Option<String>, GitError> {
@@ -710,5 +823,40 @@ mod tests {
 
         assert_eq!(projects_root, "projects");
         assert_eq!(project_dir, "project-123");
+    }
+
+    #[test]
+    fn parses_worktree_status_paths_for_preview_and_discard() {
+        let status = " M tracked.txt\0A  staged-new.txt\0?? untracked.txt\0UU conflicted.txt\0";
+
+        let paths = parse_worktree_status_paths(status);
+
+        assert_eq!(paths.revert_paths, vec!["tracked.txt"]);
+        assert_eq!(paths.remove_paths, vec!["staged-new.txt", "untracked.txt"]);
+        assert_eq!(paths.conflicted_paths, vec!["conflicted.txt"]);
+        assert!(paths.reset_required);
+    }
+
+    #[test]
+    fn discard_worktree_changes_resets_tracked_and_removes_new_files() {
+        let repo = crate::test_utils::TempGitRepo::new();
+        repo.write_file("tracked.txt", "base\n");
+        repo.commit("base");
+
+        repo.write_file("tracked.txt", "modified\n");
+        repo.write_file("staged-new.txt", "new\n");
+        repo.run_git(&["add", "staged-new.txt"]);
+        repo.write_file("untracked.txt", "untracked\n");
+
+        let changes = list_worktree_change_paths(repo.path()).unwrap();
+        discard_worktree_changes(repo.path(), &changes).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("tracked.txt")).unwrap(),
+            "base\n"
+        );
+        assert!(!repo.path().join("staged-new.txt").exists());
+        assert!(!repo.path().join("untracked.txt").exists());
+        assert!(repo.run_git(&["status", "--porcelain"]).trim().is_empty());
     }
 }

--- a/apps/staged/src-tauri/src/git/worktree.rs
+++ b/apps/staged/src-tauri/src/git/worktree.rs
@@ -479,12 +479,7 @@ impl WorktreeChangePaths {
     }
 }
 
-fn is_conflicted_status(x: char, y: char) -> bool {
-    matches!(
-        (x, y),
-        ('D', 'D') | ('A', 'U') | ('U', 'D') | ('U', 'A') | ('D', 'U') | ('A', 'A') | ('U', 'U')
-    )
-}
+use super::status_parse::is_conflicted_status;
 
 fn literal_pathspec(path: &str) -> String {
     format!(":(literal){path}")
@@ -528,6 +523,8 @@ pub fn parse_worktree_status_paths(output: &str) -> WorktreeChangePaths {
         if matches!(x, 'A' | 'C') || matches!(y, 'A' | 'C') {
             remove_paths.push(path);
         } else if let Some(original) = original_path {
+            // Display-only: this arrow format is used for the WorktreeChangesPreview
+            // shown to the user. It is never passed back to git commands as a pathspec.
             revert_paths.push(format!("{original} -> {path}"));
         } else {
             revert_paths.push(path);

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -190,6 +190,7 @@ pub struct BranchTimeline {
     pub notes: Vec<NoteTimelineItem>,
     pub reviews: Vec<ReviewTimelineItem>,
     pub images: Vec<ImageTimelineItem>,
+    pub git_state: Option<git::BranchGitState>,
 }
 
 // =============================================================================
@@ -1802,6 +1803,7 @@ pub fn run() {
             delete_action_context,
             // Timeline
             timeline::get_branch_timeline,
+            timeline::pull_branch_ff_only,
             // Notes
             note_commands::create_note,
             note_commands::delete_note,
@@ -1816,6 +1818,8 @@ pub fn run() {
             image_commands::list_branch_images,
             image_commands::create_image_from_data,
             // Timeline delete commands
+            timeline::get_worktree_changes_preview,
+            timeline::discard_worktree_changes,
             timeline::delete_review,
             timeline::delete_commit,
             timeline::delete_pending_commit,

--- a/apps/staged/src-tauri/src/prs.rs
+++ b/apps/staged/src-tauri/src/prs.rs
@@ -191,6 +191,17 @@ fn base_branch_name(branch: &store::Branch) -> &str {
     git::branch_name_without_origin(&branch.base_branch)
 }
 
+/// Determine the remote ref to rebase onto based on the `target` parameter.
+///
+/// - `None` or `Some("base")` → base branch name (e.g. `main`)
+/// - `Some("origin")` → the branch's own name (e.g. `feature-xyz`)
+fn rebase_ref_for_target<'a>(branch: &'a store::Branch, target: Option<&str>) -> String {
+    match target {
+        Some("origin") => branch.branch_name.clone(),
+        _ => base_branch_name(branch).to_string(),
+    }
+}
+
 fn commit_pipeline_prompt(kind: &PipelineKind) -> &'static str {
     match kind {
         PipelineKind::Rebase => "Rebase branch",
@@ -349,6 +360,7 @@ async fn start_or_queue_commit_pipeline_for_branch(
     branch_id: String,
     kind: PipelineKind,
     provider: Option<String>,
+    target: Option<String>,
 ) -> Result<String, String> {
     let prompt = commit_pipeline_prompt(&kind);
 
@@ -361,15 +373,12 @@ async fn start_or_queue_commit_pipeline_for_branch(
         .is_empty();
 
     if branch_has_running_session || branch_has_queued_session {
-        // Only need the branch model (for base_branch) to build pipeline steps.
-        // Defer the full context resolution (worktree lookup, remote path
-        // resolution) until the session actually starts running.
         let branch = store
             .get_branch(&branch_id)
             .map_err(|e| e.to_string())?
             .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
-        let base_branch = base_branch_name(&branch);
-        let steps = build_commit_pipeline_steps(&kind, base_branch);
+        let rebase_ref = rebase_ref_for_target(&branch, target.as_deref());
+        let steps = build_commit_pipeline_steps(&kind, &rebase_ref);
         let pipeline = PipelineExecution::from_steps(&steps).with_kind(kind);
         let mut session = store::Session::new_queued(prompt);
         if let Some(ref p) = provider {
@@ -384,11 +393,9 @@ async fn start_or_queue_commit_pipeline_for_branch(
         return Ok(session.id);
     }
 
-    // Resolve the full pipeline context (working directory, remote paths)
-    // only when the session will run immediately.
     let ctx = resolve_branch_pipeline_context(&store, &branch_id)?;
-    let base_branch = base_branch_name(&ctx.branch);
-    let steps = build_commit_pipeline_steps(&kind, base_branch);
+    let rebase_ref = rebase_ref_for_target(&ctx.branch, target.as_deref());
+    let steps = build_commit_pipeline_steps(&kind, &rebase_ref);
 
     start_running_commit_pipeline_for_branch(
         ctx,
@@ -1060,12 +1067,12 @@ pub async fn push_branch(
     )
 }
 
-/// Rebase a branch onto its base branch via a pipeline.
+/// Rebase a branch via a pipeline.
 ///
-/// Fetches the latest base branch, then runs `git rebase --signoff origin/{base}`.
-/// If the rebase succeeds (no conflicts), the pipeline completes without AI.
-/// If the rebase fails, AI is handed off to recover and resolve conflicts when
-/// present.
+/// When `target` is `None` or `"base"`, rebases onto `origin/{base_branch}`
+/// (the default behaviour used by the base-moved row and the `…` menu).
+/// When `target` is `"origin"`, rebases onto `origin/{branch_name}` so that
+/// the local branch incorporates remote-only commits (used by the diverged row).
 #[tauri::command(rename_all = "camelCase")]
 pub async fn rebase_branch(
     store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
@@ -1073,6 +1080,7 @@ pub async fn rebase_branch(
     app_handle: tauri::AppHandle,
     branch_id: String,
     provider: Option<String>,
+    target: Option<String>,
 ) -> Result<String, String> {
     let store = get_store(&store)?;
     start_or_queue_commit_pipeline_for_branch(
@@ -1082,6 +1090,7 @@ pub async fn rebase_branch(
         branch_id,
         PipelineKind::Rebase,
         provider,
+        target,
     )
     .await
 }
@@ -1109,6 +1118,7 @@ pub async fn squash_commits(
         branch_id,
         PipelineKind::Squash,
         provider,
+        None,
     )
     .await
 }

--- a/apps/staged/src-tauri/src/prs.rs
+++ b/apps/staged/src-tauri/src/prs.rs
@@ -283,20 +283,6 @@ Here is the context from the prior steps:
     }
 }
 
-async fn current_head_for_pipeline_context(ctx: &BranchPipelineContext) -> Result<String, String> {
-    if let Some(workspace_name) = ctx.workspace_name.clone() {
-        tauri::async_runtime::spawn_blocking(move || {
-            crate::blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"])
-        })
-        .await
-        .map_err(|e| format!("HEAD lookup task failed: {e}"))?
-        .map(|s| s.trim().to_string())
-        .map_err(|e| e.to_string())
-    } else {
-        git::get_head_sha(&ctx.working_dir).map_err(|e| format!("Failed to get HEAD SHA: {e}"))
-    }
-}
-
 async fn start_running_commit_pipeline_for_branch(
     ctx: BranchPipelineContext,
     kind: PipelineKind,
@@ -307,11 +293,6 @@ async fn start_running_commit_pipeline_for_branch(
     registry: &Arc<session_runner::SessionRegistry>,
 ) -> Result<String, String> {
     let prompt = commit_pipeline_prompt(&kind);
-    let pre_head_sha = if kind == PipelineKind::Rebase {
-        Some(current_head_for_pipeline_context(&ctx).await?)
-    } else {
-        None
-    };
     let pipeline = PipelineExecution::from_steps(&steps).with_kind(kind);
 
     let mut session = store::Session::new_running(prompt, &ctx.working_dir);
@@ -339,7 +320,7 @@ async fn start_running_commit_pipeline_for_branch(
             steps,
             pipeline,
             working_dir: ctx.working_dir,
-            pre_head_sha,
+            pre_head_sha: None,
             provider,
             workspace_name: ctx.workspace_name,
             remote_working_dir: ctx.remote_working_dir,
@@ -427,11 +408,6 @@ pub(crate) async fn start_queued_commit_pipeline_for_branch(
     let base_branch = base_branch_name(&ctx.branch);
     let steps = build_commit_pipeline_steps(&kind, base_branch);
     let prompt = commit_pipeline_prompt(&kind);
-    let pre_head_sha = if kind == PipelineKind::Rebase {
-        Some(current_head_for_pipeline_context(&ctx).await?)
-    } else {
-        None
-    };
     let pipeline = PipelineExecution::from_steps(&steps).with_kind(kind);
     let effective_provider = session.provider.clone().or(provider);
 
@@ -468,7 +444,7 @@ pub(crate) async fn start_queued_commit_pipeline_for_branch(
             steps,
             pipeline,
             working_dir: ctx.working_dir,
-            pre_head_sha,
+            pre_head_sha: None,
             provider: effective_provider,
             workspace_name: ctx.workspace_name,
             remote_working_dir: ctx.remote_working_dir,

--- a/apps/staged/src-tauri/src/prs.rs
+++ b/apps/staged/src-tauri/src/prs.rs
@@ -195,7 +195,7 @@ fn base_branch_name(branch: &store::Branch) -> &str {
 ///
 /// - `None` or `Some("base")` → base branch name (e.g. `main`)
 /// - `Some("origin")` → the branch's own name (e.g. `feature-xyz`)
-fn rebase_ref_for_target<'a>(branch: &'a store::Branch, target: Option<&str>) -> String {
+fn rebase_ref_for_target(branch: &store::Branch, target: Option<&str>) -> String {
     match target {
         Some("origin") => branch.branch_name.clone(),
         _ => base_branch_name(branch).to_string(),

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -643,9 +643,10 @@ pub fn start_pipeline_session(
             .build()
             .expect("Failed to create runtime for pipeline session");
 
+        let mut config = config;
         let local = tokio::task::LocalSet::new();
         let outcome = local.block_on(&rt, async {
-            run_pipeline(&config, &store, &app_handle, &cancel_token).await
+            run_pipeline(&mut config, &store, &app_handle, &cancel_token).await
         });
 
         match outcome {
@@ -975,11 +976,22 @@ fn drain_queued_after_pipeline_terminal(
 
 /// Execute pipeline steps sequentially, emitting events as each step progresses.
 async fn run_pipeline(
-    config: &PipelineConfig,
+    config: &mut PipelineConfig,
     store: &Arc<Store>,
     app_handle: &AppHandle,
     cancel_token: &CancellationToken,
 ) -> PipelineOutcome {
+    // Capture HEAD before the first step for rebase pipelines. This is deferred
+    // from session creation so the (potentially slow) remote HEAD lookup doesn't
+    // block session visibility in the UI.
+    if config.pre_head_sha.is_none() && config.pipeline.kind.as_ref() == Some(&PipelineKind::Rebase)
+    {
+        match current_pipeline_head(config) {
+            Ok(head) => config.pre_head_sha = Some(head),
+            Err(e) => log::warn!("Failed to capture pre-rebase HEAD: {e}"),
+        }
+    }
+
     // Use the pipeline execution state that was already persisted with the
     // session, rather than reconstructing from step definitions. This keeps
     // the data flow clear: callers build + persist the pipeline, and we

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -1025,8 +1025,21 @@ async fn run_pipeline(
                 let _ = store.update_session_pipeline(&config.session_id, &execution);
                 emit_pipeline_step(app_handle, &config.session_id, idx, &execution.steps[idx]);
 
-                // Execute the shell command.
-                let result = run_pipeline_command(command, &config.working_dir, cancel_token).await;
+                // Execute the shell command — locally or on a remote workspace.
+                let result = if let Some(ref ws_name) = config.workspace_name {
+                    run_remote_pipeline_command(
+                        command,
+                        ws_name,
+                        config
+                            .remote_working_dir
+                            .as_deref()
+                            .and_then(|p| p.to_str()),
+                        cancel_token,
+                    )
+                    .await
+                } else {
+                    run_pipeline_command(command, &config.working_dir, cancel_token).await
+                };
 
                 match result {
                     Ok(PipelineCommandResult::Completed(output)) => {
@@ -1301,6 +1314,80 @@ async fn run_pipeline_command(
             let stdout = collect_pipe_output(stdout_task, "stdout").await;
             let stderr = collect_pipe_output(stderr_task, "stderr").await;
             Ok(PipelineCommandResult::Cancelled { stdout, stderr })
+        }
+    }
+}
+
+/// Execute a pipeline command on a remote Blox workspace via `ws_exec`.
+///
+/// Wraps the command in `cd <remote_dir> && sh -lc '<command>'` so it runs
+/// in the correct working directory on the remote, mirroring how the local
+/// path runs `sh -lc` with `current_dir`.
+async fn run_remote_pipeline_command(
+    command: &str,
+    workspace_name: &str,
+    remote_working_dir: Option<&str>,
+    cancel_token: &CancellationToken,
+) -> io::Result<PipelineCommandResult> {
+    // Build the remote shell command.
+    let shell_command = if let Some(dir) = remote_working_dir {
+        // Escape single quotes in the directory and command for the outer sh -c.
+        let escaped_dir = dir.replace('\'', "'\\''");
+        let escaped_cmd = command.replace('\'', "'\\''");
+        format!("cd '{escaped_dir}' && sh -lc '{escaped_cmd}'")
+    } else {
+        let escaped_cmd = command.replace('\'', "'\\''");
+        format!("sh -lc '{escaped_cmd}'")
+    };
+
+    let ws = workspace_name.to_string();
+    let handle = tokio::task::spawn_blocking(move || {
+        crate::blox::ws_exec_output(&ws, &["sh", "-c", &shell_command])
+    });
+
+    // Check for pre-existing cancellation before waiting.
+    if cancel_token.is_cancelled() {
+        handle.abort();
+        return Ok(PipelineCommandResult::Cancelled {
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        });
+    }
+
+    tokio::select! {
+        result = handle => {
+            match result {
+                Ok(Ok(output)) => {
+                    use std::os::unix::process::ExitStatusExt;
+                    let status = if output.success {
+                        std::process::ExitStatus::from_raw(0)
+                    } else {
+                        // Encode exit code 1 in wait-status format (exit code << 8).
+                        std::process::ExitStatus::from_raw(1 << 8)
+                    };
+                    Ok(PipelineCommandResult::Completed(Output {
+                        status,
+                        stdout: output.stdout,
+                        stderr: output.stderr,
+                    }))
+                }
+                Ok(Err(e)) => {
+                    // Infrastructure error (CLI not found, timeout, auth failure).
+                    Err(io::Error::other(e.to_string()))
+                }
+                Err(e) => {
+                    // spawn_blocking panicked or was cancelled.
+                    Err(io::Error::other(e.to_string()))
+                }
+            }
+        }
+        _ = cancel_token.cancelled() => {
+            // ws_exec is blocking and not cancellable — the background thread
+            // will finish naturally, but we return immediately.
+            Ok(PipelineCommandResult::Cancelled {
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
         }
     }
 }

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -1,4 +1,19 @@
 //! Timeline — branch timeline construction and related delete commands.
+//!
+//! When a fetch is needed (TTL expired), the timeline is built using a
+//! **two-stream** approach:
+//!
+//! - **Fast stream**: local-only git commands (HEAD, branch, status, commits)
+//!   complete in <1ms (local) or ~2s (one remote round-trip). A partial timeline
+//!   event is emitted so the frontend can show commits and worktree state
+//!   immediately.
+//!
+//! - **Slow stream**: `git fetch` + ref comparisons. Runs concurrently with
+//!   the fast stream for remote projects. The full `BranchTimeline` returned
+//!   by the command includes the complete git state from this stream.
+//!
+//! When the fetch cache is fresh, everything runs as a single fast stream
+//! and no partial event is emitted.
 
 use crate::git;
 use crate::session_runner;
@@ -11,8 +26,116 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use tauri::Emitter;
 
-fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTimeline, String> {
+/// Payload for the `timeline-partial` event emitted by the fast stream.
+/// Contains commits and a placeholder git state (worktree populated,
+/// upstream/base set to loading defaults). The frontend merges this
+/// into the existing timeline while waiting for the full result.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TimelinePartialPayload {
+    branch_id: String,
+    commits: Vec<CommitTimelineItem>,
+    git_state: git::BranchGitState,
+}
+
+/// Parse `%H|%h|%s|%an|%ct` formatted commit lines into timeline items,
+/// looking up DB metadata for session linkage.
+fn parse_commit_lines(
+    store: &Arc<Store>,
+    branch_id: &str,
+    lines: &[String],
+) -> Vec<CommitTimelineItem> {
+    let mut commits = Vec::new();
+    for line in lines {
+        let parts: Vec<&str> = line.splitn(5, '|').collect();
+        if parts.len() >= 5 {
+            let sha = parts[0].to_string();
+            let our_commit = store.get_commit_by_sha(branch_id, &sha).unwrap_or(None);
+            let resolved = store
+                .resolve_session_status(our_commit.as_ref().and_then(|c| c.session_id.as_deref()));
+            commits.push(CommitTimelineItem {
+                id: our_commit.as_ref().map(|c| c.id.clone()),
+                sha,
+                short_sha: parts[1].to_string(),
+                subject: parts[2].to_string(),
+                author: parts[3].to_string(),
+                timestamp: parts[4].parse().unwrap_or(0),
+                order: 0,
+                session_id: resolved.session_id,
+                session_status: resolved.status,
+                completion_reason: resolved.completion_reason,
+            });
+        }
+    }
+    let len = commits.len() as i64;
+    for (i, commit) in commits.iter_mut().enumerate() {
+        commit.order = len - 1 - i as i64;
+    }
+    commits
+}
+
+/// Fetch commits from a remote workspace using merge-base + git log.
+fn fetch_remote_commits(
+    ws_name: &str,
+    repo_subpath: Option<&str>,
+    store: &Arc<Store>,
+    branch_id: &str,
+    base_ref: &str,
+) -> Result<Vec<CommitTimelineItem>, String> {
+    let range = if let Ok(mb_output) =
+        branches::run_workspace_git(ws_name, repo_subpath, &["merge-base", base_ref, "HEAD"])
+    {
+        let mb = mb_output.trim().to_string();
+        format!("{mb}..HEAD")
+    } else {
+        format!("{base_ref}..HEAD")
+    };
+    let format_arg = "--format=%H|%h|%s|%an|%ct";
+    let output = branches::run_workspace_git(ws_name, repo_subpath, &["log", format_arg, &range])
+        .map_err(|e| format!("Failed to load commits from workspace: {e}"))?;
+    let lines: Vec<String> = output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+    Ok(parse_commit_lines(store, branch_id, &lines))
+}
+
+/// Map local CommitInfo entries to CommitTimelineItems with DB metadata.
+fn map_local_commits(
+    store: &Arc<Store>,
+    branch_id: &str,
+    git_commits: &[git::CommitInfo],
+) -> Vec<CommitTimelineItem> {
+    git_commits
+        .iter()
+        .map(|gc| {
+            let our_commit = store.get_commit_by_sha(branch_id, &gc.sha).unwrap_or(None);
+            let resolved = store
+                .resolve_session_status(our_commit.as_ref().and_then(|c| c.session_id.as_deref()));
+            CommitTimelineItem {
+                id: our_commit.as_ref().map(|c| c.id.clone()),
+                sha: gc.sha.clone(),
+                short_sha: gc.short_sha.clone(),
+                subject: gc.subject.clone(),
+                author: gc.author.clone(),
+                timestamp: gc.timestamp,
+                order: gc.order,
+                session_id: resolved.session_id,
+                session_status: resolved.status,
+                completion_reason: resolved.completion_reason,
+            }
+        })
+        .collect()
+}
+
+fn build_branch_timeline(
+    store: &Arc<Store>,
+    branch_id: &str,
+    app: Option<&tauri::AppHandle>,
+) -> Result<BranchTimeline, String> {
     // Get the branch and its workdir for git operations
     let branch = store
         .get_branch(branch_id)
@@ -36,108 +159,139 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
             &branch.base_branch,
         );
         let resolved_path = resolve_repo_path(ws_name, repo_subpath.as_deref())?;
-        git_state = Some(git::compute_branch_git_state_batched(
-            &cache_key,
-            |script, args| {
-                branches::run_workspace_shell(ws_name, script, args).map_err(|e| e.to_string())
-            },
-            &resolved_path,
-            &branch.branch_name,
-            &branch.base_branch,
-            git::FetchMode::Ttl,
-        ));
-
         let base_ref = git::origin_ref_for_branch(&branch.base_branch);
-        // Remote branch: fetch commits via ws_exec.
-        // Use merge-base to find the fork point so that only the branch's
-        // own commits are shown, even after a rebase or when the base ref
-        // has moved forward.
-        let range = if let Ok(mb_output) = branches::run_workspace_git(
-            ws_name,
-            repo_subpath.as_deref(),
-            &["merge-base", &base_ref, "HEAD"],
-        ) {
-            let mb = mb_output.trim().to_string();
-            format!("{mb}..HEAD")
-        } else {
-            // Fallback: if merge-base fails (e.g. shallow clone), use
-            // the remote-tracking base ref.
-            format!("{base_ref}..HEAD")
-        };
-        let format_arg = "--format=%H|%h|%s|%an|%ct";
-        let output = branches::run_workspace_git(
-            ws_name,
-            repo_subpath.as_deref(),
-            &["log", format_arg, &range],
-        )
-        .map_err(|e| format!("Failed to load commits from workspace: {e}"))?;
-        // git log returns newest-first; parse then assign order so 0 = oldest.
-        for line in output.lines() {
-            if line.is_empty() {
-                continue;
-            }
-            let parts: Vec<&str> = line.splitn(5, '|').collect();
-            if parts.len() >= 5 {
-                let sha = parts[0].to_string();
-                let our_commit = store.get_commit_by_sha(branch_id, &sha).unwrap_or(None);
-                let resolved = store.resolve_session_status(
-                    our_commit.as_ref().and_then(|c| c.session_id.as_deref()),
-                );
 
-                commits.push(CommitTimelineItem {
-                    id: our_commit.as_ref().map(|c| c.id.clone()),
-                    sha,
-                    short_sha: parts[1].to_string(),
-                    subject: parts[2].to_string(),
-                    author: parts[3].to_string(),
-                    timestamp: parts[4].parse().unwrap_or(0),
-                    order: 0, // placeholder, assigned below
-                    session_id: resolved.session_id,
-                    session_status: resolved.status,
-                    completion_reason: resolved.completion_reason,
+        if app.is_some() && git::needs_fetch(&cache_key, git::FetchMode::Ttl) {
+            // Two-stream: run fast + slow scripts concurrently.
+            // The fast script returns local state + commits in one round-trip.
+            // The slow script performs fetch + ref comparisons in another.
+            let slow_git_state = std::thread::scope(|s| {
+                let slow_handle = s.spawn(|| {
+                    git::compute_branch_git_state_batched(
+                        &cache_key,
+                        |script, args| {
+                            branches::run_workspace_shell(ws_name, script, args)
+                                .map_err(|e| e.to_string())
+                        },
+                        &resolved_path,
+                        &branch.branch_name,
+                        &branch.base_branch,
+                        git::FetchMode::Ttl,
+                    )
                 });
+
+                // Fast stream: local state + commits (no fetch)
+                if let Ok(fast_output) = git::compute_fast_git_state_batched(
+                    &|script, args| {
+                        branches::run_workspace_shell(ws_name, script, args)
+                            .map_err(|e| e.to_string())
+                    },
+                    &resolved_path,
+                    &branch.base_branch,
+                ) {
+                    let (fast, commit_lines) = fast_output.into_fast_git_state(&branch.branch_name);
+                    commits = parse_commit_lines(store, branch_id, &commit_lines);
+                    let partial_state =
+                        fast.into_placeholder_git_state(&branch.branch_name, &branch.base_branch);
+                    if let Some(app) = app {
+                        let _ = app.emit(
+                            "timeline-partial",
+                            TimelinePartialPayload {
+                                branch_id: branch_id.to_string(),
+                                commits: commits.clone(),
+                                git_state: partial_state,
+                            },
+                        );
+                    }
+                }
+
+                slow_handle.join().expect("slow git state thread panicked")
+            });
+
+            // If fast stream failed to get commits, fall back to traditional path
+            if commits.is_empty() {
+                commits = fetch_remote_commits(
+                    ws_name,
+                    repo_subpath.as_deref(),
+                    store,
+                    branch_id,
+                    &base_ref,
+                )?;
             }
-        }
-        let len = commits.len() as i64;
-        for (i, commit) in commits.iter_mut().enumerate() {
-            commit.order = len - 1 - i as i64;
+            git_state = Some(slow_git_state);
+        } else {
+            // Single stream: fetch cache is fresh, everything is fast
+            git_state = Some(git::compute_branch_git_state_batched(
+                &cache_key,
+                |script, args| {
+                    branches::run_workspace_shell(ws_name, script, args).map_err(|e| e.to_string())
+                },
+                &resolved_path,
+                &branch.branch_name,
+                &branch.base_branch,
+                git::FetchMode::Ttl,
+            ));
+            commits = fetch_remote_commits(
+                ws_name,
+                repo_subpath.as_deref(),
+                store,
+                branch_id,
+                &base_ref,
+            )?;
         }
     } else if let Some(ref wd) = workdir {
         // Local branch: fetch commits from the local worktree
         let worktree_path = Path::new(&wd.path);
         if worktree_path.exists() {
-            git_state = Some(git::compute_local_branch_git_state(
+            let base_ref = git::origin_ref_for_branch(&branch.base_branch);
+            let cache_key = git::local_git_state_cache_key(
                 worktree_path,
                 &branch.branch_name,
                 &branch.base_branch,
-                git::FetchMode::Ttl,
-            ));
+            );
 
-            let base_ref = git::origin_ref_for_branch(&branch.base_branch);
-            let git_commits =
-                git::get_commits_since_base(worktree_path, &base_ref).map_err(|e| {
-                    format!("Failed to get commits since base for branch {branch_id}: {e:?}")
-                })?;
-
-            // For each git commit, look up our metadata (session linkage)
-            for gc in git_commits {
-                let our_commit = store.get_commit_by_sha(branch_id, &gc.sha).unwrap_or(None);
-                let resolved = store.resolve_session_status(
-                    our_commit.as_ref().and_then(|c| c.session_id.as_deref()),
-                );
-
-                commits.push(CommitTimelineItem {
-                    id: our_commit.as_ref().map(|c| c.id.clone()),
-                    sha: gc.sha,
-                    short_sha: gc.short_sha,
-                    subject: gc.subject,
-                    author: gc.author,
-                    timestamp: gc.timestamp,
-                    order: gc.order,
-                    session_id: resolved.session_id,
-                    session_status: resolved.status,
-                    completion_reason: resolved.completion_reason,
-                });
+            if app.is_some() && git::needs_fetch(&cache_key, git::FetchMode::Ttl) {
+                // Two-stream: fast state + commits → emit partial → slow state
+                let fast = git::compute_fast_local_git_state(worktree_path, &branch.branch_name);
+                let git_commits =
+                    git::get_commits_since_base(worktree_path, &base_ref).map_err(|e| {
+                        format!("Failed to get commits since base for branch {branch_id}: {e:?}")
+                    })?;
+                commits = map_local_commits(store, branch_id, &git_commits);
+                if let Some(app) = app {
+                    let partial_state = fast
+                        .clone()
+                        .into_placeholder_git_state(&branch.branch_name, &branch.base_branch);
+                    let _ = app.emit(
+                        "timeline-partial",
+                        TimelinePartialPayload {
+                            branch_id: branch_id.to_string(),
+                            commits: commits.clone(),
+                            git_state: partial_state,
+                        },
+                    );
+                }
+                // Slow stream: fetch + ref comparisons
+                git_state = Some(git::complete_local_git_state(
+                    worktree_path,
+                    &fast,
+                    &branch.branch_name,
+                    &branch.base_branch,
+                    git::FetchMode::Ttl,
+                ));
+            } else {
+                // Single stream: fetch cache is fresh
+                git_state = Some(git::compute_local_branch_git_state(
+                    worktree_path,
+                    &branch.branch_name,
+                    &branch.base_branch,
+                    git::FetchMode::Ttl,
+                ));
+                let git_commits =
+                    git::get_commits_since_base(worktree_path, &base_ref).map_err(|e| {
+                        format!("Failed to get commits since base for branch {branch_id}: {e:?}")
+                    })?;
+                commits = map_local_commits(store, branch_id, &git_commits);
             }
         }
     }
@@ -166,8 +320,8 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
                     })
                     .unwrap_or_else(|| "Pending commit".to_string()),
                 author: String::new(),
-                timestamp: dc.created_at / 1000, // convert ms to seconds
-                order: 0, // created_at is ms divided by 1000, so two pending commits in the same second could tie; rare in practice since they're created one at a time
+                timestamp: dc.created_at / 1000,
+                order: 0,
                 session_id: resolved.session_id,
                 session_status: resolved.status,
                 completion_reason: resolved.completion_reason,
@@ -294,14 +448,17 @@ fn review_is_visible_in_timeline(review: &Review, visible_shas: &HashSet<&str>) 
 
 #[tauri::command]
 pub async fn get_branch_timeline(
+    app: tauri::AppHandle,
     store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
     branch_id: String,
 ) -> Result<BranchTimeline, String> {
     let store = crate::get_store(&store)?;
 
-    tauri::async_runtime::spawn_blocking(move || build_branch_timeline(&store, &branch_id))
-        .await
-        .map_err(|e| format!("Timeline task failed: {e}"))?
+    tauri::async_runtime::spawn_blocking(move || {
+        build_branch_timeline(&store, &branch_id, Some(&app))
+    })
+    .await
+    .map_err(|e| format!("Timeline task failed: {e}"))?
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -812,7 +969,7 @@ mod tests {
         store.create_review(&visible_review).unwrap();
         store.create_review(&stale_review).unwrap();
 
-        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+        let timeline = build_branch_timeline(&store, &branch.id, None).unwrap();
 
         assert_eq!(timeline.commits.len(), 1);
         assert_eq!(timeline.commits[0].sha, visible_sha);
@@ -831,7 +988,7 @@ mod tests {
         store.create_review(&stale_review).unwrap();
         store.add_comment(&stale_review.id, &agent_comment).unwrap();
 
-        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+        let timeline = build_branch_timeline(&store, &branch.id, None).unwrap();
 
         assert_eq!(timeline.commits.len(), 1);
         assert!(timeline.reviews.is_empty());
@@ -847,7 +1004,7 @@ mod tests {
         store.create_review(&stale_review).unwrap();
         store.add_comment(&stale_review.id, &user_comment).unwrap();
 
-        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+        let timeline = build_branch_timeline(&store, &branch.id, None).unwrap();
 
         assert_eq!(timeline.commits.len(), 1);
         assert_eq!(timeline.reviews.len(), 1);
@@ -866,7 +1023,7 @@ mod tests {
         store.add_comment(&stale_review.id, &user_comment).unwrap();
         store.delete_comment(&user_comment.id).unwrap();
 
-        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+        let timeline = build_branch_timeline(&store, &branch.id, None).unwrap();
 
         assert_eq!(timeline.commits.len(), 1);
         assert!(timeline.reviews.is_empty());

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -7,6 +7,7 @@ use crate::{
     blox, branches, BranchTimeline, CommitTimelineItem, ImageTimelineItem, NoteTimelineItem,
     ReviewTimelineItem,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -22,10 +23,29 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         .get_workdir_for_branch(branch_id)
         .map_err(|e| e.to_string())?;
 
+    let mut git_state = None;
+
     // Get commits from git (the source of truth for commit data)
     let mut commits = Vec::new();
     if let Some(ref ws_name) = branch.workspace_name {
         let repo_subpath = branches::resolve_branch_workspace_subpath(store, &branch)?;
+        let cache_key = remote_git_state_cache_key(
+            ws_name,
+            repo_subpath.as_deref(),
+            &branch.branch_name,
+            &branch.base_branch,
+        );
+        git_state = Some(git::compute_branch_git_state(
+            &cache_key,
+            |args| {
+                branches::run_workspace_git(ws_name, repo_subpath.as_deref(), args)
+                    .map_err(|e| e.to_string())
+            },
+            &branch.branch_name,
+            &branch.base_branch,
+            git::FetchMode::Ttl,
+        ));
+
         let base_ref = git::origin_ref_for_branch(&branch.base_branch);
         // Remote branch: fetch commits via ws_exec.
         // Use merge-base to find the fork point so that only the branch's
@@ -85,6 +105,13 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         // Local branch: fetch commits from the local worktree
         let worktree_path = Path::new(&wd.path);
         if worktree_path.exists() {
+            git_state = Some(git::compute_local_branch_git_state(
+                worktree_path,
+                &branch.branch_name,
+                &branch.base_branch,
+                git::FetchMode::Ttl,
+            ));
+
             let base_ref = git::origin_ref_for_branch(&branch.base_branch);
             let git_commits =
                 git::get_commits_since_base(worktree_path, &base_ref).map_err(|e| {
@@ -230,7 +257,20 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         notes,
         reviews,
         images,
+        git_state,
     })
+}
+
+fn remote_git_state_cache_key(
+    workspace_name: &str,
+    repo_subpath: Option<&str>,
+    branch_name: &str,
+    base_branch: &str,
+) -> String {
+    format!(
+        "remote:{workspace_name}:{}:{branch_name}:{base_branch}",
+        repo_subpath.unwrap_or("")
+    )
 }
 
 fn review_is_visible_in_timeline(review: &Review, visible_shas: &HashSet<&str>) -> bool {
@@ -252,6 +292,256 @@ pub async fn get_branch_timeline(
     tauri::async_runtime::spawn_blocking(move || build_branch_timeline(&store, &branch_id))
         .await
         .map_err(|e| format!("Timeline task failed: {e}"))?
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn pull_branch_ff_only(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    branch_id: String,
+) -> Result<(), String> {
+    let store = crate::get_store(&store)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let branch = store
+            .get_branch(&branch_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+        if let Some(ref ws_name) = branch.workspace_name {
+            let repo_subpath = branches::resolve_branch_workspace_subpath(&store, &branch)?;
+            let cache_key = remote_git_state_cache_key(
+                ws_name,
+                repo_subpath.as_deref(),
+                &branch.branch_name,
+                &branch.base_branch,
+            );
+            let state = git::compute_branch_git_state(
+                &cache_key,
+                |args| {
+                    branches::run_workspace_git(ws_name, repo_subpath.as_deref(), args)
+                        .map_err(|e| e.to_string())
+                },
+                &branch.branch_name,
+                &branch.base_branch,
+                git::FetchMode::Force,
+            );
+            git::ensure_fast_forward_pullable(&state)?;
+            branches::run_workspace_git(
+                ws_name,
+                repo_subpath.as_deref(),
+                &["merge", "--ff-only", &state.upstream.r#ref],
+            )
+            .map_err(|e| e.to_string())?;
+            return Ok(());
+        }
+
+        let workdir = store
+            .get_workdir_for_branch(&branch_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
+        let worktree = Path::new(&workdir.path);
+        let state = git::compute_local_branch_git_state(
+            worktree,
+            &branch.branch_name,
+            &branch.base_branch,
+            git::FetchMode::Force,
+        );
+        git::ensure_fast_forward_pullable(&state)?;
+        git::fast_forward_to_ref(worktree, &state.upstream.r#ref).map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Pull task failed: {e}"))?
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeChangesPreview {
+    revert_paths: Vec<String>,
+    remove_paths: Vec<String>,
+    conflicted_paths: Vec<String>,
+}
+
+fn preview_from_change_paths(paths: git::WorktreeChangePaths) -> WorktreeChangesPreview {
+    WorktreeChangesPreview {
+        revert_paths: paths.revert_paths,
+        remove_paths: paths.remove_paths,
+        conflicted_paths: paths.conflicted_paths,
+    }
+}
+
+fn ensure_preview_matches(
+    changes: &git::WorktreeChangePaths,
+    expected: Option<&WorktreeChangesPreview>,
+) -> Result<(), String> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let actual = preview_from_change_paths(changes.clone());
+    if &actual == expected {
+        Ok(())
+    } else {
+        Err("Worktree changes changed; review the discard preview again".to_string())
+    }
+}
+
+fn ensure_worktree_discardable(state: &git::BranchGitState) -> Result<(), String> {
+    if state.detached_head {
+        return Err("Cannot discard changes while HEAD is detached".to_string());
+    }
+    if !state.expected_branch_matches {
+        let current = state
+            .current_branch
+            .as_deref()
+            .unwrap_or("an unknown branch");
+        return Err(format!(
+            "Cannot discard changes while checked out on {current}"
+        ));
+    }
+    if state.worktree.conflicted > 0 {
+        return Err("Resolve merge conflicts before discarding changes".to_string());
+    }
+    Ok(())
+}
+
+fn remote_worktree_change_paths(
+    workspace_name: &str,
+    repo_subpath: Option<&str>,
+) -> Result<git::WorktreeChangePaths, String> {
+    let output = branches::run_workspace_git(
+        workspace_name,
+        repo_subpath,
+        &["status", "--porcelain=1", "-z", "--untracked-files=all"],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(git::parse_worktree_status_paths(&output))
+}
+
+fn discard_remote_worktree_changes(
+    workspace_name: &str,
+    repo_subpath: Option<&str>,
+    changes: &git::WorktreeChangePaths,
+) -> Result<(), String> {
+    if changes.reset_required {
+        branches::run_workspace_git(workspace_name, repo_subpath, &["reset", "--hard", "HEAD"])
+            .map_err(|e| e.to_string())?;
+    }
+
+    if !changes.remove_paths.is_empty() {
+        let pathspecs = changes
+            .remove_paths
+            .iter()
+            .map(|path| format!(":(literal){path}"))
+            .collect::<Vec<_>>();
+        let mut args = vec!["clean", "-fd", "--"];
+        args.extend(pathspecs.iter().map(String::as_str));
+        branches::run_workspace_git(workspace_name, repo_subpath, &args)
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_worktree_changes_preview(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    branch_id: String,
+) -> Result<WorktreeChangesPreview, String> {
+    let store = crate::get_store(&store)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let branch = store
+            .get_branch(&branch_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+        if let Some(ref ws_name) = branch.workspace_name {
+            let repo_subpath = branches::resolve_branch_workspace_subpath(&store, &branch)?;
+            return remote_worktree_change_paths(ws_name, repo_subpath.as_deref())
+                .map(preview_from_change_paths);
+        }
+
+        let workdir = store
+            .get_workdir_for_branch(&branch_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
+        let paths =
+            git::list_worktree_change_paths(Path::new(&workdir.path)).map_err(|e| e.to_string())?;
+        Ok(preview_from_change_paths(paths))
+    })
+    .await
+    .map_err(|e| format!("Worktree preview task failed: {e}"))?
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn discard_worktree_changes(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    branch_id: String,
+    expected_preview: Option<WorktreeChangesPreview>,
+) -> Result<(), String> {
+    let store = crate::get_store(&store)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let branch = store
+            .get_branch(&branch_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+        if let Some(ref ws_name) = branch.workspace_name {
+            let repo_subpath = branches::resolve_branch_workspace_subpath(&store, &branch)?;
+            let cache_key = remote_git_state_cache_key(
+                ws_name,
+                repo_subpath.as_deref(),
+                &branch.branch_name,
+                &branch.base_branch,
+            );
+            let state = git::compute_branch_git_state(
+                &cache_key,
+                |args| {
+                    branches::run_workspace_git(ws_name, repo_subpath.as_deref(), args)
+                        .map_err(|e| e.to_string())
+                },
+                &branch.branch_name,
+                &branch.base_branch,
+                git::FetchMode::Never,
+            );
+            ensure_worktree_discardable(&state)?;
+            let changes = remote_worktree_change_paths(ws_name, repo_subpath.as_deref())?;
+            ensure_preview_matches(&changes, expected_preview.as_ref())?;
+            if changes.is_empty() {
+                return Ok(());
+            }
+            if !changes.conflicted_paths.is_empty() {
+                return Err("Resolve merge conflicts before discarding changes".to_string());
+            }
+            return discard_remote_worktree_changes(ws_name, repo_subpath.as_deref(), &changes);
+        }
+
+        let workdir = store
+            .get_workdir_for_branch(&branch_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
+        let worktree = Path::new(&workdir.path);
+        let state = git::compute_local_branch_git_state(
+            worktree,
+            &branch.branch_name,
+            &branch.base_branch,
+            git::FetchMode::Never,
+        );
+        ensure_worktree_discardable(&state)?;
+        let changes = git::list_worktree_change_paths(worktree).map_err(|e| e.to_string())?;
+        ensure_preview_matches(&changes, expected_preview.as_ref())?;
+        if changes.is_empty() {
+            return Ok(());
+        }
+        if !changes.conflicted_paths.is_empty() {
+            return Err("Resolve merge conflicts before discarding changes".to_string());
+        }
+        git::discard_worktree_changes(worktree, &changes).map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Discard task failed: {e}"))?
 }
 
 /// Cancel and delete any reviews (auto or manual) created at or after a commit's

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -35,12 +35,13 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
             &branch.branch_name,
             &branch.base_branch,
         );
-        git_state = Some(git::compute_branch_git_state(
+        let resolved_path = resolve_repo_path(ws_name, repo_subpath.as_deref())?;
+        git_state = Some(git::compute_branch_git_state_batched(
             &cache_key,
-            |args| {
-                branches::run_workspace_git(ws_name, repo_subpath.as_deref(), args)
-                    .map_err(|e| e.to_string())
+            |script, args| {
+                branches::run_workspace_shell(ws_name, script, args).map_err(|e| e.to_string())
             },
+            &resolved_path,
             &branch.branch_name,
             &branch.base_branch,
             git::FetchMode::Ttl,
@@ -261,6 +262,15 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
     })
 }
 
+fn resolve_repo_path(ws_name: &str, repo_subpath: Option<&str>) -> Result<String, String> {
+    match repo_subpath.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(subpath) => {
+            branches::resolve_workspace_repo_path(ws_name, subpath).map_err(|e| e.to_string())
+        }
+        None => Ok(".".to_string()),
+    }
+}
+
 fn remote_git_state_cache_key(
     workspace_name: &str,
     repo_subpath: Option<&str>,
@@ -309,18 +319,19 @@ pub async fn pull_branch_ff_only(
 
         if let Some(ref ws_name) = branch.workspace_name {
             let repo_subpath = branches::resolve_branch_workspace_subpath(&store, &branch)?;
+            let resolved_path = resolve_repo_path(ws_name, repo_subpath.as_deref())?;
             let cache_key = remote_git_state_cache_key(
                 ws_name,
                 repo_subpath.as_deref(),
                 &branch.branch_name,
                 &branch.base_branch,
             );
-            let state = git::compute_branch_git_state(
+            let state = git::compute_branch_git_state_batched(
                 &cache_key,
-                |args| {
-                    branches::run_workspace_git(ws_name, repo_subpath.as_deref(), args)
-                        .map_err(|e| e.to_string())
+                |script, args| {
+                    branches::run_workspace_shell(ws_name, script, args).map_err(|e| e.to_string())
                 },
+                &resolved_path,
                 &branch.branch_name,
                 &branch.base_branch,
                 git::FetchMode::Force,
@@ -489,18 +500,19 @@ pub async fn discard_worktree_changes(
 
         if let Some(ref ws_name) = branch.workspace_name {
             let repo_subpath = branches::resolve_branch_workspace_subpath(&store, &branch)?;
+            let resolved_path = resolve_repo_path(ws_name, repo_subpath.as_deref())?;
             let cache_key = remote_git_state_cache_key(
                 ws_name,
                 repo_subpath.as_deref(),
                 &branch.branch_name,
                 &branch.base_branch,
             );
-            let state = git::compute_branch_git_state(
+            let state = git::compute_branch_git_state_batched(
                 &cache_key,
-                |args| {
-                    branches::run_workspace_git(ws_name, repo_subpath.as_deref(), args)
-                        .map_err(|e| e.to_string())
+                |script, args| {
+                    branches::run_workspace_shell(ws_name, script, args).map_err(|e| e.to_string())
                 },
+                &resolved_path,
                 &branch.branch_name,
                 &branch.base_branch,
                 git::FetchMode::Never,

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -33,6 +33,14 @@ import type {
   SuggestedRepo,
 } from './types';
 
+export type DiffScope = 'branch' | 'commit' | 'worktree';
+
+export interface WorktreeChangesPreview {
+  revertPaths: string[];
+  removePaths: string[];
+  conflictedPaths: string[];
+}
+
 // =============================================================================
 // Store status
 // =============================================================================
@@ -392,6 +400,10 @@ export function invalidateProjectBranchTimelines(branchIds: string[]): void {
   window.dispatchEvent(new CustomEvent('timeline-invalidated', { detail: { branchIds } }));
 }
 
+export function pullBranchFastForward(branchId: string): Promise<void> {
+  return invoke('pull_branch_ff_only', { branchId });
+}
+
 // =============================================================================
 // Actions
 // =============================================================================
@@ -654,6 +666,19 @@ export function deletePendingCommit(commitId: string, deleteSession = true): Pro
   return invoke('delete_pending_commit', { commitId, deleteSession });
 }
 
+/** Preview the exact worktree paths that would be reverted or removed. */
+export function getWorktreeChangesPreview(branchId: string): Promise<WorktreeChangesPreview> {
+  return invoke('get_worktree_changes_preview', { branchId });
+}
+
+/** Discard all uncommitted worktree changes after backend safety checks. */
+export function discardWorktreeChanges(
+  branchId: string,
+  expectedPreview?: WorktreeChangesPreview
+): Promise<void> {
+  return invoke('discard_worktree_changes', { branchId, expectedPreview });
+}
+
 /** Delete a review and all its comments, optionally its linked session. */
 export function deleteReview(reviewId: string, deleteSession = true): Promise<void> {
   return invoke('delete_review', { reviewId, deleteSession });
@@ -675,7 +700,7 @@ export function deleteReview(reviewId: string, deleteSession = true): Promise<vo
 export function getDiffFiles(
   branchId: string,
   commitSha?: string,
-  scope: 'branch' | 'commit' = 'branch'
+  scope: DiffScope = 'branch'
 ): Promise<DiffFilesResponse> {
   return invoke('get_diff_files', { branchId, commitSha, scope });
 }
@@ -684,7 +709,7 @@ export function getDiffFiles(
 export function getFileDiff(
   branchId: string,
   commitSha: string,
-  scope: 'branch' | 'commit',
+  scope: DiffScope,
   path: string
 ): Promise<FileDiff> {
   return invoke('get_file_diff', { branchId, commitSha, scope, path });
@@ -913,13 +938,19 @@ export interface GitHubCommentResult {
   commentType: string;
 }
 
-/** Rebase a branch onto its base branch via a pipeline.
- *  Fetches the latest base, then runs git rebase. AI handles conflicts if any.
+/** Rebase a branch via a pipeline.
+ *  When target is 'base' (default), rebases onto origin/{base_branch}.
+ *  When target is 'origin', rebases onto origin/{branch_name}.
  *  Returns the session ID so the frontend can track progress. */
-export function rebaseBranch(branchId: string, provider?: string): Promise<string> {
+export function rebaseBranch(
+  branchId: string,
+  provider?: string,
+  target?: 'base' | 'origin'
+): Promise<string> {
   return invoke('rebase_branch', {
     branchId,
     provider: provider ?? null,
+    target: target ?? null,
   });
 }
 

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -515,8 +515,8 @@
   }
 
   // Synchronously hydrate timeline from cache so isSettingUp is never true
-  // on remount (e.g. project switch). This prevents the "Looking for changes…"
-  // flash and the slide-in animation for already-cached rows.
+  // on remount (e.g. project switch). This prevents the loading flash and
+  // the slide-in animation for already-cached rows.
   {
     // svelte-ignore state_referenced_locally
     const initBranch = branch;
@@ -1331,6 +1331,9 @@
         warning={branchIdentityWarning}
       />
       <div class="header-actions">
+        {#if revalidating}
+          <Spinner size={14} />
+        {/if}
         {#if isRemote && remoteWorkspaceStatus !== 'running' && remoteWorkspaceStatus !== 'starting'}
           <RemoteWorkspaceStatusBadge status={remoteWorkspaceStatus} />
         {/if}
@@ -1381,7 +1384,6 @@
           pendingDropNotes={isLocal ? pendingDropNotes : undefined}
           pendingItems={sessionMgr.pendingSessionItems}
           {prunedSessionIds}
-          {revalidating}
           {error}
           gitActionDisabledReason={branchIdentityWarning}
           onRetry={() => loadTimeline()}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -526,6 +526,7 @@
 
   function gitIdentityWarning(state: BranchGitState | null | undefined): string | null {
     if (!state) return null;
+    if (state.fetch.status === 'failed') return null; // branch info unreliable when fetch failed
     if (state.detachedHead) return 'Detached HEAD';
     if (!state.expectedBranchMatches) {
       return state.currentBranch ? `Checked out ${state.currentBranch}` : 'Wrong branch';

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -825,8 +825,12 @@
   }
 
   async function confirmForcePush() {
+    if (commandPipelinePending || branchSessionBusy) {
+      // Another operation is in progress — keep the dialog open so the user
+      // understands why the action didn't proceed.
+      return;
+    }
     showForcePushDialog = false;
-    if (commandPipelinePending || branchSessionBusy) return;
     commandPipelinePending = true;
     const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
     const provider = getPreferredAgent(agents) ?? undefined;

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -270,12 +270,21 @@
     commandPipelinePending = true;
     const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
     const provider = getPreferredAgent(agents) ?? undefined;
+    const pendingKey = `pipeline-${kind}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     try {
+      let sessionId: string;
       if (kind === 'rebase') {
-        await commands.rebaseBranch(branch.id, provider, rebaseTarget);
+        sessionId = await commands.rebaseBranch(branch.id, provider, rebaseTarget);
       } else {
-        await commands.squashCommits(branch.id, provider);
+        sessionId = await commands.squashCommits(branch.id, provider);
       }
+      // Add a pending session item so the session stub appears instantly
+      // instead of waiting for the full timeline refresh.
+      const title = kind === 'rebase' ? 'Rebasing…' : 'Squashing…';
+      sessionMgr.pendingSessionItems = [
+        ...sessionMgr.pendingSessionItems,
+        { key: pendingKey, type: 'pending-commit', title, sessionId },
+      ];
       await loadTimeline();
     } catch (e) {
       notifyError(kind === 'rebase' ? 'Rebase failed' : 'Squash failed', e);
@@ -640,8 +649,7 @@
       const { branchIds } = (e as CustomEvent<{ branchIds: string[] }>).detail;
       const timelineKey = branchTimelineReadyKey(branch);
       if (branchIds.includes(branch.id) && timelineKey) {
-        loadedTimelineKey = null;
-        void loadTimeline({ timelineKey, force: true });
+        void loadTimeline({ force: true });
       }
     };
     window.addEventListener('timeline-invalidated', handler);

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -127,7 +127,8 @@
 
   let timeline = $state<BranchTimelineData | null>(null);
   let loading = $state(true);
-  let revalidating = $state(false);
+  /** True from the start of any timeline load until the full (slow) git state arrives. */
+  let refreshingGitState = $state(true);
   let error = $state<string | null>(null);
   let pullingOrigin = $state(false);
   let discardingWorktreeChanges = $state(false);
@@ -510,7 +511,7 @@
     loading = false;
     prunedSessionIds = sessionMgr.prunePendingSessionItems(cached);
     if (fresh) {
-      revalidating = true;
+      refreshingGitState = true;
       const version = ++revalidationVersion;
       fresh
         .then((next) => {
@@ -533,9 +534,10 @@
           if (version !== revalidationVersion || branchTimelineReadyKey(branch) !== timelineKey) {
             return;
           }
-          revalidating = false;
+          refreshingGitState = false;
         });
     } else {
+      refreshingGitState = false;
       void loadTimelineReviewDetails(cached.reviews);
     }
   }
@@ -747,7 +749,7 @@
     error = null;
     // Cancel any in-flight revalidation so it can't overwrite fresher data
     revalidationVersion++;
-    revalidating = false;
+    refreshingGitState = true;
 
     try {
       if (isInitialLoad) {
@@ -781,6 +783,7 @@
       }
       if (isCurrentTimelineLoad(loadVersion, timelineKey)) {
         loading = false;
+        refreshingGitState = false;
       }
     }
   }
@@ -1345,7 +1348,7 @@
     </div>
   {:else}
     <div class="card-header">
-      {#if revalidating}
+      {#if refreshingGitState}
         <Spinner size={14} />
       {:else if isRemote}
         <Cloud size={14} class="header-icon {cloudStatusClass(remoteWorkspaceStatus)}" />

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -572,6 +572,14 @@
           return;
         }
 
+        // Clear push/force-push session tracking on completion
+        if (eventSessionId === pushSessionId) {
+          pushSessionId = null;
+        }
+        if (eventSessionId === forcePushSessionId) {
+          forcePushSessionId = null;
+        }
+
         // Skip normal completion handling for any auto review session
         if (isAutoReview) {
           return;
@@ -801,20 +809,24 @@
     }
   }
 
-  let pushingOrigin = $state(false);
+  let pushSessionId = $state<string | null>(null);
+  let pushingOrigin = $derived(!!pushSessionId);
 
   async function handlePushOrigin() {
-    if (pushingOrigin) return;
-    pushingOrigin = true;
+    if (pushSessionId || commandPipelinePending || branchSessionBusy) return;
     const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
     const provider = getPreferredAgent(agents) ?? undefined;
     try {
-      await commands.pushBranch(branch.id, provider, false);
-      await loadTimeline();
+      pushSessionId = await commands.pushBranch(branch.id, provider, false);
     } catch (e) {
+      pushSessionId = null;
       notifyError('Push failed', e);
-    } finally {
-      pushingOrigin = false;
+    }
+  }
+
+  function openPushSession() {
+    if (pushSessionId) {
+      sessionMgr.openSessionId = pushSessionId;
     }
   }
 
@@ -824,23 +836,29 @@
     showForcePushDialog = true;
   }
 
+  let forcePushSessionId = $state<string | null>(null);
+  let forcePushingOrigin = $derived(!!forcePushSessionId);
+
   async function confirmForcePush() {
-    if (commandPipelinePending || branchSessionBusy) {
+    if (forcePushSessionId || commandPipelinePending || branchSessionBusy) {
       // Another operation is in progress — keep the dialog open so the user
       // understands why the action didn't proceed.
       return;
     }
     showForcePushDialog = false;
-    commandPipelinePending = true;
     const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
     const provider = getPreferredAgent(agents) ?? undefined;
     try {
-      await commands.pushBranch(branch.id, provider, true);
-      await loadTimeline();
+      forcePushSessionId = await commands.pushBranch(branch.id, provider, true);
     } catch (e) {
+      forcePushSessionId = null;
       notifyError('Force push failed', e);
-    } finally {
-      commandPipelinePending = false;
+    }
+  }
+
+  function openForcePushSession() {
+    if (forcePushSessionId) {
+      sessionMgr.openSessionId = forcePushSessionId;
     }
   }
 
@@ -1342,9 +1360,12 @@
             : undefined}
           onPullOrigin={handlePullOrigin}
           onPushOrigin={handlePushOrigin}
+          onOpenPushSession={pushSessionId ? openPushSession : undefined}
           onRebaseBranch={() => startBranchCommandPipeline('rebase')}
           onRebaseBranchOntoOrigin={() => startBranchCommandPipeline('rebase', 'origin')}
           onForcePush={handleForcePush}
+          onOpenForcePushSession={forcePushSessionId ? openForcePushSession : undefined}
+          {forcePushingOrigin}
           rebaseBranchDisabledReason={branchCommandDisabledReason}
           onViewWorktreeDiff={isLocal ? () => (showWorktreeDiff = true) : undefined}
           onCommitWorktreeChanges={() =>

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -572,7 +572,8 @@
           return;
         }
 
-        // Clear push/force-push session tracking on completion
+        // Clear push/force-push session tracking on terminal status only
+        // (guarded by the outer completed/error/cancelled check above)
         if (eventSessionId === pushSessionId) {
           pushSessionId = null;
         }

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -12,7 +12,15 @@
 -->
 <script lang="ts">
   import { untrack } from 'svelte';
-  import { FileDiff, AlertCircle, Cloud, Trash2 } from 'lucide-svelte';
+  import {
+    FileDiff,
+    AlertCircle,
+    Cloud,
+    Trash2,
+    GitPullRequest,
+    GitPullRequestClosed,
+    GitPullRequestDraft,
+  } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
   import { subscribeDragDrop } from './dragDrop';
@@ -24,6 +32,7 @@
     HashtagItem,
     ProjectRepo,
     SessionStatusPayload,
+    WorkspaceStatus,
   } from '../../types';
   import * as commands from '../../api/commands';
   import BranchTimeline from '../timeline/BranchTimeline.svelte';
@@ -49,6 +58,7 @@
   import RemoteWorkspaceStatusView from './RemoteWorkspaceStatusView.svelte';
   import { branchTimelineReadyKey } from './branchTimelineReady';
   import { alerts } from '../../shared/alerts.svelte';
+  import { aggregateProjectPrStatus } from '../../shared/utils';
   import { timelineToHashtagItems, projectNotesToHashtagItems } from '../sessions/hashtagItems';
   import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
   import { getPreferredAgent } from '../settings/preferences.svelte';
@@ -85,6 +95,22 @@
   const isLocal = $derived(branch.branchType === 'local');
   const isRemote = $derived(branch.branchType === 'remote');
   const remoteWorkspaceStatus = $derived(branch.workspaceStatus);
+  const prStatus = $derived(aggregateProjectPrStatus([branch]));
+
+  function cloudStatusClass(status: WorkspaceStatus | null): string {
+    switch (status) {
+      case 'running':
+        return 'cloud-running';
+      case 'starting':
+        return 'cloud-starting';
+      case 'error':
+        return 'cloud-error';
+      case 'stopped':
+      case 'suspended':
+      default:
+        return 'cloud-inactive';
+    }
+  }
 
   function notifyError(title: string, e: unknown): void {
     alerts.show({
@@ -1319,8 +1345,22 @@
     </div>
   {:else}
     <div class="card-header">
-      {#if isRemote}
-        <Cloud size={14} class="header-icon cloud-icon" />
+      {#if revalidating}
+        <Spinner size={14} />
+      {:else if isRemote}
+        <Cloud size={14} class="header-icon {cloudStatusClass(remoteWorkspaceStatus)}" />
+      {:else if prStatus === 'merged'}
+        <GitPullRequest size={14} class="header-icon pr-status-merged" />
+      {:else if prStatus === 'checks_failing'}
+        <GitPullRequest size={14} class="header-icon pr-status-checks-failing" />
+      {:else if prStatus === 'open'}
+        <GitPullRequest size={14} class="header-icon" />
+      {:else if prStatus === 'closed'}
+        <GitPullRequestClosed size={14} class="header-icon" />
+      {:else if prStatus === 'conflict'}
+        <GitPullRequestClosed size={14} class="header-icon pr-status-conflict" />
+      {:else}
+        <GitPullRequestDraft size={14} class="header-icon pr-status-draft" />
       {/if}
       <BranchCardHeaderInfo
         branchName={branch.branchName}
@@ -1331,9 +1371,6 @@
         warning={branchIdentityWarning}
       />
       <div class="header-actions">
-        {#if revalidating}
-          <Spinner size={14} />
-        {/if}
         {#if isRemote && remoteWorkspaceStatus !== 'running' && remoteWorkspaceStatus !== 'starting'}
           <RemoteWorkspaceStatusBadge status={remoteWorkspaceStatus} />
         {/if}
@@ -1754,8 +1791,36 @@
     stroke: var(--text-faint);
   }
 
-  .card-header :global(svg.cloud-icon) {
+  .card-header :global(svg.pr-status-merged) {
+    stroke: var(--ui-success);
+  }
+
+  .card-header :global(svg.pr-status-conflict) {
+    stroke: var(--ui-danger);
+  }
+
+  .card-header :global(svg.pr-status-checks-failing) {
+    stroke: var(--ui-danger);
+  }
+
+  .card-header :global(svg.pr-status-draft) {
+    stroke: var(--text-muted);
+  }
+
+  .card-header :global(svg.cloud-running) {
     stroke: var(--ui-accent);
+  }
+
+  .card-header :global(svg.cloud-starting) {
+    stroke: var(--ui-info);
+  }
+
+  .card-header :global(svg.cloud-error) {
+    stroke: var(--ui-danger);
+  }
+
+  .card-header :global(svg.cloud-inactive) {
+    stroke: var(--text-muted);
   }
 
   .more-button {

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -20,6 +20,7 @@
     Branch,
     BranchGitState,
     BranchTimeline as BranchTimelineData,
+    CommitTimelineItem,
     HashtagItem,
     ProjectRepo,
     SessionStatusPayload,
@@ -631,6 +632,58 @@
 
     return () => {
       unlistenStatus?.();
+    };
+  });
+
+  // Listen for partial timeline events emitted by the fast stream.
+  // When the backend needs to fetch, it emits commits + fast git state
+  // (worktree, HEAD, branch identity) before the slow fetch completes.
+  // This lets the UI show commits and worktree state immediately.
+  let unlistenPartial: UnlistenFn | null = null;
+  $effect(() => {
+    const branchId = branch.id;
+
+    listen<{ branchId: string; commits: CommitTimelineItem[]; gitState: BranchGitState }>(
+      'timeline-partial',
+      (event) => {
+        if (event.payload.branchId !== branchId) return;
+        const { commits: partialCommits, gitState: partialGitState } = event.payload;
+
+        if (!timeline) {
+          // No existing timeline — create a minimal one from the partial data
+          timeline = {
+            commits: partialCommits,
+            notes: [],
+            reviews: [],
+            images: [],
+            gitState: partialGitState,
+          };
+          loading = false;
+        } else {
+          // Merge: update commits and fast git state fields, preserve
+          // existing upstream/base data so those rows don't flash away
+          timeline = {
+            ...timeline,
+            commits: partialCommits,
+            gitState: timeline.gitState
+              ? {
+                  ...timeline.gitState,
+                  headSha: partialGitState.headSha,
+                  currentBranch: partialGitState.currentBranch,
+                  detachedHead: partialGitState.detachedHead,
+                  expectedBranchMatches: partialGitState.expectedBranchMatches,
+                  worktree: partialGitState.worktree,
+                }
+              : partialGitState,
+          };
+        }
+      }
+    ).then((unlisten) => {
+      unlistenPartial = unlisten;
+    });
+
+    return () => {
+      unlistenPartial?.();
     };
   });
 

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -18,6 +18,7 @@
   import { subscribeDragDrop } from './dragDrop';
   import type {
     Branch,
+    BranchGitState,
     BranchTimeline as BranchTimelineData,
     HashtagItem,
     ProjectRepo,
@@ -51,6 +52,7 @@
   import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
+  import type { WorktreeChangesPreview } from '../../commands';
 
   interface Props {
     branch: Branch;
@@ -100,7 +102,10 @@
   let loading = $state(true);
   let revalidating = $state(false);
   let error = $state<string | null>(null);
+  let pullingOrigin = $state(false);
+  let discardingWorktreeChanges = $state(false);
   let showBranchDiff = $state(false);
+  let showWorktreeDiff = $state(false);
   let loadedTimelineKey = $state<string | null>(null);
   type TimelineFullReview = NonNullable<Awaited<ReturnType<typeof commands.getReview>>>;
   type TimelineReviewDetails = {
@@ -153,7 +158,13 @@
   );
 
   /** Empty timeline used during provisioning so the action buttons render. */
-  const emptyTimeline: BranchTimelineData = { commits: [], notes: [], reviews: [], images: [] };
+  const emptyTimeline: BranchTimelineData = {
+    commits: [],
+    notes: [],
+    reviews: [],
+    images: [],
+    gitState: null,
+  };
 
   // =========================================================================
   // Worktree setup progress (event-driven phases)
@@ -251,14 +262,17 @@
   let commandPipelinePending = $state(false);
   let branchSessionBusy = $derived(timeline ? hasActiveSessions(timeline) : false);
 
-  async function startBranchCommandPipeline(kind: 'rebase' | 'squash') {
+  async function startBranchCommandPipeline(
+    kind: 'rebase' | 'squash',
+    rebaseTarget?: 'base' | 'origin'
+  ) {
     if (commandPipelinePending || branchSessionBusy) return;
     commandPipelinePending = true;
     const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
     const provider = getPreferredAgent(agents) ?? undefined;
     try {
       if (kind === 'rebase') {
-        await commands.rebaseBranch(branch.id, provider);
+        await commands.rebaseBranch(branch.id, provider, rebaseTarget);
       } else {
         await commands.squashCommits(branch.id, provider);
       }
@@ -419,6 +433,7 @@
   let confirmDelete = $state<{
     title: string;
     message: string;
+    confirmLabel?: string;
     onConfirm: () => void;
   } | null>(null);
 
@@ -508,6 +523,26 @@
 
   /** Number of finalized commits on this branch. */
   let commitCount = $derived(timeline?.commits.filter((c) => c.sha).length ?? 0);
+
+  function gitIdentityWarning(state: BranchGitState | null | undefined): string | null {
+    if (!state) return null;
+    if (state.detachedHead) return 'Detached HEAD';
+    if (!state.expectedBranchMatches) {
+      return state.currentBranch ? `Checked out ${state.currentBranch}` : 'Wrong branch';
+    }
+    return null;
+  }
+
+  let branchIdentityWarning = $derived(gitIdentityWarning(timeline?.gitState));
+  let gitUnsafeActionsDisabled = $derived(!!branchIdentityWarning);
+  let branchCommandDisabledReason = $derived(
+    branchIdentityWarning ??
+      (commandPipelinePending
+        ? 'Command in progress'
+        : branchSessionBusy
+          ? 'Session in progress'
+          : null)
+  );
 
   // =========================================================================
   // PR button ref
@@ -751,6 +786,121 @@
       console.error('Failed to open review:', e);
       notifyError('Failed to open review', e);
     }
+  }
+
+  async function handlePullOrigin() {
+    if (pullingOrigin) return;
+    pullingOrigin = true;
+    try {
+      await commands.pullBranchFastForward(branch.id);
+      await loadTimeline();
+    } catch (e) {
+      notifyError('Pull failed', e);
+    } finally {
+      pullingOrigin = false;
+    }
+  }
+
+  let pushingOrigin = $state(false);
+
+  async function handlePushOrigin() {
+    if (pushingOrigin) return;
+    pushingOrigin = true;
+    const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
+    const provider = getPreferredAgent(agents) ?? undefined;
+    try {
+      await commands.pushBranch(branch.id, provider, false);
+      await loadTimeline();
+    } catch (e) {
+      notifyError('Push failed', e);
+    } finally {
+      pushingOrigin = false;
+    }
+  }
+
+  let showForcePushDialog = $state(false);
+
+  function handleForcePush() {
+    showForcePushDialog = true;
+  }
+
+  async function confirmForcePush() {
+    showForcePushDialog = false;
+    if (commandPipelinePending || branchSessionBusy) return;
+    commandPipelinePending = true;
+    const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
+    const provider = getPreferredAgent(agents) ?? undefined;
+    try {
+      await commands.pushBranch(branch.id, provider, true);
+      await loadTimeline();
+    } catch (e) {
+      notifyError('Force push failed', e);
+    } finally {
+      commandPipelinePending = false;
+    }
+  }
+
+  function formatDiscardPreview(preview: WorktreeChangesPreview): string {
+    const sections: string[] = [];
+    if (preview.revertPaths.length > 0) {
+      sections.push(
+        `Revert tracked changes:\n${preview.revertPaths.map((path) => `- ${path}`).join('\n')}`
+      );
+    }
+    if (preview.removePaths.length > 0) {
+      sections.push(
+        `Remove untracked/new files:\n${preview.removePaths.map((path) => `- ${path}`).join('\n')}`
+      );
+    }
+    return `This will discard uncommitted worktree changes.\n\n${sections.join('\n\n')}`;
+  }
+
+  async function handleDiscardWorktreeChanges() {
+    if (discardingWorktreeChanges) return;
+
+    let preview: WorktreeChangesPreview;
+    try {
+      preview = await commands.getWorktreeChangesPreview(branch.id);
+    } catch (e) {
+      notifyError('Could not inspect changes', e);
+      return;
+    }
+
+    if (preview.conflictedPaths.length > 0) {
+      alerts.show({
+        tone: 'error',
+        title: 'Conflicts need manual recovery',
+        message: preview.conflictedPaths.join('\n'),
+        durationMs: 0,
+      });
+      return;
+    }
+
+    if (preview.revertPaths.length === 0 && preview.removePaths.length === 0) {
+      await loadTimeline();
+      return;
+    }
+
+    const doDiscard = async () => {
+      confirmDelete = null;
+      discardingWorktreeChanges = true;
+      try {
+        await commands.discardWorktreeChanges(branch.id, preview);
+        commands.invalidateBranchTimeline(branch.id);
+        await loadTimeline();
+      } catch (e) {
+        notifyError('Discard failed', e);
+      } finally {
+        discardingWorktreeChanges = false;
+      }
+    };
+
+    confirmDelete = {
+      title: 'Discard Changes',
+      message: formatDiscardPreview(preview),
+      confirmLabel: 'Discard',
+      onConfirm: doDiscard,
+    };
   }
 
   function handleDeleteCommit(sha: string, sessionId?: string, opts?: { altKey: boolean }) {
@@ -1093,6 +1243,7 @@
         secondaryLabel={isRemote
           ? (branch.workspaceName ?? formatBaseBranch(branch.baseBranch))
           : formatBaseBranch(branch.baseBranch)}
+        warning={branchIdentityWarning}
       />
       <div class="header-actions">
         {#if isRemote && remoteWorkspaceStatus !== 'running' && remoteWorkspaceStatus !== 'starting'}
@@ -1112,7 +1263,8 @@
           onSquashCommits={() => startBranchCommandPipeline('squash')}
           newCommitDisabled={sessionMgr.isNewSessionDisabled ||
             commandPipelinePending ||
-            branchSessionBusy}
+            branchSessionBusy ||
+            gitUnsafeActionsDisabled}
           {commitCount}
         />
       </div>
@@ -1146,6 +1298,7 @@
           {prunedSessionIds}
           {revalidating}
           {error}
+          gitActionDisabledReason={branchIdentityWarning}
           onRetry={() => loadTimeline()}
           deletingItems={timelineDeletingItems}
           reviewCommentBreakdown={timelineReviewDetailsById}
@@ -1183,8 +1336,21 @@
           onNewReview={hasCodeChanges || sessionMgr.hasCommitSessionInProgress
             ? (e) => sessionMgr.openNewSession('review', e)
             : undefined}
+          onPullOrigin={handlePullOrigin}
+          onPushOrigin={handlePushOrigin}
+          onRebaseBranch={() => startBranchCommandPipeline('rebase')}
+          onRebaseBranchOntoOrigin={() => startBranchCommandPipeline('rebase', 'origin')}
+          onForcePush={handleForcePush}
+          rebaseBranchDisabledReason={branchCommandDisabledReason}
+          onViewWorktreeDiff={isLocal ? () => (showWorktreeDiff = true) : undefined}
+          onCommitWorktreeChanges={() =>
+            sessionMgr.startOrQueueSession('commit', 'Commit uncommitted changes')}
+          onDiscardWorktreeChanges={handleDiscardWorktreeChanges}
           onNewSessionReferring={(ref) => sessionMgr.openNewSessionReferring(ref)}
-          newSessionDisabled={sessionMgr.isNewSessionDisabled}
+          newSessionDisabled={sessionMgr.isNewSessionDisabled || gitUnsafeActionsDisabled}
+          {pullingOrigin}
+          {pushingOrigin}
+          {discardingWorktreeChanges}
           {provisioningLabel}
           {provisioningDetail}
         >
@@ -1244,6 +1410,26 @@
     onClose={() => {
       showBranchDiff = false;
       reviewDiffTarget = null;
+      loadTimeline();
+    }}
+  />
+{/if}
+
+{#if showWorktreeDiff}
+  <DiffModal
+    branchId={branch.id}
+    projectId={branch.projectId}
+    scope="worktree"
+    readonly
+    beforeLabel="HEAD"
+    afterLabel="worktree"
+    baseBranchLabel={formatBaseBranch(branch.baseBranch)}
+    branchLabel={branch.branchName}
+    {projectName}
+    githubRepo={repoLabel?.headRepo ?? repoLabel?.githubRepo}
+    subpath={repoLabel?.subpath}
+    onClose={() => {
+      showWorktreeDiff = false;
       loadTimeline();
     }}
   />
@@ -1405,11 +1591,22 @@
   />
 {/if}
 
+{#if showForcePushDialog}
+  <ConfirmDialog
+    title="Force Push"
+    message="The remote branch has commits that would be lost. Do you want to force push? This will overwrite the remote branch with your local version."
+    confirmLabel="Force Push"
+    danger
+    onConfirm={confirmForcePush}
+    onCancel={() => (showForcePushDialog = false)}
+  />
+{/if}
+
 {#if confirmDelete}
   <ConfirmDialog
     title={confirmDelete.title}
     message={confirmDelete.message}
-    confirmLabel="Delete"
+    confirmLabel={confirmDelete.confirmLabel ?? 'Delete'}
     danger
     onConfirm={confirmDelete.onConfirm}
     onCancel={() => (confirmDelete = null)}

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { GitBranch } from 'lucide-svelte';
+  import { AlertTriangle, GitBranch } from 'lucide-svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
   import type { ProjectRepo } from '../../types';
 
@@ -7,9 +7,10 @@
     branchName: string;
     repoLabel?: ProjectRepo | null;
     secondaryLabel?: string | null;
+    warning?: string | null;
   }
 
-  let { branchName, repoLabel = null, secondaryLabel = null }: Props = $props();
+  let { branchName, repoLabel = null, secondaryLabel = null, warning = null }: Props = $props();
 </script>
 
 <div class="header-left">
@@ -22,6 +23,12 @@
     >
     <div class="header-meta">
       <span class="branch-name">{branchName}</span>
+      {#if warning}
+        <span class="branch-warning" title={warning}>
+          <AlertTriangle size={12} />
+          <span>{warning}</span>
+        </span>
+      {/if}
       {#if secondaryLabel}
         <span class="meta-separator" aria-hidden="true">&middot;</span>
         <GitBranch size={12} />
@@ -30,9 +37,17 @@
     </div>
   {:else}
     <span class="repo-name">{branchName}</span>
-    {#if secondaryLabel}
+    {#if secondaryLabel || warning}
       <div class="header-meta">
-        <span class="base-branch-name" title={secondaryLabel}>{secondaryLabel}</span>
+        {#if secondaryLabel}
+          <span class="base-branch-name" title={secondaryLabel}>{secondaryLabel}</span>
+        {/if}
+        {#if warning}
+          <span class="branch-warning" title={warning}>
+            <AlertTriangle size={12} />
+            <span>{warning}</span>
+          </span>
+        {/if}
       </div>
     {/if}
   {/if}
@@ -79,6 +94,22 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .branch-warning {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    max-width: 180px;
+    color: var(--ui-warning, var(--status-modified));
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .branch-warning span {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .base-branch-name {

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -49,6 +49,7 @@
     SmartDiffAnnotation,
     Span,
   } from '../../types';
+  import type { DiffScope } from '../../commands';
   import { findFreshAutoReview, getSession } from '../../commands';
   import * as commands from '../../api/commands';
   import {
@@ -73,7 +74,7 @@
     projectId?: string | null;
     /** Optional — for branch scope, resolved automatically. */
     commitSha?: string;
-    scope?: 'branch' | 'commit';
+    scope?: DiffScope;
     /** When set, opens a specific existing review by ID instead of searching by triple. */
     reviewId?: string;
     /** Label for the before pane header. */
@@ -143,15 +144,15 @@
   // be needed to keep the effect firing on context switches.
   $effect(() => {
     const sha = diffViewer.state.commitSha;
-    if (sha && !reviewHandle && !readonly) {
+    if (sha && !reviewHandle && !readonly && activeScope !== 'worktree') {
       // svelte-ignore state_referenced_locally
-      reviewHandle = createReviewState(branchId, sha, activeScope, activeReviewId);
+      reviewHandle = createReviewState(branchId, sha, reviewableScope(), activeReviewId);
     }
   });
 
   // Context switcher state
   // svelte-ignore state_referenced_locally
-  let activeScope = $state<'branch' | 'commit'>(scope);
+  let activeScope = $state<DiffScope>(scope);
   // svelte-ignore state_referenced_locally
   let activeCommitSha = $state<string | undefined>(commitSha);
   // svelte-ignore state_referenced_locally
@@ -166,15 +167,21 @@
   /** Tracks the active auto-review reload promise so it can be ignored on stale switches. */
   let contextSwitchGeneration = 0;
 
+  function reviewableScope(): 'branch' | 'commit' {
+    return activeScope === 'worktree' ? 'branch' : activeScope;
+  }
+
   /** Label for the current context shown in the dropdown trigger. */
   let contextLabel = $derived(
-    activeScope === 'branch'
-      ? 'All changes'
-      : (commits?.find((c) => c.sha === activeCommitSha)?.subject ?? 'Commit')
+    activeScope === 'worktree'
+      ? 'Uncommitted changes'
+      : activeScope === 'branch'
+        ? 'All changes'
+        : (commits?.find((c) => c.sha === activeCommitSha)?.subject ?? 'Commit')
   );
 
   /** Whether the context switcher should be shown. */
-  let showContextSwitcher = $derived((commits?.length ?? 0) > 0);
+  let showContextSwitcher = $derived(activeScope !== 'worktree' && (commits?.length ?? 0) > 0);
 
   async function switchDiffContext(newScope: 'branch' | 'commit', newCommitSha?: string) {
     showContextDropdown = false;
@@ -420,7 +427,7 @@
     const prompt = buildCommentPrompt(comment, mode as 'note' | 'commit');
     const launchContext = {
       source: 'diff_viewer' as const,
-      scope: activeScope,
+      scope: reviewableScope(),
       commitSha: diffViewer.state.commitSha ?? '',
       reviewId: activeReviewId ?? null,
     };
@@ -500,7 +507,7 @@
     showNewSessionModal = false;
     const launchContext = {
       source: 'diff_viewer' as const,
-      scope: activeScope,
+      scope: reviewableScope(),
       commitSha: diffViewer.state.commitSha ?? '',
       reviewId: activeReviewId ?? null,
     };
@@ -1167,7 +1174,7 @@
           {branchId}
           {projectId}
           commitSha={diffViewer.state.commitSha}
-          scope={activeScope}
+          scope={reviewableScope()}
           reviewId={activeReviewId}
           visibleCommentCount={currentComments.length}
           onStarted={onClose}

--- a/apps/staged/src/lib/features/diff/diffViewerState.svelte.ts
+++ b/apps/staged/src/lib/features/diff/diffViewerState.svelte.ts
@@ -1,17 +1,131 @@
-// Re-export types and helpers from shared package
-export { fileSummaryPath, type DiffViewerState } from '@builderbot/diff-viewer/state';
+// Re-export helper from shared package
+export { fileSummaryPath } from '@builderbot/diff-viewer/state';
+export type { DiffViewerState as SharedDiffViewerState } from '@builderbot/diff-viewer/state';
 
-// Re-export with Staged's Tauri commands pre-bound
 import * as commands from '../../api/commands';
-import { createDiffViewerState as _create } from '@builderbot/diff-viewer/state';
+import type { DiffScope } from '../../commands';
+import type { FileDiff, FileDiffSummary } from '../../types';
+import { fileSummaryPath as sharedFileSummaryPath } from '@builderbot/diff-viewer/state';
+
+export interface DiffViewerState {
+  branchId: string;
+  commitSha: string | null;
+  scope: DiffScope;
+  files: FileDiffSummary[];
+  diffCache: Map<string, FileDiff>;
+  selectedFile: string | null;
+  loading: boolean;
+  loadingFile: string | null;
+  error: string | null;
+}
 
 /**
  * Create a reactive diff viewer state instance, pre-bound to Staged's Tauri commands.
  */
-export function createDiffViewerState(
-  branchId: string,
-  scope: 'branch' | 'commit',
-  commitSha?: string
-) {
-  return _create(commands, branchId, scope, commitSha);
+export function createDiffViewerState(branchId: string, scope: DiffScope, commitSha?: string) {
+  const state: DiffViewerState = $state({
+    branchId,
+    commitSha: commitSha ?? null,
+    scope,
+    files: [],
+    diffCache: new Map(),
+    selectedFile: null,
+    loading: true,
+    loadingFile: null,
+    error: null,
+  });
+
+  let selectionGeneration = 0;
+  let contextGeneration = 0;
+
+  async function loadFiles(generation: number): Promise<void> {
+    state.loading = true;
+    state.error = null;
+
+    try {
+      const response = await commands.getDiffFiles(
+        state.branchId,
+        state.commitSha ?? undefined,
+        state.scope
+      );
+      if (generation !== contextGeneration) return;
+
+      state.commitSha = response.commitSha;
+      state.files = response.files;
+
+      if (state.files.length > 0) {
+        await selectFile(sharedFileSummaryPath(state.files[0]));
+      }
+    } catch (e) {
+      if (generation !== contextGeneration) return;
+      state.error = e instanceof Error ? e.message : String(e);
+      state.files = [];
+    } finally {
+      if (generation === contextGeneration) {
+        state.loading = false;
+      }
+    }
+  }
+
+  async function selectFile(path: string | null): Promise<void> {
+    const thisGeneration = ++selectionGeneration;
+    state.selectedFile = path;
+
+    if (path && !state.diffCache.has(path)) {
+      await loadFileDiff(path);
+      if (selectionGeneration !== thisGeneration) return;
+    }
+  }
+
+  async function loadFileDiff(path: string): Promise<FileDiff | null> {
+    if (!state.commitSha) return null;
+
+    const cached = state.diffCache.get(path);
+    if (cached) return cached;
+
+    state.loadingFile = path;
+
+    try {
+      const diff = await commands.getFileDiff(state.branchId, state.commitSha, state.scope, path);
+      const newCache = new Map(state.diffCache);
+      newCache.set(path, diff);
+      state.diffCache = newCache;
+      return diff;
+    } catch (e) {
+      console.error(`Failed to load diff for ${path}:`, e);
+      return null;
+    } finally {
+      state.loadingFile = null;
+    }
+  }
+
+  function getCurrentDiff(): FileDiff | null {
+    if (!state.selectedFile) return null;
+    return state.diffCache.get(state.selectedFile) ?? null;
+  }
+
+  async function switchContext(
+    newScope: 'branch' | 'commit',
+    newCommitSha?: string
+  ): Promise<void> {
+    const generation = ++contextGeneration;
+    state.scope = newScope;
+    state.commitSha = newCommitSha ?? null;
+    state.diffCache = new Map();
+    state.selectedFile = null;
+    state.loadingFile = null;
+    state.files = [];
+    state.error = null;
+    await loadFiles(generation);
+  }
+
+  loadFiles(contextGeneration);
+
+  return {
+    state,
+    selectFile,
+    loadFileDiff,
+    getCurrentDiff,
+    switchContext,
+  };
 }

--- a/apps/staged/src/lib/features/sessions/SessionLauncher.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionLauncher.svelte
@@ -53,7 +53,7 @@
         if (s.id === sessionId) {
           return {
             ...s,
-            status: status as SessionStatus,
+            status,
             errorMessage: errorMessage ?? s.errorMessage,
             updatedAt: Date.now(),
           };

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -96,8 +96,6 @@
     pullingOrigin?: boolean;
     pushingOrigin?: boolean;
     discardingWorktreeChanges?: boolean;
-    /** Whether the timeline is being revalidated in the background. */
-    revalidating?: boolean;
     /** Error message from a failed load/revalidation. */
     error?: string | null;
     /** When set, git-mutating row actions are disabled with this reason. */
@@ -153,7 +151,6 @@
     pullingOrigin = false,
     pushingOrigin = false,
     discardingWorktreeChanges = false,
-    revalidating = false,
     error,
     gitActionDisabledReason,
     onRetry,
@@ -918,7 +915,6 @@
             pendingDropNotes.length === 0 &&
             pendingItems.length === 0 &&
             gitFooterItems.length === 0 &&
-            !revalidating &&
             !error &&
             !actionFooterVisible}
           sessionId={item.sessionId}
@@ -950,7 +946,6 @@
           isLast={index === pendingDropNotes.length - 1 &&
             pendingItems.length === 0 &&
             gitFooterItems.length === 0 &&
-            !revalidating &&
             !error &&
             !actionFooterVisible}
         />
@@ -971,7 +966,6 @@
             : item.secondaryMeta}
           isLast={index === pendingItems.length - 1 &&
             gitFooterItems.length === 0 &&
-            !revalidating &&
             !error &&
             !actionFooterVisible}
         />
@@ -1002,7 +996,7 @@
           onDiscardChangesClick={item.onDiscardChanges}
           discardChangesDisabledReason={item.discardChangesDisabledReason}
           deleting={item.deleting}
-          isLast={index === gitFooterItems.length - 1 && !revalidating && !error}
+          isLast={index === gitFooterItems.length - 1 && !error}
           sessionId={item.sessionId}
           deleteDisabledReason={isDeletable(item) ? item.deleteDisabledReason : undefined}
           commitSha={item.commitSha}
@@ -1023,16 +1017,7 @@
         />
       </div>
     {/each}
-    {#if revalidating}
-      <div transition:slide={{ duration: 200 }}>
-        <TimelineRow
-          type="revalidating"
-          title="Looking for changes..."
-          isLast={!actionFooterVisible}
-        />
-      </div>
-    {/if}
-    {#if error && !revalidating}
+    {#if error}
       <div transition:slide={{ duration: 200 }}>
         <TimelineRow
           type="load-error"

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -84,6 +84,9 @@
     onRebaseBranch?: () => void;
     onRebaseBranchOntoOrigin?: () => void;
     onForcePush?: () => void;
+    onOpenForcePushSession?: () => void;
+    forcePushingOrigin?: boolean;
+    onOpenPushSession?: () => void;
     rebaseBranchDisabledReason?: string | null;
     onViewWorktreeDiff?: () => void;
     onCommitWorktreeChanges?: () => void;
@@ -138,6 +141,9 @@
     onRebaseBranch,
     onRebaseBranchOntoOrigin,
     onForcePush,
+    onOpenForcePushSession,
+    forcePushingOrigin = false,
+    onOpenPushSession,
     rebaseBranchDisabledReason,
     onViewWorktreeDiff,
     onCommitWorktreeChanges,
@@ -243,6 +249,8 @@
     rebaseDisabledReason?: string;
     onForcePush?: () => void;
     forcePushDisabledReason?: string;
+    forcePushing?: boolean;
+    pushing?: boolean;
     onViewDiff?: () => void;
     onCommitChanges?: () => void;
     commitChangesDisabledReason?: string;
@@ -421,7 +429,7 @@
           );
           const summary = `is ${plural(state.upstream.ahead, 'commit')} behind`;
           const disabledReason = pushingOrigin
-            ? 'Pushing...'
+            ? undefined // button is clickable during push (opens session)
             : (rebaseBranchDisabledReason ?? undefined);
           rows.push({
             key: 'git-local-ahead',
@@ -430,8 +438,9 @@
             titleHtml: `<span class="git-ref-badge">origin</span> ${escapeHtml(summary)}`,
             timestamp: placement.timestamp,
             order: placement.order,
-            onPush: disabledReason ? undefined : onPushOrigin,
+            onPush: pushingOrigin ? onOpenPushSession : disabledReason ? undefined : onPushOrigin,
             pushDisabledReason: disabledReason,
+            pushing: pushingOrigin,
           });
         }
         break;
@@ -464,14 +473,24 @@
           titleHtml: `<span class="git-ref-badge">origin</span> diverges here and has ${escapeHtml(plural(behindCount, 'more commit'))}`,
           timestamp: placement.timestamp,
           order: placement.order,
-          onRebase: rebaseBranchDisabledReason ? undefined : onRebaseBranchOntoOrigin,
-          rebaseDisabledReason: onRebaseBranchOntoOrigin
-            ? (rebaseBranchDisabledReason ?? undefined)
-            : undefined,
-          onForcePush: rebaseBranchDisabledReason ? undefined : onForcePush,
-          forcePushDisabledReason: onForcePush
-            ? (rebaseBranchDisabledReason ?? undefined)
-            : undefined,
+          onRebase:
+            rebaseBranchDisabledReason || forcePushingOrigin ? undefined : onRebaseBranchOntoOrigin,
+          rebaseDisabledReason: forcePushingOrigin
+            ? 'Force push in progress'
+            : onRebaseBranchOntoOrigin
+              ? (rebaseBranchDisabledReason ?? undefined)
+              : undefined,
+          onForcePush: forcePushingOrigin
+            ? onOpenForcePushSession
+            : rebaseBranchDisabledReason
+              ? undefined
+              : onForcePush,
+          forcePushDisabledReason: forcePushingOrigin
+            ? undefined
+            : onForcePush
+              ? (rebaseBranchDisabledReason ?? undefined)
+              : undefined,
+          forcePushing: forcePushingOrigin,
         });
         break;
       }
@@ -887,6 +906,8 @@
           rebaseDisabledReason={item.rebaseDisabledReason}
           onForcePushClick={item.onForcePush}
           forcePushDisabledReason={item.forcePushDisabledReason}
+          forcePushing={item.forcePushing}
+          pushing={item.pushing}
           onViewDiffClick={item.onViewDiff}
           onCommitChangesClick={item.onCommitChanges}
           commitChangesDisabledReason={item.commitChangesDisabledReason}
@@ -973,6 +994,8 @@
           rebaseDisabledReason={item.rebaseDisabledReason}
           onForcePushClick={item.onForcePush}
           forcePushDisabledReason={item.forcePushDisabledReason}
+          forcePushing={item.forcePushing}
+          pushing={item.pushing}
           onViewDiffClick={item.onViewDiff}
           onCommitChangesClick={item.onCommitChanges}
           commitChangesDisabledReason={item.commitChangesDisabledReason}

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -2,7 +2,8 @@
   BranchTimeline.svelte - Renders the unified timeline for a branch
 
   Commits, notes, and reviews are merged by timestamp into a single linear list.
-  Active pending items (running sessions, generating notes) appear at the bottom.
+  Active pending items (running sessions, generating notes) appear near the bottom.
+  Bottom git status rows appear below active and queued work.
   Failed sessions appear in chronological order with completed items.
 -->
 <script lang="ts">
@@ -11,11 +12,15 @@
   import { slide } from 'svelte/transition';
   import { FileText, GitCommitVertical, FileSearch, Plus } from 'lucide-svelte';
   import { isResumableReason } from '../../types';
-  import type { BranchTimeline as BranchTimelineData, HashtagItem } from '../../types';
+  import type {
+    BranchGitState,
+    BranchTimeline as BranchTimelineData,
+    HashtagItem,
+  } from '../../types';
   import TimelineRow from './TimelineRow.svelte';
   import type { TimelineItemType, TimelineBadge } from './TimelineRow.svelte';
   import TimelineContextMenu from './TimelineContextMenu.svelte';
-  import { hasHashtagTokens, renderHashtagTokens } from '../sessions/hashtagItems';
+  import { escapeHtml, hasHashtagTokens, renderHashtagTokens } from '../sessions/hashtagItems';
   import {
     formatRelativeTime,
     formatRelativeTimeSeconds,
@@ -74,12 +79,26 @@
     onNewNote?: () => void;
     onNewCommit?: () => void;
     onNewReview?: (e: MouseEvent) => void;
+    onPullOrigin?: () => void;
+    onPushOrigin?: () => void;
+    onRebaseBranch?: () => void;
+    onRebaseBranchOntoOrigin?: () => void;
+    onForcePush?: () => void;
+    rebaseBranchDisabledReason?: string | null;
+    onViewWorktreeDiff?: () => void;
+    onCommitWorktreeChanges?: () => void;
+    onDiscardWorktreeChanges?: () => void;
     onNewSessionReferring?: (hashtagRef: string) => void;
     newSessionDisabled?: boolean;
+    pullingOrigin?: boolean;
+    pushingOrigin?: boolean;
+    discardingWorktreeChanges?: boolean;
     /** Whether the timeline is being revalidated in the background. */
     revalidating?: boolean;
     /** Error message from a failed load/revalidation. */
     error?: string | null;
+    /** When set, git-mutating row actions are disabled with this reason. */
+    gitActionDisabledReason?: string | null;
     /** Callback to retry loading the timeline. */
     onRetry?: () => void;
     /** When set, a provisioning row is shown at the start of the timeline. */
@@ -114,10 +133,23 @@
     onNewNote,
     onNewCommit,
     onNewReview,
+    onPullOrigin,
+    onPushOrigin,
+    onRebaseBranch,
+    onRebaseBranchOntoOrigin,
+    onForcePush,
+    rebaseBranchDisabledReason,
+    onViewWorktreeDiff,
+    onCommitWorktreeChanges,
+    onDiscardWorktreeChanges,
     onNewSessionReferring,
     newSessionDisabled = false,
+    pullingOrigin = false,
+    pushingOrigin = false,
+    discardingWorktreeChanges = false,
     revalidating = false,
     error,
+    gitActionDisabledReason,
     onRetry,
     provisioningLabel,
     hashtagItems = [],
@@ -203,11 +235,38 @@
     imageId?: string;
     imageFilename?: string;
     badges?: TimelineBadge[];
+    onPull?: () => void;
+    pullDisabledReason?: string;
+    onPush?: () => void;
+    pushDisabledReason?: string;
+    onRebase?: () => void;
+    rebaseDisabledReason?: string;
+    onForcePush?: () => void;
+    forcePushDisabledReason?: string;
+    onViewDiff?: () => void;
+    onCommitChanges?: () => void;
+    commitChangesDisabledReason?: string;
+    onDiscardChanges?: () => void;
+    discardChangesDisabledReason?: string;
     /** When set, delete button is shown but disabled with this tooltip. */
     deleteDisabledReason?: string;
     completionReason?: string | null;
     /** Hashtag reference token for context menu (e.g. "#commit:abc123"). */
     hashtagRef?: string;
+    showConnector?: boolean;
+    placement?: 'git-footer';
+  };
+
+  type CommitAnchor = {
+    timestamp: number;
+    order: number;
+    shortSha?: string;
+  };
+
+  type TimelinePlacement = {
+    timestamp: number;
+    order: number;
+    anchor?: CommitAnchor;
   };
 
   let runningSessionIds = $derived.by(() => collectRunningSessionIds(timeline, pendingItems));
@@ -229,6 +288,16 @@
     return false;
   });
 
+  let hasActiveCommitSession = $derived.by(() => {
+    for (const commit of timeline.commits) {
+      if (commit.sessionStatus === 'running') return true;
+    }
+    for (const item of pendingItems) {
+      if (item.type === 'pending-commit' && item.sessionId) return true;
+    }
+    return false;
+  });
+
   $effect(() => {
     liveSessionHintPoller.syncRunningSessionIds(runningSessionIds);
   });
@@ -237,10 +306,210 @@
     liveSessionHintPoller.destroy();
   });
 
+  function plural(count: number, noun: string): string {
+    return `${count} ${noun}${count === 1 ? '' : 's'}`;
+  }
+
+  function worktreeSummary(state: BranchGitState): string {
+    const parts: string[] = [];
+    if (state.worktree.conflicted > 0) parts.push(plural(state.worktree.conflicted, 'conflict'));
+    if (state.worktree.staged > 0) parts.push(`${state.worktree.staged} staged`);
+    if (state.worktree.unstaged > 0) parts.push(`${state.worktree.unstaged} unstaged`);
+    if (state.worktree.untracked > 0) parts.push(`${state.worktree.untracked} untracked`);
+    return parts.join(', ');
+  }
+
+  function withDetail(title: string, detail: string): string {
+    return detail ? `${title}: ${detail}` : title;
+  }
+
+  function pullDisabledReason(state: BranchGitState): string | undefined {
+    if (pullingOrigin) return 'Pulling...';
+    if (state.detachedHead) return 'Detached HEAD';
+    if (!state.expectedBranchMatches) {
+      return state.currentBranch ? `Checked out ${state.currentBranch}` : 'Wrong branch';
+    }
+    if (state.worktree.dirty) return 'Clean worktree required';
+    if (state.upstream.relation !== 'originAhead') return 'Not fast-forwardable';
+    return undefined;
+  }
+
+  function timelinePlacementAfter(
+    commitAnchors: Map<string, CommitAnchor>,
+    sha: string | null | undefined,
+    fallbackTimestamp: number,
+    fallbackOrder: number,
+    offset = 0.25
+  ): TimelinePlacement {
+    const anchor = sha ? commitAnchors.get(sha) : undefined;
+    if (!anchor) {
+      return { timestamp: fallbackTimestamp, order: fallbackOrder };
+    }
+    return {
+      timestamp: anchor.timestamp,
+      order: anchor.order + offset,
+      anchor,
+    };
+  }
+
+  function baseDisplayName(ref: string): string {
+    return ref.replace(/^refs\/remotes\/origin\//, '').replace(/^origin\//, '');
+  }
+
+  function baseMovedTitleHtml(ref: string, count: number): string {
+    const branchName = baseDisplayName(ref);
+    return `<span class="git-ref-badge">${escapeHtml(branchName)}</span> has ${escapeHtml(
+      plural(count, 'new commit')
+    )}`;
+  }
+
+  function gitStateRows(
+    state: BranchGitState,
+    commitAnchors: Map<string, CommitAnchor>
+  ): DisplayItem[] {
+    const rows: DisplayItem[] = [];
+    const topTimestamp = 0;
+    const bottomTimestamp = Number.MAX_SAFE_INTEGER - 1000;
+    const commitChangesDisabledReason = gitActionDisabledReason
+      ? gitActionDisabledReason
+      : newSessionDisabled
+        ? 'Session in progress'
+        : undefined;
+    const discardChangesDisabledReason = discardingWorktreeChanges
+      ? 'Discarding...'
+      : gitActionDisabledReason
+        ? gitActionDisabledReason
+        : hasActiveSession
+          ? 'Session in progress'
+          : undefined;
+
+    if (state.fetch.status === 'failed') {
+      rows.push({
+        key: 'git-fetch-failed',
+        type: 'git-warning',
+        title: 'Could not refresh git state',
+        timestamp: topTimestamp,
+        order: 0,
+      });
+    }
+
+    if (state.base.commitsSinceFork > 0) {
+      rows.push({
+        key: 'git-base-moved',
+        type: 'git-merge',
+        title: `${baseDisplayName(state.base.ref)} has ${plural(state.base.commitsSinceFork, 'new commit')}`,
+        titleHtml: baseMovedTitleHtml(state.base.ref, state.base.commitsSinceFork),
+        timestamp: topTimestamp,
+        order: 1,
+        onRebase: rebaseBranchDisabledReason ? undefined : onRebaseBranch,
+        rebaseDisabledReason: onRebaseBranch
+          ? (rebaseBranchDisabledReason ?? undefined)
+          : undefined,
+      });
+    }
+
+    switch (state.upstream.relation) {
+      case 'missing':
+        break;
+      case 'localAhead':
+        {
+          const placement = timelinePlacementAfter(
+            commitAnchors,
+            state.upstream.sha,
+            topTimestamp,
+            2
+          );
+          const summary = `is ${plural(state.upstream.ahead, 'commit')} behind`;
+          const disabledReason = pushingOrigin
+            ? 'Pushing...'
+            : (rebaseBranchDisabledReason ?? undefined);
+          rows.push({
+            key: 'git-local-ahead',
+            type: 'git-push',
+            title: `origin ${summary}`,
+            titleHtml: `<span class="git-ref-badge">origin</span> ${escapeHtml(summary)}`,
+            timestamp: placement.timestamp,
+            order: placement.order,
+            onPush: disabledReason ? undefined : onPushOrigin,
+            pushDisabledReason: disabledReason,
+          });
+        }
+        break;
+      case 'originAhead': {
+        const disabledReason = pullDisabledReason(state);
+        rows.push({
+          key: 'git-origin-ahead',
+          type: 'git-pull',
+          title: `Origin has ${plural(state.upstream.behind, 'new commit')}`,
+          timestamp: bottomTimestamp,
+          order: 1,
+          placement: 'git-footer',
+          onPull: disabledReason ? undefined : onPullOrigin,
+          pullDisabledReason: disabledReason,
+        });
+        break;
+      }
+      case 'diverged': {
+        const placement = timelinePlacementAfter(
+          commitAnchors,
+          state.upstream.mergeBaseSha,
+          topTimestamp,
+          2
+        );
+        const behindCount = state.upstream.behind;
+        rows.push({
+          key: 'git-diverged',
+          type: 'git-merge-warning',
+          title: `origin diverges here and has ${plural(behindCount, 'more commit')}`,
+          titleHtml: `<span class="git-ref-badge">origin</span> diverges here and has ${escapeHtml(plural(behindCount, 'more commit'))}`,
+          timestamp: placement.timestamp,
+          order: placement.order,
+          onRebase: rebaseBranchDisabledReason ? undefined : onRebaseBranchOntoOrigin,
+          rebaseDisabledReason: onRebaseBranchOntoOrigin
+            ? (rebaseBranchDisabledReason ?? undefined)
+            : undefined,
+          onForcePush: rebaseBranchDisabledReason ? undefined : onForcePush,
+          forcePushDisabledReason: onForcePush
+            ? (rebaseBranchDisabledReason ?? undefined)
+            : undefined,
+        });
+        break;
+      }
+    }
+
+    if (state.worktree.conflicted > 0 && !hasActiveCommitSession) {
+      rows.push({
+        key: 'git-conflicted',
+        type: 'git-warning',
+        title: withDetail('Merge conflicts in worktree', worktreeSummary(state)),
+        timestamp: bottomTimestamp,
+        order: 2,
+        placement: 'git-footer',
+      });
+    } else if (state.worktree.dirty && !hasActiveCommitSession) {
+      rows.push({
+        key: 'git-dirty',
+        type: 'git-diff',
+        title: withDetail('Uncommitted changes', worktreeSummary(state)),
+        timestamp: bottomTimestamp,
+        order: 2,
+        placement: 'git-footer',
+        onViewDiff: onViewWorktreeDiff,
+        onCommitChanges: commitChangesDisabledReason ? undefined : onCommitWorktreeChanges,
+        commitChangesDisabledReason,
+        onDiscardChanges: discardChangesDisabledReason ? undefined : onDiscardWorktreeChanges,
+        discardChangesDisabledReason,
+      });
+    }
+
+    return rows;
+  }
+
   // Merge commits, notes, and reviews into a single sorted list
   let items = $derived.by(() => {
     const nowMs = minuteNow.now();
     const all: DisplayItem[] = [];
+    const commitAnchors = new Map<string, CommitAnchor>();
     const deletingCommitIds = new Set(
       deletingItems.filter((item) => item.type === 'commit').map((item) => item.id)
     );
@@ -293,10 +562,22 @@
         sessionId: commit.sessionId ?? undefined,
         commitSha: commit.sha || undefined,
         commitId: commit.id ?? undefined,
-        deleteDisabledReason: isDeleting ? 'Deleting...' : undefined,
+        deleteDisabledReason: isDeleting
+          ? 'Deleting...'
+          : type === 'commit'
+            ? (gitActionDisabledReason ?? undefined)
+            : undefined,
         completionReason: commit.completionReason,
         hashtagRef: type === 'commit' ? `#commit:${commit.sha}` : undefined,
       });
+
+      if (type === 'commit' && commit.sha) {
+        commitAnchors.set(commit.sha, {
+          timestamp: commit.timestamp,
+          order: commit.order,
+          shortSha: commit.shortSha || undefined,
+        });
+      }
     }
 
     for (const note of timeline.notes) {
@@ -424,6 +705,10 @@
       });
     }
 
+    if (timeline.gitState) {
+      all.push(...gitStateRows(timeline.gitState, commitAnchors));
+    }
+
     // Provisioning row appears at the very start of the timeline
     if (provisioningLabel) {
       all.unshift({
@@ -484,6 +769,12 @@
     return all;
   });
 
+  let normalItems = $derived(items.filter((item) => item.placement !== 'git-footer'));
+  let gitFooterItems = $derived(items.filter((item) => item.placement === 'git-footer'));
+  let actionFooterVisible = $derived(
+    !!onNewNote || !!onNewCommit || !!onNewReview || !!footerActions
+  );
+
   /** True when the timeline has no content and action buttons should be enlarged. */
   let actionButtonsEnlarged = $derived(
     items.length === 0 && pendingDropNotes.length === 0 && pendingItems.length === 0
@@ -543,14 +834,43 @@
       onDeleteImage(item.imageId, opts);
     }
   }
+
+  function isDeletable(item: DisplayItem): boolean {
+    if (item.type === 'commit') return !!item.commitSha && !!onDeleteCommit;
+    if (
+      item.type === 'failed-commit' ||
+      item.type === 'pending-commit' ||
+      item.type === 'queued-commit'
+    ) {
+      return !!item.commitId && !!onDeletePendingCommit;
+    }
+    if (
+      item.type === 'note' ||
+      item.type === 'failed-note' ||
+      item.type === 'generating-note' ||
+      item.type === 'queued-note'
+    ) {
+      return !!item.noteId && !!onDeleteNote;
+    }
+    if (
+      item.type === 'review' ||
+      item.type === 'failed-review' ||
+      item.type === 'generating-review' ||
+      item.type === 'queued-review'
+    ) {
+      return !!item.reviewId && !!onDeleteReview;
+    }
+    if (item.type === 'image') return !!item.imageId && !!onDeleteImage;
+    return false;
+  }
 </script>
 
-{#if items.length === 0 && !onNewNote && !onNewCommit && !onNewReview && pendingDropNotes.length === 0 && pendingItems.length === 0}
+{#if items.length === 0 && !actionFooterVisible && pendingDropNotes.length === 0 && pendingItems.length === 0}
   <p class="no-items">No commits or notes yet</p>
 {:else}
   <!-- Unified timeline (vertical) -->
   <div class="timeline">
-    {#each items as item, index (item.key)}
+    {#each normalItems as item, index (item.key)}
       <div in:maybeSlide={{ sessionId: item.sessionId }} out:slide={{ duration: 200 }}>
         <TimelineRow
           type={item.type}
@@ -559,22 +879,36 @@
           meta={item.meta}
           secondaryMeta={item.secondaryMeta}
           badges={item.badges}
+          onPullClick={item.onPull}
+          pullDisabledReason={item.pullDisabledReason}
+          onPushClick={item.onPush}
+          pushDisabledReason={item.pushDisabledReason}
+          onRebaseClick={item.onRebase}
+          rebaseDisabledReason={item.rebaseDisabledReason}
+          onForcePushClick={item.onForcePush}
+          forcePushDisabledReason={item.forcePushDisabledReason}
+          onViewDiffClick={item.onViewDiff}
+          onCommitChangesClick={item.onCommitChanges}
+          commitChangesDisabledReason={item.commitChangesDisabledReason}
+          onDiscardChangesClick={item.onDiscardChanges}
+          discardChangesDisabledReason={item.discardChangesDisabledReason}
           deleting={item.deleting}
-          isLast={index === items.length - 1 &&
-            !onNewNote &&
-            !onNewCommit &&
+          isLast={index === normalItems.length - 1 &&
             pendingDropNotes.length === 0 &&
             pendingItems.length === 0 &&
+            gitFooterItems.length === 0 &&
             !revalidating &&
-            !error}
+            !error &&
+            !actionFooterVisible}
           sessionId={item.sessionId}
-          deleteDisabledReason={item.deleteDisabledReason}
+          deleteDisabledReason={isDeletable(item) ? item.deleteDisabledReason : undefined}
           commitSha={item.commitSha}
           hashtagRef={item.hashtagRef}
+          showConnector={item.showConnector}
           onContextMenu={(e) => contextMenuRef?.open(e)}
           {onSessionClick}
           onItemClick={() => handleItemClick(item)}
-          onDeleteClick={item.deleteDisabledReason
+          onDeleteClick={!isDeletable(item) || item.deleteDisabledReason
             ? undefined
             : (opts) => handleDeleteClick(item, opts)}
           onStartClick={item.type.startsWith('queued-') && !hasActiveSession
@@ -594,10 +928,10 @@
           secondaryMeta="adding..."
           isLast={index === pendingDropNotes.length - 1 &&
             pendingItems.length === 0 &&
+            gitFooterItems.length === 0 &&
             !revalidating &&
             !error &&
-            !onNewNote &&
-            !onNewCommit}
+            !actionFooterVisible}
         />
       </div>
     {/each}
@@ -615,10 +949,54 @@
               fallbackHintForPendingType(item.type))
             : item.secondaryMeta}
           isLast={index === pendingItems.length - 1 &&
+            gitFooterItems.length === 0 &&
             !revalidating &&
             !error &&
-            !onNewNote &&
-            !onNewCommit}
+            !actionFooterVisible}
+        />
+      </div>
+    {/each}
+    {#each gitFooterItems as item, index (item.key)}
+      <div transition:slide={{ duration: 200 }}>
+        <TimelineRow
+          type={item.type}
+          title={item.title}
+          titleHtml={item.titleHtml}
+          meta={item.meta}
+          secondaryMeta={item.secondaryMeta}
+          badges={item.badges}
+          onPullClick={item.onPull}
+          pullDisabledReason={item.pullDisabledReason}
+          onPushClick={item.onPush}
+          pushDisabledReason={item.pushDisabledReason}
+          onRebaseClick={item.onRebase}
+          rebaseDisabledReason={item.rebaseDisabledReason}
+          onForcePushClick={item.onForcePush}
+          forcePushDisabledReason={item.forcePushDisabledReason}
+          onViewDiffClick={item.onViewDiff}
+          onCommitChangesClick={item.onCommitChanges}
+          commitChangesDisabledReason={item.commitChangesDisabledReason}
+          onDiscardChangesClick={item.onDiscardChanges}
+          discardChangesDisabledReason={item.discardChangesDisabledReason}
+          deleting={item.deleting}
+          isLast={index === gitFooterItems.length - 1 && !revalidating && !error}
+          sessionId={item.sessionId}
+          deleteDisabledReason={isDeletable(item) ? item.deleteDisabledReason : undefined}
+          commitSha={item.commitSha}
+          hashtagRef={item.hashtagRef}
+          showConnector={item.showConnector}
+          onContextMenu={(e) => contextMenuRef?.open(e)}
+          {onSessionClick}
+          onItemClick={() => handleItemClick(item)}
+          onDeleteClick={!isDeletable(item) || item.deleteDisabledReason
+            ? undefined
+            : (opts) => handleDeleteClick(item, opts)}
+          onStartClick={item.type.startsWith('queued-') && !hasActiveSession
+            ? onStartQueued
+            : undefined}
+          onResumeClick={isResumable(item) && onResumeClick && item.sessionId && !hasActiveSession
+            ? () => onResumeClick!(item.sessionId!)
+            : undefined}
         />
       </div>
     {/each}
@@ -627,7 +1005,7 @@
         <TimelineRow
           type="revalidating"
           title="Looking for changes..."
-          isLast={!error && !onNewNote && !onNewCommit}
+          isLast={!actionFooterVisible}
         />
       </div>
     {/if}
@@ -637,12 +1015,12 @@
           type="load-error"
           title="Failed to load commits"
           secondaryMeta={error}
-          isLast={true}
+          isLast={!actionFooterVisible}
           onRetryClick={onRetry}
         />
       </div>
     {/if}
-    {#if onNewNote || onNewCommit || onNewReview || footerActions}
+    {#if actionFooterVisible}
       <div class="footer-row" class:footer-row-enlarged={actionButtonsEnlarged}>
         <div class="footer-left-actions" class:footer-left-actions-enlarged={actionButtonsEnlarged}>
           {#if onNewNote}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -7,6 +7,7 @@
 <script lang="ts">
   import {
     GitCommitVertical,
+    FileDiff,
     FileText,
     FileSearch,
     Image as ImageLucide,
@@ -14,6 +15,9 @@
     Trash2,
     AlertTriangle,
     Clock,
+    GitBranch,
+    GitMerge,
+    ChevronsDown,
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
 
@@ -31,6 +35,13 @@
     | 'queued-review'
     | 'failed-review'
     | 'image'
+    | 'git-info'
+    | 'git-warning'
+    | 'git-merge'
+    | 'git-merge-warning'
+    | 'git-pull'
+    | 'git-push'
+    | 'git-diff'
     | 'revalidating'
     | 'provisioning'
     | 'load-error';
@@ -67,6 +78,20 @@
     onRetryClick?: () => void;
     onStartClick?: () => void;
     onResumeClick?: () => void;
+    onPullClick?: () => void;
+    pullDisabledReason?: string;
+    onPushClick?: () => void;
+    pushDisabledReason?: string;
+    onRebaseClick?: () => void;
+    rebaseDisabledReason?: string;
+    onForcePushClick?: () => void;
+    forcePushDisabledReason?: string;
+    onViewDiffClick?: () => void;
+    onCommitChangesClick?: () => void;
+    commitChangesDisabledReason?: string;
+    onDiscardChangesClick?: () => void;
+    discardChangesDisabledReason?: string;
+    showConnector?: boolean;
     /** Full commit SHA for the context menu "Copy SHA" action. */
     commitSha?: string;
     /** Hashtag reference token (e.g. "#commit:abc123") for "New session referring to this". */
@@ -92,6 +117,20 @@
     onRetryClick,
     onStartClick,
     onResumeClick,
+    onPullClick,
+    pullDisabledReason,
+    onPushClick,
+    pushDisabledReason,
+    onRebaseClick,
+    rebaseDisabledReason,
+    onForcePushClick,
+    forcePushDisabledReason,
+    onViewDiffClick,
+    onCommitChangesClick,
+    commitChangesDisabledReason,
+    onDiscardChangesClick,
+    discardChangesDisabledReason,
+    showConnector = true,
     commitSha,
     hashtagRef,
     onContextMenu,
@@ -110,6 +149,15 @@
       type === 'failed-review'
   );
   let isImage = $derived(type === 'image');
+  let isGitState = $derived(
+    type === 'git-info' ||
+      type === 'git-warning' ||
+      type === 'git-merge' ||
+      type === 'git-merge-warning' ||
+      type === 'git-pull' ||
+      type === 'git-push' ||
+      type === 'git-diff'
+  );
   let isQueued = $derived(
     type === 'queued-commit' || type === 'queued-note' || type === 'queued-review'
   );
@@ -165,6 +213,41 @@
     onResumeClick?.();
   }
 
+  function handlePullClick(e: MouseEvent) {
+    e.stopPropagation();
+    onPullClick?.();
+  }
+
+  function handlePushClick(e: MouseEvent) {
+    e.stopPropagation();
+    onPushClick?.();
+  }
+
+  function handleRebaseClick(e: MouseEvent) {
+    e.stopPropagation();
+    onRebaseClick?.();
+  }
+
+  function handleForcePushClick(e: MouseEvent) {
+    e.stopPropagation();
+    onForcePushClick?.();
+  }
+
+  function handleViewDiffClick(e: MouseEvent) {
+    e.stopPropagation();
+    onViewDiffClick?.();
+  }
+
+  function handleCommitChangesClick(e: MouseEvent) {
+    e.stopPropagation();
+    onCommitChangesClick?.();
+  }
+
+  function handleDiscardChangesClick(e: MouseEvent) {
+    e.stopPropagation();
+    onDiscardChangesClick?.();
+  }
+
   // ── Context menu ────────────────────────────────────────────────────
   let hasContextMenu = $derived(!!commitSha || !!hashtagRef);
 
@@ -183,6 +266,7 @@
   class:pending={isPending}
   class:failed={isFailed}
   class:clickable={isClickable}
+  class:git-state={isGitState}
   class:compact={type === 'revalidating' || type === 'load-error'}
   onclick={handleRowClick}
   oncontextmenu={handleContextMenu}
@@ -196,6 +280,8 @@
         type === 'generating-review' ||
         type === 'queued-review'}
       class:image-icon={isImage}
+      class:branch-icon={isGitState}
+      class:warning-icon={type === 'git-warning' || type === 'git-merge-warning'}
       class:failed-icon={isFailed}
     >
       {#if isQueued}
@@ -204,6 +290,16 @@
         <Spinner size={12} />
       {:else if isFailed}
         <AlertTriangle size={12} />
+      {:else if type === 'git-warning'}
+        <AlertTriangle size={12} />
+      {:else if type === 'git-merge' || type === 'git-merge-warning'}
+        <GitMerge size={12} />
+      {:else if type === 'git-pull'}
+        <ChevronsDown size={12} />
+      {:else if type === 'git-push'}
+        <ChevronsDown size={12} />
+      {:else if type === 'git-diff'}
+        <FileDiff size={12} />
       {:else if type === 'commit'}
         <GitCommitVertical size={12} />
       {:else if isNote}
@@ -212,9 +308,11 @@
         <FileSearch size={12} />
       {:else if isImage}
         <ImageLucide size={12} />
+      {:else if isGitState}
+        <GitBranch size={12} />
       {/if}
     </div>
-    {#if !isLast}
+    {#if showConnector && !isLast}
       <div class="timeline-line"></div>
     {/if}
   </div>
@@ -254,7 +352,22 @@
     </div>
     <div
       class="timeline-actions"
-      class:always-visible={!!onRetryClick || !!onStartClick || !!onResumeClick}
+      class:always-visible={!!onRetryClick ||
+        !!onStartClick ||
+        !!onResumeClick ||
+        !!onPullClick ||
+        !!pullDisabledReason ||
+        !!onPushClick ||
+        !!pushDisabledReason ||
+        !!onRebaseClick ||
+        !!rebaseDisabledReason ||
+        !!onForcePushClick ||
+        !!forcePushDisabledReason ||
+        !!onViewDiffClick ||
+        !!onCommitChangesClick ||
+        !!commitChangesDisabledReason ||
+        !!onDiscardChangesClick ||
+        !!discardChangesDisabledReason}
     >
       {#if onStartClick}
         <button class="action-btn start-btn" onclick={handleStartClick} title="Start">
@@ -269,6 +382,71 @@
       {#if onResumeClick}
         <button class="action-btn resume-btn" onclick={handleResumeClick} title="Resume session">
           Resume
+        </button>
+      {/if}
+      {#if onPullClick || pullDisabledReason}
+        <button
+          class="action-btn resume-btn"
+          onclick={handlePullClick}
+          disabled={!!pullDisabledReason}
+          title={pullDisabledReason ?? 'Pull'}
+        >
+          Pull
+        </button>
+      {/if}
+      {#if onPushClick || pushDisabledReason}
+        <button
+          class="action-btn resume-btn"
+          onclick={handlePushClick}
+          disabled={!!pushDisabledReason}
+          title={pushDisabledReason ?? 'Push'}
+        >
+          Push
+        </button>
+      {/if}
+      {#if onForcePushClick || forcePushDisabledReason}
+        <button
+          class="action-btn danger-btn"
+          onclick={handleForcePushClick}
+          disabled={!!forcePushDisabledReason}
+          title={forcePushDisabledReason ?? 'Force push local branch to origin'}
+        >
+          Force Push
+        </button>
+      {/if}
+      {#if onRebaseClick || rebaseDisabledReason}
+        <button
+          class="action-btn resume-btn"
+          onclick={handleRebaseClick}
+          disabled={!!rebaseDisabledReason}
+          title={rebaseDisabledReason ?? 'Rebase'}
+        >
+          Rebase
+        </button>
+      {/if}
+      {#if onViewDiffClick}
+        <button class="action-btn resume-btn" onclick={handleViewDiffClick} title="View diff">
+          Diff
+        </button>
+      {/if}
+      {#if onCommitChangesClick || commitChangesDisabledReason}
+        <button
+          class="action-btn resume-btn"
+          onclick={handleCommitChangesClick}
+          disabled={!!commitChangesDisabledReason}
+          title={commitChangesDisabledReason ?? 'Commit changes'}
+        >
+          Commit
+        </button>
+      {/if}
+      {#if onDiscardChangesClick || discardChangesDisabledReason}
+        <button
+          class="action-btn resume-btn"
+          onclick={handleDiscardChangesClick}
+          disabled={!!discardChangesDisabledReason}
+          title={discardChangesDisabledReason ?? 'Discard changes'}
+        >
+          Discard
         </button>
       {/if}
       {#if hasSession && !onStartClick && !isQueued}
@@ -339,6 +517,13 @@
     margin-top: 6px;
   }
 
+  .timeline-row.git-state .timeline-line {
+    flex: none;
+    height: 6px;
+    min-height: 0;
+    margin-top: 6px;
+  }
+
   .timeline-content {
     flex: 1;
     display: flex;
@@ -380,6 +565,18 @@
   .timeline-icon.image-icon {
     color: var(--image-color);
     background-color: var(--image-bg);
+    border-color: transparent;
+  }
+
+  .timeline-icon.branch-icon {
+    color: var(--text-muted);
+    background-color: var(--bg-hover);
+    border-color: transparent;
+  }
+
+  .timeline-icon.warning-icon {
+    color: var(--ui-danger);
+    background-color: var(--ui-danger-bg);
     border-color: transparent;
   }
 
@@ -443,6 +640,29 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     line-height: 1.4;
+  }
+
+  .timeline-row.git-state .timeline-title {
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+
+  .timeline-title :global(.git-ref-badge) {
+    display: inline;
+    padding: 1px 6px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    font: inherit;
+    font-weight: 600;
+    line-height: inherit;
+    vertical-align: baseline;
+  }
+
+  .timeline-row.git-state .timeline-title :global(.git-ref-badge) {
+    color: var(--text-muted);
+    font-weight: inherit;
   }
 
   .skeleton-title {
@@ -531,7 +751,8 @@
     background: var(--bg-hover);
   }
 
-  .delete-btn:disabled {
+  .delete-btn:disabled,
+  .action-btn:disabled {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -559,6 +780,21 @@
     border-color: var(--border-muted);
     color: var(--text-primary);
     background: var(--bg-hover);
+  }
+
+  .danger-btn {
+    width: auto;
+    padding: 0 8px;
+    font-size: var(--size-xs);
+    font-weight: 500;
+    border: 1px solid var(--ui-danger-bg, var(--ui-danger));
+    border-radius: 6px;
+    color: var(--ui-danger);
+  }
+
+  .danger-btn:not(:disabled):hover {
+    background: var(--ui-danger-bg, rgba(255, 59, 48, 0.1));
+    border-color: var(--ui-danger);
   }
 
   .start-btn {

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -86,6 +86,8 @@
     rebaseDisabledReason?: string;
     onForcePushClick?: () => void;
     forcePushDisabledReason?: string;
+    forcePushing?: boolean;
+    pushing?: boolean;
     onViewDiffClick?: () => void;
     onCommitChangesClick?: () => void;
     commitChangesDisabledReason?: string;
@@ -125,6 +127,8 @@
     rebaseDisabledReason,
     onForcePushClick,
     forcePushDisabledReason,
+    forcePushing = false,
+    pushing = false,
     onViewDiffClick,
     onCommitChangesClick,
     commitChangesDisabledReason,
@@ -399,19 +403,20 @@
           class="action-btn resume-btn"
           onclick={handlePushClick}
           disabled={!!pushDisabledReason}
-          title={pushDisabledReason ?? 'Push'}
+          title={pushDisabledReason ?? (pushing ? 'View push session' : 'Push')}
         >
-          Push
+          {pushing ? 'Pushing\u2026' : 'Push'}
         </button>
       {/if}
       {#if onForcePushClick || forcePushDisabledReason}
         <button
-          class="action-btn danger-btn"
+          class="action-btn {forcePushing ? 'resume-btn' : 'danger-btn'}"
           onclick={handleForcePushClick}
           disabled={!!forcePushDisabledReason}
-          title={forcePushDisabledReason ?? 'Force push local branch to origin'}
+          title={forcePushDisabledReason ??
+            (forcePushing ? 'View push session' : 'Force push local branch to origin')}
         >
-          Force Push
+          {forcePushing ? 'Pushing\u2026' : 'Force Push'}
         </button>
       {/if}
       {#if onRebaseClick || rebaseDisabledReason}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -42,7 +42,6 @@
     | 'git-pull'
     | 'git-push'
     | 'git-diff'
-    | 'revalidating'
     | 'provisioning'
     | 'load-error';
 
@@ -171,7 +170,6 @@
       type === 'pending-commit' ||
       type === 'generating-note' ||
       type === 'generating-review' ||
-      type === 'revalidating' ||
       type === 'provisioning'
   );
   let isFailed = $derived(
@@ -270,8 +268,8 @@
   class:pending={isPending}
   class:failed={isFailed}
   class:clickable={isClickable}
-  class:git-state={isGitState || type === 'revalidating'}
-  class:compact={type === 'revalidating' || type === 'load-error'}
+  class:git-state={isGitState}
+  class:compact={type === 'load-error'}
   onclick={handleRowClick}
   oncontextmenu={handleContextMenu}
 >

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -270,7 +270,7 @@
   class:pending={isPending}
   class:failed={isFailed}
   class:clickable={isClickable}
-  class:git-state={isGitState}
+  class:git-state={isGitState || type === 'revalidating'}
   class:compact={type === 'revalidating' || type === 'load-error'}
   onclick={handleRowClick}
   oncontextmenu={handleContextMenu}

--- a/apps/staged/src/lib/listeners/sessionStatusListener.ts
+++ b/apps/staged/src/lib/listeners/sessionStatusListener.ts
@@ -21,7 +21,7 @@ import { projectStateStore } from '../stores/projectState.svelte';
 import { prStateStore } from '../stores/prState.svelte';
 import { pushStateStore } from '../stores/pushState.svelte';
 import { sessionRegistry, type SessionType } from '../stores/sessionRegistry.svelte';
-import type { SessionStatusPayload } from '../types';
+import type { SessionStatus, SessionStatusPayload } from '../types';
 
 export function listenForSessionStatus(): Promise<UnlistenFn> {
   return listen<SessionStatusPayload>('session-status-changed', async (event) => {
@@ -58,7 +58,7 @@ export function listenForSessionStatus(): Promise<UnlistenFn> {
 // Completion sub-handlers
 // ---------------------------------------------------------------------------
 
-async function handleSessionEnd(sessionId: string, status: string) {
+async function handleSessionEnd(sessionId: string, status: SessionStatus) {
   const sessionProjectId = sessionRegistry.getProjectId(sessionId);
   const sessionType = sessionRegistry.getType(sessionId);
   const branchId = sessionRegistry.getBranchId(sessionId);
@@ -87,7 +87,7 @@ async function handleSessionEnd(sessionId: string, status: string) {
   sessionRegistry.cleanupSession(sessionId);
 }
 
-async function handlePrCompletion(sessionId: string, branchId: string, status: string) {
+async function handlePrCompletion(sessionId: string, branchId: string, status: SessionStatus) {
   if (status === 'completed') {
     try {
       // Try session messages first (AI session writes PR_URL: marker).
@@ -145,7 +145,7 @@ async function handlePrCompletion(sessionId: string, branchId: string, status: s
   }
 }
 
-async function handlePushCompletion(sessionId: string, branchId: string, status: string) {
+async function handlePushCompletion(sessionId: string, branchId: string, status: SessionStatus) {
   if (status === 'completed') {
     try {
       const session = await commands.getSession(sessionId);

--- a/apps/staged/src/lib/shared/ConfirmDialog.svelte
+++ b/apps/staged/src/lib/shared/ConfirmDialog.svelte
@@ -191,6 +191,9 @@
     font-size: var(--size-sm);
     color: var(--text-muted);
     line-height: 1.5;
+    max-height: 42vh;
+    overflow: auto;
+    white-space: pre-line;
   }
 
   .text-content .error-text {

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -178,6 +178,44 @@ export interface BranchTimeline {
   notes: NoteTimelineItem[];
   reviews: ReviewTimelineItem[];
   images: ImageTimelineItem[];
+  gitState?: BranchGitState | null;
+}
+
+export type UpstreamRelation = 'missing' | 'inSync' | 'localAhead' | 'originAhead' | 'diverged';
+
+export type FetchStatus = 'fresh' | 'stale' | 'failed';
+
+export interface BranchGitState {
+  headSha: string | null;
+  currentBranch: string | null;
+  detachedHead: boolean;
+  expectedBranchMatches: boolean;
+  upstream: {
+    ref: string;
+    exists: boolean;
+    sha: string | null;
+    relation: UpstreamRelation;
+    ahead: number;
+    behind: number;
+    mergeBaseSha: string | null;
+  };
+  base: {
+    ref: string;
+    sha: string | null;
+    commitsSinceFork: number;
+  };
+  worktree: {
+    dirty: boolean;
+    staged: number;
+    unstaged: number;
+    untracked: number;
+    conflicted: number;
+  };
+  fetch: {
+    status: FetchStatus;
+    fetchedAt: number | null;
+    error: string | null;
+  };
 }
 
 export interface Image {

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -398,7 +398,7 @@ export interface BranchSessionResponse {
 /** Payload emitted by the `session-status-changed` Tauri event. */
 export interface SessionStatusPayload {
   sessionId: string;
-  status: string;
+  status: SessionStatus;
   errorMessage?: string | null;
   completionReason?: string | null;
   branchId?: string;

--- a/crates/blox-cli/src/lib.rs
+++ b/crates/blox-cli/src/lib.rs
@@ -308,6 +308,78 @@ fn run_bytes(args: &[&str], timeout: Duration) -> Result<Vec<u8>, BloxError> {
     Ok(stdout)
 }
 
+/// Run `sq blox <args…>` and return stdout, stderr, and exit status.
+///
+/// Unlike `run_bytes`, a non-zero exit from the remote command does NOT
+/// produce an `Err` — only infrastructure failures (CLI missing, timeout,
+/// auth) do. This lets callers inspect both streams on command failure.
+fn run_bytes_full(args: &[&str], timeout: Duration) -> Result<WsExecOutput, BloxError> {
+    let sq = sq_binary()?;
+
+    let mut full_args = vec!["blox"];
+    full_args.extend_from_slice(args);
+
+    let mut child = Command::new(&sq)
+        .args(&full_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| BloxError::CommandFailed(e.to_string()))?;
+
+    let stdout_handle = child
+        .stdout
+        .take()
+        .ok_or_else(|| BloxError::CommandFailed("Failed to capture stdout".to_string()))?;
+    let stderr_handle = child
+        .stderr
+        .take()
+        .ok_or_else(|| BloxError::CommandFailed("Failed to capture stderr".to_string()))?;
+
+    let stdout_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let mut reader = stdout_handle;
+        let _ = reader.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let mut reader = stderr_handle;
+        let _ = reader.read_to_end(&mut buf);
+        buf
+    });
+
+    let status = match child
+        .wait_timeout(timeout)
+        .map_err(|e| BloxError::CommandFailed(e.to_string()))?
+    {
+        Some(status) => status,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err(BloxError::Timeout(timeout.as_secs()));
+        }
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+
+    // Check for auth errors even in the full-output path.
+    if !status.success() {
+        let stderr_str = strip_ansi_escape_sequences(&String::from_utf8_lossy(&stderr));
+        if is_auth_error(&stderr_str) {
+            return Err(BloxError::NotAuthenticated);
+        }
+    }
+
+    Ok(WsExecOutput {
+        stdout,
+        stderr,
+        success: status.success(),
+    })
+}
+
 /// Run `sq blox <args…>` and return stdout as a string.
 fn run(args: &[&str], timeout: Duration) -> Result<String, BloxError> {
     let bytes = run_bytes(args, timeout)?;
@@ -425,6 +497,24 @@ pub fn ws_exec_bytes(name: &str, args: &[&str]) -> Result<Vec<u8>, BloxError> {
     let mut full_args = vec!["ws", "exec", name, "--"];
     full_args.extend_from_slice(args);
     run_bytes(&full_args, EXEC_TIMEOUT)
+}
+
+/// Output from a workspace command that preserves stdout, stderr, and exit
+/// status separately — unlike `ws_exec` which discards stdout on failure.
+pub struct WsExecOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub success: bool,
+}
+
+/// Execute a command inside a Blox workspace, returning full output regardless
+/// of exit code. Infrastructure errors (CLI not found, timeout, auth failure)
+/// still return `Err`, but a non-zero exit from the remote command returns
+/// `Ok(WsExecOutput { success: false, .. })`.
+pub fn ws_exec_output(name: &str, args: &[&str]) -> Result<WsExecOutput, BloxError> {
+    let mut full_args = vec!["ws", "exec", name, "--"];
+    full_args.extend_from_slice(args);
+    run_bytes_full(&full_args, EXEC_TIMEOUT)
 }
 
 /// A bootstrap command returned by `sq blox ws commands <name> --json`.


### PR DESCRIPTION
## Summary
- Adds `BranchGitState` computation that determines the relationship between local branch, remote tracking branch, and base branch (ahead/behind/diverged/up-to-date)
- Surfaces git state as actionable timeline rows in the branch timeline, with push/pull/force-push actions and real-time progress tracking via session IDs
- Optimizes git state computation by parallelizing independent git commands and batching remote operations into shell scripts

## Test plan
- [x] Unit tests added for git state computation (`state_tests.rs`)
- [ ] Verify timeline rows appear correctly for branches that are ahead, behind, diverged, or up-to-date with their remote
- [ ] Verify push/pull/force-push actions trigger correctly from timeline rows
- [ ] Verify progress states update in real-time during push/force-push operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)