### PR TITLE
feat(staged): add resilient web resume cache

### DIFF
--- a/apps/staged/index.html
+++ b/apps/staged/index.html
@@ -6,6 +6,8 @@
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#060606" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"

--- a/apps/staged/package.json
+++ b/apps/staged/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^24.10.1",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",
+    "fake-indexeddb": "^6.2.5",
     "prettier": "^3.7.4",
     "prettier-plugin-svelte": "^3.4.1",
     "shadcn-svelte": "^1.2.7",
@@ -52,6 +53,7 @@
     "@tauri-apps/plugin-store": "^2.4.2",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "ansi-to-html": "^0.7.2",
+    "idb-keyval": "^6.2.2",
     "marked": "^17.0.1",
     "sanitize-html": "^2.17.0",
     "shiki": "^3.20.0"

--- a/apps/staged/src/App.svelte
+++ b/apps/staged/src/App.svelte
@@ -44,6 +44,8 @@
   import { projectStateStore } from './lib/stores/projectState.svelte';
   import { initBloxEnv } from './lib/stores/bloxEnv.svelte';
   import { listenForSessionStatus } from './lib/listeners/sessionStatusListener';
+  import { listenForCacheInvalidation } from './lib/listeners/cacheInvalidationListener';
+  import { listenForPageLifecycle } from './lib/listeners/pageLifecycleListener';
   import { darkMode } from './lib/stores/isDark.svelte';
   import * as prPollingService from './lib/services/prPollingService';
   import { reposUiEnabled } from './lib/featureFlags';
@@ -61,6 +63,8 @@
   let unlistenZoomOut: UnlistenFn | undefined;
   let unlistenZoomReset: UnlistenFn | undefined;
   let unlistenSessionStatus: UnlistenFn | undefined;
+  let unlistenCacheInvalidation: UnlistenFn | undefined;
+  let unlistenPageLifecycle: (() => void) | undefined;
   let unregisterShortcuts: (() => void) | null = null;
   let stopUpdaterLoop: (() => void) | null = null;
   let storeIncompat = $state<StoreIncompatibility | null>(null);
@@ -85,7 +89,7 @@
       const projectId = navigation.selectedProjectId;
       if (!projectId) return;
       try {
-        const branches = await commands.listBranchesForProject(projectId);
+        const { data: branches } = await commands.listBranchesForProject(projectId);
         await Promise.allSettled(branches.map((b) => commands.refreshBranchGitState(b.id)));
       } catch {
         // best-effort refresh; ignore failures
@@ -235,6 +239,14 @@
     prPollingService.init();
     document.addEventListener('keydown', handleKonamiKey);
 
+    // Web resume accelerator: the restored project id is available synchronously
+    // (navigation seeds it from localStorage at module load). Warm that project's
+    // branch timelines in parallel right away so cards find data ready, rather
+    // than each doing its own serialized IndexedDB read after ProjectHome mounts.
+    if (navigation.selectedProjectId) {
+      void commands.warmProjectTimelines(navigation.selectedProjectId);
+    }
+
     // Listen for the app menu Preferences item.
     unlistenSettings = listenToEvent('menu:settings', () => {
       if (!triggerShortcut('app-open-settings')) openSettings();
@@ -261,6 +273,8 @@
     // Global session-status listener — must live at App level so it works
     // regardless of which view the user is on. See sessionStatusListener.ts.
     unlistenSessionStatus = listenForSessionStatus();
+    unlistenCacheInvalidation = listenForCacheInvalidation();
+    unlistenPageLifecycle = listenForPageLifecycle();
 
     try {
       await initPreferences();
@@ -438,6 +452,8 @@
     unlistenZoomOut?.();
     unlistenZoomReset?.();
     unlistenSessionStatus?.();
+    unlistenCacheInvalidation?.();
+    unlistenPageLifecycle?.();
     stopUpdaterLoop?.();
   });
 

--- a/apps/staged/src/lib/cache.test.ts
+++ b/apps/staged/src/lib/cache.test.ts
@@ -1,0 +1,699 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock transport — web mode (isTauri = false) with controllable invokeCommand
+const mockInvoke = vi.fn();
+vi.mock('./transport', () => ({
+  isTauri: false,
+  invokeCommand: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+import {
+  cachedInvoke,
+  cachedCommand,
+  invalidateCache,
+  invalidateCacheByArgs,
+  invalidateCacheByCommand,
+  markAllStale,
+  clearAllCache,
+  _cacheKey,
+  _CACHE_SCHEMA_VERSION,
+  _MAX_CACHE_ENTRIES,
+  _evictIfNeeded,
+} from './cache';
+
+beforeEach(async () => {
+  mockInvoke.mockReset();
+  await clearAllCache();
+});
+
+describe('cacheKey', () => {
+  it('produces deterministic keys regardless of arg order', () => {
+    expect(_cacheKey('cmd', { b: 2, a: 1 })).toBe(_cacheKey('cmd', { a: 1, b: 2 }));
+  });
+
+  it('produces different keys for different commands', () => {
+    expect(_cacheKey('foo', { a: 1 })).not.toBe(_cacheKey('bar', { a: 1 }));
+  });
+
+  it('handles undefined args', () => {
+    expect(_cacheKey('cmd')).toBe('cmd:');
+  });
+});
+
+describe('cachedInvoke', () => {
+  it('yields only network result on cache miss', async () => {
+    mockInvoke.mockResolvedValue({ items: [1, 2] });
+
+    const results = [];
+    for await (const r of cachedInvoke('list', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([
+      { data: { items: [1, 2] }, source: 'network', fetchedAt: expect.any(Number) },
+    ]);
+    expect(mockInvoke).toHaveBeenCalledWith('list', undefined);
+  });
+
+  it('short-circuits with only cache when entry is fresh', async () => {
+    mockInvoke.mockResolvedValue('first');
+
+    // Prime the cache
+    const primeResults = [];
+    for await (const r of cachedInvoke('cmd', { id: '1' }, { ttl: 60_000 })) {
+      primeResults.push(r);
+    }
+    expect(primeResults).toHaveLength(1);
+
+    // Second call within TTL should yield only cache (no network call)
+    mockInvoke.mockResolvedValue('second');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', { id: '1' }, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([{ data: 'first', source: 'cache', fetchedAt: expect.any(Number) }]);
+    expect(mockInvoke).toHaveBeenCalledTimes(1); // no second network call
+  });
+
+  it('yields expired cache then revalidates from network', async () => {
+    mockInvoke.mockResolvedValue('data');
+
+    // Prime with ttl=1ms
+    for await (const _ of cachedInvoke('cmd', undefined, { ttl: 1 })) {
+      /* consume */
+    }
+
+    // Wait for expiry
+    await new Promise((r) => setTimeout(r, 5));
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 1 })) {
+      results.push(r);
+    }
+
+    // Expired entry is still usable — yield stale cache, then network
+    expect(results).toEqual([
+      { data: 'data', source: 'cache', fetchedAt: expect.any(Number) },
+      { data: 'fresh', source: 'network', fetchedAt: expect.any(Number) },
+    ]);
+  });
+
+  it('swallows network errors when usable stale cache exists', async () => {
+    mockInvoke.mockResolvedValue('cached-data');
+
+    // Prime
+    for await (const _ of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      /* consume */
+    }
+
+    // Mark stale so revalidation is attempted
+    await markAllStale();
+
+    // Network fails on second call
+    mockInvoke.mockRejectedValue(new Error('offline'));
+    const results = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    // Stale cache is still served despite network failure
+    expect(results).toEqual([
+      { data: 'cached-data', source: 'cache', fetchedAt: expect.any(Number) },
+    ]);
+  });
+
+  it('throws network errors when no valid cache exists', async () => {
+    mockInvoke.mockRejectedValue(new Error('offline'));
+
+    const results = [];
+    let thrown: Error | undefined;
+    try {
+      for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+        results.push(r);
+      }
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    expect(thrown?.message).toBe('offline');
+    expect(results).toEqual([]);
+  });
+});
+
+describe('cachedInvoke with bypassRead', () => {
+  it('skips the cache yield and goes to network even when a fresh entry exists', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    for await (const _ of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      /* prime */
+    }
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000, bypassRead: true })) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
+  });
+
+  it('writes the fresh response back to IDB so subsequent reads are warm', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    for await (const _ of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      /* prime */
+    }
+
+    mockInvoke.mockResolvedValue('fresh');
+    for await (const _ of cachedInvoke('cmd', undefined, { ttl: 60_000, bypassRead: true })) {
+      /* consume */
+    }
+
+    mockInvoke.mockResolvedValue('should-not-be-used');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([{ data: 'fresh', source: 'cache', fetchedAt: expect.any(Number) }]);
+  });
+
+  it('rethrows network errors instead of falling back to the cached entry', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    for await (const _ of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      /* prime */
+    }
+
+    mockInvoke.mockRejectedValue(new Error('offline'));
+    let thrown: Error | undefined;
+    const results = [];
+    try {
+      for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000, bypassRead: true })) {
+        results.push(r);
+      }
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    expect(thrown?.message).toBe('offline');
+    expect(results).toEqual([]);
+  });
+
+  it('honors epoch invalidation during an in-flight bypassRead fetch', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    for await (const _ of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      /* prime */
+    }
+
+    let resolveNetwork!: (value: string) => void;
+    const pending = new Promise<string>((res) => {
+      resolveNetwork = res;
+    });
+    mockInvoke.mockReturnValueOnce(pending);
+
+    const consumer = (async () => {
+      const out = [];
+      for await (const r of cachedInvoke<string>('cmd', undefined, {
+        ttl: 60_000,
+        bypassRead: true,
+      })) {
+        out.push(r);
+      }
+      return out;
+    })();
+
+    // Let cachedInvoke reach the network step
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await invalidateCache('cmd');
+
+    resolveNetwork('post-invalidate');
+    const results = await consumer;
+
+    expect(results).toEqual([
+      { data: 'post-invalidate', source: 'network', fetchedAt: expect.any(Number) },
+    ]);
+
+    // The epoch bump should have suppressed the write — a subsequent read is a miss.
+    mockInvoke.mockResolvedValueOnce('fresh');
+    const followUp = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      followUp.push(r);
+    }
+    expect(followUp).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+  });
+});
+
+describe('cachedCommand', () => {
+  it('returns network result with no revalidation on cache miss', async () => {
+    mockInvoke.mockResolvedValue('value');
+
+    const result = await cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+
+    expect(result.data).toBe('value');
+    expect(result.revalidating).toBeNull();
+  });
+
+  it('returns only cached data when entry is fresh', async () => {
+    mockInvoke.mockResolvedValue('v1');
+    await cachedCommand('cmd', undefined, { ttl: 60_000 });
+
+    mockInvoke.mockResolvedValue('v2');
+    const result = await cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+
+    // Fresh entry short-circuits — no network call
+    expect(result.data).toBe('v1');
+    expect(result.revalidating).toBeNull();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns stale data with a revalidating promise that resolves to fresh', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    await cachedCommand('cmd', undefined, { ttl: 60_000 });
+
+    await markAllStale();
+
+    mockInvoke.mockResolvedValue('fresh');
+    const result = await cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+
+    expect(result.data).toBe('cached');
+    expect(result.revalidating).not.toBeNull();
+    await expect(result.revalidating).resolves.toBe('fresh');
+  });
+
+  it('keeps revalidating promise resolving to cached data when network fails', async () => {
+    mockInvoke.mockResolvedValue('cached-data');
+    await cachedCommand('cmd', undefined, { ttl: 60_000 });
+
+    await markAllStale();
+
+    mockInvoke.mockRejectedValue(new Error('offline'));
+    const result = await cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+
+    expect(result.data).toBe('cached-data');
+    await expect(result.revalidating).resolves.toBe('cached-data');
+  });
+
+  it('throws on miss when the network fails', async () => {
+    mockInvoke.mockRejectedValue(new Error('offline'));
+    await expect(cachedCommand('cmd', undefined, { ttl: 60_000 })).rejects.toThrow('offline');
+  });
+});
+
+describe('invalidateCache', () => {
+  it('removes a specific entry so next call is a miss', async () => {
+    mockInvoke.mockResolvedValue('data');
+    await cachedCommand('cmd', { id: '1' }, { ttl: 60_000 });
+
+    await invalidateCache('cmd', { id: '1' });
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', { id: '1' }, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    // Only network, no cache hit
+    expect(results).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+  });
+});
+
+describe('invalidateCacheByCommand', () => {
+  it('removes all entries for a command', async () => {
+    mockInvoke.mockResolvedValue('a');
+    await cachedCommand('cmd', { id: '1' }, { ttl: 60_000 });
+    mockInvoke.mockResolvedValue('b');
+    await cachedCommand('cmd', { id: '2' }, { ttl: 60_000 });
+
+    await invalidateCacheByCommand('cmd');
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', { id: '1' }, { ttl: 60_000 })) {
+      results.push(r);
+    }
+    expect(results).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+  });
+
+  it('does not affect other commands', async () => {
+    mockInvoke.mockResolvedValue('keep');
+    await cachedCommand('other', undefined, { ttl: 60_000 });
+
+    await invalidateCacheByCommand('cmd');
+
+    mockInvoke.mockResolvedValue('new');
+    const results = [];
+    for await (const r of cachedInvoke('other', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+    // Should still have cache hit (fresh, so no network call)
+    expect(results).toEqual([{ data: 'keep', source: 'cache', fetchedAt: expect.any(Number) }]);
+  });
+});
+
+describe('invalidateCacheByArgs', () => {
+  it('removes matching entries for the same command and branchId', async () => {
+    mockInvoke.mockResolvedValue('branch-a-head');
+    await cachedCommand(
+      'get_diff_files',
+      { branchId: 'branch-a', commitSha: undefined, scope: 'branch' },
+      { ttl: 60_000 }
+    );
+    mockInvoke.mockResolvedValue('branch-a-commit');
+    await cachedCommand(
+      'get_diff_files',
+      { branchId: 'branch-a', commitSha: 'abc123', scope: 'commit' },
+      { ttl: 60_000 }
+    );
+
+    await invalidateCacheByArgs('get_diff_files', { branchId: 'branch-a' });
+
+    mockInvoke.mockResolvedValue('fresh');
+    const headResults = [];
+    for await (const r of cachedInvoke(
+      'get_diff_files',
+      { branchId: 'branch-a', commitSha: undefined, scope: 'branch' },
+      { ttl: 60_000 }
+    )) {
+      headResults.push(r);
+    }
+
+    const commitResults = [];
+    for await (const r of cachedInvoke(
+      'get_diff_files',
+      { branchId: 'branch-a', commitSha: 'abc123', scope: 'commit' },
+      { ttl: 60_000 }
+    )) {
+      commitResults.push(r);
+    }
+
+    expect(headResults).toEqual([
+      { data: 'fresh', source: 'network', fetchedAt: expect.any(Number) },
+    ]);
+    expect(commitResults).toEqual([
+      { data: 'fresh', source: 'network', fetchedAt: expect.any(Number) },
+    ]);
+  });
+
+  it('keeps entries for other branches cached', async () => {
+    mockInvoke.mockResolvedValue('branch-a');
+    await cachedCommand(
+      'get_diff_files',
+      { branchId: 'branch-a', commitSha: 'abc123', scope: 'commit' },
+      { ttl: 60_000 }
+    );
+    mockInvoke.mockResolvedValue('branch-b');
+    await cachedCommand(
+      'get_diff_files',
+      { branchId: 'branch-b', commitSha: 'def456', scope: 'commit' },
+      { ttl: 60_000 }
+    );
+
+    await invalidateCacheByArgs('get_diff_files', { branchId: 'branch-a' });
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke(
+      'get_diff_files',
+      { branchId: 'branch-b', commitSha: 'def456', scope: 'commit' },
+      { ttl: 60_000 }
+    )) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([{ data: 'branch-b', source: 'cache', fetchedAt: expect.any(Number) }]);
+  });
+
+  it('keeps entries for other commands cached', async () => {
+    mockInvoke.mockResolvedValue('diff');
+    await cachedCommand(
+      'get_diff_files',
+      { branchId: 'branch-a', commitSha: 'abc123', scope: 'commit' },
+      { ttl: 60_000 }
+    );
+    mockInvoke.mockResolvedValue('messages');
+    await cachedCommand('get_session_messages', { branchId: 'branch-a' }, { ttl: 60_000 });
+
+    await invalidateCacheByArgs('get_diff_files', { branchId: 'branch-a' });
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke(
+      'get_session_messages',
+      { branchId: 'branch-a' },
+      { ttl: 60_000 }
+    )) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([{ data: 'messages', source: 'cache', fetchedAt: expect.any(Number) }]);
+  });
+
+  it('matches entries with optional args missing when branchId matches', async () => {
+    mockInvoke.mockResolvedValue('branch-diff');
+    await cachedCommand(
+      'get_diff_files',
+      { branchId: 'branch-a', scope: 'branch' },
+      { ttl: 60_000 }
+    );
+
+    await invalidateCacheByArgs('get_diff_files', { branchId: 'branch-a' });
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke(
+      'get_diff_files',
+      { branchId: 'branch-a', scope: 'branch' },
+      { ttl: 60_000 }
+    )) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+  });
+});
+
+describe('first-load race protection', () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  it('invalidateCacheByCommand blocks a cache write from an in-flight first-load fetch', async () => {
+    const pending = deferred<string>();
+    mockInvoke.mockReturnValueOnce(pending.promise);
+
+    const inFlight = cachedCommand<string>('list_projects', undefined, { ttl: 60_000 });
+
+    // Let cachedCommand reach the network step (IDB miss, addInFlight, network promise constructed)
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await invalidateCacheByCommand('list_projects');
+
+    pending.resolve('pre-mutation');
+    await expect(inFlight).resolves.toEqual({ data: 'pre-mutation', revalidating: null });
+
+    // The pre-mutation write should have been suppressed by the epoch bump,
+    // so a subsequent read must hit the network.
+    mockInvoke.mockResolvedValueOnce('fresh');
+    const results = [];
+    for await (const r of cachedInvoke('list_projects', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+    expect(results).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+  });
+
+  it('invalidateCacheByArgs blocks a cache write from an in-flight first-load fetch', async () => {
+    const pending = deferred<string>();
+    mockInvoke.mockReturnValueOnce(pending.promise);
+
+    const inFlight = cachedCommand<string>(
+      'get_diff_files',
+      { branchId: 'branch-a' },
+      { ttl: 60_000 }
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await invalidateCacheByArgs('get_diff_files', { branchId: 'branch-a' });
+
+    pending.resolve('pre-mutation');
+    await expect(inFlight).resolves.toEqual({ data: 'pre-mutation', revalidating: null });
+
+    mockInvoke.mockResolvedValueOnce('fresh');
+    const results = [];
+    for await (const r of cachedInvoke(
+      'get_diff_files',
+      { branchId: 'branch-a' },
+      { ttl: 60_000 }
+    )) {
+      results.push(r);
+    }
+    expect(results).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+  });
+
+  it('refcounts in-flight keys so concurrent reads of the same key both honor invalidation', async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    mockInvoke.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const callA = cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+    const callB = cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Resolve the first call; let the cache write settle.
+    first.resolve('a');
+    await callA;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Refcount should still hold the in-flight key from callB. The invalidator
+    // must bump that key's epoch even though IDB now has an entry too.
+    await invalidateCacheByCommand('cmd');
+
+    second.resolve('b');
+    await callB;
+
+    // Both writes are suppressed (the first by the IDB delete, the second by
+    // the epoch bump), so a subsequent read must hit the network.
+    mockInvoke.mockResolvedValueOnce('fresh');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+    expect(results).toEqual([{ data: 'fresh', source: 'network', fetchedAt: expect.any(Number) }]);
+  });
+});
+
+describe('markAllStale', () => {
+  it('yields stale cache first then revalidates from network', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    await cachedCommand('cmd', undefined, { ttl: 60_000 });
+
+    await markAllStale();
+
+    mockInvoke.mockResolvedValue('fresh');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([
+      { data: 'cached', source: 'cache', fetchedAt: expect.any(Number) },
+      { data: 'fresh', source: 'network', fetchedAt: expect.any(Number) },
+    ]);
+  });
+
+  it('preserves original fetchedAt on cache yield and uses fresh timestamp on network yield', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    const beforePrime = Date.now();
+    await cachedCommand('cmd', undefined, { ttl: 60_000 });
+    const afterPrime = Date.now();
+
+    // Wait so a new Date.now() is meaningfully later than the prime timestamp
+    await new Promise((r) => setTimeout(r, 10));
+    await markAllStale();
+
+    mockInvoke.mockResolvedValue('fresh');
+    const beforeFetch = Date.now();
+    const results = [];
+    for await (const r of cachedInvoke<string>('cmd', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    expect(results).toHaveLength(2);
+    const [cacheYield, networkYield] = results;
+    expect(cacheYield.source).toBe('cache');
+    expect(cacheYield.fetchedAt).toBeGreaterThanOrEqual(beforePrime);
+    expect(cacheYield.fetchedAt).toBeLessThanOrEqual(afterPrime);
+    expect(networkYield.source).toBe('network');
+    expect(networkYield.fetchedAt).toBeGreaterThanOrEqual(beforeFetch);
+    expect(networkYield.fetchedAt).toBeGreaterThan(cacheYield.fetchedAt);
+  });
+
+  it('cachedCommand returns stale value with a revalidating promise resolving to fresh', async () => {
+    mockInvoke.mockResolvedValue('cached');
+    await cachedCommand('cmd', undefined, { ttl: 60_000 });
+
+    await markAllStale();
+
+    mockInvoke.mockResolvedValue('fresh');
+    const result = await cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+
+    expect(result.data).toBe('cached');
+    expect(result.revalidating).not.toBeNull();
+    await expect(result.revalidating).resolves.toBe('fresh');
+  });
+
+  it('revalidation clears the stale flag', async () => {
+    mockInvoke.mockResolvedValue('v1');
+    await cachedCommand('cmd', undefined, { ttl: 60_000 });
+
+    await markAllStale();
+
+    // Revalidate — await the revalidation promise so the cache write completes
+    mockInvoke.mockResolvedValue('v2');
+    const { revalidating } = await cachedCommand<string>('cmd', undefined, { ttl: 60_000 });
+    await revalidating;
+
+    // Now the entry should be fresh — short-circuit with only cache
+    mockInvoke.mockResolvedValue('v3');
+    const results = [];
+    for await (const r of cachedInvoke('cmd', undefined, { ttl: 60_000 })) {
+      results.push(r);
+    }
+
+    expect(results).toEqual([{ data: 'v2', source: 'cache', fetchedAt: expect.any(Number) }]);
+    expect(mockInvoke).toHaveBeenCalledTimes(2); // v1 + v2, not v3
+  });
+});
+
+describe('evictIfNeeded', () => {
+  it('evicts oldest entries when cache exceeds MAX_CACHE_ENTRIES', async () => {
+    // Fill cache beyond the limit
+    const total = _MAX_CACHE_ENTRIES + 10;
+    for (let i = 0; i < total; i++) {
+      mockInvoke.mockResolvedValue(`value-${i}`);
+      await cachedCommand('cmd', { id: String(i) }, { ttl: 60_000 });
+    }
+
+    // Explicit eviction (also triggered by cacheSet, but let's verify directly)
+    await _evictIfNeeded();
+
+    // Verify: the oldest entries should have been evicted.
+    // The first 10 entries (id 0-9) should be gone; entries 10+ should remain.
+    mockInvoke.mockResolvedValue('new');
+
+    // Entry 0 should be a cache miss (evicted)
+    const missResults = [];
+    for await (const r of cachedInvoke('cmd', { id: '0' }, { ttl: 60_000 })) {
+      missResults.push(r);
+    }
+    expect(missResults).toEqual([
+      { data: 'new', source: 'network', fetchedAt: expect.any(Number) },
+    ]);
+
+    // Entry at the tail (most recent) should still be a cache hit
+    const hitResults = [];
+    for await (const r of cachedInvoke('cmd', { id: String(total - 1) }, { ttl: 60_000 })) {
+      hitResults.push(r);
+    }
+    expect(hitResults[0]).toEqual({
+      data: `value-${total - 1}`,
+      source: 'cache',
+      fetchedAt: expect.any(Number),
+    });
+  });
+});

--- a/apps/staged/src/lib/cache.ts
+++ b/apps/staged/src/lib/cache.ts
@@ -1,0 +1,330 @@
+import { get, set, del, keys, entries, clear, createStore } from 'idb-keyval';
+import { invokeCommand, isTauri } from './transport';
+
+const CACHE_SCHEMA_VERSION = 1;
+const MAX_CACHE_ENTRIES = 200;
+
+/**
+ * Tracks the last invalidation time per cache key. When a read starts, it
+ * captures the current epoch for that key. If the key is invalidated while
+ * the network request is in flight, the epoch advances and the stale write
+ * is skipped — preventing pre-mutation data from repopulating the cache.
+ */
+const invalidationEpochs = new Map<string, number>();
+
+function getEpoch(key: string): number {
+  return invalidationEpochs.get(key) ?? 0;
+}
+
+function bumpEpoch(key: string): void {
+  invalidationEpochs.set(key, Date.now());
+}
+
+/**
+ * Refcount of cache keys with an active network fetch. Scoped invalidators
+ * union this with the IDB key set so first-load races (key not yet written to
+ * IDB) still get their epoch bumped — otherwise the in-flight fetch would
+ * resolve and write pre-mutation data into the invalidated namespace.
+ */
+const inFlightKeys = new Map<string, number>();
+
+function addInFlight(key: string): void {
+  inFlightKeys.set(key, (inFlightKeys.get(key) ?? 0) + 1);
+}
+
+function removeInFlight(key: string): void {
+  const n = inFlightKeys.get(key) ?? 0;
+  if (n <= 1) inFlightKeys.delete(key);
+  else inFlightKeys.set(key, n - 1);
+}
+
+let cacheStore: ReturnType<typeof createStore> | undefined;
+
+function getStore() {
+  if (!cacheStore) {
+    cacheStore = createStore('staged-cache', 'responses');
+  }
+  return cacheStore;
+}
+
+interface CacheEntry<T> {
+  key: string;
+  data: T;
+  fetchedAt: number;
+  schemaVersion: number;
+  stale?: boolean;
+}
+
+export interface CacheConfig {
+  ttl: number;
+  /**
+   * Skip the IDB read and always go to the network. The fresh response is
+   * still written back to IDB (subject to the same epoch race protection).
+   * Use this when a caller explicitly wants a real revalidation and not a
+   * potentially within-TTL cached value — e.g. `getBranchTimeline({ force })`.
+   */
+  bypassRead?: boolean;
+}
+
+/**
+ * Result of a cached command call.
+ *
+ * `data` is the best value available immediately (cached if usable, otherwise
+ * from the network). When `revalidating` is non-null, a network fetch is in
+ * flight: await it to get the fresh value. Callers can render `data` instantly
+ * and then re-render once `revalidating` resolves.
+ */
+export interface SwrResult<T> {
+  data: T;
+  revalidating: Promise<T> | null;
+}
+
+function cacheKey(command: string, args?: Record<string, unknown>): string {
+  const argsStr = args ? JSON.stringify(args, Object.keys(args).sort()) : '';
+  return `${command}:${argsStr}`;
+}
+
+/**
+ * Stale-while-revalidate wrapper around invokeCommand.
+ *
+ * Yields:
+ *   1. Cached data (if available and schema matches) — instant
+ *   2. Fresh network data — if cached data is stale or expired
+ *
+ * Fresh entries (within TTL and not marked stale) short-circuit with
+ * only the cache yield. If no cache exists, only the network result
+ * is yielded.
+ */
+export async function* cachedInvoke<T>(
+  command: string,
+  args: Record<string, unknown> | undefined,
+  config: CacheConfig
+): AsyncGenerator<{ data: T; source: 'cache' | 'network'; fetchedAt: number }> {
+  if (isTauri) {
+    const data = await invokeCommand<T>(command, args);
+    yield { data, source: 'network', fetchedAt: Date.now() };
+    return;
+  }
+
+  const key = cacheKey(command, args);
+  const store = getStore();
+
+  let entry: CacheEntry<T> | undefined;
+  let isUsable = false;
+  if (!config.bypassRead) {
+    entry = await get<CacheEntry<T>>(key, store).catch(() => undefined);
+    isUsable = entry != null && entry.schemaVersion === CACHE_SCHEMA_VERSION;
+    const isFresh = isUsable && !entry!.stale && Date.now() - entry!.fetchedAt < config.ttl;
+
+    if (isUsable) {
+      yield { data: entry!.data, source: 'cache', fetchedAt: entry!.fetchedAt };
+    }
+
+    if (isFresh) return;
+  }
+
+  addInFlight(key);
+  const epochAtStart = getEpoch(key);
+
+  try {
+    const data = await invokeCommand<T>(command, args);
+    const fetchedAt = Date.now();
+    // Skip the cache write if the key was invalidated while we were fetching —
+    // writing would repopulate the cache with pre-mutation data.
+    if (getEpoch(key) === epochAtStart) {
+      await cacheSet(key, {
+        key,
+        data,
+        fetchedAt,
+        schemaVersion: CACHE_SCHEMA_VERSION,
+      } satisfies CacheEntry<T>);
+    }
+    yield { data, source: 'network', fetchedAt };
+  } catch (err) {
+    // With bypassRead the caller asked for a real fetch — surface the failure
+    // instead of silently falling back to whatever IDB had.
+    if (config.bypassRead || !isUsable) throw err;
+    console.warn(`[cache] Network error for ${command}, serving stale cache`, err);
+  } finally {
+    removeInFlight(key);
+  }
+}
+
+/**
+ * Like invokeCommand, but with SWR caching.
+ *
+ * Returns `{ data, revalidating }`:
+ * - `data` is the best value available immediately (cached if usable, else network).
+ * - `revalidating` is non-null when a background network fetch is in flight;
+ *   callers can await it to get the fresh value.
+ */
+export async function cachedCommand<T>(
+  command: string,
+  args: Record<string, unknown> | undefined,
+  config: CacheConfig
+): Promise<SwrResult<T>> {
+  if (isTauri) {
+    const data = await invokeCommand<T>(command, args);
+    return { data, revalidating: null };
+  }
+
+  const key = cacheKey(command, args);
+  const store = getStore();
+
+  const entry = await get<CacheEntry<T>>(key, store).catch(() => undefined);
+  const isUsable = entry != null && entry.schemaVersion === CACHE_SCHEMA_VERSION;
+  const isFresh = isUsable && !entry.stale && Date.now() - entry.fetchedAt < config.ttl;
+
+  if (isUsable && isFresh) {
+    return { data: entry.data, revalidating: null };
+  }
+
+  addInFlight(key);
+  const epochAtStart = getEpoch(key);
+  const network = invokeCommand<T>(command, args)
+    .then(async (data) => {
+      // Skip the cache write if the key was invalidated while we were fetching —
+      // writing would repopulate the cache with pre-mutation data.
+      if (getEpoch(key) === epochAtStart) {
+        await cacheSet(key, {
+          key,
+          data,
+          fetchedAt: Date.now(),
+          schemaVersion: CACHE_SCHEMA_VERSION,
+        } satisfies CacheEntry<T>);
+      }
+      return data;
+    })
+    .finally(() => removeInFlight(key));
+
+  if (isUsable) {
+    // Stale/expired but usable — return cached data immediately and let the
+    // caller await revalidation. Swallow network errors so the stale entry
+    // remains the resolved value (mirrors cachedInvoke behavior).
+    const revalidating = network.catch((err) => {
+      console.warn(`[cache] Network error for ${command}, serving stale cache`, err);
+      return entry.data;
+    });
+    return { data: entry.data, revalidating };
+  }
+
+  // Miss — must await the network before we can return anything usable.
+  const data = await network;
+  return { data, revalidating: null };
+}
+
+/**
+ * Evict the oldest cache entries (by fetchedAt) until the store is under the
+ * MAX_CACHE_ENTRIES limit. Called after writes and on quota errors.
+ */
+async function evictIfNeeded(): Promise<void> {
+  try {
+    const store = getStore();
+    const allEntries = await entries<string, CacheEntry<unknown>>(store);
+    if (allEntries.length <= MAX_CACHE_ENTRIES) return;
+
+    // Sort by fetchedAt ascending (oldest first) and evict the excess
+    const sorted = allEntries.sort((a, b) => a[1].fetchedAt - b[1].fetchedAt);
+    const toEvict = sorted.slice(0, sorted.length - MAX_CACHE_ENTRIES);
+    await Promise.all(toEvict.map(([k]) => del(k, store)));
+  } catch {
+    // Best-effort eviction — don't let this block the caller
+  }
+}
+
+/**
+ * Write a cache entry, with quota-error recovery via LRU eviction.
+ */
+async function cacheSet<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+  const store = getStore();
+  try {
+    await set(key, entry, store);
+  } catch (err) {
+    // On quota error, evict old entries and retry once
+    if (err instanceof DOMException && err.name === 'QuotaExceededError') {
+      await evictIfNeeded();
+      await set(key, entry, store).catch(() => {});
+      return;
+    }
+    // Swallow other write errors — cache is best-effort
+  }
+  // Proactive eviction after successful writes
+  evictIfNeeded();
+}
+
+/** Invalidate a specific cache entry. */
+export async function invalidateCache(
+  command: string,
+  args?: Record<string, unknown>
+): Promise<void> {
+  if (isTauri) return;
+  const key = cacheKey(command, args);
+  bumpEpoch(key);
+  await del(key, getStore()).catch(() => {});
+}
+
+/** Invalidate all entries for a command (regardless of args). */
+export async function invalidateCacheByCommand(command: string): Promise<void> {
+  if (isTauri) return;
+  const store = getStore();
+  const prefix = `${command}:`;
+  const idbMatching = (await keys<string>(store)).filter((k) => k.startsWith(prefix));
+  const inFlightMatching = [...inFlightKeys.keys()].filter((k) => k.startsWith(prefix));
+  const toBump = new Set<string>([...idbMatching, ...inFlightMatching]);
+  toBump.forEach(bumpEpoch);
+  await Promise.all(idbMatching.map((k) => del(k, store)));
+}
+
+function parseCacheArgs(key: string, command: string): Record<string, unknown> | undefined {
+  const prefix = `${command}:`;
+  if (!key.startsWith(prefix)) return undefined;
+
+  try {
+    const parsed = JSON.parse(key.slice(prefix.length)) as unknown;
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Invalidate entries for a command whose cached args include all partial args. */
+export async function invalidateCacheByArgs(
+  command: string,
+  partialArgs: Record<string, unknown>
+): Promise<void> {
+  if (isTauri) return;
+  const store = getStore();
+  const matches = (key: string): boolean => {
+    const args = parseCacheArgs(key, command);
+    if (!args) return false;
+    return Object.entries(partialArgs).every(([argKey, argValue]) => args[argKey] === argValue);
+  };
+  const idbMatching = (await keys<string>(store)).filter(matches);
+  const inFlightMatching = [...inFlightKeys.keys()].filter(matches);
+  const toBump = new Set<string>([...idbMatching, ...inFlightMatching]);
+  toBump.forEach(bumpEpoch);
+  await Promise.all(idbMatching.map((k) => del(k, store)));
+}
+
+/** Mark all entries as stale so SWR serves them while revalidating. */
+export async function markAllStale(): Promise<void> {
+  if (isTauri) return;
+  const store = getStore();
+  const allEntries = await entries<string, CacheEntry<unknown>>(store);
+  await Promise.all(allEntries.map(([k, entry]) => set(k, { ...entry, stale: true }, store)));
+}
+
+/** Remove all cached entries. */
+export async function clearAllCache(): Promise<void> {
+  if (isTauri) return;
+  await clear(getStore());
+}
+
+// Exported for testing
+export {
+  cacheKey as _cacheKey,
+  CACHE_SCHEMA_VERSION as _CACHE_SCHEMA_VERSION,
+  MAX_CACHE_ENTRIES as _MAX_CACHE_ENTRIES,
+  evictIfNeeded as _evictIfNeeded,
+};

--- a/apps/staged/src/lib/commands.test.ts
+++ b/apps/staged/src/lib/commands.test.ts
@@ -7,6 +7,8 @@ describe('browser-native command wrappers', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.doUnmock('./transport');
+    vi.doUnmock('./cache');
   });
 
   it('opens URLs with browser navigation in web mode', async () => {
@@ -59,5 +61,148 @@ describe('browser-native command wrappers', () => {
     await expect(getAvailableOpeners()).resolves.toEqual([]);
     await expect(openInApp('/tmp/repo', 'finder')).rejects.toThrow('web mode');
     expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('cached mutation command wrappers', () => {
+  function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  let invokeCommand: ReturnType<typeof vi.fn>;
+  let cachedCommand: ReturnType<typeof vi.fn>;
+  let invalidateCache: ReturnType<typeof vi.fn>;
+  let invalidateCacheByCommand: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    invokeCommand = vi.fn();
+    cachedCommand = vi.fn();
+    invalidateCache = vi.fn();
+    invalidateCacheByCommand = vi.fn();
+
+    vi.doMock('./transport', () => ({
+      isTauri: false,
+      invokeCommand,
+    }));
+    vi.doMock('./cache', () => ({
+      cachedCommand,
+      cachedInvoke: vi.fn(),
+      invalidateCache,
+      invalidateCacheByCommand,
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('./transport');
+    vi.doUnmock('./cache');
+  });
+
+  it('waits for repo list invalidation before resolving addProjectRepo', async () => {
+    const repo = { id: 'repo-1' };
+    const invalidated = deferred();
+    invokeCommand.mockResolvedValue(repo);
+    invalidateCache.mockReturnValue(invalidated.promise);
+
+    const { addProjectRepo } = await import('./commands');
+
+    let settled = false;
+    const result = addProjectRepo('project-1', 'block/builderbot').then((value) => {
+      settled = true;
+      return value;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invalidateCache).toHaveBeenCalledWith('list_project_repos', { projectId: 'project-1' });
+    expect(settled).toBe(false);
+
+    invalidated.resolve();
+
+    await expect(result).resolves.toBe(repo);
+  });
+
+  it('waits for all project cache invalidations before resolving deleteProject', async () => {
+    const projectsInvalidated = deferred();
+    const branchesInvalidated = deferred();
+    const reposInvalidated = deferred();
+    invokeCommand.mockResolvedValue(undefined);
+    invalidateCacheByCommand
+      .mockReturnValueOnce(projectsInvalidated.promise)
+      .mockReturnValueOnce(branchesInvalidated.promise)
+      .mockReturnValueOnce(reposInvalidated.promise);
+
+    const { deleteProject } = await import('./commands');
+
+    let settled = false;
+    const result = deleteProject('project-1').then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invalidateCacheByCommand.mock.calls).toEqual([
+      ['list_projects'],
+      ['list_branches_for_project'],
+      ['list_project_repos'],
+    ]);
+    expect(settled).toBe(false);
+
+    projectsInvalidated.resolve();
+    branchesInvalidated.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    reposInvalidated.resolve();
+
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('bypasses the SWR cache when fetching fresh session messages', async () => {
+    const messages = [{ id: 1, sessionId: 'session-1', role: 'assistant', content: 'done' }];
+    invokeCommand.mockResolvedValue(messages);
+
+    const { getFreshSessionMessages } = await import('./commands');
+
+    await expect(getFreshSessionMessages('session-1')).resolves.toBe(messages);
+    expect(invokeCommand).toHaveBeenCalledWith('get_session_messages', {
+      sessionId: 'session-1',
+    });
+    expect(cachedCommand).not.toHaveBeenCalled();
+  });
+
+  it('uses the standard provider discovery cache by default', async () => {
+    const providers = [{ id: 'goose', label: 'Goose' }];
+    cachedCommand.mockResolvedValue({ data: providers, revalidating: null });
+
+    const { discoverAcpProviders } = await import('./commands');
+
+    await expect(discoverAcpProviders()).resolves.toEqual({
+      data: providers,
+      revalidating: null,
+    });
+    expect(cachedCommand).toHaveBeenCalledWith('discover_acp_providers', undefined, {
+      ttl: 30 * 60_000,
+    });
+  });
+
+  it('forces provider discovery revalidation without bypassing the cached value', async () => {
+    const providers = [{ id: 'goose', label: 'Goose' }];
+    const revalidating = Promise.resolve([{ id: 'codex', label: 'Codex' }]);
+    cachedCommand.mockResolvedValue({ data: providers, revalidating });
+
+    const { discoverAcpProviders } = await import('./commands');
+
+    await expect(discoverAcpProviders({ force: true })).resolves.toEqual({
+      data: providers,
+      revalidating,
+    });
+    expect(cachedCommand).toHaveBeenCalledWith('discover_acp_providers', undefined, { ttl: 0 });
   });
 });

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -5,6 +5,14 @@
  */
 
 import { invokeCommand, isTauri } from './transport';
+import {
+  cachedCommand,
+  cachedInvoke,
+  invalidateCacheByCommand,
+  invalidateCache,
+  type SwrResult,
+} from './cache';
+import { readSnapshot, writeSnapshot, SNAPSHOT_KEYS } from './shared/webSnapshot';
 import type {
   Project,
   ProjectRepo,
@@ -60,11 +68,11 @@ export function confirmResetStore(): Promise<void> {
 // Projects
 // =============================================================================
 
-export function listProjects(): Promise<Project[]> {
-  return invokeCommand('list_projects');
+export function listProjects(): Promise<SwrResult<Project[]>> {
+  return cachedCommand('list_projects', undefined, { ttl: 5 * 60_000 });
 }
 
-export function createProject(
+export async function createProject(
   name: string,
   location: 'local' | 'remote',
   githubRepo?: string,
@@ -74,7 +82,7 @@ export function createProject(
   defaultBranch?: string,
   headRepo?: string
 ): Promise<Project> {
-  return invokeCommand('create_project', {
+  const project = await invokeCommand<Project>('create_project', {
     name,
     location,
     githubRepo: githubRepo ?? null,
@@ -84,21 +92,28 @@ export function createProject(
     defaultBranch: defaultBranch ?? null,
     headRepo: headRepo ?? null,
   });
+  await invalidateCacheByCommand('list_projects');
+  return project;
 }
 
-export function deleteProject(id: string): Promise<void> {
-  return invokeCommand('delete_project', { id });
+export async function deleteProject(id: string): Promise<void> {
+  await invokeCommand('delete_project', { id });
+  await Promise.all([
+    invalidateCacheByCommand('list_projects'),
+    invalidateCacheByCommand('list_branches_for_project'),
+    invalidateCacheByCommand('list_project_repos'),
+  ]);
 }
 
-export function listProjectRepos(projectId: string): Promise<ProjectRepo[]> {
-  return invokeCommand('list_project_repos', { projectId });
+export function listProjectRepos(projectId: string): Promise<SwrResult<ProjectRepo[]>> {
+  return cachedCommand('list_project_repos', { projectId }, { ttl: 10 * 60_000 });
 }
 
 export function listRecentRepos(limit?: number): Promise<RecentRepo[]> {
   return invokeCommand('list_recent_repos', { limit: limit ?? 10 });
 }
 
-export function addProjectRepo(
+export async function addProjectRepo(
   projectId: string,
   githubRepo: string,
   branchName?: string,
@@ -108,7 +123,7 @@ export function addProjectRepo(
   defaultBranch?: string,
   headRepo?: string
 ): Promise<ProjectRepo> {
-  return invokeCommand('add_project_repo', {
+  const repo = await invokeCommand<ProjectRepo>('add_project_repo', {
     projectId,
     githubRepo,
     branchName: branchName ?? null,
@@ -118,6 +133,8 @@ export function addProjectRepo(
     defaultBranch: defaultBranch ?? null,
     headRepo: headRepo ?? null,
   });
+  await invalidateCache('list_project_repos', { projectId });
+  return repo;
 }
 
 export function updateProjectRepoBranchName(
@@ -128,12 +145,17 @@ export function updateProjectRepoBranchName(
   return invokeCommand('update_project_repo_branch_name', { projectId, projectRepoId, branchName });
 }
 
-export function removeProjectRepo(projectId: string, projectRepoId: string): Promise<void> {
-  return invokeCommand('remove_project_repo', { projectId, projectRepoId });
+export async function removeProjectRepo(projectId: string, projectRepoId: string): Promise<void> {
+  await invokeCommand('remove_project_repo', { projectId, projectRepoId });
+  await invalidateCache('list_project_repos', { projectId });
 }
 
-export function setPrimaryProjectRepo(projectId: string, projectRepoId: string): Promise<void> {
-  return invokeCommand('set_primary_project_repo', { projectId, projectRepoId });
+export async function setPrimaryProjectRepo(
+  projectId: string,
+  projectRepoId: string
+): Promise<void> {
+  await invokeCommand('set_primary_project_repo', { projectId, projectRepoId });
+  await invalidateCache('list_project_repos', { projectId });
 }
 
 export function getSuggestedRepos(projectId: string, limit?: number): Promise<SuggestedRepo[]> {
@@ -227,8 +249,8 @@ export function startProjectSession(
 // Branches
 // =============================================================================
 
-export function listBranchesForProject(projectId: string): Promise<Branch[]> {
-  return invokeCommand('list_branches_for_project', { projectId });
+export function listBranchesForProject(projectId: string): Promise<SwrResult<Branch[]>> {
+  return cachedCommand('list_branches_for_project', { projectId }, { ttl: 2 * 60_000 });
 }
 
 /** Get a single branch by ID. */
@@ -239,13 +261,20 @@ export function getBranch(branchId: string): Promise<Branch | null> {
 /** Create a local branch record (DB only — no git worktree yet).
  *  Returns immediately with worktreePath = null.
  *  Call `setupWorktree` separately to create the git worktree. */
-export function createBranch(
+export async function createBranch(
   projectId: string,
   branchName: string,
   baseBranch?: string,
   projectRepoId?: string
 ): Promise<Branch> {
-  return invokeCommand('create_branch', { projectId, branchName, baseBranch, projectRepoId });
+  const branch = await invokeCommand<Branch>('create_branch', {
+    projectId,
+    branchName,
+    baseBranch,
+    projectRepoId,
+  });
+  await invalidateCacheByCommand('list_branches_for_project');
+  return branch;
 }
 
 /** Create the git worktree for a local branch and record its workdir.
@@ -306,8 +335,12 @@ export function resumeWorkspace(workspaceName: string): Promise<string[]> {
   return invokeCommand('resume_workspace', { workspaceName });
 }
 
-export function deleteBranch(branchId: string): Promise<void> {
-  return invokeCommand('delete_branch', { branchId });
+export async function deleteBranch(branchId: string): Promise<void> {
+  await invokeCommand('delete_branch', { branchId });
+  await Promise.all([
+    invalidateCacheByCommand('list_branches_for_project'),
+    invalidateCache('get_branch_timeline', { branchId }),
+  ]);
 }
 
 export function renameBranch(branchId: string, branchName: string): Promise<Branch> {
@@ -341,12 +374,73 @@ export function pollAllWorkspaceStatuses(
 // =============================================================================
 
 const TIMELINE_FRESH_MS = 10_000;
+const TIMELINE_CACHE_TTL = 30_000;
 const timelineCache = new Map<string, { timeline: BranchTimeline; fetchedAt: number }>();
 const inFlightTimelines = new Map<string, Promise<BranchTimeline>>();
+
+/** Cap snapshot size so it stays comfortably under the localStorage quota. */
+const MAX_SNAPSHOT_TIMELINES = 40;
+
+type TimelineCacheEntry = { timeline: BranchTimeline; fetchedAt: number };
+
+/**
+ * Seed the in-memory timeline cache synchronously from the previous session's
+ * localStorage snapshot. This runs at module init (before any BranchCard mounts)
+ * so cached timelines can paint on the first frame of a cold iOS reload, instead
+ * of each card awaiting its own asynchronous IndexedDB read. IndexedDB remains
+ * the source of truth; the snapshot is only a paint-on-first-frame accelerator.
+ * The seeded entries carry their original `fetchedAt`, so they read as stale and
+ * `getBranchTimelineWithRevalidation` still kicks off a fresh fetch.
+ */
+function seedTimelineCacheFromSnapshot(): void {
+  const snapshot = readSnapshot<Record<string, TimelineCacheEntry>>(SNAPSHOT_KEYS.timelines);
+  if (!snapshot) return;
+  for (const [branchId, entry] of Object.entries(snapshot)) {
+    if (entry?.timeline && !timelineCache.has(branchId)) {
+      timelineCache.set(branchId, entry);
+    }
+  }
+}
+seedTimelineCacheFromSnapshot();
+
+/**
+ * Persist a compact snapshot of the in-memory timeline cache to localStorage so
+ * the next cold boot can re-seed it synchronously. Called from the page
+ * lifecycle listener right before the tab is hidden/torn down (the last moment
+ * we can capture state synchronously on iOS). Keeps only the most recently
+ * fetched entries to bound the serialized size.
+ */
+export function persistTimelineSnapshot(): void {
+  if (isTauri || timelineCache.size === 0) return;
+  const snapshot: Record<string, TimelineCacheEntry> = Object.fromEntries(
+    [...timelineCache.entries()]
+      .sort((a, b) => b[1].fetchedAt - a[1].fetchedAt)
+      .slice(0, MAX_SNAPSHOT_TIMELINES)
+  );
+  writeSnapshot(SNAPSHOT_KEYS.timelines, snapshot);
+}
+
+/**
+ * Eagerly warm the in-memory timeline cache for every branch of a project, in
+ * parallel. Called during boot for the restored project so cards find data
+ * ready instead of each kicking off its own serialized IndexedDB read after
+ * `ProjectHome` mounts. Requests dedupe against `inFlightTimelines`, so this is
+ * safe to run alongside the per-card reads.
+ */
+export async function warmProjectTimelines(projectId: string): Promise<void> {
+  if (isTauri) return;
+  try {
+    const { data: branches } = await listBranchesForProject(projectId);
+    await Promise.allSettled(branches.map((b) => getBranchTimeline(b.id)));
+  } catch {
+    // Best-effort warm — cards fall back to their own lazy reads.
+  }
+}
 
 export function invalidateBranchTimeline(branchId: string): void {
   timelineCache.delete(branchId);
   inFlightTimelines.delete(branchId);
+  invalidateCache('get_branch_timeline', { branchId });
   window.dispatchEvent(
     new CustomEvent('timeline-invalidated', { detail: { branchIds: [branchId] } })
   );
@@ -372,18 +466,30 @@ export function getBranchTimeline(
     }
   }
 
-  const request = invokeCommand<BranchTimeline>('get_branch_timeline', { branchId })
-    .then((timeline) => {
-      if (inFlightTimelines.get(branchId) === request) {
-        timelineCache.set(branchId, { timeline, fetchedAt: Date.now() });
+  // Use cachedInvoke so IndexedDB serves data on cold start while the network
+  // fetch runs in parallel (SWR). The first yield may be cached; the last is
+  // always the freshest available value.
+  let request: Promise<BranchTimeline> | undefined;
+  const timelineRequest = (async () => {
+    let timeline: BranchTimeline | undefined;
+    for await (const { data, fetchedAt } of cachedInvoke<BranchTimeline>(
+      'get_branch_timeline',
+      { branchId },
+      { ttl: TIMELINE_CACHE_TTL, bypassRead: force }
+    )) {
+      timeline = data;
+      if (request && inFlightTimelines.get(branchId) === request) {
+        timelineCache.set(branchId, { timeline, fetchedAt });
       }
-      return timeline;
-    })
-    .finally(() => {
-      if (inFlightTimelines.get(branchId) === request) {
-        inFlightTimelines.delete(branchId);
-      }
-    });
+    }
+    return timeline!;
+  })();
+
+  request = timelineRequest.finally(() => {
+    if (request && inFlightTimelines.get(branchId) === request) {
+      inFlightTimelines.delete(branchId);
+    }
+  });
 
   inFlightTimelines.set(branchId, request);
   return request;
@@ -431,6 +537,7 @@ export function invalidateProjectBranchTimelines(branchIds: string[]): void {
   for (const id of branchIds) {
     timelineCache.delete(id);
     inFlightTimelines.delete(id);
+    invalidateCache('get_branch_timeline', { branchId: id });
   }
   window.dispatchEvent(new CustomEvent('timeline-invalidated', { detail: { branchIds } }));
 }
@@ -583,9 +690,19 @@ export interface AcpProviderInfo {
   label: string;
 }
 
+export interface DiscoverAcpProvidersOptions {
+  force?: boolean;
+}
+
+const ACP_PROVIDER_CACHE_TTL = 30 * 60_000;
+
 /** Scan the system for installed ACP-compatible agents. */
-export function discoverAcpProviders(): Promise<AcpProviderInfo[]> {
-  return invokeCommand('discover_acp_providers');
+export function discoverAcpProviders(
+  options: DiscoverAcpProvidersOptions = {}
+): Promise<SwrResult<AcpProviderInfo[]>> {
+  return cachedCommand('discover_acp_providers', undefined, {
+    ttl: options.force ? 0 : ACP_PROVIDER_CACHE_TTL,
+  });
 }
 
 // =============================================================================
@@ -596,7 +713,12 @@ export function getSession(sessionId: string): Promise<Session | null> {
   return invokeCommand('get_session', { sessionId });
 }
 
-export function getSessionMessages(sessionId: string): Promise<SessionMessage[]> {
+export function getSessionMessages(sessionId: string): Promise<SwrResult<SessionMessage[]>> {
+  return cachedCommand('get_session_messages', { sessionId }, { ttl: 5 * 60_000 });
+}
+
+/** Fetch session messages without SWR cache, for terminal status handlers. */
+export function getFreshSessionMessages(sessionId: string): Promise<SessionMessage[]> {
   return invokeCommand('get_session_messages', { sessionId });
 }
 
@@ -781,8 +903,8 @@ export function getDiffFiles(
   branchId: string,
   commitSha?: string,
   scope: DiffScope = 'branch'
-): Promise<DiffFilesResponse> {
-  return invokeCommand('get_diff_files', { branchId, commitSha, scope });
+): Promise<SwrResult<DiffFilesResponse>> {
+  return cachedCommand('get_diff_files', { branchId, commitSha, scope }, { ttl: 2 * 60_000 });
 }
 
 /** Get the full diff content for a single file. */
@@ -791,8 +913,8 @@ export function getFileDiff(
   commitSha: string,
   scope: DiffScope,
   path: string
-): Promise<FileDiff> {
-  return invokeCommand('get_file_diff', { branchId, commitSha, scope, path });
+): Promise<SwrResult<FileDiff>> {
+  return cachedCommand('get_file_diff', { branchId, commitSha, scope, path }, { ttl: 2 * 60_000 });
 }
 
 /** Get file content at a specific ref (for reference files). */

--- a/apps/staged/src/lib/features/agents/agent.svelte.ts
+++ b/apps/staged/src/lib/features/agents/agent.svelte.ts
@@ -80,11 +80,20 @@ export const agentState = $state({
  * Safe to call multiple times — each call replaces the cached list.
  * Called once at startup and again when the user clicks "Refresh".
  */
-export async function refreshProviders(): Promise<AcpProviderInfo[]> {
+export async function refreshProviders(
+  options: { force?: boolean } = {}
+): Promise<AcpProviderInfo[]> {
   try {
-    const providers = await discoverAcpProviders();
+    const { data: providers, revalidating } = await discoverAcpProviders(options);
     agentState.providers = providers;
     agentState.loaded = true;
+    if (revalidating) {
+      revalidating
+        .then((fresh) => {
+          agentState.providers = fresh;
+        })
+        .catch((e) => console.error('Failed to revalidate ACP providers:', e));
+    }
     return providers;
   } catch (e) {
     console.error('Failed to discover ACP providers:', e);

--- a/apps/staged/src/lib/features/agents/agent.test.ts
+++ b/apps/staged/src/lib/features/agents/agent.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AcpProviderInfo } from '../../api/commands';
+
+describe('refreshProviders', () => {
+  let discoverAcpProviders: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('$state', (initial: unknown) => initial);
+    discoverAcpProviders = vi.fn();
+    vi.doMock('../../api/commands', () => ({
+      discoverAcpProviders,
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.doUnmock('../../api/commands');
+  });
+
+  it('updates provider state from forced SWR revalidation', async () => {
+    const cachedProviders: AcpProviderInfo[] = [{ id: 'goose', label: 'Goose' }];
+    const freshProviders: AcpProviderInfo[] = [
+      { id: 'goose', label: 'Goose' },
+      { id: 'codex', label: 'Codex' },
+    ];
+    let resolveFresh!: (providers: AcpProviderInfo[]) => void;
+    const revalidating = new Promise<AcpProviderInfo[]>((resolve) => {
+      resolveFresh = resolve;
+    });
+    discoverAcpProviders.mockResolvedValue({ data: cachedProviders, revalidating });
+
+    const { agentState, refreshProviders } = await import('./agent.svelte');
+
+    await expect(refreshProviders({ force: true })).resolves.toBe(cachedProviders);
+
+    expect(discoverAcpProviders).toHaveBeenCalledWith({ force: true });
+    expect(agentState.providers).toBe(cachedProviders);
+    expect(agentState.loaded).toBe(true);
+
+    resolveFresh(freshProviders);
+    await revalidating;
+    await Promise.resolve();
+
+    expect(agentState.providers).toBe(freshProviders);
+  });
+});

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -707,6 +707,17 @@
     return () => window.removeEventListener('project-notes-invalidated', handler);
   });
 
+  // Re-fetch timeline when page resumes from a freeze (cache-stale event)
+  $effect(() => {
+    const handler = () => {
+      if (branchTimelineReadyKey(branch)) {
+        void loadTimeline();
+      }
+    };
+    window.addEventListener('cache-stale', handler);
+    return () => window.removeEventListener('cache-stale', handler);
+  });
+
   async function loadTimeline({
     timelineKey = branchTimelineReadyKey(branch),
     force = false,

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -443,7 +443,7 @@
 
     try {
       if (status === 'completed' && sid) {
-        const messages = await commands.getSessionMessages(sid);
+        const messages = await commands.getFreshSessionMessages(sid);
         const foundUrl = extractPrUrl(messages);
 
         if (foundUrl) {
@@ -516,7 +516,7 @@
     }
 
     try {
-      const messages = await commands.getSessionMessages(sid);
+      const messages = await commands.getFreshSessionMessages(sid);
       const pipelineOutcome = classifyPipelinePushCompletion(pipeline, messages);
       if (pipelineOutcome) return pipelineOutcome;
       return classifyCompletedPushSession(pipeline, messages);

--- a/apps/staged/src/lib/features/diff/diffViewerState.svelte.ts
+++ b/apps/staged/src/lib/features/diff/diffViewerState.svelte.ts
@@ -43,18 +43,25 @@ export function createDiffViewerState(branchId: string, scope: DiffScope, commit
     state.error = null;
 
     try {
-      const response = await commands.getDiffFiles(
+      const { data: response, revalidating } = await commands.getDiffFiles(
         state.branchId,
         state.commitSha ?? undefined,
         state.scope
       );
       if (generation !== contextGeneration) return;
 
-      state.commitSha = response.commitSha;
-      state.files = response.files;
-
+      applyDiffFilesResponse(response);
       if (state.files.length > 0) {
         await selectFile(sharedFileSummaryPath(state.files[0]));
+      }
+      if (generation === contextGeneration) {
+        state.loading = false;
+      }
+
+      if (revalidating) {
+        const fresh = await revalidating;
+        if (generation !== contextGeneration) return;
+        applyDiffFilesResponse(fresh);
       }
     } catch (e) {
       if (generation !== contextGeneration) return;
@@ -65,6 +72,11 @@ export function createDiffViewerState(branchId: string, scope: DiffScope, commit
         state.loading = false;
       }
     }
+  }
+
+  function applyDiffFilesResponse(response: { commitSha: string; files: FileDiffSummary[] }) {
+    state.commitSha = response.commitSha;
+    state.files = response.files;
   }
 
   async function selectFile(path: string | null): Promise<void> {
@@ -84,18 +96,40 @@ export function createDiffViewerState(branchId: string, scope: DiffScope, commit
     if (cached) return cached;
 
     state.loadingFile = path;
+    const commitSha = state.commitSha;
+    const generation = contextGeneration;
 
     try {
-      const diff = await commands.getFileDiff(state.branchId, state.commitSha, state.scope, path);
+      const { data: diff, revalidating } = await commands.getFileDiff(
+        state.branchId,
+        commitSha,
+        state.scope,
+        path
+      );
+      if (generation !== contextGeneration) return null;
       const newCache = new Map(state.diffCache);
       newCache.set(path, diff);
       state.diffCache = newCache;
+
+      if (revalidating) {
+        revalidating
+          .then((fresh) => {
+            if (generation !== contextGeneration) return;
+            const next = new Map(state.diffCache);
+            next.set(path, fresh);
+            state.diffCache = next;
+          })
+          .catch(() => {});
+      }
       return diff;
     } catch (e) {
+      if (generation !== contextGeneration) return null;
       console.error(`Failed to load diff for ${path}:`, e);
       return null;
     } finally {
-      state.loadingFile = null;
+      if (generation === contextGeneration) {
+        state.loadingFile = null;
+      }
     }
   }
 

--- a/apps/staged/src/lib/features/layout/navigation.svelte.ts
+++ b/apps/staged/src/lib/features/layout/navigation.svelte.ts
@@ -9,6 +9,12 @@
  */
 
 import { getStoreValue, setStoreValue } from '../../shared/persistentStore';
+import {
+  readSnapshot,
+  writeSnapshot,
+  clearSnapshot,
+  SNAPSHOT_KEYS,
+} from '../../shared/webSnapshot';
 import * as commands from '../../api/commands';
 import type { DiffScope } from '../../commands';
 import type { CommitTimelineItem } from '../../types';
@@ -52,7 +58,10 @@ function rootRoute(): DetailRoute {
 
 export const navigation = $state({
   activeView: 'workspace' as 'workspace' | 'settings',
-  selectedProjectId: null as string | null,
+  // Web-only: seed synchronously from the localStorage mirror so <ProjectHome>
+  // can paint on the first frame of a cold iOS reload, before the async
+  // persistent store and `listProjects()` validation resolve (see initNavigation).
+  selectedProjectId: readSnapshot<string>(SNAPSHOT_KEYS.lastProject),
   showReposList: false,
   settingsSection: 'general' as SettingsSection,
   detailStack: [rootRoute()] as DetailRoute[],
@@ -120,6 +129,9 @@ function pushOrReplaceRoute(route: DetailRoute): void {
  */
 function persistLastProject(projectId: string | null): void {
   setStoreValue(LAST_PROJECT_STORE_KEY, projectId);
+  // Mirror to localStorage for the synchronous cold-boot restore (web only).
+  if (projectId) writeSnapshot(SNAPSHOT_KEYS.lastProject, projectId);
+  else clearSnapshot(SNAPSHOT_KEYS.lastProject);
 }
 
 /**
@@ -130,25 +142,33 @@ function persistLastProject(projectId: string | null): void {
  * user is sent to the home screen instead.
  */
 export async function initNavigation(): Promise<void> {
-  const lastProjectId = await getStoreValue<string | null>(LAST_PROJECT_STORE_KEY);
+  // `selectedProjectId` may already be set synchronously from the localStorage
+  // mirror (web cold boot). Fall back to the async persistent store otherwise —
+  // it is the source of truth in Tauri mode. Either way we render immediately
+  // and only *correct* the route here if the project turns out to be gone.
+  const lastProjectId =
+    navigation.selectedProjectId ?? (await getStoreValue<string | null>(LAST_PROJECT_STORE_KEY));
   if (!lastProjectId) return;
 
-  // Validate the project still exists before navigating to it
+  // Validate the project still exists; this runs in the background relative to
+  // the first paint, which already shows the restored project.
   try {
-    const projects = await commands.listProjects();
+    const { data: projects } = await commands.listProjects();
     projectsList.current = projects;
     const existingIds = new Set(projects.map((p) => p.id));
     if (existingIds.has(lastProjectId)) {
       setDetailStack([rootRoute(), { kind: 'project', projectId: lastProjectId }]);
     } else {
-      // Project was deleted — clear the stale value
+      // Project was deleted — back out to home and clear the persisted values.
+      navigation.selectedProjectId = null;
       await setStoreValue(LAST_PROJECT_STORE_KEY, null);
+      clearSnapshot(SNAPSHOT_KEYS.lastProject);
     }
     // Remove unread entries for projects that no longer exist
     await projectStateStore.pruneDeletedProjects(existingIds);
   } catch {
-    // If we can't list projects (e.g. store error), stay on home
-    console.warn('[Navigation] Could not verify last project, falling back to home');
+    // If we can't list projects (e.g. store error), keep whatever we restored.
+    console.warn('[Navigation] Could not verify last project, keeping restored route');
   }
 }
 

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -135,7 +135,9 @@
     void projectRunActionsStore.startListening();
 
     const onNewProject = () => handleNewProject();
+    const onCacheStale = () => loadData();
     window.addEventListener('staged:new-project', onNewProject);
+    window.addEventListener('cache-stale', onCacheStale);
 
     const unlistenDetection = listenToRepoActionsDetection((event) => {
       const matchingProjectIds = projects
@@ -167,18 +169,18 @@
             commands.listBranchesForProject(projectId),
             commands.listProjectRepos(projectId),
           ]);
-          setProjects(projectsList);
-          projects = projectsList;
+          setProjects(projectsList.data);
+          projects = projectsList.data;
           const mergedBranches = mergeBranchesPreservingWorktree(
             branchesByProject.get(projectId) || [],
-            branches
+            branches.data
           );
           branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
           commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
           workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);
-          replaceProjectRepos(projectId, repos);
+          replaceProjectRepos(projectId, repos.data);
           void repoBadgeStore.ensureForRepos(
-            repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+            repos.data.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
           );
         } catch (e) {
           console.error('[ProjectHome] Failed to refresh project after setup progress:', e);
@@ -247,8 +249,20 @@
         const projectId = payload.projectId;
         if (!projectId || !branchesByProject.has(projectId)) return;
         try {
-          const branches = await commands.listBranchesForProject(projectId);
+          const { data: branches, revalidating } = await commands.listBranchesForProject(projectId);
           branchesByProject = new Map(branchesByProject).set(projectId, branches);
+          if (revalidating) {
+            revalidating
+              .then((fresh) => {
+                branchesByProject = new Map(branchesByProject).set(projectId, fresh);
+              })
+              .catch((e) => {
+                console.error(
+                  `Failed to revalidate branches for project ${projectId} after commit:`,
+                  e
+                );
+              });
+          }
         } catch (e) {
           console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
         }
@@ -258,6 +272,7 @@
     return () => {
       loadGeneration++;
       window.removeEventListener('staged:new-project', onNewProject);
+      window.removeEventListener('cache-stale', onCacheStale);
       unlistenDetection();
       unlistenProjectRepoAdded();
       unlistenPrStatus();
@@ -355,27 +370,20 @@
     }, 3000);
   }
 
-  async function hydrateProject(
-    project: Project,
+  function applyProjectBranches(
+    projectId: string,
+    branches: Branch[],
     generation: number,
     options: { drainQueuedSessions?: boolean } = {}
-  ): Promise<Branch[] | null> {
-    const [branches, repos] = await Promise.all([
-      commands.listBranchesForProject(project.id),
-      commands.listProjectRepos(project.id),
-    ]);
+  ): Branch[] | null {
     if (generation !== loadGeneration) return null;
 
     const mergedBranches = mergeBranchesPreservingWorktree(
-      branchesByProject.get(project.id) || [],
+      branchesByProject.get(projectId) || [],
       branches
     );
-    branchesByProject = new Map(branchesByProject).set(project.id, mergedBranches);
-    workspaceLifecycle.enqueueInitialSetup(project.id, mergedBranches);
-    replaceProjectRepos(project.id, repos);
-    void repoBadgeStore.ensureForRepos(
-      repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
-    );
+    branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
+    workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);
     projectRunActionsStore
       .hydrateFromProjectBranches(branchesByProject, {
         branchIds: mergedBranches.map((b) => b.id),
@@ -384,6 +392,53 @@
 
     if (options.drainQueuedSessions) {
       scheduleQueuedSessionDrain(mergedBranches);
+    }
+
+    return mergedBranches;
+  }
+
+  function applyProjectRepos(projectId: string, repos: ProjectRepo[], generation: number) {
+    if (generation !== loadGeneration) return;
+    replaceProjectRepos(projectId, repos);
+    void repoBadgeStore.ensureForRepos(
+      repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+    );
+  }
+
+  async function hydrateProject(
+    project: Project,
+    generation: number,
+    options: { drainQueuedSessions?: boolean } = {}
+  ): Promise<Branch[] | null> {
+    const [branchesResult, reposResult] = await Promise.all([
+      commands.listBranchesForProject(project.id),
+      commands.listProjectRepos(project.id),
+    ]);
+    if (generation !== loadGeneration) return null;
+
+    const mergedBranches = applyProjectBranches(project.id, branchesResult.data, generation, {
+      drainQueuedSessions: options.drainQueuedSessions,
+    });
+    applyProjectRepos(project.id, reposResult.data, generation);
+
+    if (branchesResult.revalidating) {
+      branchesResult.revalidating
+        .then((fresh) => {
+          applyProjectBranches(project.id, fresh, generation, {
+            drainQueuedSessions: options.drainQueuedSessions,
+          });
+        })
+        .catch((e) => {
+          console.error(`[ProjectHome] Failed to revalidate branches for '${project.id}':`, e);
+        });
+    }
+
+    if (reposResult.revalidating) {
+      reposResult.revalidating
+        .then((fresh) => applyProjectRepos(project.id, fresh, generation))
+        .catch((e) => {
+          console.error(`[ProjectHome] Failed to revalidate repos for '${project.id}':`, e);
+        });
     }
 
     return mergedBranches;
@@ -493,48 +548,21 @@
     error = null;
     await repoBadgeStore.loadAll();
     try {
-      const projectList = await commands.listProjects();
+      const { data: initialProjectList, revalidating: projectsRevalidating } =
+        await commands.listProjects();
       if (generation !== loadGeneration) return;
-      projects = projectList;
-      setProjects(projectList);
+      await applyProjectList(initialProjectList, generation);
       loading = false;
 
-      // Seed maps so project sections can render immediately.
-      const branchMap = new Map<string, Branch[]>();
-      for (const project of projectList) {
-        branchMap.set(project.id, branchesByProject.get(project.id) || []);
-      }
-      branchesByProject = branchMap;
-
-      // Drop cached repos for projects that no longer exist.
-      const projectIds = new Set(projectList.map((p) => p.id));
-      const prunedRepos = new Map<string, ProjectRepo>();
-      for (const [id, repo] of reposById) {
-        if (projectIds.has(repo.projectId)) prunedRepos.set(id, repo);
-      }
-      reposById = prunedRepos;
-
-      if (selectedProjectId) {
-        const selectedProject = projectList.find((project) => project.id === selectedProjectId);
-        if (selectedProject) {
-          try {
-            await hydrateProject(selectedProject, generation, { drainQueuedSessions: true });
-          } catch (e) {
-            console.error(
-              `[ProjectHome] Failed to hydrate selected project '${selectedProject.id}':`,
-              e
-            );
-          }
+      if (projectsRevalidating) {
+        try {
+          const fresh = await projectsRevalidating;
+          if (generation !== loadGeneration) return;
+          await applyProjectList(fresh, generation);
+        } catch (e) {
+          console.error('[ProjectHome] Failed to revalidate project list:', e);
         }
-        if (generation !== loadGeneration) return;
-        scheduleBackgroundHydration(projectList, selectedProjectId, generation);
-      } else {
-        await hydrateAllProjects(projectList, generation);
       }
-
-      lastSelectedProjectId = selectedProjectId;
-      initialLoadComplete = true;
-      void hydrateActionDetection(projectList, generation);
     } catch (e) {
       if (generation !== loadGeneration) return;
       error = e instanceof Error ? e.message : String(e);
@@ -543,6 +571,57 @@
         loading = false;
       }
     }
+  }
+
+  /**
+   * Apply a list of projects fetched from the backend: seed branch/repo maps,
+   * hydrate the selected project first, and background-hydrate the rest.
+   * Called once with cached data and again if SWR revalidation yields fresh data.
+   */
+  async function applyProjectList(projectList: Project[], generation: number) {
+    projects = projectList;
+    setProjects(projectList);
+
+    // Seed maps so project sections can render immediately.
+    const branchMap = new Map<string, Branch[]>();
+    for (const project of projectList) {
+      branchMap.set(project.id, branchesByProject.get(project.id) || []);
+    }
+    branchesByProject = branchMap;
+
+    // Drop cached repos for projects that no longer exist.
+    const projectIds = new Set(projectList.map((p) => p.id));
+    const prunedRepos = new Map<string, ProjectRepo>();
+    for (const [id, repo] of reposById) {
+      if (projectIds.has(repo.projectId)) prunedRepos.set(id, repo);
+    }
+    reposById = prunedRepos;
+
+    cancelBackgroundHydration();
+
+    if (selectedProjectId) {
+      const selectedProject = projectList.find((project) => project.id === selectedProjectId);
+      if (selectedProject) {
+        try {
+          await hydrateProject(selectedProject, generation, { drainQueuedSessions: true });
+        } catch (e) {
+          if (generation !== loadGeneration) return;
+          console.error(
+            `[ProjectHome] Failed to hydrate selected project '${selectedProject.id}':`,
+            e
+          );
+        }
+      }
+      if (generation !== loadGeneration) return;
+      scheduleBackgroundHydration(projectList, selectedProjectId, generation);
+    } else {
+      await hydrateAllProjects(projectList, generation);
+    }
+
+    if (generation !== loadGeneration) return;
+    lastSelectedProjectId = selectedProjectId;
+    initialLoadComplete = true;
+    void hydrateActionDetection(projectList, generation);
   }
 
   $effect(() => {
@@ -763,9 +842,9 @@
         commands.listBranchesForProject(project.id),
         commands.listProjectRepos(project.id),
       ]);
-      branchesByProject = new Map(branchesByProject).set(project.id, branches);
-      workspaceLifecycle.enqueueInitialSetup(project.id, branches);
-      replaceProjectRepos(project.id, repos);
+      branchesByProject = new Map(branchesByProject).set(project.id, branches.data);
+      workspaceLifecycle.enqueueInitialSetup(project.id, branches.data);
+      replaceProjectRepos(project.id, repos.data);
     } catch (e) {
       console.error('[ProjectHome] Failed to hydrate newly created project:', e);
     }
@@ -873,18 +952,18 @@
         commands.listBranchesForProject(projectId),
         commands.listProjectRepos(projectId),
       ]);
-      setProjects(projectsList);
-      projects = projectsList;
+      setProjects(projectsList.data);
+      projects = projectsList.data;
       const mergedBranches = mergeBranchesPreservingWorktree(
         branchesByProject.get(projectId) || [],
-        branches
+        branches.data
       );
       branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
       commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
       workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);
-      replaceProjectRepos(projectId, repos);
+      replaceProjectRepos(projectId, repos.data);
       void repoBadgeStore.ensureForRepos(
-        repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+        repos.data.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
       );
     } catch (e) {
       console.error('Failed to add repo:', e);
@@ -992,10 +1071,10 @@
           commands.listBranchesForProject(branch.projectId),
           commands.listProjectRepos(branch.projectId),
         ]);
-        setProjects(projectsList);
-        projects = projectsList;
-        branchesByProject = new Map(branchesByProject).set(branch.projectId, branches);
-        replaceProjectRepos(branch.projectId, repos);
+        setProjects(projectsList.data);
+        projects = projectsList.data;
+        branchesByProject = new Map(branchesByProject).set(branch.projectId, branches.data);
+        replaceProjectRepos(branch.projectId, repos.data);
       } else {
         await commands.deleteBranch(branch.id);
         // Fallback for legacy branches without repo linkage

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -298,9 +298,11 @@
       deletingProjectNames = next;
       loadProjects();
     };
+    const onCacheStale = () => loadProjects();
     window.addEventListener('staged:new-project', onNewProject);
     window.addEventListener('staged:project-delete-start', onProjectDeleteStart);
     window.addEventListener('staged:project-delete-end', onProjectDeleteEnd);
+    window.addEventListener('cache-stale', onCacheStale);
 
     // Listen for PR status changes to update branch state
     const unlistenPrStatus = listenToEvent<PrStatusChangedEvent>('pr-status-changed', (payload) => {
@@ -336,8 +338,20 @@
         const projectId = payload.projectId;
         if (!projectId || !projectBranches.has(projectId)) return;
         try {
-          const branches = await commands.listBranchesForProject(projectId);
+          const { data: branches, revalidating } = await commands.listBranchesForProject(projectId);
           projectBranches = new Map(projectBranches).set(projectId, branches);
+          if (revalidating) {
+            revalidating
+              .then((fresh) => {
+                projectBranches = new Map(projectBranches).set(projectId, fresh);
+              })
+              .catch((e) => {
+                console.error(
+                  `Failed to revalidate branches for project ${projectId} after commit:`,
+                  e
+                );
+              });
+          }
         } catch (e) {
           console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
         }
@@ -349,6 +363,7 @@
       window.removeEventListener('staged:new-project', onNewProject);
       window.removeEventListener('staged:project-delete-start', onProjectDeleteStart);
       window.removeEventListener('staged:project-delete-end', onProjectDeleteEnd);
+      window.removeEventListener('cache-stale', onCacheStale);
       unlistenPrStatus();
       unlistenSessionStatus();
     };
@@ -360,26 +375,15 @@
     try {
       await repoBadgeStore.loadAll();
       if (reposUiEnabled) void loadHomeRepos();
-      const loadedProjects = await commands.listProjects();
-      projects = loadedProjects;
-      setProjects(loadedProjects);
-      void hydrateRepos(loadedProjects);
-      // Load branches for each project to calculate PR status
-      const branchesMap = new Map<string, Branch[]>();
-      await Promise.all(
-        loadedProjects.map(async (project) => {
-          try {
-            const branches = await commands.listBranchesForProject(project.id);
-            branchesMap.set(project.id, branches);
-          } catch (e) {
-            console.error(`Failed to load branches for project ${project.id}:`, e);
-            branchesMap.set(project.id, []);
-          }
-        })
-      );
-      projectBranches = branchesMap;
+      const { data: initialProjects, revalidating: projectsRevalidating } =
+        await commands.listProjects();
+      await applyProjects(initialProjects);
+      loading = false;
 
-      projectRunActionsStore.hydrateFromProjectBranches(branchesMap).catch(console.error);
+      if (projectsRevalidating) {
+        const fresh = await projectsRevalidating;
+        await applyProjects(fresh);
+      }
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
     } finally {
@@ -409,14 +413,60 @@
     }
   }
 
+  async function applyProjects(loadedProjects: Project[]) {
+    projects = loadedProjects;
+    setProjects(loadedProjects);
+    void hydrateRepos(loadedProjects);
+
+    const branchesMap = new Map<string, Branch[]>();
+    const branchRevalidations: Array<{ projectId: string; promise: Promise<Branch[]> }> = [];
+    await Promise.all(
+      loadedProjects.map(async (project) => {
+        try {
+          const { data: branches, revalidating } = await commands.listBranchesForProject(
+            project.id
+          );
+          branchesMap.set(project.id, branches);
+          if (revalidating) {
+            branchRevalidations.push({ projectId: project.id, promise: revalidating });
+          }
+        } catch (e) {
+          console.error(`Failed to load branches for project ${project.id}:`, e);
+          branchesMap.set(project.id, []);
+        }
+      })
+    );
+    projectBranches = branchesMap;
+    projectRunActionsStore.hydrateFromProjectBranches(branchesMap).catch(console.error);
+
+    if (branchRevalidations.length > 0) {
+      void Promise.all(
+        branchRevalidations.map(async ({ projectId, promise }) => {
+          try {
+            const fresh = await promise;
+            projectBranches = new Map(projectBranches).set(projectId, fresh);
+          } catch (e) {
+            console.error(`Failed to revalidate branches for project ${projectId}:`, e);
+          }
+        })
+      ).then(() =>
+        projectRunActionsStore.hydrateFromProjectBranches(projectBranches).catch(console.error)
+      );
+    }
+  }
+
   async function hydrateRepos(projectList: Project[]) {
     const generation = ++repoLoadGeneration;
     reposHydrating = true;
     try {
+      const revalidations: Array<{ projectId: string; promise: Promise<ProjectRepo[]> }> = [];
       const entries = await Promise.all(
         projectList.map(async (project) => {
           try {
-            const repos = await commands.listProjectRepos(project.id);
+            const { data: repos, revalidating } = await commands.listProjectRepos(project.id);
+            if (revalidating) {
+              revalidations.push({ projectId: project.id, promise: revalidating });
+            }
             return [project.id, repos] as const;
           } catch (e) {
             console.error(`[ProjectsList] Failed to load repos for project '${project.id}':`, e);
@@ -432,6 +482,20 @@
         repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
       );
       void repoBadgeStore.ensureForRepos(allRepos);
+
+      for (const { projectId, promise } of revalidations) {
+        void promise
+          .then((fresh) => {
+            if (generation !== repoLoadGeneration) return;
+            reposByProject = new Map(reposByProject).set(projectId, fresh);
+            void repoBadgeStore.ensureForRepos(
+              fresh.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+            );
+          })
+          .catch((e) => {
+            console.error(`[ProjectsList] Failed to revalidate repos for '${projectId}':`, e);
+          });
+      }
     } finally {
       if (generation === repoLoadGeneration) {
         reposHydrating = false;

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -457,14 +457,26 @@
     loading = true;
     error = null;
     try {
-      const [s, msgs] = await Promise.all([getSession(sessionId), getSessionMessages(sessionId)]);
+      const [s, msgsResult] = await Promise.all([
+        getSession(sessionId),
+        getSessionMessages(sessionId),
+      ]);
       if (closed) return;
       if (!s) {
         error = 'Session not found';
         return;
       }
       session = s;
-      messages = msgs;
+      messages = msgsResult.data;
+      if (msgsResult.revalidating) {
+        msgsResult.revalidating
+          .then((fresh) => {
+            if (closed) return;
+            messages = fresh;
+            scrollToBottomIfNear(true);
+          })
+          .catch(() => {});
+      }
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
     } finally {
@@ -490,7 +502,7 @@
 
       // Incremental message fetch
       if (messages.length === 0) {
-        const msgs = await getSessionMessages(sessionId);
+        const { data: msgs } = await getSessionMessages(sessionId);
         if (closed) return;
         if (msgs.length > 0) {
           messages = msgs;

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -199,10 +199,10 @@
       const contextIdByRepo = new Map(
         actionContexts.map((context) => [repoKey(context.githubRepo, context.subpath), context.id])
       );
-      const projects = await commands.listProjects();
+      const { data: projects } = await commands.listProjects();
       const reposByProject = await Promise.all(
         projects.map(async (project) => {
-          const repos = await commands.listProjectRepos(project.id);
+          const { data: repos } = await commands.listProjectRepos(project.id);
           return { project, repos };
         })
       );

--- a/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
@@ -27,12 +27,12 @@
   });
 
   /** Run checks, then refresh the agent selector if still mounted. */
-  async function runChecksAndRefresh() {
+  async function runChecksAndRefresh(options: { forceProviderRefresh?: boolean } = {}) {
     await runChecks();
     if (mounted) {
       // Re-discover providers so newly-installed agents are immediately
       // available in the agent selector without requiring an app reload.
-      refreshProviders();
+      refreshProviders({ force: options.forceProviderRefresh });
     }
   }
 
@@ -111,7 +111,7 @@
           variant="outline"
           size="sm"
           disabled={doctorState.updatingAll}
-          onclick={runChecksAndRefresh}
+          onclick={() => runChecksAndRefresh({ forceProviderRefresh: true })}
         >
           <RefreshCw size={14} />
           Re-run

--- a/apps/staged/src/lib/features/settings/preferences.svelte.ts
+++ b/apps/staged/src/lib/features/settings/preferences.svelte.ts
@@ -225,6 +225,12 @@ export async function initPreferences(): Promise<void> {
   ensureSystemModeListener();
   applyChromeTheme();
 
+  // Unblock the UI as soon as size + chrome theme are applied. Everything below
+  // (diff/Shiki theme, recent agents, auto-review) only feeds the diff viewer and
+  // settings, not the first paint of the project view — so gating the whole app
+  // on it just lengthens the staged reveal on resume. Loading continues below.
+  preferences.loaded = true;
+
   // Load diff theme (migrating from the legacy combined `syntax-theme` key).
   let savedDiffTheme = await getStoreValue<string>(DIFF_THEME_STORE_KEY);
   if (!savedDiffTheme) {
@@ -256,8 +262,6 @@ export async function initPreferences(): Promise<void> {
   } else {
     preferences.autoReviewMode = (await loadSqAvailabilityForDefault()) ? 'after-changes' : 'never';
   }
-
-  preferences.loaded = true;
 }
 
 // =============================================================================

--- a/apps/staged/src/lib/features/timeline/liveSessionHints.ts
+++ b/apps/staged/src/lib/features/timeline/liveSessionHints.ts
@@ -231,7 +231,7 @@ export function createLiveSessionHints(
 
       const updatedMessages =
         tracker.lastMessageId === null
-          ? await commands.getSessionMessages(sessionId)
+          ? (await commands.getSessionMessages(sessionId)).data
           : await commands.getSessionMessagesSince(sessionId, tracker.lastMessageId);
 
       if (destroyed || !hintTrackers.has(sessionId)) return;

--- a/apps/staged/src/lib/listeners/cacheInvalidationListener.ts
+++ b/apps/staged/src/lib/listeners/cacheInvalidationListener.ts
@@ -1,0 +1,55 @@
+/**
+ * Event-driven cache invalidation listener.
+ *
+ * Listens for backend events (pr-status-changed, branch-git-state-changed)
+ * and invalidates the corresponding IndexedDB cache entries so that stale
+ * data is never served after the backend pushes an update.
+ */
+
+import { listenToEvent, type UnlistenFn } from '../transport';
+import { invalidateCache, invalidateCacheByArgs, invalidateCacheByCommand } from '../cache';
+import { invalidateBranchTimeline } from '../commands';
+import type { PrStatusChangedEvent, SessionStatusPayload } from '../types';
+
+interface BranchGitStateChangedEvent {
+  branchId: string;
+}
+
+export function listenForCacheInvalidation(): UnlistenFn {
+  const unlisteners: UnlistenFn[] = [];
+
+  // PR status changed → invalidate branch listings (they embed PR state)
+  unlisteners.push(
+    listenToEvent<PrStatusChangedEvent>('pr-status-changed', () => {
+      invalidateCacheByCommand('list_branches_for_project');
+    })
+  );
+
+  // Branch git state changed → invalidate timeline and diff caches
+  unlisteners.push(
+    listenToEvent<BranchGitStateChangedEvent>('branch-git-state-changed', (payload) => {
+      invalidateBranchTimeline(payload.branchId);
+      invalidateCacheByCommand('list_branches_for_project');
+      invalidateCacheByArgs('get_diff_files', { branchId: payload.branchId });
+      invalidateCacheByArgs('get_file_diff', { branchId: payload.branchId });
+    })
+  );
+
+  // Session status changed → invalidate cached session messages when a session
+  // completes, errors, or is cancelled (messages are now final)
+  unlisteners.push(
+    listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
+      if (
+        payload.status === 'completed' ||
+        payload.status === 'error' ||
+        payload.status === 'cancelled'
+      ) {
+        invalidateCache('get_session_messages', { sessionId: payload.sessionId });
+      }
+    })
+  );
+
+  return () => {
+    for (const unlisten of unlisteners) unlisten();
+  };
+}

--- a/apps/staged/src/lib/listeners/pageLifecycleListener.test.ts
+++ b/apps/staged/src/lib/listeners/pageLifecycleListener.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock transport — web mode
+vi.mock('../transport', () => ({
+  isTauri: false,
+  invokeCommand: vi.fn(),
+}));
+
+// Spy on markAllStale
+const mockMarkAllStale = vi.fn().mockResolvedValue(undefined);
+vi.mock('../cache', () => ({
+  markAllStale: (...args: unknown[]) => mockMarkAllStale(...args),
+}));
+
+import {
+  listenForPageLifecycle,
+  _setLastActivityTimestamp,
+  _getLastActivityTimestamp,
+  _setHiddenAt,
+  _STALE_THRESHOLD_MS,
+} from './pageLifecycleListener';
+
+describe('pageLifecycleListener', () => {
+  let unlisten: () => void;
+  let cacheStaleEvents: Event[];
+
+  function onCacheStale(e: Event) {
+    cacheStaleEvents.push(e);
+  }
+
+  beforeEach(() => {
+    mockMarkAllStale.mockClear();
+    cacheStaleEvents = [];
+    window.addEventListener('cache-stale', onCacheStale);
+    _setLastActivityTimestamp(Date.now());
+    // Reset the hide timestamp so each test starts from "no recorded hide",
+    // which (safely) revalidates on resume.
+    _setHiddenAt(0);
+    unlisten = listenForPageLifecycle();
+  });
+
+  afterEach(() => {
+    unlisten();
+    window.removeEventListener('cache-stale', onCacheStale);
+  });
+
+  describe('resume event', () => {
+    it('marks all cache entries stale and dispatches cache-stale', async () => {
+      document.dispatchEvent(new Event('resume'));
+
+      // markAllStale is async, give it a tick
+      await vi.waitFor(() => {
+        expect(mockMarkAllStale).toHaveBeenCalledTimes(1);
+      });
+      expect(cacheStaleEvents).toHaveLength(1);
+    });
+
+    it('updates lastActivityTimestamp after resume', async () => {
+      _setLastActivityTimestamp(0);
+      const before = Date.now();
+      document.dispatchEvent(new Event('resume'));
+
+      await vi.waitFor(() => {
+        expect(mockMarkAllStale).toHaveBeenCalled();
+      });
+      expect(_getLastActivityTimestamp()).toBeGreaterThanOrEqual(before);
+    });
+  });
+
+  describe('visibilitychange event', () => {
+    it('marks stale when returning after >30s gap', async () => {
+      // Simulate being hidden for longer than the threshold
+      _setLastActivityTimestamp(Date.now() - _STALE_THRESHOLD_MS - 1000);
+
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      await vi.waitFor(() => {
+        expect(mockMarkAllStale).toHaveBeenCalledTimes(1);
+      });
+      expect(cacheStaleEvents).toHaveLength(1);
+    });
+
+    it('does NOT mark stale when returning within 30s', async () => {
+      // Activity was recent
+      _setLastActivityTimestamp(Date.now() - 1000);
+
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      // Give a tick for any async work
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockMarkAllStale).not.toHaveBeenCalled();
+      expect(cacheStaleEvents).toHaveLength(0);
+    });
+
+    it('records timestamp when going hidden', () => {
+      const before = Date.now();
+
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      expect(_getLastActivityTimestamp()).toBeGreaterThanOrEqual(before);
+      expect(mockMarkAllStale).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pageshow event', () => {
+    function makePageShowEvent(persisted: boolean): Event {
+      const event = new Event('pageshow');
+      Object.defineProperty(event, 'persisted', {
+        value: persisted,
+        configurable: true,
+      });
+      return event;
+    }
+
+    it('marks all cache entries stale when persisted (bfcache restore)', async () => {
+      window.dispatchEvent(makePageShowEvent(true));
+
+      await vi.waitFor(() => {
+        expect(mockMarkAllStale).toHaveBeenCalledTimes(1);
+      });
+      expect(cacheStaleEvents).toHaveLength(1);
+    });
+
+    it('does NOT mark stale on a short hide before a persisted restore', async () => {
+      // Simulate a brief tab switch: hidden a moment ago, well within threshold.
+      _setHiddenAt(Date.now() - 2000);
+
+      window.dispatchEvent(makePageShowEvent(true));
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockMarkAllStale).not.toHaveBeenCalled();
+      expect(cacheStaleEvents).toHaveLength(0);
+    });
+
+    it('marks stale on a long hide before a persisted restore', async () => {
+      _setHiddenAt(Date.now() - _STALE_THRESHOLD_MS - 1000);
+
+      window.dispatchEvent(makePageShowEvent(true));
+
+      await vi.waitFor(() => {
+        expect(mockMarkAllStale).toHaveBeenCalledTimes(1);
+      });
+      expect(cacheStaleEvents).toHaveLength(1);
+    });
+
+    it('is a no-op when not persisted (initial navigation / reload)', async () => {
+      window.dispatchEvent(makePageShowEvent(false));
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockMarkAllStale).not.toHaveBeenCalled();
+      expect(cacheStaleEvents).toHaveLength(0);
+    });
+
+    it('updates lastActivityTimestamp on persisted restore', async () => {
+      _setLastActivityTimestamp(0);
+      const before = Date.now();
+      window.dispatchEvent(makePageShowEvent(true));
+
+      await vi.waitFor(() => {
+        expect(mockMarkAllStale).toHaveBeenCalled();
+      });
+      expect(_getLastActivityTimestamp()).toBeGreaterThanOrEqual(before);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes listeners on unlisten', async () => {
+      unlisten();
+
+      _setLastActivityTimestamp(0);
+      document.dispatchEvent(new Event('resume'));
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      const pageShow = new Event('pageshow');
+      Object.defineProperty(pageShow, 'persisted', {
+        value: true,
+        configurable: true,
+      });
+      window.dispatchEvent(pageShow);
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockMarkAllStale).not.toHaveBeenCalled();
+      expect(cacheStaleEvents).toHaveLength(0);
+    });
+  });
+});

--- a/apps/staged/src/lib/listeners/pageLifecycleListener.ts
+++ b/apps/staged/src/lib/listeners/pageLifecycleListener.ts
@@ -1,0 +1,126 @@
+/**
+ * Page Lifecycle integration for cache staleness detection.
+ *
+ * Listens for `resume`, `visibilitychange`, `pagehide`, and `pageshow` events to
+ * detect when the browser tab (or iOS PWA) has been frozen and restored. When a
+ * significant time gap is detected, all IndexedDB cache entries are marked stale
+ * and a `cache-stale` CustomEvent is dispatched so components revalidate.
+ *
+ * Revalidation is *gated on how long the page was hidden*: a brief tab switch
+ * (a few seconds) keeps the cached data as-is, so resuming does not trigger a
+ * network revalidation storm across every cached entry. Only a hide longer than
+ * the threshold forces a full revalidation.
+ *
+ * Going hidden also persists a synchronous snapshot of the in-memory timeline
+ * cache (see commands.ts) — iOS tears the tab down while hidden, so this is the
+ * last chance to capture state for the next cold boot's first-frame paint.
+ */
+
+import { isTauri } from '../transport';
+import { markAllStale } from '../cache';
+import { persistTimelineSnapshot } from '../commands';
+
+const STALE_THRESHOLD_MS = 30_000;
+
+/**
+ * Minimum hidden duration before a resume forces a full revalidation. Chosen so
+ * a quick app/tab switch (the common case on iOS) keeps the just-cached data,
+ * while a longer absence — where branches, commits, or PR state have likely
+ * moved on — revalidates everything.
+ */
+const RESUME_REVALIDATE_THRESHOLD_MS = STALE_THRESHOLD_MS;
+
+let lastActivityTimestamp = Date.now();
+/** When the page last went hidden (0 = not hidden / unknown). */
+let hiddenAt = 0;
+
+/** True when we have no recorded hide, or the hide outlasted the threshold. */
+function shouldRevalidateAfterResume(): boolean {
+  return hiddenAt === 0 || Date.now() - hiddenAt > RESUME_REVALIDATE_THRESHOLD_MS;
+}
+
+async function revalidateAll() {
+  await markAllStale();
+  window.dispatchEvent(new CustomEvent('cache-stale'));
+}
+
+/** Record the page going hidden and snapshot caches for the next cold boot. */
+function handleHidden() {
+  hiddenAt = Date.now();
+  lastActivityTimestamp = hiddenAt;
+  // Capture synchronously now — on iOS the tab may be torn down before any
+  // async work (IndexedDB) could complete.
+  persistTimelineSnapshot();
+}
+
+async function handleResume() {
+  // The Page Lifecycle `resume` event follows a real freeze, but still gate on
+  // the hidden duration so a brief freeze doesn't force a full revalidation.
+  const revalidate = shouldRevalidateAfterResume();
+  lastActivityTimestamp = Date.now();
+  hiddenAt = 0;
+  if (revalidate) await revalidateAll();
+}
+
+async function handleVisibilityChange() {
+  if (document.visibilityState === 'visible') {
+    const now = Date.now();
+    if (now - lastActivityTimestamp > STALE_THRESHOLD_MS) {
+      await revalidateAll();
+    }
+    lastActivityTimestamp = now;
+    hiddenAt = 0;
+  } else {
+    handleHidden();
+  }
+}
+
+function handlePageHide() {
+  handleHidden();
+}
+
+async function handlePageShow(event: PageTransitionEvent) {
+  // bfcache restore: JS context survived but data may be stale. Only revalidate
+  // when the page was hidden long enough for the data to plausibly be stale —
+  // otherwise a 2-second tab switch would force a network re-fetch of everything.
+  if (!event.persisted) return;
+  const revalidate = shouldRevalidateAfterResume();
+  lastActivityTimestamp = Date.now();
+  hiddenAt = 0;
+  if (revalidate) await revalidateAll();
+}
+
+/**
+ * Start listening for page lifecycle events. Returns an unlisten function.
+ * No-ops in Tauri mode (no page eviction).
+ */
+export function listenForPageLifecycle(): () => void {
+  if (isTauri) return () => {};
+
+  document.addEventListener('resume', handleResume);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  window.addEventListener('pagehide', handlePageHide);
+  window.addEventListener('pageshow', handlePageShow);
+
+  return () => {
+    document.removeEventListener('resume', handleResume);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    window.removeEventListener('pagehide', handlePageHide);
+    window.removeEventListener('pageshow', handlePageShow);
+  };
+}
+
+// Exported for testing
+export function _setLastActivityTimestamp(ts: number) {
+  lastActivityTimestamp = ts;
+}
+export function _getLastActivityTimestamp() {
+  return lastActivityTimestamp;
+}
+export function _setHiddenAt(ts: number) {
+  hiddenAt = ts;
+}
+export function _getHiddenAt() {
+  return hiddenAt;
+}
+export { STALE_THRESHOLD_MS as _STALE_THRESHOLD_MS };

--- a/apps/staged/src/lib/listeners/sessionStatusListener.ts
+++ b/apps/staged/src/lib/listeners/sessionStatusListener.ts
@@ -10,6 +10,7 @@
  */
 
 import { listenToEvent, type UnlistenFn } from '../transport';
+import { invalidateBranchTimeline } from '../commands';
 import * as commands from '../api/commands';
 import {
   classifyCompletedPushSession,
@@ -49,6 +50,10 @@ export function listenForSessionStatus(): UnlistenFn {
     }
 
     if (status === 'completed' || status === 'error' || status === 'cancelled') {
+      // Invalidate cached timeline for the branch affected by this session
+      if (eventBranchId) {
+        invalidateBranchTimeline(eventBranchId);
+      }
       handleSessionEnd(sessionId, status);
     }
   });
@@ -91,7 +96,7 @@ async function handlePrCompletion(sessionId: string, branchId: string, status: S
   if (status === 'completed') {
     try {
       // Try session messages first (AI session writes PR_URL: marker).
-      const messages = await commands.getSessionMessages(sessionId);
+      const messages = await commands.getFreshSessionMessages(sessionId);
       let foundUrl = extractPrUrl(messages);
 
       // Also check pipeline step outputs for older or partially migrated PR sessions.
@@ -150,7 +155,7 @@ async function handlePushCompletion(sessionId: string, branchId: string, status:
     try {
       const session = await commands.getSession(sessionId);
       const pipeline = session?.pipeline;
-      const messages = await commands.getSessionMessages(sessionId);
+      const messages = await commands.getFreshSessionMessages(sessionId);
       const outcome = classifyCompletedPushSession(pipeline, messages);
 
       if (outcome === 'rejected_non_fast_forward') {

--- a/apps/staged/src/lib/shared/webSnapshot.ts
+++ b/apps/staged/src/lib/shared/webSnapshot.ts
@@ -1,0 +1,51 @@
+/**
+ * Synchronous, web-only boot snapshots.
+ *
+ * On iOS, Safari tears down the tab and reloads the page from scratch when the
+ * user leaves and returns. Both the Tauri-style persistent store and the
+ * IndexedDB SWR cache are read asynchronously, so neither can paint on the very
+ * first frame of a cold boot. These helpers persist tiny snapshots to
+ * `localStorage` (a synchronous API) so the navigation route and cached branch
+ * timelines can be restored before any component mounts.
+ *
+ * No-ops in Tauri mode (the native app is never torn down this way) and tolerant
+ * of environments where `localStorage` is unavailable or full.
+ */
+
+import { isTauri } from '../transport';
+
+/** localStorage keys for the synchronous boot accelerators. */
+export const SNAPSHOT_KEYS = {
+  /** The last viewed project id, mirrored for synchronous restore. */
+  lastProject: 'staged:boot:last-project',
+  /** Compact snapshot of the in-memory branch timeline cache. */
+  timelines: 'staged:boot:timelines',
+} as const;
+
+export function readSnapshot<T>(key: string): T | null {
+  if (isTauri || typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSnapshot<T>(key: string, value: T): void {
+  if (isTauri || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Best-effort — ignore quota or serialization errors.
+  }
+}
+
+export function clearSnapshot(key: string): void {
+  if (isTauri || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // Best-effort — ignore.
+  }
+}

--- a/apps/staged/src/main.ts
+++ b/apps/staged/src/main.ts
@@ -2,6 +2,16 @@ import { mount } from 'svelte';
 import './app.css';
 import App from './App.svelte';
 
+if (
+  import.meta.env.PROD &&
+  'serviceWorker' in navigator &&
+  ['http:', 'https:'].includes(window.location.protocol)
+) {
+  navigator.serviceWorker
+    .register('/sw.js')
+    .catch((error) => console.warn('Service worker registration failed', error));
+}
+
 const app = mount(App, {
   target: document.getElementById('app')!,
 });

--- a/apps/staged/src/service-worker.js
+++ b/apps/staged/src/service-worker.js
@@ -1,0 +1,94 @@
+// @ts-nocheck
+/// <reference lib="webworker" />
+
+const CACHE_NAME = '__STAGED_CACHE_NAME__';
+
+// The app shell entry. Precached on install so navigations can be served
+// cache-first (instant paint) without ever awaiting the network.
+const APP_SHELL_URL = '/';
+
+// Install: pre-cache the app shell entry point.
+// Vite-hashed assets (the JS/CSS bundle) are cached on first fetch via the
+// fetch handler; once cached they are immutable and served cache-first too, so
+// after the first load the entire shell paints from cache with no network.
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll([APP_SHELL_URL])));
+  // Activate immediately instead of waiting for old tabs to close.
+  self.skipWaiting();
+});
+
+// Activate: clean up old caches from previous versions.
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+  );
+  // Start controlling all open clients immediately.
+  self.clients.claim();
+});
+
+// Fetch: stale-while-revalidate for navigation, cache-first for hashed assets,
+// never-cache for the API.
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  // Never cache API calls or WebSocket upgrades.
+  if (url.pathname.startsWith('/api/')) return;
+
+  // Navigation requests (HTML pages): stale-while-revalidate against the
+  // precached app shell. Serving the cached shell immediately is what removes
+  // the multi-second blank screen on an iOS resume — the previous network-first
+  // strategy awaited a full round trip and only fell back to cache on a network
+  // *error*, so a slow connection still produced a blank page. We revalidate the
+  // shell in the background and fall back to the network only on a cache miss.
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(async (cache) => {
+        const cached = (await cache.match(event.request)) || (await cache.match(APP_SHELL_URL));
+
+        const network = fetch(event.request)
+          .then((response) => {
+            if (response.ok) cache.put(APP_SHELL_URL, response.clone());
+            return response;
+          })
+          .catch(() => null);
+
+        if (cached) {
+          // Paint immediately; revalidate the shell for the next load.
+          event.waitUntil(network);
+          return cached;
+        }
+
+        // Cold cache (first ever load): fall back to the network.
+        const response = await network;
+        return response || new Response('', { status: 503, statusText: 'Service Unavailable' });
+      })
+    );
+    return;
+  }
+
+  // Static assets (JS, CSS, images): Vite hashes these filenames, so they are
+  // immutable and safe to serve cache-first.
+  if (
+    url.pathname.startsWith('/assets/') ||
+    url.pathname.endsWith('.svg') ||
+    url.pathname.endsWith('.png') ||
+    url.pathname.endsWith('.ico')
+  ) {
+    event.respondWith(
+      caches.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request).then((response) => {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+            return response;
+          })
+      )
+    );
+    return;
+  }
+});

--- a/apps/staged/vite.config.ts
+++ b/apps/staged/vite.config.ts
@@ -1,20 +1,122 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { defineConfig } from 'vite';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { defineConfig, type Plugin, type Rollup } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
 
 const port = parseInt(process.env.VITE_PORT || '5174', 10);
+const rootDir = import.meta.dirname;
+const publicDir = resolve(rootDir, 'public');
+const serviceWorkerTemplatePath = resolve(rootDir, 'src/service-worker.js');
+const serviceWorkerCacheNamePlaceholder = '__STAGED_CACHE_NAME__';
+const serviceWorkerCacheHashLength = 12;
 const packageJson = JSON.parse(
-  readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf8')
+  readFileSync(resolve(rootDir, 'package.json'), 'utf8')
 ) as { version: string };
+
+type HashInput = {
+  contents: string | Uint8Array;
+  fileName: string;
+  kind: 'bundle' | 'public' | 'template';
+};
+
+function generatedServiceWorkerPlugin(): Plugin {
+  return {
+    name: 'staged-generated-service-worker',
+    apply: 'build',
+    enforce: 'post',
+    generateBundle(_options, bundle) {
+      const template = readFileSync(serviceWorkerTemplatePath, 'utf8');
+
+      if (!template.includes(serviceWorkerCacheNamePlaceholder)) {
+        throw new Error(
+          `Service worker template must contain ${serviceWorkerCacheNamePlaceholder}`
+        );
+      }
+
+      const cacheName = `staged-${hashInputs([
+        ...collectBundleInputs(bundle),
+        ...collectPublicAssetInputs(publicDir),
+        {
+          contents: template,
+          fileName: 'src/service-worker.js',
+          kind: 'template',
+        },
+      ])}`;
+
+      this.emitFile({
+        fileName: 'sw.js',
+        source: template.replaceAll(serviceWorkerCacheNamePlaceholder, cacheName),
+        type: 'asset',
+      });
+    },
+  };
+}
+
+function collectBundleInputs(bundle: Rollup.OutputBundle): HashInput[] {
+  return Object.values(bundle).map((output) => ({
+    contents: output.type === 'chunk' ? output.code : output.source,
+    fileName: output.fileName,
+    kind: 'bundle',
+  }));
+}
+
+function collectPublicAssetInputs(directory: string): HashInput[] {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  return collectFiles(directory).map((filePath) => ({
+    contents: readFileSync(filePath),
+    fileName: toPosixPath(relative(directory, filePath)),
+    kind: 'public',
+  }));
+}
+
+function collectFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const filePath = resolve(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return collectFiles(filePath);
+    }
+
+    return entry.isFile() ? [filePath] : [];
+  });
+}
+
+function hashInputs(inputs: HashInput[]): string {
+  const hash = createHash('sha256');
+
+  for (const input of [...inputs].sort(compareHashInputs)) {
+    hash.update(input.kind);
+    hash.update('\0');
+    hash.update(input.fileName);
+    hash.update('\0');
+    hash.update(
+      typeof input.contents === 'string' ? input.contents : Buffer.from(input.contents)
+    );
+    hash.update('\0');
+  }
+
+  return hash.digest('hex').slice(0, serviceWorkerCacheHashLength);
+}
+
+function compareHashInputs(left: HashInput, right: HashInput): number {
+  return `${left.kind}:${left.fileName}`.localeCompare(`${right.kind}:${right.fileName}`);
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.replaceAll('\\', '/');
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(packageJson.version),
   },
-  plugins: [svelte(), tailwindcss()],
+  plugins: [svelte(), tailwindcss(), generatedServiceWorkerPlugin()],
   resolve: {
     alias: {
       $lib: resolve(import.meta.dirname, 'src/lib'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       ansi-to-html:
         specifier: ^0.7.2
         version: 0.7.2
+      idb-keyval:
+        specifier: ^6.2.2
+        version: 6.2.5
       marked:
         specifier: ^17.0.1
         version: 17.0.3
@@ -238,6 +241,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       prettier:
         specifier: ^3.7.4
         version: 3.8.1
@@ -1966,6 +1972,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2076,6 +2086,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  idb-keyval@6.2.5:
+    resolution: {integrity: sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4699,6 +4712,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fake-indexeddb@6.2.5: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -4862,6 +4877,8 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  idb-keyval@6.2.5: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## Summary
- Add persistent web snapshot caching and invalidation for staged web sessions
- Restore project, session, diff, and navigation state after page lifecycle reloads
- Register service worker support and add cache, command, agent, and page lifecycle test coverage