### PR TITLE
feat: auto-create project note from PR title and body

### DIFF
--- a/apps/staged/src-tauri/src/git/github.rs
+++ b/apps/staged/src-tauri/src/git/github.rs
@@ -31,6 +31,7 @@ pub struct GitHubAuthStatus {
 pub struct PullRequest {
     pub number: u64,
     pub title: String,
+    pub body: String,
     pub author: String,
     /// Target branch (e.g., "main")
     pub base_ref: String,
@@ -584,7 +585,7 @@ pub fn get_pr_for_repo(github_repo: &str, pr_number: u64) -> Result<PullRequest,
         &pr_number.to_string(),
         "-R",
         github_repo,
-        "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
+        "--json=number,title,body,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
     ])?;
 
     let item: GhPrListItem =
@@ -607,7 +608,7 @@ pub fn get_pr_for_branch_for_repo(
         branch_name,
         "--state=open",
         "--limit=1",
-        "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
+        "--json=number,title,body,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
     ])?;
 
     let items: Vec<GhPrListItem> =
@@ -625,7 +626,7 @@ pub fn list_pull_requests_for_repo(github_repo: &str) -> Result<Vec<PullRequest>
         github_repo,
         "--state=open",
         "--limit=50",
-        "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
+        "--json=number,title,body,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
     ])?;
 
     let items: Vec<GhPrListItem> =
@@ -1141,6 +1142,8 @@ pub fn fetch_for_worktree(
 struct GhPrListItem {
     number: u64,
     title: String,
+    #[serde(default)]
+    body: String,
     author: GhAuthor,
     #[serde(rename = "baseRefName")]
     base_ref_name: String,
@@ -1170,6 +1173,7 @@ impl From<GhPrListItem> for PullRequest {
         PullRequest {
             number: item.number,
             title: item.title,
+            body: item.body,
             author: item.author.login,
             base_ref: item.base_ref_name,
             head_ref: item.head_ref_name,
@@ -1194,7 +1198,7 @@ pub fn list_pull_requests(repo: &Path) -> Result<Vec<PullRequest>, GitError> {
             "list",
             "--state=open",
             "--limit=50",
-            "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
+            "--json=number,title,body,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
         ],
     )?;
 
@@ -1221,7 +1225,7 @@ pub fn search_pull_requests(repo: &Path, query: &str) -> Result<Vec<PullRequest>
             "--state=open",
             "--limit=50",
             &format!("--search={query}"),
-            "--json=number,title,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
+            "--json=number,title,body,author,baseRefName,headRefName,headRepository,isDraft,updatedAt",
         ],
     )?;
 

--- a/apps/staged/src/lib/features/projects/AddRepoModal.svelte
+++ b/apps/staged/src/lib/features/projects/AddRepoModal.svelte
@@ -73,6 +73,8 @@
         prNumber,
         defaultBranch: matchedPr?.baseRef ?? defaultBranch ?? undefined,
         headRepo: headRepo ?? undefined,
+        prTitle: matchedPr?.title,
+        prBody: matchedPr?.body,
       });
       onClose();
     } catch (e) {

--- a/apps/staged/src/lib/features/projects/NewProjectForm.svelte
+++ b/apps/staged/src/lib/features/projects/NewProjectForm.svelte
@@ -106,6 +106,10 @@
         matchedPr?.baseRef ?? defaultBranch ?? undefined,
         headRepo ?? undefined
       );
+      if (matchedPr) {
+        const noteTitle = `PR #${matchedPr.number}: ${matchedPr.title}`;
+        await commands.createProjectNote(project.id, noteTitle, matchedPr.body ?? '');
+      }
       onCreated(project);
     } catch (e) {
       if (typeof e === 'string') {

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -528,6 +528,10 @@
         selection.defaultBranch ?? undefined,
         selection.headRepo ?? undefined
       );
+      if (selection.prNumber != null && selection.prTitle) {
+        const noteTitle = `PR #${selection.prNumber}: ${selection.prTitle}`;
+        await commands.createProjectNote(projectId, noteTitle, selection.prBody ?? '');
+      }
       const [projectsList, branches, repos] = await Promise.all([
         commands.listProjects(),
         commands.listBranchesForProject(projectId),

--- a/apps/staged/src/lib/shared/githubUrl.ts
+++ b/apps/staged/src/lib/shared/githubUrl.ts
@@ -7,6 +7,10 @@ export interface RepoSelection {
   defaultBranch?: string | null;
   /** For fork PRs, the head (fork) repo slug when it differs from nameWithOwner. */
   headRepo?: string | null;
+  /** PR title, carried through for auto-creating project notes. */
+  prTitle?: string;
+  /** PR body/description, carried through for auto-creating project notes. */
+  prBody?: string;
 }
 
 /**

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -250,6 +250,7 @@ export interface RepoBadge {
 export interface PullRequest {
   number: number;
   title: string;
+  body: string;
   author: string;
   baseRef: string;
   headRef: string;


### PR DESCRIPTION
## Summary
- When adding a repo from a PR, automatically creates a project note containing the PR title and body
- Adds `body` field to the `PullRequest` type (Rust backend + TypeScript frontend) and fetches it from the GitHub CLI
- Passes PR title/body through `RepoSelection` so both `AddRepoModal`, `NewProjectForm`, and `ProjectHome` can create the note

## Test plan
- [ ] Add a repo to a project via a PR URL and verify a note is auto-created with the PR title and body
- [ ] Add a repo via a non-PR URL and verify no note is created
- [ ] Create a new project from a PR and verify the note is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)