### PR TITLE
fix(staged): resolve project session state from backend instead of content heuristics

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -1855,6 +1855,7 @@ pub fn run() {
             note_commands::delete_note,
             note_commands::create_project_note,
             note_commands::list_project_notes,
+            note_commands::get_project_note_by_session,
             note_commands::delete_project_note,
             // Images
             image_commands::create_image,

--- a/apps/staged/src-tauri/src/note_commands.rs
+++ b/apps/staged/src-tauri/src/note_commands.rs
@@ -83,6 +83,17 @@ pub fn list_project_notes(
         .map_err(|e| e.to_string())
 }
 
+/// Get a single project note by its linked session ID, with resolved session status.
+#[tauri::command(rename_all = "camelCase")]
+pub fn get_project_note_by_session(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    session_id: String,
+) -> Result<Option<crate::store::ProjectNote>, String> {
+    crate::get_store(&store)?
+        .get_project_note_by_session_with_status(&session_id)
+        .map_err(|e| e.to_string())
+}
+
 /// Delete a project note and its linked session (if any).
 #[tauri::command(rename_all = "camelCase")]
 pub fn delete_project_note(

--- a/apps/staged/src-tauri/src/note_commands.rs
+++ b/apps/staged/src-tauri/src/note_commands.rs
@@ -79,7 +79,7 @@ pub fn list_project_notes(
     project_id: String,
 ) -> Result<Vec<crate::store::ProjectNote>, String> {
     crate::get_store(&store)?
-        .list_project_notes(&project_id)
+        .list_project_notes_with_status(&project_id)
         .map_err(|e| e.to_string())
 }
 

--- a/apps/staged/src-tauri/src/note_commands.rs
+++ b/apps/staged/src-tauri/src/note_commands.rs
@@ -90,16 +90,11 @@ pub fn delete_project_note(
     note_id: String,
 ) -> Result<(), String> {
     let store = crate::get_store(&store)?;
-    let note = store
-        .get_project_note(&note_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Project note not found: {note_id}"))?;
-
-    store
+    let session_id = store
         .delete_project_note(&note_id)
         .map_err(|e| e.to_string())?;
 
-    if let Some(sid) = note.session_id {
+    if let Some(sid) = session_id {
         let _ = store.delete_session(&sid);
     }
     Ok(())

--- a/apps/staged/src-tauri/src/note_commands.rs
+++ b/apps/staged/src-tauri/src/note_commands.rs
@@ -83,12 +83,24 @@ pub fn list_project_notes(
         .map_err(|e| e.to_string())
 }
 
-#[tauri::command]
+/// Delete a project note and its linked session (if any).
+#[tauri::command(rename_all = "camelCase")]
 pub fn delete_project_note(
     store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
     note_id: String,
 ) -> Result<(), String> {
-    crate::get_store(&store)?
+    let store = crate::get_store(&store)?;
+    let note = store
+        .get_project_note(&note_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Project note not found: {note_id}"))?;
+
+    store
         .delete_project_note(&note_id)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    if let Some(sid) = note.session_id {
+        let _ = store.delete_session(&sid);
+    }
+    Ok(())
 }

--- a/apps/staged/src-tauri/src/prs.rs
+++ b/apps/staged/src-tauri/src/prs.rs
@@ -153,11 +153,14 @@ fn start_pipeline_for_branch(
     // Emit "running" event *before* returning so the global session listener
     // registers this session atomically — avoiding the race where the session
     // completes before the frontend `.then()` callback fires.
+    let branch_id = ctx.branch.id.clone();
+    let project_id = ctx.branch.project_id.clone();
+
     session_runner::emit_session_running(
         app_handle,
         &session.id,
-        &ctx.branch.id,
-        &ctx.branch.project_id,
+        &branch_id,
+        &project_id,
         session_type,
     );
 
@@ -172,6 +175,8 @@ fn start_pipeline_for_branch(
             provider,
             workspace_name: ctx.workspace_name,
             remote_working_dir: ctx.remote_working_dir,
+            branch_id: Some(branch_id),
+            project_id: Some(project_id),
         },
         store,
         app_handle.clone(),
@@ -313,14 +318,17 @@ async fn start_running_commit_pipeline_for_branch(
     session.pipeline = Some(pipeline.clone());
     store.create_session(&session).map_err(|e| e.to_string())?;
 
-    let commit = store::Commit::new_pending(&ctx.branch.id).with_session(&session.id);
+    let branch_id = ctx.branch.id.clone();
+    let project_id = ctx.branch.project_id.clone();
+
+    let commit = store::Commit::new_pending(&branch_id).with_session(&session.id);
     store.create_commit(&commit).map_err(|e| e.to_string())?;
 
     session_runner::emit_session_running(
         app_handle,
         &session.id,
-        &ctx.branch.id,
-        &ctx.branch.project_id,
+        &branch_id,
+        &project_id,
         "commit",
     );
 
@@ -335,6 +343,8 @@ async fn start_running_commit_pipeline_for_branch(
             provider,
             workspace_name: ctx.workspace_name,
             remote_working_dir: ctx.remote_working_dir,
+            branch_id: Some(branch_id),
+            project_id: Some(project_id),
         },
         store,
         app_handle.clone(),
@@ -440,11 +450,14 @@ pub(crate) async fn start_queued_commit_pipeline_for_branch(
         .update_session_pipeline(&session.id, &pipeline)
         .map_err(|e| e.to_string())?;
 
+    let branch_id = ctx.branch.id.clone();
+    let project_id = ctx.branch.project_id.clone();
+
     session_runner::emit_session_running(
         &app_handle,
         &session.id,
-        &ctx.branch.id,
-        &ctx.branch.project_id,
+        &branch_id,
+        &project_id,
         "commit",
     );
 
@@ -459,6 +472,8 @@ pub(crate) async fn start_queued_commit_pipeline_for_branch(
             provider: effective_provider,
             workspace_name: ctx.workspace_name,
             remote_working_dir: ctx.remote_working_dir,
+            branch_id: Some(branch_id),
+            project_id: Some(project_id),
         },
         store,
         app_handle,

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -611,8 +611,8 @@ Begin the note with a markdown H1 heading as the title.\n\n"
     }
     store.create_session(&session).map_err(|e| e.to_string())?;
 
-    // Always create a project note stub with empty title and content so that the
-    // frontend can detect it as "generating" via the !title && !content check.
+    // Create a project note stub linked to the session. The frontend uses the
+    // backend-resolved sessionStatus to determine whether the note is generating.
     let note = store::ProjectNote::new(&project_id, "", "").with_session(&session.id);
     store
         .create_project_note(&note)

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -160,6 +160,8 @@ pub async fn start_session(
             action_registry: None,
             remote_working_dir: None,
             image_ids: vec![],
+            branch_id: None,
+            project_id: None,
         },
         store,
         app_handle,
@@ -321,6 +323,9 @@ pub async fn resume_session(
         return Err("Session is already running".to_string());
     }
 
+    let config_branch_id = event_branch_id.clone();
+    let config_project_id = event_project_id.clone().or(mcp_project_id.clone());
+
     crate::web_server::emit_to_all(
         &app_handle,
         "session-status-changed",
@@ -363,6 +368,8 @@ pub async fn resume_session(
             },
             remote_working_dir,
             image_ids: image_ids.unwrap_or_default(),
+            branch_id: config_branch_id,
+            project_id: config_project_id,
         },
         store,
         app_handle,
@@ -407,6 +414,8 @@ pub fn cancel_session(
                     None,
                     Some(&store::CompletionReason::Interrupted),
                 );
+                let branch_id = store.get_branch_id_for_session(&session_id).ok().flatten();
+                let project_id = store.get_project_id_for_session(&session_id).ok().flatten();
                 crate::web_server::emit_to_all(
                     &app_handle,
                     "session-status-changed",
@@ -415,8 +424,8 @@ pub fn cancel_session(
                         status: "cancelled".to_string(),
                         error_message: None,
                         completion_reason: Some("interrupted".to_string()),
-                        branch_id: None,
-                        project_id: None,
+                        branch_id,
+                        project_id,
                         session_type: None,
                         is_auto_review: false,
                     },
@@ -625,6 +634,8 @@ Begin the note with a markdown H1 heading as the title.\n\n"
             action_registry: Some(Arc::clone(&action_registry)),
             remote_working_dir: None,
             image_ids: image_ids.unwrap_or_default(),
+            branch_id: None,
+            project_id: Some(project_id),
         },
         store,
         app_handle,
@@ -876,6 +887,8 @@ pub async fn start_branch_session(
             action_registry: None,
             remote_working_dir,
             image_ids: image_ids.unwrap_or_default(),
+            branch_id: Some(branch_id),
+            project_id: Some(branch.project_id.clone()),
         },
         store,
         app_handle,
@@ -1283,6 +1296,8 @@ pub async fn drain_queued_sessions_for_branch(
             action_registry: None,
             remote_working_dir,
             image_ids,
+            branch_id: Some(branch_id),
+            project_id: Some(branch.project_id.clone()),
         },
         store,
         app_handle,
@@ -1567,6 +1582,8 @@ pub async fn trigger_auto_review(
             action_registry: None,
             remote_working_dir,
             image_ids: vec![],
+            branch_id: Some(branch_id.clone()),
+            project_id: Some(branch.project_id.clone()),
         },
         store,
         app_handle,

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -226,6 +226,12 @@ pub struct SessionConfig {
     /// Image IDs to include in the prompt. The runner reads the image files,
     /// base64-encodes them, and passes them as content blocks to the driver.
     pub image_ids: Vec<String>,
+    /// Branch that owns this session (branch-level sessions only).
+    /// Threaded through so terminal events carry the same context as start events.
+    pub branch_id: Option<String>,
+    /// Project that owns this session. Set for both project-note sessions
+    /// (directly) and branch-level sessions (via the branch's project).
+    pub project_id: Option<String>,
 }
 
 /// Start a session: persist the user message, spawn the agent, stream to DB.
@@ -476,13 +482,12 @@ pub fn start_session(
             new_status,
             error_msg,
             Some(&completion_reason),
+            config.branch_id.clone(),
+            config.project_id.clone(),
         );
 
         if transitioned {
-            let branch_id = store_for_status
-                .get_branch_id_for_session(&session_id_for_status)
-                .ok()
-                .flatten();
+            let branch_id = config.branch_id.clone();
             let auto_review_branch_id = committed_branch_id.clone();
 
             if let Some(branch_id) = branch_id {
@@ -587,6 +592,11 @@ pub struct PipelineConfig {
     pub workspace_name: Option<String>,
     /// Remote working directory for remote branches.
     pub remote_working_dir: Option<PathBuf>,
+    /// Branch that owns this pipeline session. Copied to `SessionConfig` on
+    /// AI handoff and used by `emit_status` for terminal events.
+    pub branch_id: Option<String>,
+    /// Project that owns this pipeline session.
+    pub project_id: Option<String>,
 }
 
 /// Result of running a pipeline — tells the caller what happened.
@@ -653,10 +663,6 @@ pub fn start_pipeline_session(
         match outcome {
             PipelineOutcome::CompletedWithoutAi => {
                 // Pipeline completed successfully — transition session to completed.
-                let branch_id = store_for_status
-                    .get_branch_id_for_session(&session_id)
-                    .ok()
-                    .flatten();
                 resolve_pipeline_artifacts_without_ai(&config, &store_for_status, true);
                 let status_enum = SessionStatus::Completed;
                 let reason = CompletionReason::TurnComplete;
@@ -664,13 +670,21 @@ pub fn start_pipeline_session(
                 let transitioned = store_for_status
                     .transition_from_running(&session_id, status_enum, None, Some(&reason))
                     .unwrap_or(false);
-                emit_status(&app_handle, &session_id, "completed", None, Some(&reason));
+                emit_status(
+                    &app_handle,
+                    &session_id,
+                    "completed",
+                    None,
+                    Some(&reason),
+                    config.branch_id.clone(),
+                    config.project_id.clone(),
+                );
                 if transitioned {
                     drain_queued_after_pipeline_terminal(
                         Arc::clone(&store_for_status),
                         Arc::clone(&registry),
                         app_handle.clone(),
-                        branch_id,
+                        config.branch_id.clone(),
                     );
                 }
             }
@@ -712,6 +726,8 @@ pub fn start_pipeline_session(
                     action_registry: None,
                     remote_working_dir: config.remote_working_dir.clone(),
                     image_ids: vec![],
+                    branch_id: config.branch_id.clone(),
+                    project_id: config.project_id.clone(),
                 };
                 if let Err(e) = start_session(
                     ai_config,
@@ -743,10 +759,6 @@ pub fn start_pipeline_session(
                             }
                         }
                     }
-                    let branch_id = store_for_status
-                        .get_branch_id_for_session(&session_id)
-                        .ok()
-                        .flatten();
                     resolve_pipeline_artifacts_without_ai(&config, &store_for_status, false);
                     let transitioned = finish_failed_pipeline_handoff_start(
                         &store_for_status,
@@ -760,13 +772,15 @@ pub fn start_pipeline_session(
                         "error",
                         Some(e),
                         Some(&CompletionReason::Crashed),
+                        config.branch_id.clone(),
+                        config.project_id.clone(),
                     );
                     if transitioned {
                         drain_queued_after_pipeline_terminal(
                             Arc::clone(&store_for_status),
                             Arc::clone(&registry),
                             app_handle.clone(),
-                            branch_id,
+                            config.branch_id.clone(),
                         );
                     }
                 }
@@ -774,10 +788,6 @@ pub fn start_pipeline_session(
             PipelineOutcome::Aborted { .. } => {
                 // Pipeline aborted (e.g. non-fast-forward). Mark as completed so
                 // the frontend can inspect the pipeline steps for the failure.
-                let branch_id = store_for_status
-                    .get_branch_id_for_session(&session_id)
-                    .ok()
-                    .flatten();
                 resolve_pipeline_artifacts_without_ai(&config, &store_for_status, false);
                 let reason = CompletionReason::TurnComplete;
                 registry.deregister(&session_id);
@@ -789,21 +799,25 @@ pub fn start_pipeline_session(
                         Some(&reason),
                     )
                     .unwrap_or(false);
-                emit_status(&app_handle, &session_id, "completed", None, Some(&reason));
+                emit_status(
+                    &app_handle,
+                    &session_id,
+                    "completed",
+                    None,
+                    Some(&reason),
+                    config.branch_id.clone(),
+                    config.project_id.clone(),
+                );
                 if transitioned {
                     drain_queued_after_pipeline_terminal(
                         Arc::clone(&store_for_status),
                         Arc::clone(&registry),
                         app_handle.clone(),
-                        branch_id,
+                        config.branch_id.clone(),
                     );
                 }
             }
             PipelineOutcome::Cancelled => {
-                let branch_id = store_for_status
-                    .get_branch_id_for_session(&session_id)
-                    .ok()
-                    .flatten();
                 resolve_pipeline_artifacts_without_ai(&config, &store_for_status, false);
                 let reason = CompletionReason::Interrupted;
                 registry.deregister(&session_id);
@@ -815,13 +829,21 @@ pub fn start_pipeline_session(
                         Some(&reason),
                     )
                     .unwrap_or(false);
-                emit_status(&app_handle, &session_id, "cancelled", None, Some(&reason));
+                emit_status(
+                    &app_handle,
+                    &session_id,
+                    "cancelled",
+                    None,
+                    Some(&reason),
+                    config.branch_id.clone(),
+                    config.project_id.clone(),
+                );
                 if transitioned {
                     drain_queued_after_pipeline_terminal(
                         Arc::clone(&store_for_status),
                         Arc::clone(&registry),
                         app_handle.clone(),
-                        branch_id,
+                        config.branch_id.clone(),
                     );
                 }
             }
@@ -1557,15 +1579,19 @@ pub fn recover_dead_sessions(
                     Some(&CompletionReason::AppQuit),
                 )
                 .unwrap_or(false);
+            let recovered_branch_id = store.get_branch_id_for_session(&session.id).ok().flatten();
+            let recovered_project_id = store.get_project_id_for_session(&session.id).ok().flatten();
             emit_status(
                 &app_handle,
                 &session.id,
                 "error",
                 None,
                 Some(&CompletionReason::AppQuit),
+                recovered_branch_id.clone(),
+                recovered_project_id,
             );
             if transitioned {
-                let branch_id = store.get_branch_id_for_session(&session.id).ok().flatten();
+                let branch_id = recovered_branch_id;
                 if let Some(branch_id) = branch_id {
                     let store_for_follow_up = Arc::clone(&store);
                     let registry_for_follow_up = Arc::clone(&registry);
@@ -2270,14 +2296,16 @@ fn emit_status(
     status: &str,
     error: Option<String>,
     completion_reason: Option<&CompletionReason>,
+    branch_id: Option<String>,
+    project_id: Option<String>,
 ) {
     let event = SessionStatusEvent {
         session_id: session_id.to_string(),
         status: status.to_string(),
         error_message: error,
         completion_reason: completion_reason.map(|r| r.as_str().to_string()),
-        branch_id: None,
-        project_id: None,
+        branch_id,
+        project_id,
         session_type: None,
         is_auto_review: false,
     };
@@ -2421,6 +2449,8 @@ mod tests {
             provider: None,
             workspace_name: None,
             remote_working_dir: None,
+            branch_id: None,
+            project_id: None,
         }
     }
 

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -758,6 +758,13 @@ pub struct ProjectNote {
     pub suggested_next_commit_step: Option<String>,
     /// AI-suggested prompt for a follow-up note session.
     pub suggested_next_note_step: Option<String>,
+    /// Resolved session status (e.g. "running", "completed", "cancelled").
+    /// Populated at query time via `resolve_session_status()`.
+    #[serde(skip_deserializing)]
+    pub session_status: Option<String>,
+    /// Why the session reached its terminal state.
+    #[serde(skip_deserializing)]
+    pub completion_reason: Option<String>,
 }
 
 impl ProjectNote {
@@ -775,6 +782,8 @@ impl ProjectNote {
             completed_at: if has_content { Some(now) } else { None },
             suggested_next_commit_step: None,
             suggested_next_note_step: None,
+            session_status: None,
+            completion_reason: None,
         }
     }
 

--- a/apps/staged/src-tauri/src/store/project_notes.rs
+++ b/apps/staged/src-tauri/src/store/project_notes.rs
@@ -142,6 +142,21 @@ impl Store {
         })
     }
 
+    /// Find a project note by session ID with session status resolved.
+    pub fn get_project_note_by_session_with_status(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<ProjectNote>, StoreError> {
+        let mut note = match self.get_project_note_by_session(session_id)? {
+            Some(n) => n,
+            None => return Ok(None),
+        };
+        let resolved = self.resolve_session_status(note.session_id.as_deref());
+        note.session_status = resolved.status;
+        note.completion_reason = resolved.completion_reason;
+        Ok(Some(note))
+    }
+
     /// Return project notes with session status resolved from the sessions table.
     pub fn list_project_notes_with_status(
         &self,

--- a/apps/staged/src-tauri/src/store/project_notes.rs
+++ b/apps/staged/src-tauri/src/store/project_notes.rs
@@ -130,6 +130,32 @@ impl Store {
             completed_at: row.get(7)?,
             suggested_next_commit_step: row.get(8)?,
             suggested_next_note_step: row.get(9)?,
+            session_status: None,
+            completion_reason: None,
         })
+    }
+
+    /// Return project notes with session status resolved from the sessions table.
+    /// Filters out empty stubs whose session was cancelled (nothing to show).
+    pub fn list_project_notes_with_status(
+        &self,
+        project_id: &str,
+    ) -> Result<Vec<ProjectNote>, StoreError> {
+        let mut notes = self.list_project_notes(project_id)?;
+        for note in &mut notes {
+            let resolved = self.resolve_session_status(note.session_id.as_deref());
+            note.session_status = resolved.status;
+            note.completion_reason = resolved.completion_reason;
+        }
+        // Remove empty stubs from cancelled/errored sessions — no content to display.
+        notes.retain(|n| {
+            let is_empty = n.title.trim().is_empty() && n.content.trim().is_empty();
+            let is_terminal = matches!(
+                n.session_status.as_deref(),
+                Some("cancelled") | Some("error")
+            );
+            !(is_empty && is_terminal)
+        });
+        Ok(notes)
     }
 }

--- a/apps/staged/src-tauri/src/store/project_notes.rs
+++ b/apps/staged/src-tauri/src/store/project_notes.rs
@@ -136,7 +136,6 @@ impl Store {
     }
 
     /// Return project notes with session status resolved from the sessions table.
-    /// Filters out empty stubs whose session was cancelled (nothing to show).
     pub fn list_project_notes_with_status(
         &self,
         project_id: &str,
@@ -147,15 +146,6 @@ impl Store {
             note.session_status = resolved.status;
             note.completion_reason = resolved.completion_reason;
         }
-        // Remove empty stubs from cancelled/errored sessions — no content to display.
-        notes.retain(|n| {
-            let is_empty = n.title.trim().is_empty() && n.content.trim().is_empty();
-            let is_terminal = matches!(
-                n.session_status.as_deref(),
-                Some("cancelled") | Some("error")
-            );
-            !(is_empty && is_terminal)
-        });
         Ok(notes)
     }
 }

--- a/apps/staged/src-tauri/src/store/project_notes.rs
+++ b/apps/staged/src-tauri/src/store/project_notes.rs
@@ -112,10 +112,17 @@ impl Store {
         Ok(())
     }
 
-    pub fn delete_project_note(&self, id: &str) -> Result<(), StoreError> {
+    /// Delete a project note and return its session_id (if any) atomically.
+    pub fn delete_project_note(&self, id: &str) -> Result<Option<String>, StoreError> {
         let conn = self.conn.lock().unwrap();
-        conn.execute("DELETE FROM project_notes WHERE id = ?1", params![id])?;
-        Ok(())
+        let session_id: Option<Option<String>> = conn
+            .query_row(
+                "DELETE FROM project_notes WHERE id = ?1 RETURNING session_id",
+                params![id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(session_id.flatten())
     }
 
     fn row_to_project_note(row: &rusqlite::Row) -> rusqlite::Result<ProjectNote> {

--- a/apps/staged/src-tauri/src/store/sessions.rs
+++ b/apps/staged/src-tauri/src/store/sessions.rs
@@ -332,6 +332,44 @@ impl Store {
         .map_err(Into::into)
     }
 
+    /// Resolve the project that owns a session.
+    ///
+    /// Checks project_notes first (project-note sessions), then falls back to
+    /// resolving via the branch (branch-level sessions have their branch linked
+    /// to a project). Used by the recovery path (`recover_orphaned_sessions`)
+    /// which has no caller context to pipe through.
+    pub fn get_project_id_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let direct: Option<String> = conn
+            .query_row(
+                "SELECT project_id FROM project_notes WHERE session_id = ?1 LIMIT 1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if direct.is_some() {
+            return Ok(direct);
+        }
+        conn.query_row(
+            "SELECT b.project_id FROM branches b
+             INNER JOIN (
+                 SELECT branch_id FROM commits WHERE session_id = ?1
+                 UNION ALL
+                 SELECT branch_id FROM notes WHERE session_id = ?1
+                 UNION ALL
+                 SELECT branch_id FROM reviews WHERE session_id = ?1
+             ) a ON a.branch_id = b.id
+             LIMIT 1",
+            params![session_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
     pub fn delete_session(&self, id: &str) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute("DELETE FROM sessions WHERE id = ?1", params![id])?;

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2113,9 +2113,16 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
         "delete_project_note" => {
             let store = get_store(store_mutex)?;
             let note_id: String = arg(&args, "noteId")?;
+            let note = store
+                .get_project_note(&note_id)
+                .map_err(|e| e.to_string())?
+                .ok_or_else(|| format!("Project note not found: {note_id}"))?;
             store
                 .delete_project_note(&note_id)
                 .map_err(|e| e.to_string())?;
+            if let Some(sid) = note.session_id {
+                let _ = store.delete_session(&sid);
+            }
             Ok(Value::Null)
         }
 

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2113,14 +2113,10 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
         "delete_project_note" => {
             let store = get_store(store_mutex)?;
             let note_id: String = arg(&args, "noteId")?;
-            let note = store
-                .get_project_note(&note_id)
-                .map_err(|e| e.to_string())?
-                .ok_or_else(|| format!("Project note not found: {note_id}"))?;
-            store
+            let session_id = store
                 .delete_project_note(&note_id)
                 .map_err(|e| e.to_string())?;
-            if let Some(sid) = note.session_id {
+            if let Some(sid) = session_id {
                 let _ = store.delete_session(&sid);
             }
             Ok(Value::Null)

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2110,6 +2110,14 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                 .map_err(|e| e.to_string())?;
             Ok(serde_json::to_value(notes).unwrap())
         }
+        "get_project_note_by_session" => {
+            let store = get_store(store_mutex)?;
+            let session_id: String = arg(&args, "sessionId")?;
+            let note = store
+                .get_project_note_by_session_with_status(&session_id)
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::to_value(note).unwrap())
+        }
         "delete_project_note" => {
             let store = get_store(store_mutex)?;
             let note_id: String = arg(&args, "noteId")?;

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2106,7 +2106,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
             let store = get_store(store_mutex)?;
             let project_id: String = arg(&args, "projectId")?;
             let notes = store
-                .list_project_notes(&project_id)
+                .list_project_notes_with_status(&project_id)
                 .map_err(|e| e.to_string())?;
             Ok(serde_json::to_value(notes).unwrap())
         }

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2478,6 +2478,8 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     action_registry: None,
                     remote_working_dir: None,
                     image_ids: vec![],
+                    branch_id: None,
+                    project_id: None,
                 },
                 store,
                 app_handle.clone(),
@@ -2607,6 +2609,9 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                 return Err("Session is already running".to_string());
             }
 
+            let config_branch_id = event_branch_id.clone();
+            let config_project_id = event_project_id.clone().or(mcp_project_id.clone());
+
             emit_to_all(
                 app_handle,
                 "session-status-changed",
@@ -2645,6 +2650,8 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     },
                     remote_working_dir,
                     image_ids: image_ids.unwrap_or_default(),
+                    branch_id: config_branch_id,
+                    project_id: config_project_id,
                 },
                 store,
                 app_handle.clone(),
@@ -2862,6 +2869,8 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     action_registry: None,
                     remote_working_dir,
                     image_ids: image_ids.unwrap_or_default(),
+                    branch_id: Some(branch_id),
+                    project_id: Some(branch.project_id.clone()),
                 },
                 store,
                 app_handle.clone(),
@@ -2985,6 +2994,8 @@ Begin the note with a markdown H1 heading as the title.\n\n"
                     action_registry: Some(Arc::clone(action_registry)),
                     remote_working_dir: None,
                     image_ids: image_ids.unwrap_or_default(),
+                    branch_id: None,
+                    project_id: Some(project_id),
                 },
                 store,
                 app_handle.clone(),

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -202,6 +202,12 @@ export function createProjectNote(
   return invokeCommand('create_project_note', { projectId, title, content });
 }
 
+export function getProjectNoteBySession(
+  sessionId: string
+): Promise<import('./types').ProjectNote | null> {
+  return invokeCommand('get_project_note_by_session', { sessionId });
+}
+
 export function deleteProjectNote(noteId: string): Promise<void> {
   return invokeCommand('delete_project_note', { noteId });
 }

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -22,6 +22,7 @@
     GitPullRequestDraft,
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
+  import { isSessionActive } from '../../shared/sessionStatus';
   import { listenToEvent, type UnlistenFn } from '../../transport';
   import { subscribeDragDrop } from './dragDrop';
   import type {
@@ -282,11 +283,9 @@
   /** True when the branch has at least one queued or running session. */
   function hasActiveSessions(tl: NonNullable<typeof timeline>): boolean {
     return (
-      tl.commits.some((c) => c.sessionStatus === 'queued' || c.sessionStatus === 'running') ||
-      tl.notes.some((n) => n.sessionStatus === 'queued' || n.sessionStatus === 'running') ||
-      tl.reviews.some(
-        (r) => !r.isAuto && (r.sessionStatus === 'queued' || r.sessionStatus === 'running')
-      )
+      tl.commits.some((c) => isSessionActive(c.sessionStatus)) ||
+      tl.notes.some((n) => isSessionActive(n.sessionStatus)) ||
+      tl.reviews.some((r) => !r.isAuto && isSessionActive(r.sessionStatus))
     );
   }
   let commandPipelinePending = $state(false);

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -23,6 +23,7 @@
   } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import { isSessionActive } from '../../shared/sessionStatus';
+  import { deleteSessionLinkedItem } from '../../shared/deleteSessionLinkedItem';
   import { listenToEvent, type UnlistenFn } from '../../transport';
   import { subscribeDragDrop } from './dragDrop';
   import type {
@@ -60,7 +61,6 @@
   import { alerts } from '../../shared/alerts.svelte';
   import { aggregateProjectPrStatus } from '../../shared/utils';
   import { timelineToHashtagItems, projectNotesToHashtagItems } from '../sessions/hashtagItems';
-  import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import type { WorktreeChangesPreview } from '../../commands';
@@ -1032,19 +1032,8 @@
     const doDelete = async () => {
       confirmDelete = null;
       try {
-        if (sessionId) {
-          try {
-            await commands.cancelSession(sessionId);
-          } catch {
-            // Session may already be finished
-          }
-        }
-        await commands.deleteNote(noteId, !!sessionId);
-        if (sessionId) {
-          sessionRegistry.cleanupSession(sessionId);
-        }
+        await deleteSessionLinkedItem(() => commands.deleteNote(noteId, !!sessionId), sessionId);
         loadTimeline();
-        // Drain the next queued session now that this one has been removed.
         commands
           .drainQueuedSessions(branch.id)
           .catch((e) => console.error('Failed to drain queued sessions:', e));
@@ -1070,19 +1059,11 @@
     const doDelete = async () => {
       confirmDelete = null;
       try {
-        if (sessionId) {
-          try {
-            await commands.cancelSession(sessionId);
-          } catch {
-            // Session may already be finished
-          }
-        }
-        await commands.deleteReview(reviewId, !!sessionId);
-        if (sessionId) {
-          sessionRegistry.cleanupSession(sessionId);
-        }
+        await deleteSessionLinkedItem(
+          () => commands.deleteReview(reviewId, !!sessionId),
+          sessionId
+        );
         loadTimeline();
-        // Drain the next queued session now that this one has been removed.
         commands
           .drainQueuedSessions(branch.id)
           .catch((e) => console.error('Failed to drain queued sessions:', e));
@@ -1143,19 +1124,11 @@
   async function handleDeletePendingCommit(commitId: string, sessionId?: string) {
     deletingCommitKeys = new Set([...deletingCommitKeys, commitId]);
     try {
-      if (sessionId) {
-        try {
-          await commands.cancelSession(sessionId);
-        } catch {
-          // Session may already be finished, that's fine
-        }
-      }
-      await commands.deletePendingCommit(commitId, !!sessionId);
-      if (sessionId) {
-        sessionRegistry.cleanupSession(sessionId);
-      }
+      await deleteSessionLinkedItem(
+        () => commands.deletePendingCommit(commitId, !!sessionId),
+        sessionId
+      );
       await loadTimeline();
-      // Drain the next queued session now that this one has been removed.
       commands
         .drainQueuedSessions(branch.id)
         .catch((e) => console.error('Failed to drain queued sessions:', e));

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -11,6 +11,7 @@
 
 import type { Branch, BranchTimeline as BranchTimelineData, BranchSessionType } from '../../types';
 import * as commands from '../../api/commands';
+import { isSessionActive } from '../../shared/sessionStatus';
 import { getPreferredAgent } from '../settings/preferences.svelte';
 import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
 import { alerts } from '../../shared/alerts.svelte';
@@ -66,9 +67,9 @@ export default class BranchCardSessionManager {
     const tl = this.getTimeline();
     if (!tl) return false;
     return (
-      tl.commits.some((c) => c.sessionStatus === 'running') ||
-      tl.notes.some((n) => n.sessionStatus === 'running') ||
-      tl.reviews.some((r) => r.sessionStatus === 'running' && !r.isAuto)
+      tl.commits.some((c) => isSessionActive(c.sessionStatus)) ||
+      tl.notes.some((n) => isSessionActive(n.sessionStatus)) ||
+      tl.reviews.some((r) => isSessionActive(r.sessionStatus) && !r.isAuto)
     );
   });
 

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -206,7 +206,9 @@
 
   // Hashtag reference items
   let hashtagItems = $state<HashtagItem[]>([]);
+  let hashtagVersion = $state(0);
   $effect(() => {
+    const _v = hashtagVersion; // reactive dependency for manual invalidation
     let stale = false;
     buildProjectHashtagItems(project.id, branches, reposById)
       .then((items) => {
@@ -447,6 +449,12 @@
   onMount(() => {
     loadProjectNotes();
 
+    // Refresh hashtag items when branch timelines are invalidated (e.g. branch session completion)
+    const onTimelineInvalidated = () => {
+      hashtagVersion++;
+    };
+    window.addEventListener('timeline-invalidated', onTimelineInvalidated);
+
     let unlistenSession: (() => void) | undefined;
     listenToEvent<{ sessionId: string; status: string; projectId?: string }>(
       'session-status-changed',
@@ -474,6 +482,12 @@
             // Note was filtered out (e.g. deleted) — remove from local list
             projectNotes = projectNotes.filter((n) => n.sessionId !== sessionId);
           }
+
+          // Invalidate timeline caches so hashtag items pick up new commits/notes
+          for (const b of branches) {
+            commands.invalidateBranchTimeline(b.id);
+          }
+          hashtagVersion++;
         }
       }
     ).then((unlisten) => {
@@ -482,6 +496,7 @@
 
     return () => {
       unlistenSession?.();
+      window.removeEventListener('timeline-invalidated', onTimelineInvalidated);
     };
   });
 </script>

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -207,9 +207,17 @@
   // Hashtag reference items
   let hashtagItems = $state<HashtagItem[]>([]);
   $effect(() => {
-    buildProjectHashtagItems(project.id, branches, reposById).then((items) => {
-      hashtagItems = items;
-    });
+    let stale = false;
+    buildProjectHashtagItems(project.id, branches, reposById)
+      .then((items) => {
+        if (!stale) hashtagItems = items;
+      })
+      .catch((err) => {
+        console.error('[ProjectSection] Failed to build hashtag items:', err);
+      });
+    return () => {
+      stale = true;
+    };
   });
 
   // Image attachment state

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -450,23 +450,31 @@
     let unlistenSession: (() => void) | undefined;
     listenToEvent<{ sessionId: string; status: string; projectId?: string }>(
       'session-status-changed',
-      (payload) => {
+      async (payload) => {
         const { sessionId, status, projectId } = payload;
         if (projectId !== project.id) return;
 
         if (status === 'running') {
-          // Bridge: track until next loadProjectNotes() picks it up via sessionStatus
+          // Bridge: track until the stub (already loaded by startProjectSession) is
+          // updated with an authoritative sessionStatus on the terminal event.
           activeSessionIds = new Set([...activeSessionIds, sessionId]);
+          return;
         }
 
         if (status === 'completed' || status === 'error' || status === 'cancelled') {
           const next = new Set(activeSessionIds);
           next.delete(sessionId);
           activeSessionIds = next;
-        }
 
-        // Always refresh — backend now provides authoritative status
-        loadProjectNotes();
+          // Surgically update just the affected note instead of reloading all
+          const updatedNote = await commands.getProjectNoteBySession(sessionId);
+          if (updatedNote) {
+            projectNotes = projectNotes.map((n) => (n.id === updatedNote.id ? updatedNote : n));
+          } else {
+            // Note was filtered out (e.g. deleted) — remove from local list
+            projectNotes = projectNotes.filter((n) => n.sessionId !== sessionId);
+          }
+        }
       }
     ).then((unlisten) => {
       unlistenSession = unlisten;

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -40,6 +40,7 @@
   import { projectStateStore } from '../../stores/projectState.svelte';
   import BranchCard from '../branches/BranchCard.svelte';
   import Spinner from '../../shared/Spinner.svelte';
+  import { isSessionActive } from '../../shared/sessionStatus';
   import AddRepoModal from './AddRepoModal.svelte';
   import SuggestedRepos from './SuggestedRepos.svelte';
   import type { RepoSelection as RepoPickerSelection } from '../../shared/githubUrl';
@@ -184,7 +185,7 @@
   let runningNoteSessionIds = $derived.by(() => {
     const ids = new Set<string>();
     for (const note of projectNotes) {
-      if (!note.title.trim() && !note.content.trim() && note.sessionId) {
+      if (isSessionActive(note.sessionStatus) && note.sessionId) {
         ids.add(note.sessionId);
       }
     }
@@ -440,36 +441,21 @@
       'session-status-changed',
       (payload) => {
         const { sessionId, status, projectId } = payload;
-        const isTracked = activeSessionIds.has(sessionId);
-        // Also reload if this session belongs to a known project note (handles
-        // sessions that were already running when the component mounted).
-        const isKnownNoteSession = projectNotes.some((n) => n.sessionId === sessionId);
+        if (projectId !== project.id) return;
 
-        // Handle resumed sessions: when a project note session is resumed,
-        // the backend emits a "running" event with the projectId. Re-add it
-        // to active tracking so the row spinner and sidebar spinner appear.
-        if (
-          status === 'running' &&
-          !isTracked &&
-          isKnownNoteSession &&
-          (projectId === project.id || !projectId)
-        ) {
+        if (status === 'running') {
+          // Bridge: track until next loadProjectNotes() picks it up via sessionStatus
           activeSessionIds = new Set([...activeSessionIds, sessionId]);
-          sessionRegistry.register(sessionId, project.id, 'note');
-          projectStateStore.addRunningSession(project.id, sessionId);
         }
 
-        if (isTracked || isKnownNoteSession) {
-          if (status === 'completed' || status === 'error' || status === 'cancelled') {
-            if (isTracked) {
-              const next = new Set(activeSessionIds);
-              next.delete(sessionId);
-              activeSessionIds = next;
-            }
-            // Refresh notes after session completes
-            loadProjectNotes();
-          }
+        if (status === 'completed' || status === 'error' || status === 'cancelled') {
+          const next = new Set(activeSessionIds);
+          next.delete(sessionId);
+          activeSessionIds = next;
         }
+
+        // Always refresh — backend now provides authoritative status
+        loadProjectNotes();
       }
     ).then((unlisten) => {
       unlistenSession = unlisten;
@@ -647,7 +633,7 @@
       </div>
       <div class="notes-timeline">
         {#each timelineNotes as note, index (note.id)}
-          {@const isRunning = !note.title.trim() && !note.content.trim()}
+          {@const isRunning = isSessionActive(note.sessionStatus)}
           {@const isFailed = !isRunning && !!note.sessionId && !note.content.trim()}
           {@const noteType = isRunning ? 'generating-note' : isFailed ? 'failed-note' : 'note'}
           {@const liveHint =

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -41,6 +41,7 @@
   import BranchCard from '../branches/BranchCard.svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import { isSessionActive } from '../../shared/sessionStatus';
+  import { deleteSessionLinkedItem } from '../../shared/deleteSessionLinkedItem';
   import AddRepoModal from './AddRepoModal.svelte';
   import SuggestedRepos from './SuggestedRepos.svelte';
   import type { RepoSelection as RepoPickerSelection } from '../../shared/githubUrl';
@@ -404,9 +405,11 @@
   }
 
   async function handleDeleteNote(noteId: string) {
+    const note = projectNotes.find((n) => n.id === noteId);
+    const sessionId = note?.sessionId ?? undefined;
     deletingNoteIds = new Set([...deletingNoteIds, noteId]);
     try {
-      await commands.deleteProjectNote(noteId);
+      await deleteSessionLinkedItem(() => commands.deleteProjectNote(noteId), sessionId);
       projectNotes = projectNotes.filter((n) => n.id !== noteId);
     } catch (e) {
       console.error('[ProjectSection] Failed to delete project note:', e);
@@ -420,9 +423,9 @@
   /** All notes: completed (oldest first) followed by generating – matches branch timeline order. */
   let timelineNotes = $derived(
     [...projectNotes].sort((a, b) => {
-      const aIsGenerating = !a.title.trim() && !a.content.trim();
-      const bIsGenerating = !b.title.trim() && !b.content.trim();
-      if (aIsGenerating !== bIsGenerating) return aIsGenerating ? 1 : -1;
+      const aIsActive = isSessionActive(a.sessionStatus);
+      const bIsActive = isSessionActive(b.sessionStatus);
+      if (aIsActive !== bIsActive) return aIsActive ? 1 : -1;
       return (a.completedAt ?? a.createdAt) - (b.completedAt ?? b.createdAt);
     })
   );

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -66,12 +66,19 @@ export async function buildProjectHashtagItems(
   const items: HashtagItem[] = [];
   const readyBranches = branches.filter((branch) => branchTimelineReadyKey(branch) !== null);
 
-  const [timelines, projectNotes] = await Promise.all([
-    Promise.all(
+  const [timelineResults, projectNotes] = await Promise.all([
+    Promise.allSettled(
       readyBranches.map((b) => getBranchTimeline(b.id).then((t) => ({ branch: b, timeline: t })))
     ),
     listProjectNotes(projectId),
   ]);
+
+  const timelines = timelineResults
+    .filter(
+      (r): r is PromiseFulfilledResult<{ branch: Branch; timeline: BranchTimeline }> =>
+        r.status === 'fulfilled'
+    )
+    .map((r) => r.value);
 
   for (const { branch, timeline } of timelines) {
     const repo = branch.projectRepoId && reposById ? reposById.get(branch.projectRepoId) : null;

--- a/apps/staged/src/lib/shared/deleteSessionLinkedItem.ts
+++ b/apps/staged/src/lib/shared/deleteSessionLinkedItem.ts
@@ -1,0 +1,23 @@
+import * as commands from '../commands';
+import { sessionRegistry } from '../stores/sessionRegistry.svelte';
+
+/**
+ * Cancel a running session, delete the linked item, and clean up the registry.
+ * Shared by branch note/review/commit deletion and project note deletion.
+ */
+export async function deleteSessionLinkedItem(
+  deleteItem: () => Promise<void>,
+  sessionId?: string
+): Promise<void> {
+  if (sessionId) {
+    try {
+      await commands.cancelSession(sessionId);
+    } catch {
+      // Session may already be finished
+    }
+  }
+  await deleteItem();
+  if (sessionId) {
+    sessionRegistry.cleanupSession(sessionId);
+  }
+}

--- a/apps/staged/src/lib/shared/sessionStatus.ts
+++ b/apps/staged/src/lib/shared/sessionStatus.ts
@@ -1,0 +1,3 @@
+export function isSessionActive(status: string | null): boolean {
+  return status === 'queued' || status === 'running';
+}

--- a/apps/staged/src/lib/shared/sessionStatus.ts
+++ b/apps/staged/src/lib/shared/sessionStatus.ts
@@ -1,3 +1,3 @@
-export function isSessionActive(status: string | null): boolean {
+export function isSessionActive(status: string | null | undefined): boolean {
   return status === 'queued' || status === 'running';
 }

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -288,6 +288,8 @@ export interface ProjectNote {
   completedAt: number | null;
   suggestedNextCommitStep: string | null;
   suggestedNextNoteStep: string | null;
+  sessionStatus: string | null;
+  completionReason: string | null;
 }
 
 export interface ProjectSessionResponse {


### PR DESCRIPTION
## Summary

- **Backend-resolved session status**: Project notes now carry `sessionStatus` and `completionReason` fields populated at query time from the sessions table, replacing the fragile frontend heuristic that inferred "generating" from empty title+content.
- **Propagate `branch_id`/`project_id` on all session events**: `SessionConfig` and `PipelineConfig` now carry ownership context so terminal events (`completed`, `error`, `cancelled`) include `project_id`/`branch_id` — eliminating the DB lookup race where `emit_status` previously sent `null` for these fields.
- **Unified delete-with-cancel helper**: Extracted `deleteSessionLinkedItem()` on the frontend and made `delete_project_note` return+delete the linked session atomically (using `DELETE ... RETURNING`) to eliminate TOCTOU races.
- **Resilient hashtag item building**: `buildProjectHashtagItems` now uses `Promise.allSettled` so a single branch timeline failure doesn't break the entire hashtag list.
- **Misc fixes**: `isSessionActive` helper consolidates active-status checks, stale comment updated, `isSessionActive` accepts `undefined`.

## Test plan

- [x] `crates-test` passing
- [x] `staged-ci` passing
- [ ] Verify project notes show spinner while generating and transition to content on completion
- [ ] Verify cancelling/deleting a generating project note cleans up the session
- [ ] Verify session status updates propagate to the project sidebar badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)