### PR TITLE
feat(staged): style recent repo options as colored badge chips

### DIFF
--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -310,7 +310,10 @@
               )}; --chip-border-hover: {badge.badgeBorderHover(
                 hue,
                 dark
-              )}; --chip-fg: {badge.badgeFg(hue, dark)};"
+              )}; --chip-fg: {badge.badgeFg(hue, dark)}; --chip-shortcut-bg: {badge.badgeShortcutBg(
+                hue,
+                dark
+              )};"
               onclick={() =>
                 handleRepoSelected({
                   nameWithOwner: recent.githubRepo,
@@ -601,7 +604,7 @@
     gap: 2px;
     margin-left: 2px;
     padding: 1px 4px;
-    background: rgba(0, 0, 0, 0.1);
+    background: var(--chip-shortcut-bg);
     border-radius: 3px;
     color: inherit;
     opacity: 0.5;

--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -12,10 +12,13 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { slide, fade } from 'svelte/transition';
-  import { GitBranch, X, Clock, Command } from 'lucide-svelte';
+  import { GitBranch, X, Plus, Command } from 'lucide-svelte';
   import type { RecentRepo, PullRequest } from '../../types';
   import * as commands from '../../api/commands';
   import RepoLabel from '../../shared/RepoLabel.svelte';
+  import { repoBadgeStore } from '../../stores/repoBadges.svelte';
+  import { darkMode } from '../../stores/isDark.svelte';
+  import * as badge from '../../shared/badgeColors';
   import Spinner from '../../shared/Spinner.svelte';
   import RepoSearchInput from './RepoSearchInput.svelte';
   import SubpathInput from './SubpathInput.svelte';
@@ -175,6 +178,20 @@
     excludeRepos ? recentRepos.filter((r) => !excludeRepos.has(r.githubRepo)) : recentRepos
   );
 
+  const dark = $derived(darkMode.value);
+
+  $effect(() => {
+    if (recentRepos.length > 0) {
+      repoBadgeStore.ensureForRepos(
+        recentRepos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+      );
+    }
+  });
+
+  function repoHue(r: RecentRepo): number {
+    return repoBadgeStore.lookup(r.githubRepo, r.subpath)?.hue ?? 210;
+  }
+
   function handleRepoSelected(selection: RepoSelection) {
     if (branchPickerTimer) clearTimeout(branchPickerTimer);
     showBranchPicker = false;
@@ -281,20 +298,31 @@
       {#if !selectedRepo && filteredRecentRepos.length > 0}
         <div class="recent-repos" out:slide={{ duration: SLIDE_DURATION }}>
           {#each filteredRecentRepos.slice(0, 5) as recent, i}
+            {@const hue = repoHue(recent)}
             <button
-              class="recent-repo-item"
+              class="recent-chip"
+              style="--chip-bg: {badge.badgeBg(hue, dark)}; --chip-bg-hover: {badge.badgeBgHover(
+                hue,
+                dark
+              )}; --chip-border: {badge.badgeBorder(
+                hue,
+                dark
+              )}; --chip-border-hover: {badge.badgeBorderHover(
+                hue,
+                dark
+              )}; --chip-fg: {badge.badgeFg(hue, dark)};"
               onclick={() =>
                 handleRepoSelected({
                   nameWithOwner: recent.githubRepo,
                   subpath: recent.subpath ?? undefined,
                 })}
             >
-              <Clock size={12} class="recent-repo-icon" />
-              <span class="recent-repo-label">
+              <Plus size={13} />
+              <span class="chip-name">
                 <RepoLabel githubRepo={recent.githubRepo} subpath={recent.subpath} />
               </span>
               {#if viewport.showShortcutHints}
-                <span class="recent-repo-shortcut">
+                <span class="recent-chip-shortcut">
                   <Command size={9} />
                   {i + 1}
                 </span>
@@ -519,52 +547,62 @@
 
   .recent-repos {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
-    margin-top: 2px;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 4px;
   }
 
-  .recent-repo-item {
-    display: flex;
+  .recent-chip {
+    display: inline-flex;
     align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 5px 8px;
-    background: none;
-    border: none;
-    border-radius: 6px;
-    text-align: left;
+    gap: 4px;
+    padding: 3px 10px;
+    border: 1px solid var(--chip-border);
+    border-radius: 5px;
+    background: var(--chip-bg);
+    color: var(--chip-fg);
+    font-size: 12.5px;
+    font-weight: 600;
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+    line-height: 1.4;
     cursor: pointer;
-    transition: background-color 0.15s ease;
-    font-family: inherit;
+    transition:
+      background 0.15s,
+      border-color 0.15s;
   }
 
-  .recent-repo-item:hover {
-    background-color: var(--bg-hover);
+  .recent-chip:hover {
+    background: var(--chip-bg-hover);
+    border-color: var(--chip-border-hover);
   }
 
-  .recent-repo-item :global(.recent-repo-icon) {
-    color: var(--text-faint);
-    flex-shrink: 0;
-  }
-
-  .recent-repo-label {
-    flex: 1;
-    min-width: 0;
-    font-size: var(--size-xs);
+  .chip-name {
+    display: inline-flex;
+    max-width: 250px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .recent-repo-shortcut {
+  .chip-name :global(.repo-label-prefix) {
+    color: inherit;
+    opacity: 0.6;
+  }
+
+  .chip-name :global(.repo-label-emphasis) {
+    color: inherit;
+  }
+
+  .recent-chip-shortcut {
     display: inline-flex;
     align-items: center;
     gap: 2px;
+    margin-left: 2px;
     padding: 1px 4px;
-    background: var(--bg-hover);
+    background: rgba(0, 0, 0, 0.1);
     border-radius: 3px;
-    color: var(--text-faint);
+    color: inherit;
+    opacity: 0.5;
     font-size: 10px;
     flex-shrink: 0;
     line-height: 1;

--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -547,7 +547,8 @@
 
   .recent-repos {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: flex-start;
     gap: 6px;
     margin-top: 4px;
   }
@@ -565,6 +566,7 @@
     font-weight: 600;
     font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
     line-height: 1.4;
+    max-width: 100%;
     cursor: pointer;
     transition:
       background 0.15s,

--- a/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
+++ b/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
@@ -14,6 +14,9 @@
   import type { GitHubRepo, RecentRepo } from '../../types';
   import { parseGitHubUrl, type RepoSelection } from '../../shared/githubUrl';
   import { viewport } from '../../shared/viewport.svelte';
+  import { repoBadgeStore } from '../../stores/repoBadges.svelte';
+  import { darkMode } from '../../stores/isDark.svelte';
+  import * as badge from '../../shared/badgeColors';
 
   export type { RepoSelection };
 
@@ -105,6 +108,20 @@
     const base = recentRepos.filter((r) => !excludeRepos.has(r.githubRepo));
     return q ? base.filter((r) => r.githubRepo.toLowerCase().includes(q)) : base;
   });
+
+  const dark = $derived(darkMode.value);
+
+  $effect(() => {
+    if (recentRepos.length > 0) {
+      repoBadgeStore.ensureForRepos(
+        recentRepos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+      );
+    }
+  });
+
+  function recentHue(r: RecentRepo): number {
+    return repoBadgeStore.lookup(r.githubRepo, r.subpath)?.hue ?? 210;
+  }
 
   onMount(async () => {
     if (autofocus) {
@@ -273,9 +290,17 @@
     <div class="repo-dropdown" style={dropdownStyle}>
       {#if filteredRecentRepos.length > 0}
         {#each filteredRecentRepos as recent, i}
+          {@const hue = recentHue(recent)}
           <button
             class="repo-item recent"
             tabindex="-1"
+            style="--recent-bg: {badge.badgeBg(hue, dark)}; --recent-bg-hover: {badge.badgeBgHover(
+              hue,
+              dark
+            )}; --recent-fg: {badge.badgeFg(hue, dark)}; --recent-border: {badge.badgeBorder(
+              hue,
+              dark
+            )};"
             onclick={() =>
               handleSelect({
                 nameWithOwner: recent.githubRepo,
@@ -474,8 +499,23 @@
     display: flex;
   }
 
+  .repo-item.recent {
+    background: var(--recent-bg);
+    border-left: 2px solid var(--recent-border);
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+  }
+
+  .repo-item.recent:hover,
+  .repo-item.recent:focus {
+    background: var(--recent-bg-hover);
+  }
+
+  .repo-item.recent .repo-name {
+    color: var(--recent-fg);
+  }
+
   .recent-icon {
-    color: var(--ui-accent);
+    color: var(--recent-fg);
   }
 
   .repo-info {

--- a/apps/staged/src/lib/shared/badgeColors.ts
+++ b/apps/staged/src/lib/shared/badgeColors.ts
@@ -24,3 +24,7 @@ export function badgeBorder(hue: number, dark: boolean): string {
 export function badgeBorderHover(hue: number, dark: boolean): string {
   return dark ? `oklch(0.50 0.08 ${hue})` : `oklch(0.72 0.09 ${hue})`;
 }
+
+export function badgeShortcutBg(hue: number, dark: boolean): string {
+  return dark ? `oklch(0.40 0.06 ${hue})` : `oklch(0.86 0.06 ${hue})`;
+}


### PR DESCRIPTION
## Summary
- Render recent repo options in `RepoConfigForm` as colored badge chips (using per-repo hues from `repoBadgeStore`) instead of clock-icon list rows, stacked vertically with a `Plus` icon and keyboard shortcut.
- Tint recent entries in the `RepoSearchInput` dropdown with the same per-repo badge color and a colored left border.
- Add `badgeShortcutBg` helper to `badgeColors.ts` for the OKLCH-derived shortcut chip background, replacing the previous hardcoded `--bg-hover`.

## Test plan
- [ ] Open a project's repo config with several recent repos and verify each chip uses its own badge color in both light and dark mode.
- [ ] Confirm chips stack vertically, hover/focus states look correct, and `⌘1`–`⌘5` shortcuts still trigger selection.
- [ ] Open the repo search input dropdown and verify recent entries show the matching tint and colored left border.