### PR TITLE
feat: show app icons and improve Open In menu organization

### DIFF
--- a/apps/staged/src-tauri/Cargo.lock
+++ b/apps/staged/src-tauri/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/apps/staged/src-tauri/Cargo.toml
+++ b/apps/staged/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-log = "2.8.0"
 thiserror = "2.0"
 anyhow = "1.0"
 base64 = "0.22"
+tempfile = "3"
 sha2 = "0.11"
 
 # Review storage

--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -23,6 +23,7 @@ const KNOWN_OPENERS: &[(&str, &str)] = &[
     ("hyper", "co.zeit.hyper"),
     ("kitty", "net.kovidgoyal.kitty"),
     ("alacritty", "org.alacritty"),
+    ("ghostty", "com.mitchellh.ghostty"),
     // Editors
     ("vscode", "com.microsoft.VSCode"),
     ("vscode-insiders", "com.microsoft.VSCodeInsiders"),
@@ -124,21 +125,35 @@ pub async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
         use std::process::Command;
         use std::thread;
 
-        // First, find which apps are installed and get their .app paths.
+        // Find which apps are installed by running mdfind in parallel.
+        let mdfind_handles: Vec<_> = KNOWN_OPENERS
+            .iter()
+            .map(|(id, bundle_id)| {
+                let id = *id;
+                let bundle_id = *bundle_id;
+                thread::spawn(move || {
+                    let output = Command::new("mdfind")
+                        .arg(format!("kMDItemCFBundleIdentifier == '{bundle_id}'"))
+                        .output()
+                        .ok()?;
+                    if !output.status.success() {
+                        return None;
+                    }
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let first_line = stdout.trim().lines().next().unwrap_or("").to_string();
+                    if first_line.is_empty() {
+                        None
+                    } else {
+                        Some((id, first_line))
+                    }
+                })
+            })
+            .collect();
+
         let mut installed: Vec<(&str, String)> = Vec::new();
-
-        for (id, bundle_id) in KNOWN_OPENERS {
-            let output = Command::new("mdfind")
-                .arg(format!("kMDItemCFBundleIdentifier == '{bundle_id}'"))
-                .output()
-                .map_err(|e| format!("Failed to run mdfind: {e}"))?;
-
-            if output.status.success() {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let first_line = stdout.trim().lines().next().unwrap_or("").to_string();
-                if !first_line.is_empty() {
-                    installed.push((id, first_line));
-                }
+        for handle in mdfind_handles {
+            if let Ok(Some((id, path))) = handle.join() {
+                installed.push((id, path));
             }
         }
 
@@ -213,13 +228,12 @@ fn extract_app_icon(app_path: &str) -> Option<String> {
     }
 
     // 3. Convert to 32×32 PNG via sips into a temp file
-    let tmp_dir = std::env::temp_dir();
-    let tmp_png = tmp_dir.join(format!(
-        "staged-icon-{}-{:?}.png",
-        std::process::id(),
-        std::thread::current().id()
-    ));
-    let tmp_png_str = tmp_png.to_string_lossy().to_string();
+    let tmp_file = tempfile::Builder::new()
+        .prefix("staged-icon-")
+        .suffix(".png")
+        .tempfile()
+        .ok()?;
+    let tmp_png_str = tmp_file.path().to_string_lossy().to_string();
 
     let sips = Command::new("sips")
         .args([
@@ -237,13 +251,11 @@ fn extract_app_icon(app_path: &str) -> Option<String> {
         .ok()?;
 
     if !sips.status.success() {
-        let _ = std::fs::remove_file(&tmp_png);
         return None;
     }
 
     // 4. Read and base64-encode the PNG
-    let png_bytes = std::fs::read(&tmp_png).ok()?;
-    let _ = std::fs::remove_file(&tmp_png);
+    let png_bytes = std::fs::read(tmp_file.path()).ok()?;
 
     use base64::Engine;
     let encoded = base64::engine::general_purpose::STANDARD.encode(&png_bytes);

--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -175,9 +175,8 @@ pub async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
 
         let mut available = Vec::with_capacity(handles.len());
         for handle in handles {
-            match handle.join() {
-                Ok(app) => available.push(app),
-                Err(_) => {} // Thread panicked — skip this app
+            if let Ok(app) = handle.join() {
+                available.push(app);
             }
         }
 

--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 pub struct OpenerApp {
     id: String,
     name: String,
+    icon: Option<String>,
 }
 
 /// Known applications with their bundle IDs (macOS).
@@ -113,15 +114,18 @@ pub async fn check_blox_auth() -> Result<(), String> {
 
 /// Get available opener applications.
 ///
-/// On macOS, uses mdfind to detect which apps are installed.
-/// On other platforms, returns an empty list.
+/// On macOS, uses mdfind to detect which apps are installed, then extracts
+/// their icons in parallel using threads. On other platforms, returns an
+/// empty list.
 #[tauri::command]
 pub async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
     #[cfg(target_os = "macos")]
     {
         use std::process::Command;
+        use std::thread;
 
-        let mut available = Vec::new();
+        // First, find which apps are installed and get their .app paths.
+        let mut installed: Vec<(&str, String)> = Vec::new();
 
         for (id, bundle_id) in KNOWN_OPENERS {
             let output = Command::new("mdfind")
@@ -131,12 +135,34 @@ pub async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
 
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                if !stdout.trim().is_empty() {
-                    available.push(OpenerApp {
-                        id: id.to_string(),
-                        name: prettify_app_name(id),
-                    });
+                let first_line = stdout.trim().lines().next().unwrap_or("").to_string();
+                if !first_line.is_empty() {
+                    installed.push((id, first_line));
                 }
+            }
+        }
+
+        // Extract icons in parallel using threads.
+        let handles: Vec<_> = installed
+            .into_iter()
+            .map(|(id, app_path)| {
+                let id = id.to_string();
+                thread::spawn(move || {
+                    let icon = extract_app_icon(&app_path);
+                    OpenerApp {
+                        name: prettify_app_name(&id),
+                        id,
+                        icon,
+                    }
+                })
+            })
+            .collect();
+
+        let mut available = Vec::with_capacity(handles.len());
+        for handle in handles {
+            match handle.join() {
+                Ok(app) => available.push(app),
+                Err(_) => {} // Thread panicked — skip this app
             }
         }
 
@@ -148,6 +174,80 @@ pub async fn get_available_openers() -> Result<Vec<OpenerApp>, String> {
         // On non-macOS platforms, return empty list
         Ok(Vec::new())
     }
+}
+
+/// Extract an app icon as a base64-encoded PNG data URI.
+///
+/// Reads the icon filename from Info.plist, resolves the .icns file,
+/// converts to a 32×32 PNG via `sips`, and base64-encodes the result.
+/// Returns `None` if any step fails.
+#[cfg(target_os = "macos")]
+fn extract_app_icon(app_path: &str) -> Option<String> {
+    use std::process::Command;
+
+    // 1. Read CFBundleIconFile from Info.plist
+    let output = Command::new("defaults")
+        .arg("read")
+        .arg(format!("{app_path}/Contents/Info"))
+        .arg("CFBundleIconFile")
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let mut icon_name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if icon_name.is_empty() {
+        return None;
+    }
+
+    // 2. Append .icns if missing
+    if !icon_name.ends_with(".icns") {
+        icon_name.push_str(".icns");
+    }
+
+    let icns_path = format!("{app_path}/Contents/Resources/{icon_name}");
+    if !Path::new(&icns_path).exists() {
+        return None;
+    }
+
+    // 3. Convert to 32×32 PNG via sips into a temp file
+    let tmp_dir = std::env::temp_dir();
+    let tmp_png = tmp_dir.join(format!(
+        "staged-icon-{}-{:?}.png",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let tmp_png_str = tmp_png.to_string_lossy().to_string();
+
+    let sips = Command::new("sips")
+        .args([
+            "-s",
+            "format",
+            "png",
+            "-z",
+            "32",
+            "32",
+            &icns_path,
+            "--out",
+            &tmp_png_str,
+        ])
+        .output()
+        .ok()?;
+
+    if !sips.status.success() {
+        let _ = std::fs::remove_file(&tmp_png);
+        return None;
+    }
+
+    // 4. Read and base64-encode the PNG
+    let png_bytes = std::fs::read(&tmp_png).ok()?;
+    let _ = std::fs::remove_file(&tmp_png);
+
+    use base64::Engine;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
+    Some(format!("data:image/png;base64,{encoded}"))
 }
 
 /// Convert app ID to a human-readable name.

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -548,15 +548,18 @@
       }
     }
 
+    const sortByLabel = (a: MenuItem, b: MenuItem) =>
+      (a.type === 'action' ? a.label : '').localeCompare(b.type === 'action' ? b.label : '');
+
     const items: MenuItem[] = [];
-    if (terminals.length > 0) items.push(...terminals);
+    if (terminals.length > 0) items.push(...terminals.sort(sortByLabel));
     if (editors.length > 0) {
       if (items.length > 0) items.push({ type: 'separator' });
-      items.push(...editors);
+      items.push(...editors.sort(sortByLabel));
     }
     if (fileBrowsers.length > 0) {
       if (items.length > 0) items.push({ type: 'separator' });
-      items.push(...fileBrowsers);
+      items.push(...fileBrowsers.sort(sortByLabel));
     }
 
     if (items.length > 0) items.push({ type: 'separator' });

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -520,6 +520,7 @@
     const items: MenuItem[] = openerApps.map((app) => ({
       type: 'action',
       label: app.name,
+      iconSrc: app.icon ?? undefined,
       onSelect: () => handleOpenInApp(app.id),
     }));
 

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -516,23 +516,56 @@
     });
   }
 
-  function buildOpenInMenuItems(): MenuItem[] {
-    const items: MenuItem[] = openerApps.map((app) => ({
-      type: 'action',
-      label: app.name,
-      iconSrc: app.icon ?? undefined,
-      onSelect: () => handleOpenInApp(app.id),
-    }));
+  const terminalAppIds = new Set([
+    'terminal',
+    'warp',
+    'iterm',
+    'hyper',
+    'kitty',
+    'alacritty',
+    'ghostty',
+  ]);
+  const fileBrowserAppIds = new Set(['finder']);
 
-    items.push(
-      { type: 'separator' },
-      {
+  function buildOpenInMenuItems(): MenuItem[] {
+    const terminals: MenuItem[] = [];
+    const editors: MenuItem[] = [];
+    const fileBrowsers: MenuItem[] = [];
+
+    for (const app of openerApps) {
+      const item: MenuItem = {
         type: 'action',
-        label: 'Copy Path',
-        icon: Copy,
-        onSelect: handleCopyPath,
+        label: app.name,
+        iconSrc: app.icon ?? undefined,
+        onSelect: () => handleOpenInApp(app.id),
+      };
+      if (terminalAppIds.has(app.id)) {
+        terminals.push(item);
+      } else if (fileBrowserAppIds.has(app.id)) {
+        fileBrowsers.push(item);
+      } else {
+        editors.push(item);
       }
-    );
+    }
+
+    const items: MenuItem[] = [];
+    if (terminals.length > 0) items.push(...terminals);
+    if (editors.length > 0) {
+      if (items.length > 0) items.push({ type: 'separator' });
+      items.push(...editors);
+    }
+    if (fileBrowsers.length > 0) {
+      if (items.length > 0) items.push({ type: 'separator' });
+      items.push(...fileBrowsers);
+    }
+
+    if (items.length > 0) items.push({ type: 'separator' });
+    items.push({
+      type: 'action',
+      label: 'Copy Path',
+      icon: Copy,
+      onSelect: handleCopyPath,
+    });
 
     return items;
   }

--- a/apps/staged/src/lib/features/branches/branch.ts
+++ b/apps/staged/src/lib/features/branches/branch.ts
@@ -5,6 +5,7 @@ import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 export interface OpenerApp {
   id: string;
   name: string;
+  icon: string | null;
 }
 
 // Cache for performance

--- a/apps/staged/src/lib/shared/menu/MenuSurface.svelte
+++ b/apps/staged/src/lib/shared/menu/MenuSurface.svelte
@@ -355,7 +355,7 @@
     padding: 4px;
     border: 1px solid var(--border-muted);
     border-radius: 8px;
-    background: var(--bg-elevated);
+    background: var(--bg-primary);
     box-shadow: var(--shadow-elevated);
     color: var(--text-primary);
   }
@@ -432,7 +432,7 @@
   .menu-separator {
     height: 1px;
     margin: 4px 0;
-    background: var(--border-subtle);
+    background: var(--border-muted);
   }
 
   .submenu-container {

--- a/apps/staged/src/lib/shared/menu/MenuSurface.svelte
+++ b/apps/staged/src/lib/shared/menu/MenuSurface.svelte
@@ -274,7 +274,14 @@
         }}
       >
         {#if item.iconSrc}
-          <img src={item.iconSrc} alt="" width="14" height="14" class="menu-item-icon" />
+          <img
+            src={item.iconSrc}
+            alt=""
+            width="14"
+            height="14"
+            draggable="false"
+            class="menu-item-icon"
+          />
         {:else if item.icon}
           <item.icon size={14} />
         {/if}

--- a/apps/staged/src/lib/shared/menu/MenuSurface.svelte
+++ b/apps/staged/src/lib/shared/menu/MenuSurface.svelte
@@ -273,7 +273,9 @@
           handleAction(item);
         }}
       >
-        {#if item.icon}
+        {#if item.iconSrc}
+          <img src={item.iconSrc} alt="" width="14" height="14" class="menu-item-icon" />
+        {:else if item.icon}
           <item.icon size={14} />
         {/if}
         <span class="menu-item-label">{item.label}</span>
@@ -401,6 +403,11 @@
   .menu-item :global(svg) {
     color: var(--text-muted);
     flex-shrink: 0;
+  }
+
+  .menu-item-icon {
+    flex-shrink: 0;
+    border-radius: 3px;
   }
 
   .menu-item.danger {

--- a/apps/staged/src/lib/shared/menu/types.ts
+++ b/apps/staged/src/lib/shared/menu/types.ts
@@ -4,6 +4,7 @@ export type MenuActionItem = {
   type: 'action';
   label: string;
   icon?: MenuIconComponent;
+  iconSrc?: string;
   disabled?: boolean;
   danger?: boolean;
   closeOnSelect?: boolean;


### PR DESCRIPTION
## Summary

- Extract and display native app icons (as base64 PNGs) in the "Open In" menu using macOS `sips` for icon conversion
- Organize menu items into sections (terminals, editors, file browsers) separated by dividers, sorted alphabetically within each section
- Add Ghostty to the list of known terminal openers
- Improve menu styling: use `--bg-primary` background, `--border-muted` separators, prevent icon dragging, and support `iconSrc` for image-based menu icons

## Test plan

- [ ] Verify app icons appear next to each app name in the "Open In" menu on macOS
- [ ] Verify menu items are grouped by category (terminals, editors, file browsers) with separators between groups
- [ ] Verify items within each group are sorted alphabetically
- [ ] Verify "Copy Path" appears at the bottom separated from app entries
- [ ] Verify non-macOS platforms still return an empty opener list without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)