### PR TITLE
fix: patch autosize to prevent spurious scrollbar on chat input

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -345,7 +345,13 @@
 
   function autoResize(el: HTMLElement) {
     el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
+    el.style.overflow = 'hidden';
+    const maxHeight = 120; // matches CSS max-height
+    const height = Math.min(el.scrollHeight, maxHeight);
+    el.style.height = height + 'px';
+    if (height >= maxHeight) {
+      el.style.overflow = 'auto';
+    }
   }
 
   async function handleSubmitPrompt() {
@@ -1057,7 +1063,7 @@
     outline: none;
     min-height: 28px;
     max-height: 120px;
-    overflow-y: auto;
+    overflow-y: hidden;
   }
 
   .prompt-input-row :global(.hashtag-input-wrapper) {

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -524,7 +524,7 @@
     white-space: pre-wrap;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    overflow-y: auto;
+    overflow-y: hidden;
     outline: none;
     line-height: 1.5;
   }

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -515,7 +515,14 @@
   function autoResize() {
     if (!inputEl) return;
     inputEl.style.height = 'auto';
-    inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
+    inputEl.style.overflow = 'hidden';
+    const borderY = inputEl.offsetHeight - inputEl.clientHeight;
+    const maxHeight = 120;
+    const height = Math.min(inputEl.scrollHeight + borderY, maxHeight);
+    inputEl.style.height = height + 'px';
+    if (height >= maxHeight) {
+      inputEl.style.overflow = 'auto';
+    }
   }
 
   // =========================================================================
@@ -2178,7 +2185,7 @@
 
   .input-area :global(.message-input) {
     flex: 1;
-    padding: 8px 12px;
+    padding: 7px 12px;
     background: var(--bg-primary);
     border: 1px solid var(--border-muted);
     border-radius: 10px;

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -2194,7 +2194,7 @@
     font-family: inherit;
     line-height: 1.5;
     resize: none;
-    overflow-y: auto;
+    overflow-y: hidden;
     min-height: 36px;
     max-height: 120px;
   }


### PR DESCRIPTION
## Summary
- Fixes the chat input textarea auto-resize logic to account for border height when calculating scroll height, preventing a spurious scrollbar from appearing
- Hides overflow while measuring height and only enables scrolling when the textarea reaches its max height (120px)
- Adjusts vertical padding from 8px to 7px to align with the corrected height calculation

## Test plan
- [ ] Open a chat session and type a message — verify no scrollbar appears on short input
- [ ] Type a multi-line message that exceeds max height — verify scrollbar appears correctly
- [ ] Verify textarea grows smoothly as content increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)