### PR TITLE
fix: pass preferred agent provider in diff viewer session launches

### DIFF
--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -9,6 +9,8 @@
   import type { SessionStatusPayload, HashtagItem } from '../../types';
   import HashtagInput from '../sessions/HashtagInput.svelte';
   import { buildBranchHashtagItems } from '../sessions/hashtagItems';
+  import { getPreferredAgent } from '../settings/preferences.svelte';
+  import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
 
   interface Props {
     branchId: string;
@@ -17,11 +19,20 @@
     scope: 'branch' | 'commit';
     reviewId?: string;
     visibleCommentCount: number;
+    isRemote: boolean;
     onStarted: () => void;
   }
 
-  let { branchId, projectId, commitSha, scope, reviewId, visibleCommentCount, onStarted }: Props =
-    $props();
+  let {
+    branchId,
+    projectId,
+    commitSha,
+    scope,
+    reviewId,
+    visibleCommentCount,
+    isRemote,
+    onStarted,
+  }: Props = $props();
 
   let draftPrompt = $state('');
   let isDirty = $state(false);
@@ -149,12 +160,15 @@
         reviewId: reviewId ?? null,
       };
 
+      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
+      const provider = getPreferredAgent(agents) ?? undefined;
+
       if (hasRunningSession) {
         await commands.queueBranchSession(
           branchId,
           finalPrompt,
           'commit',
-          undefined,
+          provider,
           undefined,
           launchContext
         );
@@ -163,7 +177,7 @@
           branchId,
           finalPrompt,
           'commit',
-          undefined,
+          provider,
           undefined,
           launchContext
         );

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -1186,6 +1186,7 @@
           scope={reviewableScope()}
           reviewId={activeReviewId}
           visibleCommentCount={currentComments.length}
+          {isRemote}
           onStarted={onClose}
         />
       {/if}

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -32,6 +32,8 @@
   import DiffCommitSessionLauncher from './DiffCommitSessionLauncher.svelte';
   import DiffReferenceSection from './DiffReferenceSection.svelte';
   import NewSessionModal from '../sessions/NewSessionModal.svelte';
+  import { getPreferredAgent } from '../settings/preferences.svelte';
+  import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { createDiffViewerState } from './diffViewerState.svelte';
   import { createReviewState } from './reviewState.svelte';
   import { createSearchState } from '@builderbot/diff-viewer/state';
@@ -406,6 +408,7 @@
       .catch((e) => console.warn('Failed to load branch:', e));
   });
 
+  let isRemote = $derived(branch?.branchType === 'remote');
   let hasPr = $derived(branch?.prNumber != null);
 
   // ==========================================================================
@@ -444,12 +447,15 @@
           (r) => !r.isAuto && (r.sessionStatus === 'running' || r.sessionStatus === 'queued')
         );
 
+      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
+      const provider = getPreferredAgent(agents) ?? undefined;
+
       if (hasRunning) {
         await commands.queueBranchSession(
           branchId,
           prompt,
           mode,
-          undefined,
+          provider,
           undefined,
           launchContext
         );
@@ -458,7 +464,7 @@
           branchId,
           prompt,
           mode,
-          undefined,
+          provider,
           undefined,
           launchContext
         );
@@ -523,12 +529,15 @@
           (r) => !r.isAuto && (r.sessionStatus === 'running' || r.sessionStatus === 'queued')
         );
 
+      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
+      const provider = getPreferredAgent(agents) ?? undefined;
+
       if (hasRunning) {
         await commands.queueBranchSession(
           branchId,
           data.prompt,
           data.mode,
-          undefined,
+          provider,
           data.imageIds,
           launchContext
         );
@@ -537,7 +546,7 @@
           branchId,
           data.prompt,
           data.mode,
-          undefined,
+          provider,
           data.imageIds,
           launchContext
         );


### PR DESCRIPTION
## Summary
- Session launches from the diff viewer (both inline comment sessions and commit-scoped sessions) were not respecting the user's preferred agent provider setting
- Now resolves the preferred agent from the available providers (remote vs local) and passes it when queuing or launching sessions from `DiffModal` and `DiffCommitSessionLauncher`

## Test plan
- [ ] Open a diff viewer and launch a session from a code review comment — verify it uses the preferred agent provider
- [ ] Launch a commit-scoped session from the diff view — verify the preferred agent is used
- [ ] Verify remote branches use `REMOTE_AGENTS` and local branches use `agentState.providers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)