### PR TITLE
fix(staged): wrap project note actions below input when content is present

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -578,6 +578,7 @@
       class="prompt-input-wrapper"
       class:drag-over={dragOver}
       class:expanded={promptExpanded}
+      class:has-content={promptText.trim() || imageIds.length > 0}
       bind:this={promptWrapperEl}
       onfocusin={handlePromptFocusIn}
       onfocusout={handlePromptFocusOut}
@@ -1080,6 +1081,20 @@
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+  }
+
+  .prompt-input-wrapper.has-content .prompt-input-row {
+    flex-wrap: wrap;
+  }
+
+  .prompt-input-wrapper.has-content .prompt-input-row :global(.hashtag-input-wrapper) {
+    flex: 1 1 calc(100% - 48px);
+  }
+
+  .prompt-input-wrapper.has-content .prompt-actions {
+    width: 100%;
+    justify-content: flex-end;
+    gap: 4px;
   }
 
   .send-button {


### PR DESCRIPTION
## Summary
- Adds a `has-content` CSS class to the project note input wrapper when the prompt has text or images
- When content is present, wraps the action buttons below the input field to prevent layout crowding

## Test plan
- [ ] Open a project note input
- [ ] Type text or add an image — verify action buttons wrap below the input
- [ ] Clear the input — verify buttons return to inline layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)