### PR TITLE
feat(staged): show Sprout icon for branches with no commits

### DIFF
--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -102,6 +102,7 @@ pub(crate) fn to_branch_with_workdir(
         worktree_path: workdir_path,
         created_at: branch.created_at,
         updated_at: branch.updated_at,
+        commit_count: None,
     }
 }
 
@@ -849,13 +850,19 @@ pub fn list_branches_for_project(
     // than eagerly here. Eager per-workspace `ws_info` calls were serial and
     // each took ~1s, causing multi-second UI freezes on project load.
 
+    let commit_counts = store
+        .count_finalized_commits_by_branch_for_project(&project_id)
+        .map_err(|e| e.to_string())?;
+
     let mut result = Vec::with_capacity(branches.len());
     for branch in branches {
         let workdir = store
             .get_workdir_for_branch(&branch.id)
             .map_err(|e| e.to_string())?;
 
-        let bw = to_branch_with_workdir(branch, workdir.map(|w| w.path));
+        let count = commit_counts.get(&branch.id).copied().unwrap_or(0);
+        let mut bw = to_branch_with_workdir(branch, workdir.map(|w| w.path));
+        bw.commit_count = Some(count);
         result.push(bw);
     }
     Ok(result)

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -104,6 +104,10 @@ pub struct BranchWithWorkdir {
     pub worktree_path: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
+    /// Number of finalized commits (with a git SHA) on this branch.
+    /// Only populated by `list_branches_for_project`; `None` elsewhere.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_count: Option<u64>,
 }
 
 /// Result of polling a remote workspace's status.

--- a/apps/staged/src-tauri/src/store/commits.rs
+++ b/apps/staged/src-tauri/src/store/commits.rs
@@ -52,6 +52,31 @@ impl Store {
         .map_err(Into::into)
     }
 
+    /// Return a map of branch_id → number of finalized commits (sha IS NOT NULL)
+    /// for every branch belonging to the given project.
+    pub fn count_finalized_commits_by_branch_for_project(
+        &self,
+        project_id: &str,
+    ) -> Result<std::collections::HashMap<String, u64>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT c.branch_id, COUNT(*)
+             FROM commits c
+             JOIN branches b ON b.id = c.branch_id
+             WHERE b.project_id = ?1 AND c.sha IS NOT NULL
+             GROUP BY c.branch_id",
+        )?;
+        let rows = stmt.query_map(params![project_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+        })?;
+        let mut map = std::collections::HashMap::new();
+        for row in rows {
+            let (branch_id, count) = row?;
+            map.insert(branch_id, count);
+        }
+        Ok(map)
+    }
+
     pub fn list_commits_for_branch(&self, branch_id: &str) -> Result<Vec<Commit>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -20,6 +20,7 @@
     GitPullRequest,
     GitPullRequestClosed,
     GitPullRequestDraft,
+    Sprout,
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import { listenToEvent, type UnlistenFn } from '../../transport';
@@ -1345,8 +1346,10 @@
         <GitPullRequestClosed size={14} class="header-icon" />
       {:else if prStatus === 'conflict'}
         <GitPullRequestClosed size={14} class="header-icon pr-status-conflict" />
-      {:else}
+      {:else if hasCodeChanges}
         <GitPullRequestDraft size={14} class="header-icon pr-status-draft" />
+      {:else}
+        <Sprout size={14} class="header-icon pr-status-clean" />
       {/if}
       <BranchCardHeaderInfo
         branchName={branch.branchName}
@@ -1800,6 +1803,10 @@
 
   .card-header :global(svg.pr-status-draft) {
     stroke: var(--text-muted);
+  }
+
+  .card-header :global(svg.pr-status-clean) {
+    stroke: var(--text-faint);
   }
 
   .card-header :global(svg.cloud-running) {

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -13,6 +13,7 @@
     GitPullRequestClosed,
     GitPullRequestDraft,
     Plus,
+    Sprout,
   } from 'lucide-svelte';
   import type {
     Project,
@@ -25,6 +26,7 @@
   import {
     projectDisplayName,
     aggregateProjectPrStatus,
+    projectHasCodeChanges,
     projectSubtitle,
   } from '../../shared/utils';
   import { projectStateStore } from '../../stores/projectState.svelte';
@@ -712,8 +714,10 @@
                     <GitPullRequestClosed size={16} />
                   {:else if prStatus === 'conflict'}
                     <GitPullRequestClosed size={16} class="pr-status-conflict" />
-                  {:else}
+                  {:else if projectHasCodeChanges(projectBranches.get(project.id) || [])}
                     <GitPullRequestDraft size={16} class="pr-status-draft" />
+                  {:else}
+                    <Sprout size={16} class="pr-status-clean" />
                   {/if}
                   <span>{projectDisplayName(project)}</span>
                 </div>
@@ -1063,6 +1067,10 @@
 
   .card-header :global(svg.pr-status-draft) {
     stroke: var(--text-muted);
+  }
+
+  .card-header :global(svg.pr-status-clean) {
+    stroke: var(--text-faint);
   }
 
   .card-header :global(svg.cloud-running) {

--- a/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
@@ -10,12 +10,14 @@
     GitPullRequestClosed,
     GitPullRequestDraft,
     GitBranch,
+    Sprout,
   } from 'lucide-svelte';
   import type { Project, ProjectRepo, Branch, WorkspaceStatus } from '../../types';
   import { goHome, navigation, selectProject } from '../layout/navigation.svelte';
   import {
     projectDisplayName,
     aggregateProjectPrStatus,
+    projectHasCodeChanges,
     projectSubtitle,
     projectActivity,
   } from '../../shared/utils';
@@ -316,8 +318,10 @@
                     <GitPullRequestClosed size={14} />
                   {:else if prStatus === 'conflict'}
                     <GitPullRequestClosed size={14} class="pr-status-conflict" />
-                  {:else}
+                  {:else if projectHasCodeChanges(projectBranches.get(project.id) || [])}
                     <GitPullRequestDraft size={14} class="pr-status-draft" />
+                  {:else}
+                    <Sprout size={14} class="pr-status-clean" />
                   {/if}
                   <div class="row-text">
                     <span class="project-name">{projectDisplayName(project)}</span>
@@ -599,6 +603,10 @@
   }
 
   .row-main :global(svg.pr-status-draft) {
+    stroke: var(--text-faint);
+  }
+
+  .row-main :global(svg.pr-status-clean) {
     stroke: var(--text-faint);
   }
 

--- a/apps/staged/src/lib/shared/utils.ts
+++ b/apps/staged/src/lib/shared/utils.ts
@@ -90,6 +90,14 @@ export function aggregateProjectPrStatus(
 }
 
 /**
+ * Whether any branch in the project has at least one finalized commit.
+ * Relies on `commitCount` populated by `list_branches_for_project`.
+ */
+export function projectHasCodeChanges(branches: Branch[]): boolean {
+  return branches.some((b) => (b.commitCount ?? 0) > 0);
+}
+
+/**
  * Human-readable label for a session type.
  * Returns the singular noun form (e.g. "commit", "note").
  */

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -79,6 +79,8 @@ export interface Branch {
   prUpdatedAt: number | null;
   prFetchedAt: number | null;
   prHeadSha: string | null;
+  /** Number of finalized commits on this branch (populated by list_branches_for_project). */
+  commitCount?: number;
 }
 
 // PR status types


### PR DESCRIPTION
## Summary
- Show a Sprout icon instead of the draft PR icon for branches that have no finalized commits, indicating they are freshly created with no code changes yet
- Add `commitCount` field to `BranchWithWorkdir` (populated via a new `count_finalized_commits_by_branch_for_project` query) so the frontend can distinguish between branches with and without code changes
- Apply the Sprout icon consistently across BranchCard, ProjectsList, and ProjectsSidebar views

## Test plan
- [ ] Create a new branch with no commits and verify it shows the Sprout icon
- [ ] Create a commit on a branch and verify it switches to the draft PR icon
- [ ] Verify project-level icons aggregate correctly (Sprout when all branches have zero commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)