### PR TITLE
feat: move parent branch state into header capsule pills

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1329,7 +1329,7 @@
       <BranchCardHeaderInfo
         branchName={branch.branchName}
         {repoLabel}
-        secondaryLabel={formatBaseBranch(branch.baseBranch)}
+        baseBranch={formatBaseBranch(branch.baseBranch)}
       />
       <div class="header-actions">
         <button class="more-button" onclick={() => onDelete?.()} title="Delete branch">
@@ -1368,9 +1368,14 @@
       <BranchCardHeaderInfo
         branchName={branch.branchName}
         {repoLabel}
-        secondaryLabel={isRemote
+        baseBranch={isRemote
           ? (branch.workspaceName ?? formatBaseBranch(branch.baseBranch))
           : formatBaseBranch(branch.baseBranch)}
+        parentAheadCount={refreshingGitState ? 0 : (timeline?.gitState?.base.commitsSinceFork ?? 0)}
+        onRebase={branchCommandDisabledReason
+          ? undefined
+          : () => startBranchCommandPipeline('rebase')}
+        rebaseDisabled={!!branchCommandDisabledReason}
         warning={branchIdentityWarning}
       />
       <div class="header-actions">

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
-  import { AlertTriangle, GitBranch } from 'lucide-svelte';
+  import { AlertTriangle, ChevronRight } from 'lucide-svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
   import type { ProjectRepo } from '../../types';
 
   interface Props {
     branchName: string;
     repoLabel?: ProjectRepo | null;
-    secondaryLabel?: string | null;
+    baseBranch?: string | null;
+    parentAheadCount?: number;
+    onRebase?: () => void;
+    rebaseDisabled?: boolean;
     warning?: string | null;
   }
 
-  let { branchName, repoLabel = null, secondaryLabel = null, warning = null }: Props = $props();
+  let {
+    branchName,
+    repoLabel = null,
+    baseBranch = null,
+    parentAheadCount = 0,
+    onRebase,
+    rebaseDisabled = false,
+    warning = null,
+  }: Props = $props();
 </script>
 
 <div class="header-left">
@@ -22,25 +33,48 @@
       /></span
     >
     <div class="header-meta">
-      <span class="branch-name">{branchName}</span>
+      <span class="branch-capsule" title={branchName}>{branchName}</span>
+      {#if baseBranch}
+        <ChevronRight size={12} />
+        <span class="branch-capsule" title={baseBranch}>
+          {baseBranch}{#if parentAheadCount > 0}<span class="ahead-count">
+              +{parentAheadCount}</span
+            >{/if}
+        </span>
+        {#if parentAheadCount > 0 && onRebase}
+          <button
+            class="rebase-btn"
+            disabled={rebaseDisabled}
+            title={rebaseDisabled ? 'Rebase unavailable' : 'Rebase onto parent'}
+            onclick={onRebase}>Rebase</button
+          >
+        {/if}
+      {/if}
       {#if warning}
         <span class="branch-warning" title={warning}>
           <AlertTriangle size={12} />
           <span>{warning}</span>
         </span>
       {/if}
-      {#if secondaryLabel}
-        <span class="meta-separator" aria-hidden="true">&middot;</span>
-        <GitBranch size={12} />
-        <span class="base-branch-name" title={secondaryLabel}>{secondaryLabel}</span>
-      {/if}
     </div>
   {:else}
     <span class="repo-name">{branchName}</span>
-    {#if secondaryLabel || warning}
+    {#if baseBranch || warning}
       <div class="header-meta">
-        {#if secondaryLabel}
-          <span class="base-branch-name" title={secondaryLabel}>{secondaryLabel}</span>
+        {#if baseBranch}
+          <span class="branch-capsule" title={baseBranch}>
+            {baseBranch}{#if parentAheadCount > 0}<span class="ahead-count">
+                +{parentAheadCount}</span
+              >{/if}
+          </span>
+          {#if parentAheadCount > 0 && onRebase}
+            <button
+              class="rebase-btn"
+              disabled={rebaseDisabled}
+              title={rebaseDisabled ? 'Rebase unavailable' : 'Rebase onto parent'}
+              onclick={onRebase}>Rebase</button
+            >
+          {/if}
         {/if}
         {#if warning}
           <span class="branch-warning" title={warning}>
@@ -87,13 +121,45 @@
     color: var(--text-faint);
   }
 
-  .branch-name {
-    max-width: 200px;
-    color: var(--text-muted);
-    min-width: 0;
+  .branch-capsule {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: var(--size-xs);
+    max-width: 160px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .ahead-count {
+    font-weight: 600;
+    color: var(--ui-accent);
+  }
+
+  .rebase-btn {
+    font-size: var(--size-xs);
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border-primary);
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .rebase-btn:hover:not(:disabled) {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+  }
+
+  .rebase-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .branch-warning {
@@ -110,18 +176,5 @@
   .branch-warning span {
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .base-branch-name {
-    color: var(--text-faint);
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .meta-separator {
-    color: var(--text-faint);
-    flex-shrink: 0;
   }
 </style>

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -122,15 +122,13 @@
   }
 
   .branch-capsule {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
+    display: inline-block;
     padding: 2px 8px;
     border-radius: 999px;
     background: var(--bg-elevated);
     color: var(--text-muted);
     font-size: var(--size-xs);
-    max-width: 160px;
+    max-width: 240px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -125,7 +125,8 @@
     display: inline-block;
     padding: 2px 8px;
     border-radius: 999px;
-    background: var(--bg-elevated);
+    background: none;
+    border: 1px solid var(--border-subtle);
     color: var(--text-muted);
     font-size: var(--size-xs);
     max-width: 240px;

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -127,8 +127,8 @@
     gap: 4px;
     padding: 2px 8px;
     border-radius: 999px;
-    background: var(--bg-secondary);
-    color: var(--text-secondary);
+    background: var(--bg-elevated);
+    color: var(--text-muted);
     font-size: var(--size-xs);
     max-width: 160px;
     overflow: hidden;
@@ -142,23 +142,33 @@
   }
 
   .rebase-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 22px;
+    padding: 0 8px;
     font-size: var(--size-xs);
-    padding: 2px 8px;
-    border-radius: 999px;
-    border: 1px solid var(--border-primary);
-    background: var(--bg-primary);
-    color: var(--text-secondary);
+    font-weight: 500;
+    color: var(--text-muted);
+    background: none;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
     cursor: pointer;
     white-space: nowrap;
+    transition:
+      color 0.15s,
+      border-color 0.15s,
+      background-color 0.15s;
   }
 
   .rebase-btn:hover:not(:disabled) {
-    background: var(--bg-secondary);
+    border-color: var(--border-muted);
     color: var(--text-primary);
+    background: var(--bg-hover);
   }
 
   .rebase-btn:disabled {
-    opacity: 0.5;
+    opacity: 0.3;
     cursor: not-allowed;
   }
 

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -24,6 +24,24 @@
   }: Props = $props();
 </script>
 
+{#snippet parentPill()}
+  {#if baseBranch}
+    <span class="branch-capsule" title={baseBranch}>
+      {baseBranch}{#if parentAheadCount > 0}<span class="ahead-count">
+          +{parentAheadCount}</span
+        >{/if}
+    </span>
+    {#if parentAheadCount > 0 && onRebase}
+      <button
+        class="rebase-btn"
+        disabled={rebaseDisabled}
+        title={rebaseDisabled ? 'Rebase unavailable' : 'Rebase onto parent'}
+        onclick={onRebase}>Rebase</button
+      >
+    {/if}
+  {/if}
+{/snippet}
+
 <div class="header-left">
   {#if repoLabel}
     <span class="repo-name"
@@ -36,20 +54,8 @@
       <span class="branch-capsule" title={branchName}>{branchName}</span>
       {#if baseBranch}
         <ChevronRight size={12} />
-        <span class="branch-capsule" title={baseBranch}>
-          {baseBranch}{#if parentAheadCount > 0}<span class="ahead-count">
-              +{parentAheadCount}</span
-            >{/if}
-        </span>
-        {#if parentAheadCount > 0 && onRebase}
-          <button
-            class="rebase-btn"
-            disabled={rebaseDisabled}
-            title={rebaseDisabled ? 'Rebase unavailable' : 'Rebase onto parent'}
-            onclick={onRebase}>Rebase</button
-          >
-        {/if}
       {/if}
+      {@render parentPill()}
       {#if warning}
         <span class="branch-warning" title={warning}>
           <AlertTriangle size={12} />
@@ -61,21 +67,7 @@
     <span class="repo-name">{branchName}</span>
     {#if baseBranch || warning}
       <div class="header-meta">
-        {#if baseBranch}
-          <span class="branch-capsule" title={baseBranch}>
-            {baseBranch}{#if parentAheadCount > 0}<span class="ahead-count">
-                +{parentAheadCount}</span
-              >{/if}
-          </span>
-          {#if parentAheadCount > 0 && onRebase}
-            <button
-              class="rebase-btn"
-              disabled={rebaseDisabled}
-              title={rebaseDisabled ? 'Rebase unavailable' : 'Rebase onto parent'}
-              onclick={onRebase}>Rebase</button
-            >
-          {/if}
-        {/if}
+        {@render parentPill()}
         {#if warning}
           <span class="branch-warning" title={warning}>
             <AlertTriangle size={12} />

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -357,17 +357,6 @@
     };
   }
 
-  function baseDisplayName(ref: string): string {
-    return ref.replace(/^refs\/remotes\/origin\//, '').replace(/^origin\//, '');
-  }
-
-  function baseMovedTitleHtml(ref: string, count: number): string {
-    const branchName = baseDisplayName(ref);
-    return `<span class="git-ref-badge">${escapeHtml(branchName)}</span> has ${escapeHtml(
-      plural(count, 'new commit')
-    )}`;
-  }
-
   function gitStateRows(
     state: BranchGitState,
     commitAnchors: Map<string, CommitAnchor>
@@ -395,21 +384,6 @@
         title: 'Could not refresh git state',
         timestamp: topTimestamp,
         order: 0,
-      });
-    }
-
-    if (state.base.commitsSinceFork > 0) {
-      rows.push({
-        key: 'git-base-moved',
-        type: 'git-merge',
-        title: `${baseDisplayName(state.base.ref)} has ${plural(state.base.commitsSinceFork, 'new commit')}`,
-        titleHtml: baseMovedTitleHtml(state.base.ref, state.base.commitsSinceFork),
-        timestamp: topTimestamp,
-        order: 1,
-        onRebase: rebaseBranchDisabledReason ? undefined : onRebaseBranch,
-        rebaseDisabledReason: onRebaseBranch
-          ? (rebaseBranchDisabledReason ?? undefined)
-          : undefined,
       });
     }
 


### PR DESCRIPTION
## Summary

- Moves the parent branch ahead count and rebase action from the timeline into the branch card header, displayed as capsule pills alongside the branch name
- Replaces the old `secondaryLabel` text with a structured `baseBranch` prop that renders as a styled capsule pill with chevron separator
- Extracts the parent pill into a Svelte snippet to eliminate template duplication between the repo-label and no-repo-label layouts
- Uses border-only styling for capsule pills with proper theme variables and text-overflow handling

## Test plan

- [ ] Verify branch name and parent branch display as capsule pills in the header
- [ ] Verify the ahead count badge appears when the parent branch has new commits
- [ ] Verify the rebase button appears next to the parent pill when ahead count > 0
- [ ] Verify rebase button is disabled when branch commands are unavailable
- [ ] Verify text overflow with ellipsis works for long branch names
- [ ] Verify the timeline no longer shows the "base has N new commits" row

🤖 Generated with [Claude Code](https://claude.com/claude-code)