### PR TITLE
fix(staged): hide keyboard shortcut hints on touch devices

### DIFF
--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -291,6 +291,10 @@ async fn ws_events(ws: WebSocketUpgrade, State(state): State<WebAppState>) -> Re
     ws.on_upgrade(move |socket| handle_ws(socket, state))
 }
 
+// clippy's suggested fix (collapsing the inner `if` into a match guard) doesn't
+// compile because `data: Bytes` can't be moved out of the pattern binding into
+// the guard expression.
+#[allow(clippy::collapsible_match)]
 async fn handle_ws(mut socket: WebSocket, state: WebAppState) {
     let mut rx = state.event_tx.subscribe();
     loop {

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -313,10 +313,10 @@ async fn handle_ws(mut socket: WebSocket, state: WebAppState) {
             msg = socket.recv() => {
                 match msg {
                     Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(Message::Ping(data)))
-                        if socket.send(Message::Pong(data)).await.is_err() =>
-                    {
-                        break;
+                    Some(Ok(Message::Ping(data))) => {
+                        if socket.send(Message::Pong(data)).await.is_err() {
+                            break;
+                        }
                     }
                     _ => {}
                 }

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -313,10 +313,10 @@ async fn handle_ws(mut socket: WebSocket, state: WebAppState) {
             msg = socket.recv() => {
                 match msg {
                     Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(Message::Ping(data))) => {
-                        if socket.send(Message::Pong(data)).await.is_err() {
-                            break;
-                        }
+                    Some(Ok(Message::Ping(data)))
+                        if socket.send(Message::Pong(data)).await.is_err() =>
+                    {
+                        break;
                     }
                     _ => {}
                 }

--- a/apps/staged/src/lib/features/actions/ActionOutputModal.svelte
+++ b/apps/staged/src/lib/features/actions/ActionOutputModal.svelte
@@ -481,7 +481,7 @@
         <button
           class="close-btn"
           onclick={onClose}
-          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+          title={viewport.showShortcutHints ? 'Close (Esc)' : 'Close'}
         >
           <X size={16} />
         </button>

--- a/apps/staged/src/lib/features/actions/ActionOutputModal.svelte
+++ b/apps/staged/src/lib/features/actions/ActionOutputModal.svelte
@@ -44,6 +44,7 @@
     listenToActionStatus,
   } from './actions';
   import { createIncrementalProcessor, type TerminalLine } from './processOutput';
+  import { viewport } from '../../shared/viewport.svelte';
 
   interface Props {
     executionId: string;
@@ -477,7 +478,11 @@
             <span>Remove</span>
           </button>
         {/if}
-        <button class="close-btn" onclick={onClose} title="Close (Esc)">
+        <button
+          class="close-btn"
+          onclick={onClose}
+          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+        >
           <X size={16} />
         </button>
       </div>

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -11,6 +11,7 @@
   import { buildBranchHashtagItems } from '../sessions/hashtagItems';
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
+  import { viewport } from '../../shared/viewport.svelte';
 
   interface Props {
     branchId: string;
@@ -223,7 +224,9 @@
       {:else}
         <Send size={14} />
         {willQueue ? 'Queue commit' : 'Start commit'}
-        <span class="shortcut-badge">⌘↵</span>
+        {#if viewport.hasKeyboard}
+          <span class="shortcut-badge">⌘↵</span>
+        {/if}
       {/if}
     </button>
   </div>

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -224,7 +224,7 @@
       {:else}
         <Send size={14} />
         {willQueue ? 'Queue commit' : 'Start commit'}
-        {#if viewport.hasKeyboard}
+        {#if viewport.showShortcutHints}
           <span class="shortcut-badge">⌘↵</span>
         {/if}
       {/if}

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -65,6 +65,7 @@
     type FileEntry,
     type TreeNode,
   } from './diffModalHelpers';
+  import { viewport } from '../../shared/viewport.svelte';
 
   // ==========================================================================
   // Props
@@ -1222,7 +1223,11 @@
     <div class="title-bar" onpointerdown={startDrag}>
       <div class="traffic-light-spacer"></div>
       <div class="left-actions">
-        <button class="icon-btn" onclick={onClose} title="Back (Esc)">
+        <button
+          class="icon-btn"
+          onclick={onClose}
+          title={viewport.hasKeyboard ? 'Back (Esc)' : 'Back'}
+        >
           <ArrowLeft size={14} />
         </button>
       </div>

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -1226,7 +1226,7 @@
         <button
           class="icon-btn"
           onclick={onClose}
-          title={viewport.hasKeyboard ? 'Back (Esc)' : 'Back'}
+          title={viewport.showShortcutHints ? 'Back (Esc)' : 'Back'}
         >
           <ArrowLeft size={14} />
         </button>

--- a/apps/staged/src/lib/features/layout/TopBar.svelte
+++ b/apps/staged/src/lib/features/layout/TopBar.svelte
@@ -69,12 +69,18 @@
       disabled={navigation.activeView === 'settings'}
       title={navigation.activeView === 'settings'
         ? 'Unavailable while viewing settings'
-        : 'New project (⌘N)'}
+        : viewport.hasKeyboard
+          ? 'New project (⌘N)'
+          : 'New project'}
     >
       <Plus size={14} />
     </button>
 
-    <button class="icon-btn" onclick={() => openSettings()} title="Settings (⌘,)">
+    <button
+      class="icon-btn"
+      onclick={() => openSettings()}
+      title={viewport.hasKeyboard ? 'Settings (⌘,)' : 'Settings'}
+    >
       <SlidersHorizontal size={14} />
     </button>
   </div>

--- a/apps/staged/src/lib/features/layout/TopBar.svelte
+++ b/apps/staged/src/lib/features/layout/TopBar.svelte
@@ -69,7 +69,7 @@
       disabled={navigation.activeView === 'settings'}
       title={navigation.activeView === 'settings'
         ? 'Unavailable while viewing settings'
-        : viewport.hasKeyboard
+        : viewport.showShortcutHints
           ? 'New project (⌘N)'
           : 'New project'}
     >
@@ -79,7 +79,7 @@
     <button
       class="icon-btn"
       onclick={() => openSettings()}
-      title={viewport.hasKeyboard ? 'Settings (⌘,)' : 'Settings'}
+      title={viewport.showShortcutHints ? 'Settings (⌘,)' : 'Settings'}
     >
       <SlidersHorizontal size={14} />
     </button>

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -209,7 +209,7 @@
         <button
           class="close-btn"
           onclick={onClose}
-          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+          title={viewport.showShortcutHints ? 'Close (Esc)' : 'Close'}
         >
           <X size={16} />
         </button>

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -14,6 +14,7 @@
   import InContentSearch from '../../shared/InContentSearch.svelte';
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
   import { registerSearchShortcutTarget } from '../keyboard/searchTargets';
+  import { viewport } from '../../shared/viewport.svelte';
 
   marked.setOptions({ breaks: true, gfm: true });
 
@@ -205,7 +206,11 @@
             View chat
           </button>
         {/if}
-        <button class="close-btn" onclick={onClose} title="Close (Esc)">
+        <button
+          class="close-btn"
+          onclick={onClose}
+          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+        >
           <X size={16} />
         </button>
       </div>

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -53,6 +53,7 @@
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { badgeBg, badgeFg, badgeBgHover } from '../../shared/badgeColors';
   import { canDeleteProjectWithoutConfirmation } from './projectDeleteSafety';
+  import { viewport } from '../../shared/viewport.svelte';
 
   type FilterKind = 'unread' | 'running' | { repo: string; subpath: string };
 
@@ -663,7 +664,7 @@
                 disabled={status.kind === 'deleting'}
                 title={status.kind === 'deleting' ? 'Project deletion in progress' : undefined}
               >
-                {#if isCommandKeyHeld && index < 9}
+                {#if viewport.hasKeyboard && isCommandKeyHeld && index < 9}
                   <div class="keyboard-shortcut-overlay">
                     <span class="command-icon">⌘</span>
                     <span class="number">{index + 1}</span>

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -664,7 +664,7 @@
                 disabled={status.kind === 'deleting'}
                 title={status.kind === 'deleting' ? 'Project deletion in progress' : undefined}
               >
-                {#if viewport.hasKeyboard && isCommandKeyHeld && index < 9}
+                {#if viewport.showShortcutHints && isCommandKeyHeld && index < 9}
                   <div class="keyboard-shortcut-overlay">
                     <span class="command-icon">⌘</span>
                     <span class="number">{index + 1}</span>

--- a/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
@@ -391,7 +391,7 @@
           <button
             class="new-project-button list-new-project-button"
             onclick={openNewProject}
-            title={viewport.hasKeyboard ? 'New project (⌘N)' : 'New project'}
+            title={viewport.showShortcutHints ? 'New project (⌘N)' : 'New project'}
           >
             <span class="plus-icon"><Plus size={12} /></span>
             New project

--- a/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
@@ -391,7 +391,7 @@
           <button
             class="new-project-button list-new-project-button"
             onclick={openNewProject}
-            title="New project (⌘N)"
+            title={viewport.hasKeyboard ? 'New project (⌘N)' : 'New project'}
           >
             <span class="plus-icon"><Plus size={12} /></span>
             New project

--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -293,7 +293,7 @@
               <span class="recent-repo-label">
                 <RepoLabel githubRepo={recent.githubRepo} subpath={recent.subpath} />
               </span>
-              {#if viewport.hasKeyboard}
+              {#if viewport.showShortcutHints}
                 <span class="recent-repo-shortcut">
                   <Command size={9} />
                   {i + 1}

--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -22,6 +22,7 @@
   import type { SubpathInputApi } from './SubpathInput.svelte';
   import BranchPicker, { type BranchSelection } from './BranchPicker.svelte';
   import type { RepoSelection } from '../../shared/githubUrl';
+  import { viewport } from '../../shared/viewport.svelte';
 
   interface Props {
     // Bindable state
@@ -292,10 +293,12 @@
               <span class="recent-repo-label">
                 <RepoLabel githubRepo={recent.githubRepo} subpath={recent.subpath} />
               </span>
-              <span class="recent-repo-shortcut">
-                <Command size={9} />
-                {i + 1}
-              </span>
+              {#if viewport.hasKeyboard}
+                <span class="recent-repo-shortcut">
+                  <Command size={9} />
+                  {i + 1}
+                </span>
+              {/if}
             </button>
           {/each}
         </div>

--- a/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
+++ b/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
@@ -290,7 +290,7 @@
                 <RepoLabel githubRepo={recent.githubRepo} subpath={recent.subpath} />
               </span>
             </div>
-            {#if viewport.hasKeyboard && i < 9}
+            {#if viewport.showShortcutHints && i < 9}
               <span class="keyboard-shortcut">
                 <Command size={10} />
                 {i + 1}

--- a/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
+++ b/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
@@ -13,6 +13,7 @@
   import * as commands from '../../api/commands';
   import type { GitHubRepo, RecentRepo } from '../../types';
   import { parseGitHubUrl, type RepoSelection } from '../../shared/githubUrl';
+  import { viewport } from '../../shared/viewport.svelte';
 
   export type { RepoSelection };
 
@@ -289,7 +290,7 @@
                 <RepoLabel githubRepo={recent.githubRepo} subpath={recent.subpath} />
               </span>
             </div>
-            {#if i < 9}
+            {#if viewport.hasKeyboard && i < 9}
               <span class="keyboard-shortcut">
                 <Command size={10} />
                 {i + 1}

--- a/apps/staged/src/lib/features/projects/SplashScreen.svelte
+++ b/apps/staged/src/lib/features/projects/SplashScreen.svelte
@@ -112,7 +112,7 @@
   {#if !showForm}
     <div class="splash-actions">
       <button class="splash-pill" onclick={openForm}> Create your first project </button>
-      {#if viewport.hasKeyboard}
+      {#if viewport.showShortcutHints}
         <span class="splash-hint">or press <kbd>⌘ N</kbd> anytime</span>
       {/if}
     </div>

--- a/apps/staged/src/lib/features/projects/SplashScreen.svelte
+++ b/apps/staged/src/lib/features/projects/SplashScreen.svelte
@@ -12,6 +12,7 @@
   import GitTreeAnimation from '../../shared/GitTreeAnimation.svelte';
   import StagedIcon from '../../shared/StagedIcon.svelte';
   import NewProjectForm from './NewProjectForm.svelte';
+  import { viewport } from '../../shared/viewport.svelte';
 
   interface Props {
     onCreated: (project: Project) => void;
@@ -111,7 +112,9 @@
   {#if !showForm}
     <div class="splash-actions">
       <button class="splash-pill" onclick={openForm}> Create your first project </button>
-      <span class="splash-hint">or press <kbd>⌘ N</kbd> anytime</span>
+      {#if viewport.hasKeyboard}
+        <span class="splash-hint">or press <kbd>⌘ N</kbd> anytime</span>
+      {/if}
     </div>
     <div class="splash-tree">
       <GitTreeAnimation />

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -32,6 +32,7 @@
     insertFilePathsAtCursor,
   } from '../branches/branchCardHelpers';
   import { createImage } from '../../commands';
+  import { viewport } from '../../shared/viewport.svelte';
 
   interface Props {
     branch: Branch;
@@ -427,7 +428,11 @@
           </div>
         {/if}
       </div>
-      <button class="close-btn" onclick={handleClose} title="Close (Esc)">
+      <button
+        class="close-btn"
+        onclick={handleClose}
+        title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+      >
         <X size={18} />
       </button>
     </header>
@@ -455,7 +460,9 @@
           disabled={starting}
           items={hashtagItems}
         />
-        <span class="hint">{willQueue ? '⌘ Enter to queue' : '⌘ Enter to start'}</span>
+        {#if viewport.hasKeyboard}
+          <span class="hint">{willQueue ? '⌘ Enter to queue' : '⌘ Enter to start'}</span>
+        {/if}
       </div>
 
       <ImageAttachment

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -431,7 +431,7 @@
       <button
         class="close-btn"
         onclick={handleClose}
-        title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+        title={viewport.showShortcutHints ? 'Close (Esc)' : 'Close'}
       >
         <X size={18} />
       </button>
@@ -460,7 +460,7 @@
           disabled={starting}
           items={hashtagItems}
         />
-        {#if viewport.hasKeyboard}
+        {#if viewport.showShortcutHints}
           <span class="hint">{willQueue ? '⌘ Enter to queue' : '⌘ Enter to start'}</span>
         {/if}
       </div>

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -980,7 +980,7 @@
         <button
           class="close-btn"
           onclick={requestClose}
-          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+          title={viewport.showShortcutHints ? 'Close (Esc)' : 'Close'}
         >
           <X size={16} />
         </button>

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -84,6 +84,7 @@
   import PipelineSteps from './PipelineSteps.svelte';
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
   import { registerSearchShortcutTarget } from '../keyboard/searchTargets';
+  import { viewport } from '../../shared/viewport.svelte';
 
   // Configure marked
   marked.setOptions({ breaks: true, gfm: true });
@@ -976,7 +977,11 @@
             View note
           </button>
         {/if}
-        <button class="close-btn" onclick={requestClose} title="Close (Esc)">
+        <button
+          class="close-btn"
+          onclick={requestClose}
+          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+        >
           <X size={16} />
         </button>
       </div>

--- a/apps/staged/src/lib/features/timeline/ImageViewerModal.svelte
+++ b/apps/staged/src/lib/features/timeline/ImageViewerModal.svelte
@@ -8,6 +8,7 @@
   import { X, Trash2 } from 'lucide-svelte';
   import { getImageData } from '../../api/commands';
   import { createBackdropDismissHandlers } from '../../shared/backdropDismiss';
+  import { viewport } from '../../shared/viewport.svelte';
 
   interface Props {
     imageId: string;
@@ -64,7 +65,11 @@
             <Trash2 size={16} />
           </button>
         {/if}
-        <button class="close-btn" onclick={onClose} title="Close (Esc)">
+        <button
+          class="close-btn"
+          onclick={onClose}
+          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+        >
           <X size={18} />
         </button>
       </div>

--- a/apps/staged/src/lib/features/timeline/ImageViewerModal.svelte
+++ b/apps/staged/src/lib/features/timeline/ImageViewerModal.svelte
@@ -68,7 +68,7 @@
         <button
           class="close-btn"
           onclick={onClose}
-          title={viewport.hasKeyboard ? 'Close (Esc)' : 'Close'}
+          title={viewport.showShortcutHints ? 'Close (Esc)' : 'Close'}
         >
           <X size={18} />
         </button>

--- a/apps/staged/src/lib/shared/InContentSearch.svelte
+++ b/apps/staged/src/lib/shared/InContentSearch.svelte
@@ -76,7 +76,7 @@
       class="search-btn"
       onclick={onPrevious}
       disabled={matchCount === 0}
-      title={viewport.hasKeyboard ? 'Previous match (Shift+Enter)' : 'Previous match'}
+      title={viewport.showShortcutHints ? 'Previous match (Shift+Enter)' : 'Previous match'}
     >
       <ChevronUp size={14} />
     </button>
@@ -84,14 +84,14 @@
       class="search-btn"
       onclick={onNext}
       disabled={matchCount === 0}
-      title={viewport.hasKeyboard ? 'Next match (Enter)' : 'Next match'}
+      title={viewport.showShortcutHints ? 'Next match (Enter)' : 'Next match'}
     >
       <ChevronDown size={14} />
     </button>
     <button
       class="search-btn close-search"
       onclick={onClose}
-      title={viewport.hasKeyboard ? 'Close search (Esc)' : 'Close search'}
+      title={viewport.showShortcutHints ? 'Close search (Esc)' : 'Close search'}
     >
       <X size={14} />
     </button>

--- a/apps/staged/src/lib/shared/InContentSearch.svelte
+++ b/apps/staged/src/lib/shared/InContentSearch.svelte
@@ -7,6 +7,7 @@
 <script lang="ts">
   import { ChevronUp, ChevronDown, X } from 'lucide-svelte';
   import { tick } from 'svelte';
+  import { viewport } from './viewport.svelte';
 
   interface Props {
     visible: boolean;
@@ -75,7 +76,7 @@
       class="search-btn"
       onclick={onPrevious}
       disabled={matchCount === 0}
-      title="Previous match (Shift+Enter)"
+      title={viewport.hasKeyboard ? 'Previous match (Shift+Enter)' : 'Previous match'}
     >
       <ChevronUp size={14} />
     </button>
@@ -83,11 +84,15 @@
       class="search-btn"
       onclick={onNext}
       disabled={matchCount === 0}
-      title="Next match (Enter)"
+      title={viewport.hasKeyboard ? 'Next match (Enter)' : 'Next match'}
     >
       <ChevronDown size={14} />
     </button>
-    <button class="search-btn close-search" onclick={onClose} title="Close search (Esc)">
+    <button
+      class="search-btn close-search"
+      onclick={onClose}
+      title={viewport.hasKeyboard ? 'Close search (Esc)' : 'Close search'}
+    >
       <X size={14} />
     </button>
   </div>

--- a/apps/staged/src/lib/shared/viewport.svelte.ts
+++ b/apps/staged/src/lib/shared/viewport.svelte.ts
@@ -2,13 +2,20 @@ const MOBILE_BREAKPOINT_PX = 768;
 
 export const viewport = $state({
   isMobile: false,
+  hasKeyboard: true,
 });
 
 let mediaQuery: MediaQueryList | null = null;
+let coarsePointerQuery: MediaQueryList | null = null;
+let noHoverQuery: MediaQueryList | null = null;
 let subscriberCount = 0;
 
 function syncViewport() {
   viewport.isMobile = mediaQuery?.matches ?? false;
+  viewport.hasKeyboard = !(
+    (coarsePointerQuery?.matches ?? false) ||
+    (noHoverQuery?.matches ?? false)
+  );
 }
 
 export function watchViewport(): () => void {
@@ -20,13 +27,25 @@ export function watchViewport(): () => void {
     mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX}px)`);
     mediaQuery.addEventListener('change', syncViewport);
   }
+  if (!coarsePointerQuery) {
+    coarsePointerQuery = window.matchMedia('(pointer: coarse)');
+    coarsePointerQuery.addEventListener('change', syncViewport);
+  }
+  if (!noHoverQuery) {
+    noHoverQuery = window.matchMedia('(hover: none)');
+    noHoverQuery.addEventListener('change', syncViewport);
+  }
   syncViewport();
 
   return () => {
     subscriberCount = Math.max(0, subscriberCount - 1);
-    if (subscriberCount === 0 && mediaQuery) {
-      mediaQuery.removeEventListener('change', syncViewport);
+    if (subscriberCount === 0) {
+      mediaQuery?.removeEventListener('change', syncViewport);
+      coarsePointerQuery?.removeEventListener('change', syncViewport);
+      noHoverQuery?.removeEventListener('change', syncViewport);
       mediaQuery = null;
+      coarsePointerQuery = null;
+      noHoverQuery = null;
     }
   };
 }

--- a/apps/staged/src/lib/shared/viewport.svelte.ts
+++ b/apps/staged/src/lib/shared/viewport.svelte.ts
@@ -2,7 +2,8 @@ const MOBILE_BREAKPOINT_PX = 768;
 
 export const viewport = $state({
   isMobile: false,
-  hasKeyboard: true,
+  // Visual shortcut affordances only; not a hardware keyboard capability check.
+  showShortcutHints: true,
 });
 
 let mediaQuery: MediaQueryList | null = null;
@@ -12,7 +13,7 @@ let subscriberCount = 0;
 
 function syncViewport() {
   viewport.isMobile = mediaQuery?.matches ?? false;
-  viewport.hasKeyboard = !(
+  viewport.showShortcutHints = !(
     (coarsePointerQuery?.matches ?? false) ||
     (noHoverQuery?.matches ?? false)
   );


### PR DESCRIPTION
## Summary
- Detect touch/coarse-pointer devices via `(pointer: coarse)` and `(hover: none)` media queries and expose a reactive `showShortcutHints` flag on the shared `viewport` state
- Conditionally hide keyboard shortcut badges, hints, and tooltip shortcut suffixes (e.g. "Close (Esc)") across all modals, the top bar, project list, repo config form, splash screen, session modals, and in-content search

## Test plan
- [ ] On a desktop browser, verify shortcut hints (e.g. `⌘↵`, `⌘N`, `Esc` in tooltips) still appear
- [ ] On a touch device or using Chrome DevTools touch emulation, verify shortcut hints are hidden
- [ ] Verify keyboard shortcuts themselves still work on desktop regardless of hint visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)