### PR TITLE
fix(staged): select first file from sidebar order instead of raw git order

### DIFF
--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -214,6 +214,9 @@
     // Reset review state — the $effect will recreate it once the new commitSha resolves
     reviewHandle = null;
 
+    // Reset so the sidebar-order effect picks the first file after reload
+    initialSelectionApplied = false;
+
     // Switch diff context (reloads file list)
     try {
       await diffViewer.switchContext(newScope, newCommitSha);
@@ -739,6 +742,16 @@
       ? flattenTreeFiles(readonlyTree)
       : [...flattenTreeFiles(needsReviewTree), ...flattenTreeFiles(reviewedTree)]
   );
+
+  // Once files finish loading, override the initial selection with the first
+  // file in sidebar order so the viewer and sidebar stay in sync.
+  let initialSelectionApplied = false;
+  $effect(() => {
+    if (!diffViewer.state.loading && orderedFiles.length > 0 && !initialSelectionApplied) {
+      initialSelectionApplied = true;
+      diffViewer.selectFile(orderedFiles[0].path);
+    }
+  });
 
   // ==========================================================================
   // Sidebar interactions

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -745,9 +745,16 @@
 
   // Once files finish loading, override the initial selection with the first
   // file in sidebar order so the viewer and sidebar stay in sync.
+  // For non-readonly reviews, also wait for reviewedPaths to load so the
+  // needs-review / reviewed split is accurate before picking the first file.
   let initialSelectionApplied = false;
   $effect(() => {
-    if (!diffViewer.state.loading && orderedFiles.length > 0 && !initialSelectionApplied) {
+    if (
+      !diffViewer.state.loading &&
+      orderedFiles.length > 0 &&
+      !initialSelectionApplied &&
+      (readonly || !reviewHandle || !reviewHandle.state.loading)
+    ) {
       initialSelectionApplied = true;
       diffViewer.selectFile(orderedFiles[0].path);
     }


### PR DESCRIPTION
## Summary
- When the diff modal opens, the initially selected file now matches the first file in the sidebar's display order (needs-review → reviewed) instead of using raw git diff order
- Resets the selection flag when switching diff context so the correct first file is picked after reload

## Test plan
- [ ] Open a diff with multiple changed files and verify the first file shown matches the top of the sidebar
- [ ] Switch between commits/scopes and confirm the first sidebar file is auto-selected each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)