### PR TITLE
fix: vendor libgit2 to avoid system library linking failures

### DIFF
--- a/crates/git-diff/Cargo.toml
+++ b/crates/git-diff/Cargo.toml
@@ -7,7 +7,7 @@ description = "Git diff computation: file listing, content diffing, and alignmen
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
-git2 = { version = "0.20", features = ["vendored-openssl"] }
+git2 = { version = "0.20", features = ["vendored-openssl", "vendored-libgit2"] }
 base64 = "0.22"
 log = "0.4"
 


### PR DESCRIPTION
## Summary
- Adds the `vendored-libgit2` feature to the `git2` dependency in `crates/git-diff/Cargo.toml`
- This ensures libgit2 is compiled from source rather than linking against system libraries, preventing linking failures in environments where system libgit2 is unavailable or incompatible

## Test plan
- [x] CI passes (crates-fmt, crates-test, crates-lint, differ-ci, staged-ci)

🤖 Generated with [Claude Code](https://claude.com/claude-code)