### PR TITLE
fix: show suggested actions in note modal regardless of recency

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -384,24 +384,6 @@
     if (!note) return null;
     if (!note.suggestedNextCommitStep && !note.suggestedNextNoteStep) return null;
 
-    if (hasActiveSessions(timeline)) return null;
-
-    // Check this note is the latest completed item using the same approach
-    // as suggestedPrefill: collect all timestamps and compare.
-    const noteTs = Math.floor((note.completedAt ?? note.createdAt) / 1000);
-    const timestamps: number[] = [];
-    for (const c of timeline.commits) {
-      if (c.sha) timestamps.push(c.timestamp);
-    }
-    for (const n of timeline.notes) {
-      if (n.id !== note.id) timestamps.push(Math.floor((n.completedAt ?? n.createdAt) / 1000));
-    }
-    for (const r of timeline.reviews) {
-      if (r.isAuto) continue;
-      timestamps.push(Math.floor((r.completedAt ?? r.createdAt) / 1000));
-    }
-    if (timestamps.some((ts) => ts > noteTs)) return null;
-
     return {
       commitStep: note.suggestedNextCommitStep,
       noteStep: note.suggestedNextNoteStep,


### PR DESCRIPTION
## Summary

- Removes the recency check that prevented suggested actions from appearing in the note modal when a newer timeline item (commit, note, or review) existed
- Removes the active session check that also blocked suggested actions
- Suggested actions from a note are now always shown when viewing that note, regardless of whether it's the latest timeline item

## Test plan

- [ ] Open a note modal for a note that has suggested actions
- [ ] Verify suggested actions appear even when newer commits/notes/reviews exist on the timeline
- [ ] Verify suggested actions still don't appear for notes without them

🤖 Generated with [Claude Code](https://claude.com/claude-code)