### PR TITLE
fix: resolve symlinked and multi-root display paths in session modal

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -1901,6 +1901,7 @@ pub fn run() {
             util_commands::open_url,
             util_commands::is_sq_available,
             util_commands::read_text_file,
+            util_commands::resolve_path_aliases,
             util_commands::preferences_store_path,
             util_commands::check_blox_auth,
             util_commands::get_available_openers,

--- a/apps/staged/src-tauri/src/util_commands.rs
+++ b/apps/staged/src-tauri/src/util_commands.rs
@@ -2,6 +2,7 @@
 
 use crate::blox;
 use serde::Serialize;
+use std::collections::HashSet;
 use std::path::Path;
 
 /// An application that can open directories.
@@ -88,12 +89,74 @@ pub fn read_text_file(file_path: String) -> Result<String, String> {
     std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {e}"))
 }
 
+/// Resolve equivalent path roots for display-only relative path formatting.
+#[tauri::command]
+pub fn resolve_path_aliases(paths: Vec<String>) -> Vec<String> {
+    resolve_path_aliases_impl(paths)
+}
+
+pub(crate) fn resolve_path_aliases_impl(paths: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut aliases = Vec::new();
+
+    for path in paths {
+        if seen.insert(path.clone()) {
+            aliases.push(path.clone());
+        }
+
+        if let Ok(canonical) = std::fs::canonicalize(&path) {
+            let canonical = canonical.to_string_lossy().to_string();
+            if seen.insert(canonical.clone()) {
+                aliases.push(canonical);
+            }
+        }
+    }
+
+    aliases
+}
+
 /// Return the absolute path for the shared preferences store file.
 #[tauri::command]
 pub fn preferences_store_path() -> Result<String, String> {
     crate::preferences_store_path_buf()
         .map(|p| p.to_string_lossy().to_string())
         .ok_or_else(|| "Cannot determine preferences store path".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_path_aliases_impl;
+
+    #[cfg(unix)]
+    #[test]
+    fn resolves_symlink_aliases_and_deduplicates_paths() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = temp.path().join("link");
+        symlink(&real, &link).unwrap();
+
+        let link = link.to_string_lossy().to_string();
+        let canonical_real = std::fs::canonicalize(&real)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let aliases = resolve_path_aliases_impl(vec![link.clone(), link.clone()]);
+
+        assert_eq!(aliases, vec![link, canonical_real]);
+    }
+
+    #[test]
+    fn keeps_missing_paths_as_original_values() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing");
+
+        let aliases = resolve_path_aliases_impl(vec![missing.to_string_lossy().to_string()]);
+
+        assert_eq!(aliases, vec![missing.to_string_lossy().to_string()]);
+    }
 }
 
 /// Check whether the user is authenticated with Blox.

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -3444,6 +3444,13 @@ Begin the note with a markdown H1 heading as the title.\n\n"
                 std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {e}"))?;
             Ok(serde_json::to_value(content).unwrap())
         }
+        "resolve_path_aliases" => {
+            let paths: Vec<String> = arg(&args, "paths")?;
+            Ok(
+                serde_json::to_value(crate::util_commands::resolve_path_aliases_impl(paths))
+                    .unwrap(),
+            )
+        }
         "preferences_store_path" => {
             let path = crate::preferences_store_path_buf()
                 .map(|p| p.to_string_lossy().to_string())

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -535,6 +535,11 @@ export function readTextFile(filePath: string): Promise<string> {
   return invokeCommand('read_text_file', { filePath });
 }
 
+/** Resolve equivalent display roots for paths that may involve symlinks. */
+export function resolvePathAliases(paths: string[]): Promise<string[]> {
+  return invokeCommand('resolve_path_aliases', { paths });
+}
+
 /** Intercept link clicks so they open in the system browser, not the webview. */
 export function handleExternalLinkClick(e: MouseEvent): void {
   const anchor = (e.target as HTMLElement).closest('a');

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -109,6 +109,9 @@
   }: Props = $props();
 
   let sortedBranches = $derived([...branches].sort((a, b) => b.createdAt - a.createdAt));
+  let projectDisplayRootCandidates = $derived(
+    branches.map((branch) => branch.worktreePath).filter((path): path is string => !!path)
+  );
   let addRepoDisabled = $derived(deleting || !canAddRepo);
   let addRepoTitle = $derived(
     deleting
@@ -179,7 +182,7 @@
     (nextHints) => {
       liveSessionHints = nextHints;
     },
-    () => branches.find((b) => b.worktreePath)?.worktreePath ?? null
+    () => projectDisplayRootCandidates
   );
 
   /** Collect session IDs from running project notes + activeSessionIds. */
@@ -748,7 +751,7 @@
   )}
   <SessionModal
     sessionId={openSessionId}
-    repoDir={branches.find((b) => b.worktreePath)?.worktreePath ?? null}
+    repoDir={projectDisplayRootCandidates}
     projectId={project.id}
     noteInfo={noteForSession
       ? { id: noteForSession.id, title: noteForSession.title, content: noteForSession.content }

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -72,7 +72,6 @@
     insertFilePathsAtCursor,
   } from '../branches/branchCardHelpers';
   import {
-    formatToolDisplay,
     groupByVerb,
     verbGroupSummary,
     hasXmlBlocks,
@@ -80,6 +79,12 @@
     stripXmlTags,
     type VerbGroup,
   } from './sessionModalHelpers';
+  import {
+    displayRootKey,
+    normalizeDisplayRoots,
+    resolveDisplayRoots,
+    type DisplayRootInput,
+  } from './pathDisplayRoots';
   import InContentSearch from '../../shared/InContentSearch.svelte';
   import PipelineSteps from './PipelineSteps.svelte';
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
@@ -91,8 +96,8 @@
   interface Props {
     sessionId: string;
     onClose: () => void;
-    /** Repo base directory — tool call paths within it are shown as relative. */
-    repoDir?: string | null;
+    /** Display roots — tool call paths within them are shown as relative. */
+    repoDir?: DisplayRootInput;
     /** Branch ID — when provided, enables image attachment on replies. */
     branchId?: string | null;
     /** Project ID — when provided, enables image attachment on replies. */
@@ -125,11 +130,35 @@
   let copiedId = $state<number | string | null>(null);
   let expandedTools = $state<Set<number>>(new Set());
   let expandedVerbGroups = $state<Set<string>>(new Set());
+  let displayRoots = $state<string[]>([]);
+  let currentDisplayRootKey = '';
 
   let isLive = $derived(session?.status === 'running');
   let hasQueuedMessages = $derived(messageQueue.length > 0);
 
   const SLIDE_DURATION = 150;
+
+  $effect(() => {
+    const rootCandidates: DisplayRootInput = [repoDir, session?.workingDir];
+    const nextKey = displayRootKey(rootCandidates);
+    if (nextKey === currentDisplayRootKey) return;
+
+    currentDisplayRootKey = nextKey;
+    displayRoots = normalizeDisplayRoots(rootCandidates);
+
+    let stale = false;
+    if (nextKey) {
+      resolveDisplayRoots(rootCandidates).then((resolvedRoots) => {
+        if (!stale && currentDisplayRootKey === nextKey) {
+          displayRoots = resolvedRoots;
+        }
+      });
+    }
+
+    return () => {
+      stale = true;
+    };
+  });
 
   /** Whether the initial load has rendered — transitions are suppressed until then. */
   let animateNewMessages = false;
@@ -903,8 +932,8 @@
     for (const group of grouped) {
       if (group.type === 'tools') {
         cache.push({
-          past: groupByVerb(group.pairs, repoDir, true),
-          present: groupByVerb(group.pairs, repoDir, false),
+          past: groupByVerb(group.pairs, displayRoots, true),
+          present: groupByVerb(group.pairs, displayRoots, false),
         });
       } else {
         // Placeholder — tool-group index won't line up otherwise.

--- a/apps/staged/src/lib/features/sessions/pathDisplayRoots.test.ts
+++ b/apps/staged/src/lib/features/sessions/pathDisplayRoots.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearDisplayRootAliasCacheForTests,
   displayRootKey,
@@ -9,6 +9,10 @@ import {
 describe('pathDisplayRoots', () => {
   beforeEach(() => {
     clearDisplayRootAliasCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('computes a stable root key from sorted normalized roots', () => {
@@ -28,5 +32,35 @@ describe('pathDisplayRoots', () => {
     expect(second).toBe(first);
     await expect(first).resolves.toEqual(['/tmp/b', '/real/tmp/b', '/tmp/a', '/real/tmp/a']);
     expect(calls).toEqual([['/tmp/b'], ['/tmp/a']]);
+  });
+
+  it('retries fallback-only aliases after a short cache window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const calls: string[][] = [];
+    const resolver: PathAliasResolver = async (paths) => {
+      calls.push(paths);
+      if (calls.length === 1) {
+        return [paths[0]];
+      }
+      return [paths[0], `/real${paths[0]}`];
+    };
+
+    await expect(resolveDisplayRoots('/tmp/worktree', resolver)).resolves.toEqual([
+      '/tmp/worktree',
+    ]);
+    await expect(resolveDisplayRoots('/tmp/worktree', resolver)).resolves.toEqual([
+      '/tmp/worktree',
+    ]);
+    expect(calls).toEqual([['/tmp/worktree']]);
+
+    vi.advanceTimersByTime(5_001);
+
+    await expect(resolveDisplayRoots('/tmp/worktree', resolver)).resolves.toEqual([
+      '/tmp/worktree',
+      '/real/tmp/worktree',
+    ]);
+    expect(calls).toEqual([['/tmp/worktree'], ['/tmp/worktree']]);
   });
 });

--- a/apps/staged/src/lib/features/sessions/pathDisplayRoots.test.ts
+++ b/apps/staged/src/lib/features/sessions/pathDisplayRoots.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearDisplayRootAliasCacheForTests,
+  displayRootKey,
+  resolveDisplayRoots,
+  type PathAliasResolver,
+} from './pathDisplayRoots';
+
+describe('pathDisplayRoots', () => {
+  beforeEach(() => {
+    clearDisplayRootAliasCacheForTests();
+  });
+
+  it('computes a stable root key from sorted normalized roots', () => {
+    expect(displayRootKey(['/tmp/b/', '/tmp/a', '/tmp/a/'])).toBe('/tmp/a\n/tmp/b');
+  });
+
+  it('caches alias resolution by normalized root set key', async () => {
+    const calls: string[][] = [];
+    const resolver: PathAliasResolver = async (paths) => {
+      calls.push(paths);
+      return [paths[0], `/real${paths[0]}`];
+    };
+
+    const first = resolveDisplayRoots(['/tmp/b/', '/tmp/a'], resolver);
+    const second = resolveDisplayRoots(['/tmp/a/', '/tmp/b'], resolver);
+
+    expect(second).toBe(first);
+    await expect(first).resolves.toEqual(['/tmp/b', '/real/tmp/b', '/tmp/a', '/real/tmp/a']);
+    expect(calls).toEqual([['/tmp/b'], ['/tmp/a']]);
+  });
+});

--- a/apps/staged/src/lib/features/sessions/pathDisplayRoots.ts
+++ b/apps/staged/src/lib/features/sessions/pathDisplayRoots.ts
@@ -1,0 +1,88 @@
+import { resolvePathAliases } from '../../api/commands';
+
+export type DisplayRootInput = string | null | undefined | readonly DisplayRootInput[];
+export type PathAliasResolver = (paths: string[]) => Promise<string[]>;
+
+const pathAliasCache = new Map<string, Promise<string[]>>();
+const rootSetCache = new Map<string, Promise<string[]>>();
+
+function visitDisplayRoots(input: DisplayRootInput, roots: string[]) {
+  if (typeof input === 'string' || input == null) {
+    const normalized = normalizeDisplayRoot(input);
+    if (normalized) {
+      roots.push(normalized);
+    }
+    return;
+  }
+
+  for (const item of input) {
+    visitDisplayRoots(item, roots);
+  }
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+export function normalizeDisplayRoot(root: string | null | undefined): string | null {
+  if (!root) return null;
+
+  let normalized = root.trim();
+  while (normalized.length > 1 && /[/\\]$/.test(normalized)) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized || null;
+}
+
+export function normalizeDisplayRoots(input: DisplayRootInput): string[] {
+  const roots: string[] = [];
+  visitDisplayRoots(input, roots);
+  return dedupe(roots);
+}
+
+export function displayRootKey(input: DisplayRootInput): string {
+  return [...normalizeDisplayRoots(input)].sort().join('\n');
+}
+
+function aliasesForRoot(root: string, resolver: PathAliasResolver): Promise<string[]> {
+  const cached = pathAliasCache.get(root);
+  if (cached) return cached;
+
+  const promise = resolver([root])
+    .then((aliases) => normalizeDisplayRoots([root, aliases]))
+    .catch(() => [root]);
+
+  pathAliasCache.set(root, promise);
+  return promise;
+}
+
+export function resolveDisplayRoots(
+  input: DisplayRootInput,
+  resolver: PathAliasResolver = resolvePathAliases
+): Promise<string[]> {
+  const roots = normalizeDisplayRoots(input);
+  const key = displayRootKey(roots);
+  if (!key) return Promise.resolve([]);
+
+  const cached = rootSetCache.get(key);
+  if (cached) return cached;
+
+  const promise = Promise.all(roots.map((root) => aliasesForRoot(root, resolver))).then((groups) =>
+    normalizeDisplayRoots(groups)
+  );
+  rootSetCache.set(key, promise);
+  return promise;
+}
+
+export function clearDisplayRootAliasCacheForTests() {
+  pathAliasCache.clear();
+  rootSetCache.clear();
+}

--- a/apps/staged/src/lib/features/sessions/pathDisplayRoots.ts
+++ b/apps/staged/src/lib/features/sessions/pathDisplayRoots.ts
@@ -3,8 +3,15 @@ import { resolvePathAliases } from '../../api/commands';
 export type DisplayRootInput = string | null | undefined | readonly DisplayRootInput[];
 export type PathAliasResolver = (paths: string[]) => Promise<string[]>;
 
-const pathAliasCache = new Map<string, Promise<string[]>>();
-const rootSetCache = new Map<string, Promise<string[]>>();
+const FALLBACK_ALIAS_RETRY_MS = 5_000;
+
+type AliasCacheEntry = {
+  promise: Promise<string[]>;
+  expiresAt?: number;
+};
+
+const pathAliasCache = new Map<string, AliasCacheEntry>();
+const rootSetCache = new Map<string, AliasCacheEntry>();
 
 function visitDisplayRoots(input: DisplayRootInput, roots: string[]) {
   if (typeof input === 'string' || input == null) {
@@ -52,15 +59,47 @@ export function displayRootKey(input: DisplayRootInput): string {
   return [...normalizeDisplayRoots(input)].sort().join('\n');
 }
 
+function cachedAliases(cache: Map<string, AliasCacheEntry>, key: string): Promise<string[]> | null {
+  const cached = cache.get(key);
+  if (!cached) return null;
+  if (cached.expiresAt !== undefined && cached.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+  return cached.promise;
+}
+
+function isFallbackOnlyAlias(root: string, aliases: string[]): boolean {
+  return aliases.length === 1 && aliases[0] === root;
+}
+
+function expireFallbackAlias(
+  cache: Map<string, AliasCacheEntry>,
+  key: string,
+  entry: AliasCacheEntry,
+  shouldRetry: boolean
+) {
+  if (!shouldRetry) return;
+  if (cache.get(key) !== entry) return;
+  entry.expiresAt = Date.now() + FALLBACK_ALIAS_RETRY_MS;
+}
+
 function aliasesForRoot(root: string, resolver: PathAliasResolver): Promise<string[]> {
-  const cached = pathAliasCache.get(root);
+  const cached = cachedAliases(pathAliasCache, root);
   if (cached) return cached;
 
-  const promise = resolver([root])
+  let entry: AliasCacheEntry;
+  const promise = Promise.resolve()
+    .then(() => resolver([root]))
     .then((aliases) => normalizeDisplayRoots([root, aliases]))
-    .catch(() => [root]);
+    .catch(() => [root])
+    .then((aliases) => {
+      expireFallbackAlias(pathAliasCache, root, entry, isFallbackOnlyAlias(root, aliases));
+      return aliases;
+    });
 
-  pathAliasCache.set(root, promise);
+  entry = { promise };
+  pathAliasCache.set(root, entry);
   return promise;
 }
 
@@ -72,13 +111,23 @@ export function resolveDisplayRoots(
   const key = displayRootKey(roots);
   if (!key) return Promise.resolve([]);
 
-  const cached = rootSetCache.get(key);
+  const cached = cachedAliases(rootSetCache, key);
   if (cached) return cached;
 
-  const promise = Promise.all(roots.map((root) => aliasesForRoot(root, resolver))).then((groups) =>
-    normalizeDisplayRoots(groups)
+  let entry: AliasCacheEntry;
+  const promise = Promise.all(roots.map((root) => aliasesForRoot(root, resolver))).then(
+    (groups) => {
+      expireFallbackAlias(
+        rootSetCache,
+        key,
+        entry,
+        groups.some((aliases, index) => isFallbackOnlyAlias(roots[index], aliases))
+      );
+      return normalizeDisplayRoots(groups);
+    }
   );
-  rootSetCache.set(key, promise);
+  entry = { promise };
+  rootSetCache.set(key, entry);
   return promise;
 }
 

--- a/apps/staged/src/lib/features/sessions/sessionModalHelpers.test.ts
+++ b/apps/staged/src/lib/features/sessions/sessionModalHelpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { formatToolDisplay, makePathsRelative } from './sessionModalHelpers';
+
+describe('makePathsRelative', () => {
+  it('matches symlink-style alias pairs', () => {
+    expect(
+      makePathsRelative('Read /Volumes/work/staged/repo/src/App.svelte', [
+        '/Users/me/.staged/repo',
+        '/Volumes/work/staged/repo',
+      ])
+    ).toBe('Read src/App.svelte');
+  });
+
+  it('uses the longest matching root before broader project roots', () => {
+    expect(
+      makePathsRelative(
+        '/work/projects/p1/builderbot--feature/src/App.svelte /work/projects/p1/other--main/README.md',
+        ['/work/projects/p1', '/work/projects/p1/builderbot--feature']
+      )
+    ).toBe('src/App.svelte other--main/README.md');
+  });
+
+  it('applies the ancestor fallback for subpath working directories', () => {
+    expect(makePathsRelative('/work/repo/src/lib.rs', '/work/repo/apps/staged')).toBe('src/lib.rs');
+  });
+
+  it('formats shell command strings with resolved alias roots', () => {
+    const call = JSON.stringify({
+      name: 'Bash',
+      arguments: {
+        command:
+          'sed -n "1,5p" /Volumes/work/repo/src/main.ts && cat /Users/me/link/repo/package.json',
+      },
+    });
+
+    expect(formatToolDisplay(call, ['/Users/me/link/repo', '/Volumes/work/repo'], true)).toEqual({
+      verb: 'Running',
+      detail: 'sed -n "1,5p" src/main.ts && cat package.json',
+    });
+  });
+});

--- a/apps/staged/src/lib/features/sessions/sessionModalHelpers.test.ts
+++ b/apps/staged/src/lib/features/sessions/sessionModalHelpers.test.ts
@@ -24,6 +24,15 @@ describe('makePathsRelative', () => {
     expect(makePathsRelative('/work/repo/src/lib.rs', '/work/repo/apps/staged')).toBe('src/lib.rs');
   });
 
+  it('applies the ancestor fallback after direct matches', () => {
+    expect(
+      makePathsRelative(
+        'cat /work/repo/apps/staged/src/App.svelte /work/repo/src-tauri/src/lib.rs',
+        '/work/repo/apps/staged'
+      )
+    ).toBe('cat src/App.svelte src-tauri/src/lib.rs');
+  });
+
   it('formats shell command strings with resolved alias roots', () => {
     const call = JSON.stringify({
       name: 'Bash',

--- a/apps/staged/src/lib/features/sessions/sessionModalHelpers.ts
+++ b/apps/staged/src/lib/features/sessions/sessionModalHelpers.ts
@@ -1,3 +1,5 @@
+import { normalizeDisplayRoots, type DisplayRootInput } from './pathDisplayRoots';
+
 export interface ParsedToolCall {
   name: string;
   args: Record<string, unknown>;
@@ -36,29 +38,76 @@ export function parseToolCall(content: string): ParsedToolCall | null {
 }
 
 /**
- * Replace absolute paths that fall within `repoDir` with relative paths.
- * If repoDir is empty/null, returns the text unchanged.
+ * Replace absolute paths that fall within any display root with relative paths.
+ * If roots are empty/null, returns the text unchanged.
  *
- * When the exact `repoDir` prefix isn't found in the text, ancestor directories
+ * When exact root prefixes aren't found in the text, ancestor directories
  * are tried (up to 3 levels). This handles the common case where the session's
  * working directory includes a repo subpath (e.g. `worktree_root/apps/staged`)
  * but tool call paths reference the worktree root directly.
  */
-export function makePathsRelative(text: string, repoDir: string | null | undefined): string {
-  if (!repoDir) return text;
+export function makePathsRelative(text: string, rootsInput: DisplayRootInput): string {
+  const roots = normalizeDisplayRoots(rootsInput);
+  if (roots.length === 0) return text;
 
-  let dir = repoDir;
-  for (let i = 0; i < 4; i++) {
-    const prefix = dir.endsWith('/') ? dir : dir + '/';
-    if (text.includes(prefix)) {
-      return text.replaceAll(prefix, '');
-    }
-    const parentEnd = dir.lastIndexOf('/');
-    if (parentEnd <= 0) break;
-    dir = dir.slice(0, parentEnd);
-  }
+  const direct = replaceRootPrefixes(text, roots);
+  if (direct.matched) return direct.text;
+
+  const fallback = replaceRootPrefixes(text, ancestorRoots(roots));
+  if (fallback.matched) return fallback.text;
 
   return text;
+}
+
+function pathSeparatorFor(root: string): '/' | '\\' {
+  return root.includes('\\') && !root.includes('/') ? '\\' : '/';
+}
+
+function rootPrefix(root: string): string {
+  if (root.endsWith('/') || root.endsWith('\\')) return root;
+  return `${root}${pathSeparatorFor(root)}`;
+}
+
+function parentRoot(root: string): string | null {
+  const trimmed = root.replace(/[/\\]+$/, '');
+  const parentEnd = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+  if (parentEnd <= 0) return null;
+
+  const parent = trimmed.slice(0, parentEnd);
+  if (/^[A-Za-z]:$/.test(parent)) return null;
+  return parent;
+}
+
+function ancestorRoots(roots: string[]): string[] {
+  const ancestors: string[] = [];
+  const seen = new Set<string>();
+  for (const root of roots) {
+    let dir = root;
+    for (let i = 0; i < 3; i++) {
+      const parent = parentRoot(dir);
+      if (!parent) break;
+      if (!seen.has(parent)) {
+        ancestors.push(parent);
+        seen.add(parent);
+      }
+      dir = parent;
+    }
+  }
+  return ancestors;
+}
+
+function replaceRootPrefixes(text: string, roots: string[]): { text: string; matched: boolean } {
+  const prefixes = [...new Set(roots.map(rootPrefix))].sort((a, b) => b.length - a.length);
+  let result = text;
+  let matched = false;
+
+  for (const prefix of prefixes) {
+    if (!result.includes(prefix)) continue;
+    matched = true;
+    result = result.split(prefix).join('');
+  }
+
+  return { text: result, matched };
 }
 
 const TOOL_VERBS: Record<string, [past: string, present: string]> = {
@@ -222,7 +271,7 @@ const VERB_NOUNS: Record<string, string> = {
 
 export function groupByVerb(
   pairs: { call: { id: number; content: string }; result: { content: string } | null }[],
-  repoDir?: string | null,
+  repoDir?: DisplayRootInput,
   forcePastTense?: boolean
 ): VerbGroup[] {
   const groups: VerbGroup[] = [];
@@ -247,7 +296,7 @@ export function verbGroupSummary(group: VerbGroup): string {
 
 export function formatToolDisplay(
   content: string,
-  repoDir?: string | null,
+  repoDir?: DisplayRootInput,
   pending?: boolean
 ): ToolDisplay {
   const tenseIdx = pending ? 1 : 0;

--- a/apps/staged/src/lib/features/sessions/sessionModalHelpers.ts
+++ b/apps/staged/src/lib/features/sessions/sessionModalHelpers.ts
@@ -41,20 +41,18 @@ export function parseToolCall(content: string): ParsedToolCall | null {
  * Replace absolute paths that fall within any display root with relative paths.
  * If roots are empty/null, returns the text unchanged.
  *
- * When exact root prefixes aren't found in the text, ancestor directories
- * are tried (up to 3 levels). This handles the common case where the session's
- * working directory includes a repo subpath (e.g. `worktree_root/apps/staged`)
- * but tool call paths reference the worktree root directly.
+ * Ancestor directories are also tried (up to 3 levels). This handles the
+ * common case where the session's working directory includes a repo subpath
+ * (e.g. `worktree_root/apps/staged`) but tool call paths reference the
+ * worktree root directly.
  */
 export function makePathsRelative(text: string, rootsInput: DisplayRootInput): string {
   const roots = normalizeDisplayRoots(rootsInput);
   if (roots.length === 0) return text;
 
   const direct = replaceRootPrefixes(text, roots);
-  if (direct.matched) return direct.text;
-
-  const fallback = replaceRootPrefixes(text, ancestorRoots(roots));
-  if (fallback.matched) return fallback.text;
+  const fallback = replaceRootPrefixes(direct.text, ancestorRoots(roots));
+  if (direct.matched || fallback.matched) return fallback.text;
 
   return text;
 }

--- a/apps/staged/src/lib/features/timeline/liveSessionHints.ts
+++ b/apps/staged/src/lib/features/timeline/liveSessionHints.ts
@@ -1,5 +1,11 @@
 import * as commands from '../../api/commands';
 import type { BranchTimeline, PipelineExecution, SessionMessage } from '../../types';
+import {
+  displayRootKey,
+  normalizeDisplayRoots,
+  resolveDisplayRoots,
+  type DisplayRootInput,
+} from '../sessions/pathDisplayRoots';
 import { formatToolDisplay, stripXmlTags } from '../sessions/sessionModalHelpers';
 
 const HINT_POLL_INTERVAL_MS = 750;
@@ -9,6 +15,8 @@ const MAX_HINT_MESSAGES = 40;
 type HintTracker = {
   lastMessageId: number | null;
   messages: SessionMessage[];
+  rootKey: string;
+  displayRoots: string[];
 };
 
 export type PendingHintItemType = 'pending-commit' | 'generating-note' | 'generating-review';
@@ -39,8 +47,8 @@ function withTrailingEllipsis(text: string): string {
   return `${text}…`;
 }
 
-function formatToolCallHint(content: string, repoDir?: string | null): string | undefined {
-  const { verb, detail } = formatToolDisplay(content, repoDir, true);
+function formatToolCallHint(content: string, displayRoots?: DisplayRootInput): string | undefined {
+  const { verb, detail } = formatToolDisplay(content, displayRoots, true);
   const text = detail ? `${verb} ${detail}` : verb;
   return normalizeHintText(withTrailingEllipsis(text));
 }
@@ -74,14 +82,17 @@ function formatAssistantHint(content: string): string | undefined {
   return undefined;
 }
 
-function deriveHint(messages: SessionMessage[], repoDir?: string | null): string | undefined {
+function deriveHint(
+  messages: SessionMessage[],
+  displayRoots?: DisplayRootInput
+): string | undefined {
   let latestToolHint: { id: number; text: string } | null = null;
   let latestAssistantHint: { id: number; text: string } | null = null;
 
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (!latestToolHint && message.role === 'tool_call') {
-      const hint = formatToolCallHint(message.content, repoDir);
+      const hint = formatToolCallHint(message.content, displayRoots);
       if (hint) {
         latestToolHint = { id: message.id, text: hint };
       }
@@ -171,7 +182,7 @@ export function collectRunningSessionIds(
 
 export function createLiveSessionHints(
   onHintsChange: (hints: Record<string, string>) => void,
-  getRepoDir?: () => string | null | undefined
+  getDisplayRootCandidates?: () => DisplayRootInput
 ) {
   const hintTrackers = new Map<string, HintTracker>();
   let hints: Record<string, string> = {};
@@ -206,6 +217,18 @@ export function createLiveSessionHints(
         return;
       }
 
+      const rootCandidates: DisplayRootInput = [getDisplayRootCandidates?.(), session.workingDir];
+      const nextRootKey = displayRootKey(rootCandidates);
+      if (tracker.rootKey !== nextRootKey) {
+        tracker.rootKey = nextRootKey;
+        tracker.displayRoots = normalizeDisplayRoots(rootCandidates);
+        if (nextRootKey) {
+          const resolvedRoots = await resolveDisplayRoots(rootCandidates);
+          if (destroyed || !hintTrackers.has(sessionId) || tracker.rootKey !== nextRootKey) return;
+          tracker.displayRoots = resolvedRoots;
+        }
+      }
+
       const updatedMessages =
         tracker.lastMessageId === null
           ? await commands.getSessionMessages(sessionId)
@@ -224,7 +247,7 @@ export function createLiveSessionHints(
       }
 
       const nextHint =
-        deriveHint(tracker.messages, getRepoDir?.()) ??
+        deriveHint(tracker.messages, tracker.displayRoots) ??
         (tracker.messages.length === 0 ? derivePipelineHint(session.pipeline) : undefined);
       if (nextHint) {
         setHint(sessionId, nextHint);
@@ -277,6 +300,8 @@ export function createLiveSessionHints(
           hintTrackers.set(sessionId, {
             lastMessageId: null,
             messages: [],
+            rootKey: '',
+            displayRoots: [],
           });
         }
       }

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -322,6 +322,7 @@ export interface Session {
   id: string;
   prompt: string;
   status: SessionStatus;
+  workingDir: string;
   provider: string | null;
   agentId: string | null;
   errorMessage: string | null;


### PR DESCRIPTION
## Summary

- Add `resolve_path_aliases` Tauri command that canonicalizes paths to surface symlink equivalents, so tool-call paths displayed in session modals can be made relative regardless of which symlink variant the agent used.
- Introduce `pathDisplayRoots` module that normalizes, deduplicates, and caches display root resolution (with short-TTL retry for initially-unresolved aliases).
- Refactor `makePathsRelative` to accept multiple display roots, match the longest root first, and fall back to ancestor directories — fixing cases where paths span multiple worktrees or reference parent directories of the session's working dir.
- Pass all branch worktree paths (plus `session.workingDir`) as display root candidates into `SessionModal` and `liveSessionHints`.

## Test plan

- [x] Unit tests for `pathDisplayRoots` (cache, retry, key computation)
- [x] Unit tests for `makePathsRelative` (multi-root, ancestor fallback, alias pairs)
- [x] Rust tests for `resolve_path_aliases_impl` (symlink dedup, missing paths)
- [ ] Manual: open a session modal for a worktree on a symlinked volume and verify tool-call paths display as relative

🤖 Generated with [Claude Code](https://claude.com/claude-code)