### PR TITLE
fix(diff-viewer): reset comment editor scroll on comment change

### DIFF
--- a/packages/diff-viewer/src/lib/components/CommentEditor.svelte
+++ b/packages/diff-viewer/src/lib/components/CommentEditor.svelte
@@ -58,10 +58,15 @@
 
   // Track current input value - initialized by effect when existingComment changes
   let currentValue = $state('');
+  let textareaEl: HTMLTextAreaElement | null = null;
 
-  // Update value when existingComment changes (for editing mode)
+  // Update value when existingComment changes (for editing mode). Reset scroll
+  // on identity change so a previously-scrolled textarea doesn't leak its
+  // offset into the next comment being viewed.
   $effect(() => {
+    existingComment?.id;
     currentValue = existingComment?.content ?? '';
+    if (textareaEl) textareaEl.scrollTop = 0;
   });
 
   function handleInput(e: Event) {
@@ -107,6 +112,7 @@
   style="top: {top}px; left: {left}px; width: {width}px;"
 >
   <textarea
+    bind:this={textareaEl}
     class="comment-textarea"
     {placeholder}
     value={currentValue}


### PR DESCRIPTION
## Summary
- Reset the `CommentEditor` textarea's `scrollTop` to 0 when the displayed comment's identity changes, so a previously-scrolled comment no longer leaks its scroll offset into the next comment being viewed.

## Test plan
- [ ] Open a review with multiple comments; scroll within a long comment, then switch to a shorter comment and confirm the textarea is scrolled to the top.
- [ ] Edit an existing comment and confirm the textarea still initializes at the top.