### PR TITLE
fix(staged): refresh project note hashtags in BranchCard after deletion

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -717,6 +717,19 @@
     return () => window.removeEventListener('timeline-invalidated', handler);
   });
 
+  // Re-fetch project note hashtag items when a project note is deleted
+  $effect(() => {
+    const projectId = branch.projectId;
+    if (!projectId) return;
+    const handler = () => {
+      commands.listProjectNotes(projectId).then((notes) => {
+        projectNoteHashtagItems = projectNotesToHashtagItems(notes);
+      });
+    };
+    window.addEventListener('project-notes-invalidated', handler);
+    return () => window.removeEventListener('project-notes-invalidated', handler);
+  });
+
   async function loadTimeline({
     timelineKey = branchTimelineReadyKey(branch),
     force = false,

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -421,6 +421,7 @@
     try {
       await deleteSessionLinkedItem(() => commands.deleteProjectNote(noteId), sessionId);
       projectNotes = projectNotes.filter((n) => n.id !== noteId);
+      hashtagVersion++;
     } catch (e) {
       console.error('[ProjectSection] Failed to delete project note:', e);
     } finally {

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -422,6 +422,7 @@
       await deleteSessionLinkedItem(() => commands.deleteProjectNote(noteId), sessionId);
       projectNotes = projectNotes.filter((n) => n.id !== noteId);
       hashtagVersion++;
+      window.dispatchEvent(new CustomEvent('project-notes-invalidated'));
     } catch (e) {
       console.error('[ProjectSection] Failed to delete project note:', e);
     } finally {


### PR DESCRIPTION
## Summary
- When a project note is deleted in `ProjectSection`, dispatch a `project-notes-invalidated` event and bump the hashtag version
- Listen for this event in `BranchCard` to re-fetch project note hashtag items, preventing stale/deleted notes from appearing in the hashtag list

## Test plan
- [ ] Create a project note, verify it appears in BranchCard hashtag suggestions
- [ ] Delete the project note, verify it is removed from BranchCard hashtag suggestions without a page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)