### PR TITLE
fix: show PR button when branch has a prNumber even without code changes

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1474,7 +1474,7 @@
           {provisioningDetail}
         >
           {#snippet footerActions()}
-            {#if hasCodeChanges}
+            {#if hasCodeChanges || branch.prNumber}
               <div class="footer-right-actions">
                 <BranchCardPrButton
                   bind:this={prButton}
@@ -1487,17 +1487,19 @@
                     sessionMgr.openSessionId = sid;
                   }}
                 />
-                <button
-                  class="pr-btn diff-btn"
-                  onclick={() => {
-                    reviewDiffTarget = null;
-                    showBranchDiff = true;
-                  }}
-                  title="View diff"
-                >
-                  <FileDiff size={13} />
-                  <span>Diff</span>
-                </button>
+                {#if hasCodeChanges}
+                  <button
+                    class="pr-btn diff-btn"
+                    onclick={() => {
+                      reviewDiffTarget = null;
+                      showBranchDiff = true;
+                    }}
+                    title="View diff"
+                  >
+                    <FileDiff size={13} />
+                    <span>Diff</span>
+                  </button>
+                {/if}
               </div>
             {/if}
           {/snippet}

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -647,7 +647,7 @@
   }
 </script>
 
-{#if hasCodeChanges}
+{#if hasCodeChanges || branch.prNumber}
   <button
     class="pr-btn"
     class:creating={prState === 'creating'}


### PR DESCRIPTION
## Summary

- Show the PR button on branch cards when a `prNumber` exists, even if there are no current code changes (e.g. after a branch is merged)
- Keep the Diff button conditional on `hasCodeChanges` only, since viewing a diff without changes is not useful
- Applies the same `hasCodeChanges || branch.prNumber` condition in both `BranchCard.svelte` and `BranchCardPrButton.svelte`

## Test plan

- [ ] Verify the PR button appears on a branch that has been merged (has `prNumber` but no code changes)
- [ ] Verify the PR button still appears on branches with code changes
- [ ] Verify the Diff button only appears when there are actual code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)