### PR TITLE
refactor(staged): clean up branch action submenu grouping and positioning

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -506,15 +506,48 @@
   }
 
   function buildActionMenuItems(): MenuItem[] {
-    return actionMenuTypes.flatMap((type) => {
-      const typeActions = type === 'run' ? remainingRunActions : groupedActions[type];
-      return typeActions.map((action) => ({
-        type: 'action' as const,
-        label: action.name,
-        icon: getActionIcon(type),
-        onSelect: () => handleRunAction(action),
-      }));
+    const toActionItem = (type: ActionType, action: ProjectAction): MenuItem => ({
+      type: 'action',
+      label: action.name,
+      icon: getActionIcon(type),
+      onSelect: () => handleRunAction(action),
     });
+
+    const formatItems = groupedActions.format.map((a) => toActionItem('format', a));
+    const checkItems = groupedActions.check.map((a) => toActionItem('check', a));
+    const combineFormatCheck = formatItems.length + checkItems.length > 2;
+
+    const groups: MenuItem[][] = [];
+    for (const type of actionMenuTypes) {
+      if (combineFormatCheck && type === 'check') continue;
+      if (combineFormatCheck && type === 'format') {
+        const children: MenuItem[] = [
+          ...formatItems,
+          ...(formatItems.length && checkItems.length ? [{ type: 'separator' as const }] : []),
+          ...checkItems,
+        ];
+        groups.push([
+          {
+            type: 'submenu',
+            label: 'Format & Check',
+            icon: Wand2,
+            children,
+          },
+        ]);
+        continue;
+      }
+
+      const typeActions = type === 'run' ? remainingRunActions : groupedActions[type];
+      if (!typeActions || typeActions.length === 0) continue;
+      groups.push(typeActions.map((action) => toActionItem(type, action)));
+    }
+
+    const items: MenuItem[] = [];
+    for (const group of groups) {
+      if (items.length > 0) items.push({ type: 'separator' });
+      items.push(...group);
+    }
+    return items;
   }
 
   const terminalAppIds = new Set([

--- a/apps/staged/src/lib/shared/menu/MenuSurface.svelte
+++ b/apps/staged/src/lib/shared/menu/MenuSurface.svelte
@@ -4,8 +4,6 @@
   import { selectMenuAction } from './actions';
   import type { MenuActionItem, MenuItem, MenuSubmenuItem } from './types';
 
-  type SubmenuPlacement = 'right' | 'left';
-
   interface Props {
     items: MenuItem[];
     left: number;
@@ -30,7 +28,7 @@
 
   let menuEl = $state<HTMLDivElement | null>(null);
   let openSubmenuPath = $state<string | null>(null);
-  let submenuPlacements = $state<Record<string, SubmenuPlacement>>({});
+  let submenuPositions = $state<Record<string, { left: number; top: number }>>({});
   let closeSubmenuTimer: ReturnType<typeof setTimeout> | null = null;
 
   const submenuContainers = new Map<string, HTMLElement>();
@@ -68,6 +66,21 @@
 
   async function openSubmenu(path: string) {
     clearSubmenuTimer();
+
+    // Pre-compute an initial position from the trigger's rect so the submenu
+    // appears in the right place on first paint, before measurement refines it.
+    const container = submenuContainers.get(path);
+    if (container && !submenuPositions[path]) {
+      const containerRect = container.getBoundingClientRect();
+      submenuPositions = {
+        ...submenuPositions,
+        [path]: {
+          left: containerRect.right + submenuGap,
+          top: containerRect.top,
+        },
+      };
+    }
+
     openSubmenuPath = path;
     await updateSubmenuPlacement(path);
   }
@@ -110,9 +123,17 @@
     const wouldOverflowRight =
       containerRect.right + submenuGap + submenuRect.width > window.innerWidth - viewportPadding;
 
-    submenuPlacements = {
-      ...submenuPlacements,
-      [path]: wouldOverflowRight ? 'left' : 'right',
+    const left = wouldOverflowRight
+      ? Math.max(viewportPadding, containerRect.left - submenuGap - submenuRect.width)
+      : containerRect.right + submenuGap;
+
+    const preferredTop = containerRect.top;
+    const maxTop = window.innerHeight - submenuRect.height - viewportPadding;
+    const top = Math.max(viewportPadding, Math.min(preferredTop, maxTop));
+
+    submenuPositions = {
+      ...submenuPositions,
+      [path]: { left, top },
     };
   }
 
@@ -324,9 +345,11 @@
         {#if isSubmenuOpen(path)}
           <div
             class="submenu"
-            class:open-left={submenuPlacements[path] === 'left'}
             role="menu"
             aria-label={item.label}
+            style:left={`${submenuPositions[path]?.left ?? 0}px`}
+            style:top={`${submenuPositions[path]?.top ?? 0}px`}
+            style:visibility={submenuPositions[path] ? 'visible' : 'hidden'}
             use:trackSubmenu={path}
           >
             {@render renderMenuItems(item.children, path)}
@@ -455,18 +478,10 @@
   }
 
   .submenu {
-    position: absolute;
-    top: 0;
-    left: calc(100% + 2px);
     z-index: 1;
     min-width: 160px;
     max-width: min(320px, calc(100vw - 16px));
     max-height: min(400px, calc(100vh - 16px));
     overflow-y: auto;
-  }
-
-  .submenu.open-left {
-    right: calc(100% + 2px);
-    left: auto;
   }
 </style>


### PR DESCRIPTION
## Summary
- Group items in the branch card action menu by type with separators between groups, and collapse format/check actions into a combined "Format & Check" submenu when they exceed two entries.
- Position nested submenus with fixed coordinates derived from the trigger rect instead of CSS-absolute positioning, so submenus render correctly when their parent is clipped or scrolled.

## Test plan
- [ ] Open a branch's action menu and verify actions are grouped by type with dividers
- [ ] Verify format and check actions collapse into a "Format & Check" submenu when there are more than two combined entries
- [ ] Open the action submenu near the right edge of the viewport and confirm it flips to the left
- [ ] Open a submenu near the bottom of the viewport and confirm it stays within the visible area