### PR TITLE
fix: don't auto-select hashtag badges in new session dialog prefill

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1619,6 +1619,9 @@
       : sessionMgr.newSessionMode === 'commit'
         ? commitPrefill
         : ''}
+  {@const hasRef =
+    (sessionMgr.newSessionMode === 'commit' && !!suggestedPrefill.commitRef) ||
+    (sessionMgr.newSessionMode === 'note' && !!suggestedPrefill.noteRef)}
   <NewSessionModal
     {branch}
     mode={sessionMgr.newSessionMode}
@@ -1626,6 +1629,7 @@
     initialPrompt={usePrefill ? prefillText : sessionMgr.draftPrompt}
     initialImageIds={sessionMgr.draftImageIds}
     prefilled={usePrefill}
+    prefillSelection={usePrefill && hasRef ? 'last-line' : 'all'}
     {commitPrefill}
     {notePrefill}
     remote={isRemote}

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -179,20 +179,29 @@
   $effect(() => {
     const _items = itemsById;
     if (hasUnresolvedTokens && _items.size > 0 && editorEl) {
-      const shouldRestoreSelectAll = selectionCoversContents(editorEl);
+      const selKind = classifySelection(editorEl);
       const sel = window.getSelection();
-      const hadCaret = sel && sel.isCollapsed && editorEl.contains(sel.anchorNode);
 
       renderContent(value);
 
-      if (shouldRestoreSelectAll) {
+      if (selKind === 'all') {
         const range = document.createRange();
         range.selectNodeContents(editorEl);
         if (sel) {
           sel.removeAllRanges();
           sel.addRange(range);
         }
-      } else if (hadCaret) {
+      } else if (selKind === 'last-line') {
+        // Restore selection from after the last <br> to end of content
+        const start = findLastBrStart(editorEl);
+        if (start && sel) {
+          const range = document.createRange();
+          range.setStart(start.node, start.offset);
+          range.setEnd(editorEl, editorEl.childNodes.length);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+      } else if (selKind === 'caret') {
         // Restore collapsed cursor to end after re-render.
         // DOM is already fresh (renderContent just ran), so use the sync variant.
         focusAtEndSync(editorEl);
@@ -200,22 +209,34 @@
     }
   });
 
-  function selectionCoversContents(root: HTMLElement): boolean {
+  function classifySelection(root: HTMLElement): 'all' | 'last-line' | 'caret' | 'none' {
     const sel = window.getSelection();
-    if (!sel || sel.isCollapsed || !sel.rangeCount || !sel.anchorNode || !sel.focusNode) {
-      return false;
+    if (!sel || !sel.rangeCount || !sel.anchorNode || !root.contains(sel.anchorNode)) {
+      return 'none';
     }
-    if (!root.contains(sel.anchorNode) || !root.contains(sel.focusNode)) {
-      return false;
-    }
+    if (sel.isCollapsed) return 'caret';
+    if (!sel.focusNode || !root.contains(sel.focusNode)) return 'none';
 
-    const selectionRange = sel.getRangeAt(0);
+    const selRange = sel.getRangeAt(0);
     const fullRange = document.createRange();
     fullRange.selectNodeContents(root);
-    return (
-      selectionRange.compareBoundaryPoints(Range.START_TO_START, fullRange) === 0 &&
-      selectionRange.compareBoundaryPoints(Range.END_TO_END, fullRange) === 0
-    );
+
+    const startsAtBeginning = selRange.compareBoundaryPoints(Range.START_TO_START, fullRange) === 0;
+    const endsAtEnd = selRange.compareBoundaryPoints(Range.END_TO_END, fullRange) === 0;
+
+    if (startsAtBeginning && endsAtEnd) return 'all';
+    if (endsAtEnd && !startsAtBeginning) return 'last-line';
+    return 'none';
+  }
+
+  function findLastBrStart(root: HTMLElement): { node: Node; offset: number } | null {
+    let result: { node: Node; offset: number } | null = null;
+    for (let i = 0; i < root.childNodes.length; i++) {
+      if (root.childNodes[i] instanceof HTMLBRElement) {
+        result = { node: root, offset: i + 1 };
+      }
+    }
+    return result;
   }
 
   function createBadgeElement(item: HashtagItem): HTMLSpanElement {

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -215,9 +215,10 @@
       newMode === 'commit' ? commitPrefill : newMode === 'note' ? notePrefill : '';
     if (modePrefill && !userDraft) {
       prompt = modePrefill;
+      const modeSelection = modePrefill.includes('\n') ? 'last-line' : prefillSelection;
       tick().then(() => {
         if (textareaEl && textareaEl.textContent) {
-          selectPromptContent(textareaEl, prefillSelection);
+          selectPromptContent(textareaEl, modeSelection);
           textareaEl.focus();
         }
       });


### PR DESCRIPTION
## Summary

When the new session dialog opens with a prefilled prompt containing a hashtag reference (e.g. `Re: #note:xyz`), the entire text including the badge was selected, so typing would replace the reference. Now only the action text after the reference line is selected so users can immediately type to replace the suggestion while keeping the reference.

## Changes

- `BranchCard.svelte`: passes `prefillSelection="last-line"` when a commit or note ref is present in the suggested prefill.
- `HashtagInput.svelte`: replaces the boolean `selectionCoversContents` check with a `classifySelection` helper that distinguishes `all` / `last-line` / `caret` / `none`, and restores `last-line` selection after re-render via a new `findLastBrStart` helper.
- `NewSessionModal.svelte`: when the mode-switch prefill contains a newline, uses `last-line` selection instead of the default.

## Test plan

- [ ] Open new session dialog on a commit/note with a hashtag ref — only the action line is selected; typing replaces the action while preserving the ref.
- [ ] Open new session dialog with a plain prefill (no ref) — entire content remains selected as before.
- [ ] Switch session mode while dialog is open — selection updates correctly.