### PR TITLE
feat: add Xcode to the "Open In" app list

### DIFF
--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -38,6 +38,8 @@ const KNOWN_OPENERS: &[(&str, &str)] = &[
     ("goland", "com.jetbrains.goland"),
     ("fleet", "fleet.app"),
     ("zed", "dev.zed.Zed"),
+    // IDEs
+    ("xcode", "com.apple.dt.Xcode"),
     // File browsers
     ("finder", "com.apple.finder"),
 ];
@@ -167,6 +169,7 @@ fn prettify_app_name(id: &str) -> String {
         "goland" => "GoLand",
         "fleet" => "Fleet",
         "zed" => "Zed",
+        "xcode" => "Xcode",
         "terminal" => "Terminal",
         "warp" => "Warp",
         "iterm" => "iTerm",


### PR DESCRIPTION
## Summary
- Adds Xcode (`com.apple.dt.Xcode`) to the known openers list so users can open files/projects directly in Xcode from the "Open In" menu
- Adds the prettified display name for Xcode

## Test plan
- [x] Pre-push CI passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)