### PR TITLE
feat: replace staged/unstaged counts with modified/added/deleted in worktree state

### DIFF
--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -63,8 +63,9 @@ pub struct BaseGitState {
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeGitState {
     pub dirty: bool,
-    pub staged: u32,
-    pub unstaged: u32,
+    pub modified: u32,
+    pub added: u32,
+    pub deleted: u32,
     pub untracked: u32,
     pub conflicted: u32,
 }
@@ -418,8 +419,9 @@ where
     let Ok(output) = run_git(&["status", "--porcelain=1", "--untracked-files=all"]) else {
         return WorktreeGitState {
             dirty: false,
-            staged: 0,
-            unstaged: 0,
+            modified: 0,
+            added: 0,
+            deleted: 0,
             untracked: 0,
             conflicted: 0,
         };
@@ -802,11 +804,14 @@ fn parse_batch_git_state_output(raw: &str) -> BatchGitStateOutput {
 fn parse_worktree_from_status(status_output: &str) -> WorktreeGitState {
     let mut state = WorktreeGitState {
         dirty: false,
-        staged: 0,
-        unstaged: 0,
+        modified: 0,
+        added: 0,
+        deleted: 0,
         untracked: 0,
         conflicted: 0,
     };
+
+    let mut seen = std::collections::HashSet::new();
 
     for line in status_output.lines() {
         let mut chars = line.chars();
@@ -821,16 +826,30 @@ fn parse_worktree_from_status(status_output: &str) -> WorktreeGitState {
             state.conflicted += 1;
             continue;
         }
-        if x != ' ' {
-            state.staged += 1;
+
+        // Skip the space after XY columns
+        let path: String = chars.skip(1).collect();
+        // For renames/copies the path contains " -> new_path"; use the destination
+        let dedup_path = path.split(" -> ").last().unwrap_or(&path).to_string();
+        if !seen.insert(dedup_path) {
+            continue;
         }
-        if y != ' ' {
-            state.unstaged += 1;
+
+        // Pick the most significant status code (prefer non-space)
+        let code = if x != ' ' { x } else { y };
+        match code {
+            'M' | 'R' => state.modified += 1,
+            'A' | 'C' => state.added += 1,
+            'D' => state.deleted += 1,
+            _ => state.modified += 1, // fallback for unexpected codes
         }
     }
 
-    state.dirty =
-        state.staged > 0 || state.unstaged > 0 || state.untracked > 0 || state.conflicted > 0;
+    state.dirty = state.modified > 0
+        || state.added > 0
+        || state.deleted > 0
+        || state.untracked > 0
+        || state.conflicted > 0;
     state
 }
 
@@ -1156,8 +1175,9 @@ where
                 },
                 worktree: WorktreeGitState {
                     dirty: false,
-                    staged: 0,
-                    unstaged: 0,
+                    modified: 0,
+                    added: 0,
+                    deleted: 0,
                     untracked: 0,
                     conflicted: 0,
                 },

--- a/apps/staged/src-tauri/src/git/state.rs
+++ b/apps/staged/src-tauri/src/git/state.rs
@@ -1231,3 +1231,168 @@ pub fn ensure_fast_forward_pullable(state: &BranchGitState) -> Result<(), String
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_worktree(
+        input: &str,
+        dirty: bool,
+        modified: u32,
+        added: u32,
+        deleted: u32,
+        untracked: u32,
+        conflicted: u32,
+    ) {
+        let state = parse_worktree_from_status(input);
+        assert_eq!(
+            state,
+            WorktreeGitState {
+                dirty,
+                modified,
+                added,
+                deleted,
+                untracked,
+                conflicted,
+            },
+            "input: {input:?}"
+        );
+    }
+
+    #[test]
+    fn empty_status() {
+        assert_worktree("", false, 0, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn single_untracked() {
+        assert_worktree("?? untracked.txt", true, 0, 0, 0, 1, 0);
+    }
+
+    #[test]
+    fn multiple_untracked() {
+        assert_worktree("?? ut1.txt\n?? ut2.txt", true, 0, 0, 0, 2, 0);
+    }
+
+    #[test]
+    fn staged_add() {
+        assert_worktree("A  file.txt", true, 0, 1, 0, 0, 0);
+    }
+
+    #[test]
+    fn unstaged_modify() {
+        assert_worktree(" M file.txt", true, 1, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn staged_modify() {
+        assert_worktree("M  file.txt", true, 1, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn staged_and_unstaged_modify() {
+        assert_worktree("MM file.txt", true, 1, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn unstaged_delete() {
+        assert_worktree(" D file.txt", true, 0, 0, 1, 0, 0);
+    }
+
+    #[test]
+    fn staged_delete() {
+        assert_worktree("D  file.txt", true, 0, 0, 1, 0, 0);
+    }
+
+    #[test]
+    fn staged_rename() {
+        assert_worktree("R  file.txt -> renamed.txt", true, 1, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn staged_modify_then_unstaged_delete() {
+        assert_worktree("MD file.txt", true, 1, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn staged_add_then_unstaged_delete() {
+        assert_worktree("AD brand_new.txt", true, 0, 1, 0, 0, 0);
+    }
+
+    #[test]
+    fn mixed_changes() {
+        assert_worktree(
+            " M a.txt\nD  b.txt\nA  c.txt\n?? d.txt",
+            true,
+            1,
+            1,
+            1,
+            1,
+            0,
+        );
+    }
+
+    #[test]
+    fn all_staged() {
+        assert_worktree("M  a.txt\nD  b.txt\nA  e.txt", true, 1, 1, 1, 0, 0);
+    }
+
+    #[test]
+    fn conflict_both_modified() {
+        assert_worktree("UU file.txt", true, 0, 0, 0, 0, 1);
+    }
+
+    #[test]
+    fn conflict_add_add() {
+        assert_worktree("AA both.txt", true, 0, 0, 0, 0, 1);
+    }
+
+    #[test]
+    fn conflict_delete_update() {
+        assert_worktree("UD a.txt", true, 0, 0, 0, 0, 1);
+    }
+
+    #[test]
+    fn conflict_plus_untracked_plus_modified() {
+        assert_worktree(
+            "UU file.txt\n?? untracked.txt\n M other.txt",
+            true,
+            1,
+            0,
+            0,
+            1,
+            1,
+        );
+    }
+
+    #[test]
+    fn dedup_same_file_two_lines() {
+        assert_worktree("M  file.txt\n M file.txt", true, 1, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn rename_destination_collides() {
+        assert_worktree("R  old.txt -> new.txt\n M new.txt", true, 1, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn is_conflicted_status_pairs() {
+        // All 7 conflict pairs
+        assert!(is_conflicted_status('D', 'D'));
+        assert!(is_conflicted_status('A', 'U'));
+        assert!(is_conflicted_status('U', 'D'));
+        assert!(is_conflicted_status('U', 'A'));
+        assert!(is_conflicted_status('D', 'U'));
+        assert!(is_conflicted_status('A', 'A'));
+        assert!(is_conflicted_status('U', 'U'));
+
+        // Non-conflict pairs
+        assert!(!is_conflicted_status('M', ' '));
+        assert!(!is_conflicted_status(' ', 'M'));
+        assert!(!is_conflicted_status('A', ' '));
+        assert!(!is_conflicted_status(' ', 'D'));
+        assert!(!is_conflicted_status('R', ' '));
+        assert!(!is_conflicted_status('?', '?'));
+    }
+}

--- a/apps/staged/src-tauri/src/git/state_tests.rs
+++ b/apps/staged/src-tauri/src/git/state_tests.rs
@@ -169,8 +169,8 @@ fn detects_dirty_worktree_counts() {
     let state = state(&clone.path, FetchMode::Never);
 
     assert!(state.worktree.dirty);
-    assert_eq!(state.worktree.staged, 1);
-    assert_eq!(state.worktree.unstaged, 1);
+    assert_eq!(state.worktree.added, 1);
+    assert_eq!(state.worktree.modified, 1);
     assert_eq!(state.worktree.untracked, 1);
 }
 

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -318,8 +318,9 @@
   function worktreeSummary(state: BranchGitState): string {
     const parts: string[] = [];
     if (state.worktree.conflicted > 0) parts.push(plural(state.worktree.conflicted, 'conflict'));
-    if (state.worktree.staged > 0) parts.push(`${state.worktree.staged} staged`);
-    if (state.worktree.unstaged > 0) parts.push(`${state.worktree.unstaged} unstaged`);
+    if (state.worktree.modified > 0) parts.push(`${state.worktree.modified} modified`);
+    if (state.worktree.added > 0) parts.push(`${state.worktree.added} new`);
+    if (state.worktree.deleted > 0) parts.push(`${state.worktree.deleted} deleted`);
     if (state.worktree.untracked > 0) parts.push(`${state.worktree.untracked} untracked`);
     return parts.join(', ');
   }

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -319,7 +319,7 @@
     const parts: string[] = [];
     if (state.worktree.conflicted > 0) parts.push(plural(state.worktree.conflicted, 'conflict'));
     if (state.worktree.modified > 0) parts.push(`${state.worktree.modified} modified`);
-    if (state.worktree.added > 0) parts.push(`${state.worktree.added} new`);
+    if (state.worktree.added > 0) parts.push(`${state.worktree.added} added`);
     if (state.worktree.deleted > 0) parts.push(`${state.worktree.deleted} deleted`);
     if (state.worktree.untracked > 0) parts.push(`${state.worktree.untracked} untracked`);
     return parts.join(', ');

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -206,8 +206,9 @@ export interface BranchGitState {
   };
   worktree: {
     dirty: boolean;
-    staged: number;
-    unstaged: number;
+    modified: number;
+    added: number;
+    deleted: number;
     untracked: number;
     conflicted: number;
   };


### PR DESCRIPTION
## Summary
- Replaces the `staged`/`unstaged` counters in `WorktreeGitState` with `modified`, `added`, and `deleted` counts, giving users a clearer picture of what changed in their worktree
- Deduplicates files that appear on multiple status lines (e.g. staged + unstaged) so each file is counted once, using the most significant status code
- Updates the frontend `BranchTimeline` summary and TypeScript types to match
- Adds comprehensive unit tests for `parse_worktree_from_status` and `is_conflicted_status`

## Test plan
- [x] Unit tests added for all status parsing cases (empty, untracked, staged/unstaged modify/add/delete, renames, conflicts, dedup)
- [x] Existing integration test (`state_tests.rs`) updated and passing
- [ ] Verify worktree summary labels display correctly in the timeline UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)