### PR TITLE
feat(staged): auto-focus repo search field when Add Repo modal opens

### DIFF
--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -274,7 +274,7 @@
           </button>
         </div>
       {:else}
-        <RepoSearchInput onSelect={handleRepoSelected} {disabled} {excludeRepos} />
+        <RepoSearchInput onSelect={handleRepoSelected} {disabled} {excludeRepos} {autofocus} />
       {/if}
 
       {#if !selectedRepo && filteredRecentRepos.length > 0}

--- a/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
+++ b/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
@@ -20,9 +20,10 @@
     onSelect: (selection: RepoSelection) => void;
     disabled?: boolean;
     excludeRepos?: Set<string>;
+    autofocus?: boolean;
   }
 
-  let { onSelect, disabled = false, excludeRepos = new Set() }: Props = $props();
+  let { onSelect, disabled = false, excludeRepos = new Set(), autofocus = false }: Props = $props();
 
   let recentRepos = $state<RecentRepo[]>([]);
   let repos = $state<GitHubRepo[]>([]);
@@ -105,6 +106,9 @@
   });
 
   onMount(async () => {
+    if (autofocus) {
+      inputEl?.focus();
+    }
     try {
       recentRepos = await commands.listRecentRepos(10);
       repos = await commands.listUserRepos(30);


### PR DESCRIPTION
## Summary
- Auto-focuses the repo search input field when the Add Repo modal opens, improving UX by letting users start typing immediately

## Test plan
- [ ] Open the Add Repo modal and verify the search field is automatically focused
- [ ] Verify typing immediately filters the repo list without needing to click the input first

🤖 Generated with [Claude Code](https://claude.com/claude-code)