### PR TITLE
feat(staged): show commit author in branch card timeline

### DIFF
--- a/apps/staged/src-tauri/src/git/mod.rs
+++ b/apps/staged/src-tauri/src/git/mod.rs
@@ -12,6 +12,7 @@ mod status_parse;
 mod types;
 mod worktree;
 
+pub(crate) use cli::run as cli_run;
 pub use cli::GitError;
 pub use commit::commit;
 pub use diff::{get_file_diff, get_unified_diff, list_diff_files};

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -192,6 +192,8 @@ pub struct BranchTimeline {
     pub reviews: Vec<ReviewTimelineItem>,
     pub images: Vec<ImageTimelineItem>,
     pub git_state: Option<git::BranchGitState>,
+    /// The configured `user.name` from git config in the repo, if available.
+    pub git_user_name: Option<String>,
 }
 
 // =============================================================================

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -140,6 +140,7 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         .map_err(|e| e.to_string())?;
 
     let mut git_state = None;
+    let mut git_user_name: Option<String> = None;
 
     // Get commits from git (the source of truth for commit data)
     let mut commits = Vec::new();
@@ -164,6 +165,11 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
             &branch.base_branch,
             git::FetchMode::Never,
         ));
+        git_user_name =
+            branches::run_workspace_git(ws_name, repo_subpath.as_deref(), &["config", "user.name"])
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
         commits = fetch_remote_commits(
             ws_name,
             repo_subpath.as_deref(),
@@ -183,6 +189,10 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
                 &branch.base_branch,
                 git::FetchMode::Never,
             ));
+            git_user_name = git::cli_run(worktree_path, &["config", "user.name"])
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
             let git_commits =
                 git::get_commits_since_base(worktree_path, &base_ref).map_err(|e| {
                     format!("Failed to get commits since base for branch {branch_id}: {e:?}")
@@ -308,6 +318,7 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         reviews,
         images,
         git_state,
+        git_user_name,
     })
 }
 

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -16,10 +16,57 @@ use crate::{
     ReviewTimelineItem,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::Emitter;
+
+/// TTL for cached git user name lookups (5 minutes).
+const GIT_USER_NAME_TTL_MS: u128 = 300_000;
+
+#[derive(Debug, Clone)]
+struct GitUserNameCacheEntry {
+    name: Option<String>,
+    fetched_at: u128,
+}
+
+fn git_user_name_cache() -> &'static Mutex<HashMap<String, GitUserNameCacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, GitUserNameCacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cached_git_user_name<F>(cache_key: &str, fetch: F) -> Option<String>
+where
+    F: FnOnce() -> Option<String>,
+{
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+
+    if let Ok(cache) = git_user_name_cache().lock() {
+        if let Some(entry) = cache.get(cache_key) {
+            if now.saturating_sub(entry.fetched_at) < GIT_USER_NAME_TTL_MS {
+                return entry.name.clone();
+            }
+        }
+    }
+
+    let name = fetch();
+
+    if let Ok(mut cache) = git_user_name_cache().lock() {
+        cache.insert(
+            cache_key.to_string(),
+            GitUserNameCacheEntry {
+                name: name.clone(),
+                fetched_at: now,
+            },
+        );
+    }
+
+    name
+}
 
 /// Payload for the `git-state-updated` event emitted by `refresh_branch_git_state`.
 #[derive(Debug, Clone, Serialize)]
@@ -165,11 +212,19 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
             &branch.base_branch,
             git::FetchMode::Never,
         ));
-        git_user_name =
-            branches::run_workspace_git(ws_name, repo_subpath.as_deref(), &["config", "user.name"])
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty());
+        {
+            let ws = ws_name.clone();
+            let sub = repo_subpath.clone();
+            git_user_name = cached_git_user_name(
+                &format!("remote:{ws}:{}", sub.as_deref().unwrap_or("")),
+                || {
+                    branches::run_workspace_git(&ws, sub.as_deref(), &["config", "user.name"])
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                },
+            );
+        }
         commits = fetch_remote_commits(
             ws_name,
             repo_subpath.as_deref(),
@@ -189,10 +244,15 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
                 &branch.base_branch,
                 git::FetchMode::Never,
             ));
-            git_user_name = git::cli_run(worktree_path, &["config", "user.name"])
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty());
+            {
+                let path_str = wd.path.clone();
+                git_user_name = cached_git_user_name(&format!("local:{path_str}"), || {
+                    git::cli_run(worktree_path, &["config", "user.name"])
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                });
+            }
             let git_commits =
                 git::get_commits_since_base(worktree_path, &base_ref).map_err(|e| {
                     format!("Failed to get commits since base for branch {branch_id}: {e:?}")

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -224,6 +224,7 @@
     titleHtml?: string;
     meta?: string;
     secondaryMeta?: string;
+    tertiaryMeta?: string;
     deleting?: boolean;
     timestamp: number;
     /** Position in git's topological order (0 = oldest). Tiebreaker for same-second timestamps. */
@@ -499,6 +500,7 @@
   // Merge commits, notes, and reviews into a single sorted list
   let items = $derived.by(() => {
     const nowMs = minuteNow.now();
+    const gitUserName = timeline.gitUserName ?? null;
     const all: DisplayItem[] = [];
     const commitAnchors = new Map<string, CommitAnchor>();
     const deletingCommitIds = new Set(
@@ -541,12 +543,19 @@
         secondaryMeta = formatRelativeTimeSeconds(commit.timestamp, nowMs);
       }
 
+      const showAuthor =
+        type === 'commit' &&
+        !isDeleting &&
+        !!commit.author &&
+        (!gitUserName || commit.author !== gitUserName);
+
       all.push({
         key: commit.sha || `pending-${commit.sessionId || commit.timestamp}`,
         type,
         title: stripXmlTags(commit.subject),
         meta: isDeleting ? 'Deleting...' : secondaryMeta,
         secondaryMeta: isDeleting || isRunning ? undefined : commit.shortSha || undefined,
+        tertiaryMeta: showAuthor ? commit.author : undefined,
         deleting: isDeleting,
         timestamp: commit.timestamp,
         order: commit.order,
@@ -869,6 +878,7 @@
           titleHtml={item.titleHtml}
           meta={item.meta}
           secondaryMeta={item.secondaryMeta}
+          tertiaryMeta={item.tertiaryMeta}
           badges={item.badges}
           onPullClick={item.onPull}
           pullDisabledReason={item.pullDisabledReason}
@@ -954,6 +964,7 @@
           titleHtml={item.titleHtml}
           meta={item.meta}
           secondaryMeta={item.secondaryMeta}
+          tertiaryMeta={item.tertiaryMeta}
           badges={item.badges}
           onPullClick={item.onPull}
           pullDisabledReason={item.pullDisabledReason}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -65,6 +65,8 @@
     titleHtml?: string;
     meta?: string;
     secondaryMeta?: string;
+    /** Tertiary metadata shown after the secondary meta (e.g. commit author). */
+    tertiaryMeta?: string;
     badges?: TimelineBadge[];
     deleting?: boolean;
     isLast?: boolean;
@@ -107,6 +109,7 @@
     titleHtml,
     meta,
     secondaryMeta,
+    tertiaryMeta,
     badges,
     deleting = false,
     isLast = false,
@@ -329,13 +332,16 @@
           >{title}</span
         >
       {/if}
-      {#if meta || secondaryMeta || (badges && badges.length > 0)}
+      {#if meta || secondaryMeta || tertiaryMeta || (badges && badges.length > 0)}
         <div class="timeline-meta">
           {#if meta}
             <span class="meta-item">{meta}</span>
           {/if}
           {#if secondaryMeta}
             <span class="meta-item meta-sha" class:failed-meta={isFailed}>{secondaryMeta}</span>
+          {/if}
+          {#if tertiaryMeta}
+            <span class="meta-item">{tertiaryMeta}</span>
           {/if}
           {#if badges}
             {#each badges as badge}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -690,7 +690,7 @@
 
   .timeline-meta {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 8px;
     margin-top: 3px;
   }

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -179,6 +179,7 @@ export interface BranchTimeline {
   reviews: ReviewTimelineItem[];
   images: ImageTimelineItem[];
   gitState?: BranchGitState | null;
+  gitUserName?: string | null;
 }
 
 export type UpstreamRelation = 'missing' | 'inSync' | 'localAhead' | 'originAhead' | 'diverged';


### PR DESCRIPTION
## Summary
- Shows the commit author name in the branch card timeline for commits not made by the current git user
- Reads `user.name` from git config and compares it against each commit's author to decide visibility
- Aligns timeline meta items by text baseline for better visual consistency

## Test plan
- [ ] Open a branch card with commits from multiple authors — non-user commits should display the author name as tertiary meta
- [ ] Commits by the current user should not show an author label
- [ ] If `user.name` is unset, all commit authors should be shown
- [ ] Verify meta items (timestamp, short SHA, author) align properly by baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)