### PR TITLE
fix(staged): move git refresh spinner and fetch error from timeline to header

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1333,9 +1333,7 @@
     </div>
   {:else}
     <div class="card-header">
-      {#if refreshingGitState}
-        <Spinner size={14} />
-      {:else if isRemote}
+      {#if isRemote}
         <Cloud size={14} class="header-icon {cloudStatusClass(remoteWorkspaceStatus)}" />
       {:else if prStatus === 'merged'}
         <GitPullRequest size={14} class="header-icon pr-status-merged" />
@@ -1362,6 +1360,8 @@
           : () => startBranchCommandPipeline('rebase')}
         rebaseDisabled={!!branchCommandDisabledReason}
         warning={branchIdentityWarning}
+        {refreshingGitState}
+        fetchError={timeline?.gitState?.fetch.error ?? null}
       />
       <div class="header-actions">
         {#if isRemote && remoteWorkspaceStatus !== 'running' && remoteWorkspaceStatus !== 'starting'}

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { fade, slide } from 'svelte/transition';
   import { AlertTriangle, ChevronRight } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
@@ -32,7 +33,10 @@
 {#snippet parentPill()}
   {#if baseBranch}
     <span class="branch-capsule" title={baseBranch}>
-      {baseBranch}{#if parentAheadCount > 0}<span class="ahead-count">
+      {baseBranch}{#if parentAheadCount > 0}<span
+          class="ahead-count"
+          transition:fade={{ duration: 150 }}
+        >
           +{parentAheadCount}</span
         >{/if}
     </span>
@@ -41,7 +45,8 @@
         class="rebase-btn"
         disabled={rebaseDisabled}
         title={rebaseDisabled ? 'Rebase unavailable' : 'Rebase onto parent'}
-        onclick={onRebase}>Rebase</button
+        onclick={onRebase}
+        transition:slide={{ axis: 'x', duration: 150 }}>Rebase</button
       >
     {/if}
   {/if}
@@ -70,7 +75,11 @@
       {#if refreshingGitState}
         <Spinner size={10} />
       {:else if fetchError}
-        <span class="fetch-error" title={fetchError}>
+        <span
+          class="fetch-error"
+          title={fetchError}
+          transition:slide={{ axis: 'x', duration: 150 }}
+        >
           <AlertTriangle size={12} />
         </span>
       {/if}
@@ -89,7 +98,11 @@
         {#if refreshingGitState}
           <Spinner size={10} />
         {:else if fetchError}
-          <span class="fetch-error" title={fetchError}>
+          <span
+            class="fetch-error"
+            title={fetchError}
+            transition:slide={{ axis: 'x', duration: 150 }}
+          >
             <AlertTriangle size={12} />
           </span>
         {/if}

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { AlertTriangle, ChevronRight } from 'lucide-svelte';
+  import Spinner from '../../shared/Spinner.svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
   import type { ProjectRepo } from '../../types';
 
@@ -11,6 +12,8 @@
     onRebase?: () => void;
     rebaseDisabled?: boolean;
     warning?: string | null;
+    refreshingGitState?: boolean;
+    fetchError?: string | null;
   }
 
   let {
@@ -21,6 +24,8 @@
     onRebase,
     rebaseDisabled = false,
     warning = null,
+    refreshingGitState = false,
+    fetchError = null,
   }: Props = $props();
 </script>
 
@@ -62,16 +67,30 @@
           <span>{warning}</span>
         </span>
       {/if}
+      {#if refreshingGitState}
+        <Spinner size={10} />
+      {:else if fetchError}
+        <span class="fetch-error" title={fetchError}>
+          <AlertTriangle size={12} />
+        </span>
+      {/if}
     </div>
   {:else}
     <span class="repo-name">{branchName}</span>
-    {#if baseBranch || warning}
+    {#if baseBranch || warning || refreshingGitState || fetchError}
       <div class="header-meta">
         {@render parentPill()}
         {#if warning}
           <span class="branch-warning" title={warning}>
             <AlertTriangle size={12} />
             <span>{warning}</span>
+          </span>
+        {/if}
+        {#if refreshingGitState}
+          <Spinner size={10} />
+        {:else if fetchError}
+          <span class="fetch-error" title={fetchError}>
+            <AlertTriangle size={12} />
           </span>
         {/if}
       </div>
@@ -177,5 +196,11 @@
   .branch-warning span {
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .fetch-error {
+    display: inline-flex;
+    align-items: center;
+    color: var(--ui-warning, var(--status-modified));
   }
 </style>

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -52,6 +52,16 @@
   {/if}
 {/snippet}
 
+{#snippet refreshStatus()}
+  {#if refreshingGitState}
+    <Spinner size={10} />
+  {:else if fetchError}
+    <span class="fetch-error" title={fetchError} transition:slide={{ axis: 'x', duration: 150 }}>
+      <AlertTriangle size={12} />
+    </span>
+  {/if}
+{/snippet}
+
 <div class="header-left">
   {#if repoLabel}
     <span class="repo-name"
@@ -72,17 +82,7 @@
           <span>{warning}</span>
         </span>
       {/if}
-      {#if refreshingGitState}
-        <Spinner size={10} />
-      {:else if fetchError}
-        <span
-          class="fetch-error"
-          title={fetchError}
-          transition:slide={{ axis: 'x', duration: 150 }}
-        >
-          <AlertTriangle size={12} />
-        </span>
-      {/if}
+      {@render refreshStatus()}
     </div>
   {:else}
     <span class="repo-name">{branchName}</span>
@@ -95,17 +95,7 @@
             <span>{warning}</span>
           </span>
         {/if}
-        {#if refreshingGitState}
-          <Spinner size={10} />
-        {:else if fetchError}
-          <span
-            class="fetch-error"
-            title={fetchError}
-            transition:slide={{ axis: 'x', duration: 150 }}
-          >
-            <AlertTriangle size={12} />
-          </span>
-        {/if}
+        {@render refreshStatus()}
       </div>
     {/if}
   {/if}

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -378,16 +378,6 @@
           ? 'Session in progress'
           : undefined;
 
-    if (state.fetch.status === 'failed') {
-      rows.push({
-        key: 'git-fetch-failed',
-        type: 'git-warning',
-        title: 'Could not refresh git state',
-        timestamp: topTimestamp,
-        order: 0,
-      });
-    }
-
     switch (state.upstream.relation) {
       case 'missing':
         break;


### PR DESCRIPTION
## Summary
- Moves the git state refresh spinner from the branch card icon area into `BranchCardHeaderInfo`, keeping the header icon slot free for its semantic icons (cloud, PR status, etc.)
- Relocates the "Could not refresh git state" warning from a timeline row into the header as a compact `AlertTriangle` icon with a tooltip
- Adds subtle `fade`/`slide` transitions to the parent branch ahead-count badge and rebase button

## Test plan
- [ ] Open a branch card and verify the refresh spinner appears in the header metadata area (not replacing the card icon)
- [ ] Simulate a git fetch failure and confirm the warning icon appears in the header with the error in its tooltip
- [ ] Verify the parent ahead-count and rebase button animate in/out smoothly
- [ ] Confirm the "Could not refresh git state" row no longer appears in the timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)