### PR TITLE
fix(staged): refresh project sidebar icon when first commit completes

### DIFF
--- a/apps/staged/src/App.svelte
+++ b/apps/staged/src/App.svelte
@@ -207,31 +207,31 @@
     document.addEventListener('keydown', handleKonamiKey);
 
     // Listen for the app menu Preferences item.
-    unlistenSettings = await listenToEvent('menu:settings', () => {
+    unlistenSettings = listenToEvent('menu:settings', () => {
       if (!triggerShortcut('app-open-settings')) openSettings();
     });
-    unlistenFind = await listenToEvent('menu:find', () => {
+    unlistenFind = listenToEvent('menu:find', () => {
       if (!triggerShortcut('search-find')) runSearchShortcut('find');
     });
-    unlistenFindNext = await listenToEvent('menu:find-next', () => {
+    unlistenFindNext = listenToEvent('menu:find-next', () => {
       if (!triggerShortcut('search-find-next')) runSearchShortcut('next');
     });
-    unlistenFindPrevious = await listenToEvent('menu:find-previous', () => {
+    unlistenFindPrevious = listenToEvent('menu:find-previous', () => {
       if (!triggerShortcut('search-find-previous')) runSearchShortcut('previous');
     });
-    unlistenZoomIn = await listenToEvent('menu:zoom-in', () => {
+    unlistenZoomIn = listenToEvent('menu:zoom-in', () => {
       if (!triggerShortcut('view-increase-size')) increaseSize();
     });
-    unlistenZoomOut = await listenToEvent('menu:zoom-out', () => {
+    unlistenZoomOut = listenToEvent('menu:zoom-out', () => {
       if (!triggerShortcut('view-decrease-size')) decreaseSize();
     });
-    unlistenZoomReset = await listenToEvent('menu:zoom-reset', () => {
+    unlistenZoomReset = listenToEvent('menu:zoom-reset', () => {
       if (!triggerShortcut('view-reset-size')) resetSize();
     });
 
     // Global session-status listener — must live at App level so it works
     // regardless of which view the user is on. See sessionStatusListener.ts.
-    unlistenSessionStatus = await listenForSessionStatus();
+    unlistenSessionStatus = listenForSessionStatus();
 
     try {
       await initPreferences();

--- a/apps/staged/src/lib/features/actions/ActionOutputModal.svelte
+++ b/apps/staged/src/lib/features/actions/ActionOutputModal.svelte
@@ -204,7 +204,7 @@
 
     (async () => {
       await loadBufferedOutput();
-      await setupListeners();
+      setupListeners();
       tick().then(() => scrollToBottom());
     })();
   });
@@ -229,40 +229,36 @@
     }
   }
 
-  async function setupListeners() {
-    try {
-      // Listen for output events — batched via requestAnimationFrame
-      unlistenOutput = await listenToActionOutput((event: ActionOutputEvent) => {
-        if (event.executionId === executionId) {
-          pendingChunks.push({
-            chunk: event.chunk,
-            stream: event.stream,
-            timestamp: Date.now(),
-          });
-          if (flushRaf === null) {
-            flushRaf = requestAnimationFrame(flushPendingChunks);
-          }
+  function setupListeners() {
+    // Listen for output events — batched via requestAnimationFrame
+    unlistenOutput = listenToActionOutput((event: ActionOutputEvent) => {
+      if (event.executionId === executionId) {
+        pendingChunks.push({
+          chunk: event.chunk,
+          stream: event.stream,
+          timestamp: Date.now(),
+        });
+        if (flushRaf === null) {
+          flushRaf = requestAnimationFrame(flushPendingChunks);
         }
-      });
+      }
+    });
 
-      // Listen for status changes
-      unlistenStatus = await listenToActionStatus((event: ActionStatusEvent) => {
-        if (event.executionId === executionId) {
-          status = event.status;
-          if (event.exitCode !== undefined) {
-            exitCode = event.exitCode;
-          }
-          // Clean up stopping state when action reaches terminal state
-          if (status !== 'running') {
-            const updated = new Set(stoppingExecutions);
-            updated.delete(executionId);
-            stoppingExecutions = updated;
-          }
+    // Listen for status changes
+    unlistenStatus = listenToActionStatus((event: ActionStatusEvent) => {
+      if (event.executionId === executionId) {
+        status = event.status;
+        if (event.exitCode !== undefined) {
+          exitCode = event.exitCode;
         }
-      });
-    } catch (e: any) {
-      console.error('Failed to setup event listeners:', e);
-    }
+        // Clean up stopping state when action reaches terminal state
+        if (status !== 'running') {
+          const updated = new Set(stoppingExecutions);
+          updated.delete(executionId);
+          stoppingExecutions = updated;
+        }
+      }
+    });
   }
 
   function cleanup() {

--- a/apps/staged/src/lib/features/actions/actions.ts
+++ b/apps/staged/src/lib/features/actions/actions.ts
@@ -213,9 +213,7 @@ export function runPrerunActions(branchId: string, provider?: string): Promise<s
  * Listen for real-time action output events.
  * Returns an unlisten function to stop listening.
  */
-export function listenToActionOutput(
-  callback: (event: ActionOutputEvent) => void
-): Promise<UnlistenFn> {
+export function listenToActionOutput(callback: (event: ActionOutputEvent) => void): UnlistenFn {
   return listenToEvent<ActionOutputEvent>('action_output', callback);
 }
 
@@ -223,9 +221,7 @@ export function listenToActionOutput(
  * Listen for action status change events.
  * Returns an unlisten function to stop listening.
  */
-export function listenToActionStatus(
-  callback: (event: ActionStatusEvent) => void
-): Promise<UnlistenFn> {
+export function listenToActionStatus(callback: (event: ActionStatusEvent) => void): UnlistenFn {
   return listenToEvent<ActionStatusEvent>('action_status', callback);
 }
 
@@ -235,14 +231,14 @@ export function listenToActionStatus(
  */
 export function listenToActionAutoCommit(
   callback: (event: ActionAutoCommitEvent) => void
-): Promise<UnlistenFn> {
+): UnlistenFn {
   return listenToEvent<ActionAutoCommitEvent>('action_auto_commit', callback);
 }
 
 /** Listen for repo action detection start/stop updates. */
 export function listenToRepoActionsDetection(
   callback: (event: RepoActionsDetectionEvent) => void
-): Promise<UnlistenFn> {
+): UnlistenFn {
   return listenToEvent<RepoActionsDetectionEvent>('repo-actions-detection', callback);
 }
 
@@ -267,6 +263,6 @@ export function updateRunDetectionMode(actionId: string, mode: RunDetectionMode)
  */
 export function listenToRunPhaseChanged(
   callback: (event: RunPhaseChangedEvent) => void
-): Promise<UnlistenFn> {
+): UnlistenFn {
   return listenToEvent<RunPhaseChangedEvent>('action:run-phase-changed', callback);
 }

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -25,7 +25,7 @@
   import Spinner from '../../shared/Spinner.svelte';
   import { isSessionActive } from '../../shared/sessionStatus';
   import { deleteSessionLinkedItem } from '../../shared/deleteSessionLinkedItem';
-  import { listenToEvent, type UnlistenFn } from '../../transport';
+  import { listenToEvent } from '../../transport';
   import { subscribeDragDrop } from './dragDrop';
   import type {
     Branch,
@@ -203,12 +203,8 @@
   let setupDetail: string | null = $state(null);
 
   $effect(() => {
-    let cancelled = false;
-
     const eventNames = ['worktree-setup-progress', 'workspace-setup-progress'] as const;
-    const unlisteners: (() => void)[] = [];
-
-    for (const eventName of eventNames) {
+    const unlisteners = eventNames.map((eventName) =>
       listenToEvent<{ branchId: string; phase: string; detail: string | null }>(
         eventName,
         (payload) => {
@@ -217,14 +213,10 @@
             setupDetail = payload.detail;
           }
         }
-      ).then((fn) => {
-        if (cancelled) fn();
-        else unlisteners.push(fn);
-      });
-    }
+      )
+    );
 
     return () => {
-      cancelled = true;
       for (const fn of unlisteners) fn();
     };
   });
@@ -595,89 +587,92 @@
   // Event listeners
   // =========================================================================
 
-  let unlistenStatus: UnlistenFn | null = null;
-
   $effect(() => {
     const branchId = branch.id;
 
-    listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
-      const { sessionId: eventSessionId, status, branchId: eventBranchId, isAutoReview } = payload;
-      if (status === 'completed' || status === 'error' || status === 'cancelled') {
-        // If this is the auto review session completing, just clear tracking
-        if (eventSessionId === sessionMgr.autoReviewSessionId) {
-          sessionMgr.autoReviewSessionId = null;
-          return;
-        }
+    const unlistenStatus = listenToEvent<SessionStatusPayload>(
+      'session-status-changed',
+      (payload) => {
+        const {
+          sessionId: eventSessionId,
+          status,
+          branchId: eventBranchId,
+          isAutoReview,
+        } = payload;
+        if (status === 'completed' || status === 'error' || status === 'cancelled') {
+          // If this is the auto review session completing, just clear tracking
+          if (eventSessionId === sessionMgr.autoReviewSessionId) {
+            sessionMgr.autoReviewSessionId = null;
+            return;
+          }
 
-        // Clear push/force-push session tracking on terminal status only
-        // (guarded by the outer completed/error/cancelled check above)
-        if (eventSessionId === pushSessionId) {
-          pushSessionId = null;
-        }
-        if (eventSessionId === forcePushSessionId) {
-          forcePushSessionId = null;
-        }
+          // Clear push/force-push session tracking on terminal status only
+          // (guarded by the outer completed/error/cancelled check above)
+          if (eventSessionId === pushSessionId) {
+            pushSessionId = null;
+          }
+          if (eventSessionId === forcePushSessionId) {
+            forcePushSessionId = null;
+          }
 
-        // Skip normal completion handling for any auto review session
-        if (isAutoReview) {
-          return;
-        }
+          // Skip normal completion handling for any auto review session
+          if (isAutoReview) {
+            return;
+          }
 
-        // Skip reload for the adopted auto-review session completing —
-        // the timeline was already updated optimistically during adoption.
-        if (eventSessionId === sessionMgr.adoptedSessionId) {
-          sessionMgr.adoptedSessionId = null;
-          return;
-        }
+          // Skip reload for the adopted auto-review session completing —
+          // the timeline was already updated optimistically during adoption.
+          if (eventSessionId === sessionMgr.adoptedSessionId) {
+            sessionMgr.adoptedSessionId = null;
+            return;
+          }
 
-        // Only reload if this session belongs to our branch
-        if (eventBranchId && eventBranchId !== branchId) return;
+          // Only reload if this session belongs to our branch
+          if (eventBranchId && eventBranchId !== branchId) return;
 
-        commands.invalidateBranchTimeline(branch.id);
-        loadTimeline();
-        // Handle PR session completion
-        if (prButton && eventSessionId === prButton.getPrSessionId()) {
-          prButton.handlePrSessionComplete(status);
-        }
-        // Handle push session completion
-        if (prButton && eventSessionId === prButton.getPushSessionId()) {
-          prButton.handlePushSessionComplete(status);
-        }
-      } else if (status === 'running' && eventBranchId === branchId) {
-        // Track auto review sessions started by the backend
-        if (isAutoReview) {
-          sessionMgr.autoReviewSessionId = eventSessionId;
-          commands.findFreshAutoReview(branchId).then((review) => {
-            if (review) {
-              sessionMgr.autoReviewId = review.id;
-            }
-          });
-        }
-        // Refresh the timeline so the pending note/commit stub appears immediately.
-        // Skip if a session start is in-flight (pending item has no sessionId yet),
-        // because startBranchSessionWithPendingItem will call loadTimeline after
-        // it gets the sessionId — otherwise pruning can't match the pending item
-        // and both the pending and real items briefly render simultaneously.
-        if (!isAutoReview && !sessionMgr.isSessionStartPending) {
+          commands.invalidateBranchTimeline(branch.id);
           loadTimeline();
+          // Handle PR session completion
+          if (prButton && eventSessionId === prButton.getPrSessionId()) {
+            prButton.handlePrSessionComplete(status);
+          }
+          // Handle push session completion
+          if (prButton && eventSessionId === prButton.getPushSessionId()) {
+            prButton.handlePushSessionComplete(status);
+          }
+        } else if (status === 'running' && eventBranchId === branchId) {
+          // Track auto review sessions started by the backend
+          if (isAutoReview) {
+            sessionMgr.autoReviewSessionId = eventSessionId;
+            commands.findFreshAutoReview(branchId).then((review) => {
+              if (review) {
+                sessionMgr.autoReviewId = review.id;
+              }
+            });
+          }
+          // Refresh the timeline so the pending note/commit stub appears immediately.
+          // Skip if a session start is in-flight (pending item has no sessionId yet),
+          // because startBranchSessionWithPendingItem will call loadTimeline after
+          // it gets the sessionId — otherwise pruning can't match the pending item
+          // and both the pending and real items briefly render simultaneously.
+          if (!isAutoReview && !sessionMgr.isSessionStartPending) {
+            loadTimeline();
+          }
         }
       }
-    }).then((unlisten) => {
-      unlistenStatus = unlisten;
-    });
+    );
 
     return () => {
-      unlistenStatus?.();
+      unlistenStatus();
     };
   });
 
   // Listen for git-state-updated events emitted by refresh_branch_git_state.
   // Merges the fresh git state into the existing timeline without a full reload.
-  let unlistenGitState: UnlistenFn | null = null;
   $effect(() => {
     const branchId = branch.id;
 
-    listenToEvent<{ branchId: string; gitState: BranchGitState }>(
+    const unlistenGitState = listenToEvent<{ branchId: string; gitState: BranchGitState }>(
       'git-state-updated',
       (payload) => {
         if (payload.branchId !== branchId) return;
@@ -686,12 +681,10 @@
         }
         refreshingGitState = false;
       }
-    ).then((unlisten) => {
-      unlistenGitState = unlisten;
-    });
+    );
 
     return () => {
-      unlistenGitState?.();
+      unlistenGitState();
     };
   });
 

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -197,8 +197,6 @@
   // More menu state
   let openerApps = $state<OpenerApp[]>([]);
 
-  let unlistenActionStatus: UnlistenFn | null = null;
-  let unlistenRunPhaseChanged: UnlistenFn | null = null;
   let unlistenRepoActionsDetection: UnlistenFn | null = null;
 
   function handleActionsChanged(event: CustomEvent) {
@@ -210,7 +208,7 @@
   $effect(() => {
     const branchId = branch.id;
 
-    listenToEvent<ActionStatusEvent>('action_status', (payload) => {
+    const unlistenActionStatus = listenToEvent<ActionStatusEvent>('action_status', (payload) => {
       // Only process events for this branch
       if (payload.branchId !== branchId) {
         return;
@@ -281,22 +279,18 @@
           }, displayTime);
         }
       }
-    }).then((unlisten) => {
-      unlistenActionStatus = unlisten;
     });
 
-    listenToRunPhaseChanged((event) => {
+    const unlistenRunPhaseChanged = listenToRunPhaseChanged((event) => {
       if (event.branchId === branchId) {
         runPhases.set(event.executionId, event.phase);
         runPhases = new Map(runPhases);
       }
-    }).then((unlisten) => {
-      unlistenRunPhaseChanged = unlisten;
     });
 
     return () => {
-      unlistenActionStatus?.();
-      unlistenRunPhaseChanged?.();
+      unlistenActionStatus();
+      unlistenRunPhaseChanged();
     };
   });
 
@@ -306,12 +300,10 @@
     getAvailableOpeners().then((apps) => (openerApps = apps));
     window.addEventListener('project-actions-changed', handleActionsChanged as EventListener);
 
-    listenToRepoActionsDetection((event) => {
+    unlistenRepoActionsDetection = listenToRepoActionsDetection((event) => {
       if (!event.detecting) {
         loadActions();
       }
-    }).then((unlisten) => {
-      unlistenRepoActionsDetection = unlisten;
     });
 
     window.addEventListener('keydown', handleAltDown);
@@ -319,8 +311,6 @@
   });
 
   onDestroy(() => {
-    unlistenActionStatus?.();
-    unlistenRunPhaseChanged?.();
     unlistenRepoActionsDetection?.();
     window.removeEventListener('project-actions-changed', handleActionsChanged as EventListener);
     window.removeEventListener('keydown', handleAltDown);

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -153,35 +153,32 @@
   let showForcePushDialog = $state(false);
 
   // =========================================================================
-  // Event listeners for PR status (fix race condition by awaiting promises)
+  // Event listeners for PR status
   // =========================================================================
   $effect(() => {
     const branchId = branch.id;
 
-    const unlistenStatusPromise = listenToEvent<PrStatusChangedEvent>(
-      'pr-status-changed',
-      (payload) => {
-        if (payload.branchId === branchId) {
-          prStatusState = payload.prState;
-          prStatusChecks = payload.prChecksStatus;
-          prStatusReviewDecision = payload.prReviewDecision;
-          prStatusMergeable = payload.prMergeable;
-          prStatusDraft = payload.prDraft;
-          prHeadSha = payload.prHeadSha;
-          prFetchedAt = payload.prFetchedAt;
-          failedChecks = payload.failedChecks ?? [];
-          prStatusCleared = false;
-          // Update the polling service with the new checks status
-          prPollingService.updateChecksStatus(
-            branchId,
-            branch.projectId,
-            payload.prChecksStatus === 'PENDING'
-          );
-        }
+    const unlistenStatus = listenToEvent<PrStatusChangedEvent>('pr-status-changed', (payload) => {
+      if (payload.branchId === branchId) {
+        prStatusState = payload.prState;
+        prStatusChecks = payload.prChecksStatus;
+        prStatusReviewDecision = payload.prReviewDecision;
+        prStatusMergeable = payload.prMergeable;
+        prStatusDraft = payload.prDraft;
+        prHeadSha = payload.prHeadSha;
+        prFetchedAt = payload.prFetchedAt;
+        failedChecks = payload.failedChecks ?? [];
+        prStatusCleared = false;
+        // Update the polling service with the new checks status
+        prPollingService.updateChecksStatus(
+          branchId,
+          branch.projectId,
+          payload.prChecksStatus === 'PENDING'
+        );
       }
-    );
+    });
 
-    const unlistenClearedPromise = listenToEvent<string>('pr-status-cleared', (clearedBranchId) => {
+    const unlistenCleared = listenToEvent<string>('pr-status-cleared', (clearedBranchId) => {
       if (clearedBranchId === branchId) {
         prStatusState = null;
         prStatusChecks = null;
@@ -197,8 +194,8 @@
     });
 
     return () => {
-      unlistenStatusPromise.then((fn) => fn());
-      unlistenClearedPromise.then((fn) => fn());
+      unlistenStatus();
+      unlistenCleared();
     };
   });
 

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { listenToEvent, type UnlistenFn } from '../../transport';
+  import { listenToEvent } from '../../transport';
   import { Send } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import { alerts } from '../../shared/alerts.svelte';
@@ -94,17 +94,14 @@
 
     document.addEventListener('keydown', handleGlobalKeydown);
 
-    let unlisten: UnlistenFn | null = null;
-    listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
+    const unlisten = listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
       if (payload.branchId !== branchId) return;
       void refreshQueueState(true);
-    }).then((fn) => {
-      unlisten = fn;
     });
 
     return () => {
       document.removeEventListener('keydown', handleGlobalKeydown);
-      unlisten?.();
+      unlisten();
     };
   });
 

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -6,7 +6,7 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { getWindowSync, listenToEvent, type UnlistenFn } from '../../transport';
+  import { getWindowSync, listenToEvent } from '../../transport';
   import type {
     Project,
     ProjectRepo,
@@ -105,8 +105,7 @@
     const onNewProject = () => handleNewProject();
     window.addEventListener('staged:new-project', onNewProject);
 
-    let unlistenDetection: (() => void) | undefined;
-    listenToRepoActionsDetection((event) => {
+    const unlistenDetection = listenToRepoActionsDetection((event) => {
       const matchingProjectIds = projects
         .filter((p) => p.githubRepo === event.githubRepo && p.subpath === event.subpath)
         .map((p) => p.id);
@@ -121,45 +120,42 @@
         }
       }
       detectingProjectIds = next;
-    }).then((unlisten) => {
-      unlistenDetection = unlisten;
     });
 
     // Listen for backend-driven setup progress events. The backend emits this
     // after repo creation, after worktree setup, and after prerun actions.
     // We only refresh display state here — setup itself is owned by the backend.
-    let unlistenProjectRepoAdded: UnlistenFn | undefined;
-    listenToEvent<string>('project-setup-progress', async (projectId) => {
-      console.log('[ProjectHome] project-setup-progress event for project', projectId);
-      try {
-        const [projectsList, branches, repos] = await Promise.all([
-          commands.listProjects(),
-          commands.listBranchesForProject(projectId),
-          commands.listProjectRepos(projectId),
-        ]);
-        setProjects(projectsList);
-        projects = projectsList;
-        const mergedBranches = mergeBranchesPreservingWorktree(
-          branchesByProject.get(projectId) || [],
-          branches
-        );
-        branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
-        commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
-        workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);
-        replaceProjectRepos(projectId, repos);
-        void repoBadgeStore.ensureForRepos(
-          repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
-        );
-      } catch (e) {
-        console.error('[ProjectHome] Failed to refresh project after setup progress:', e);
+    const unlistenProjectRepoAdded = listenToEvent<string>(
+      'project-setup-progress',
+      async (projectId) => {
+        console.log('[ProjectHome] project-setup-progress event for project', projectId);
+        try {
+          const [projectsList, branches, repos] = await Promise.all([
+            commands.listProjects(),
+            commands.listBranchesForProject(projectId),
+            commands.listProjectRepos(projectId),
+          ]);
+          setProjects(projectsList);
+          projects = projectsList;
+          const mergedBranches = mergeBranchesPreservingWorktree(
+            branchesByProject.get(projectId) || [],
+            branches
+          );
+          branchesByProject = new Map(branchesByProject).set(projectId, mergedBranches);
+          commands.invalidateProjectBranchTimelines(mergedBranches.map((b) => b.id));
+          workspaceLifecycle.enqueueInitialSetup(projectId, mergedBranches);
+          replaceProjectRepos(projectId, repos);
+          void repoBadgeStore.ensureForRepos(
+            repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+          );
+        } catch (e) {
+          console.error('[ProjectHome] Failed to refresh project after setup progress:', e);
+        }
       }
-    }).then((unlisten) => {
-      unlistenProjectRepoAdded = unlisten;
-    });
+    );
 
     // Listen for PR status changes to update branch state
-    let unlistenPrStatus: UnlistenFn | undefined;
-    listenToEvent<PrStatusChangedEvent>('pr-status-changed', (payload) => {
+    const unlistenPrStatus = listenToEvent<PrStatusChangedEvent>('pr-status-changed', (payload) => {
       // Find the project that contains this branch and update it
       for (const [projectId, branches] of branchesByProject.entries()) {
         const branchIndex = branches.findIndex((b) => b.id === payload.branchId);
@@ -180,34 +176,32 @@
           break;
         }
       }
-    }).then((unlisten) => {
-      unlistenPrStatus = unlisten;
     });
 
     // Refresh a project's branches when a commit session completes so the
     // sprout/draft-PR icon flips as soon as the first commit lands.
-    let unlistenSessionStatus: UnlistenFn | undefined;
-    listenToEvent<SessionStatusPayload>('session-status-changed', async (payload) => {
-      if (payload.status !== 'completed') return;
-      if (payload.sessionType !== 'commit') return;
-      const projectId = payload.projectId;
-      if (!projectId || !branchesByProject.has(projectId)) return;
-      try {
-        const branches = await commands.listBranchesForProject(projectId);
-        branchesByProject = new Map(branchesByProject).set(projectId, branches);
-      } catch (e) {
-        console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
+    const unlistenSessionStatus = listenToEvent<SessionStatusPayload>(
+      'session-status-changed',
+      async (payload) => {
+        if (payload.status !== 'completed') return;
+        if (payload.sessionType !== 'commit') return;
+        const projectId = payload.projectId;
+        if (!projectId || !branchesByProject.has(projectId)) return;
+        try {
+          const branches = await commands.listBranchesForProject(projectId);
+          branchesByProject = new Map(branchesByProject).set(projectId, branches);
+        } catch (e) {
+          console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
+        }
       }
-    }).then((unlisten) => {
-      unlistenSessionStatus = unlisten;
-    });
+    );
 
     return () => {
       window.removeEventListener('staged:new-project', onNewProject);
-      unlistenDetection?.();
-      unlistenProjectRepoAdded?.();
-      unlistenPrStatus?.();
-      unlistenSessionStatus?.();
+      unlistenDetection();
+      unlistenProjectRepoAdded();
+      unlistenPrStatus();
+      unlistenSessionStatus();
       workspaceLifecycle.stop();
       projectRunActionsStore.stopListening();
     };

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -12,6 +12,7 @@
     ProjectRepo,
     Branch,
     PrStatusChangedEvent,
+    SessionStatusPayload,
     StoreIncompatibility,
   } from '../../types';
   import * as commands from '../../api/commands';
@@ -183,11 +184,30 @@
       unlistenPrStatus = unlisten;
     });
 
+    // Refresh a project's branches when a commit session completes so the
+    // sprout/draft-PR icon flips as soon as the first commit lands.
+    let unlistenSessionStatus: UnlistenFn | undefined;
+    listenToEvent<SessionStatusPayload>('session-status-changed', async (payload) => {
+      if (payload.status !== 'completed') return;
+      if (payload.sessionType !== 'commit') return;
+      const projectId = payload.projectId;
+      if (!projectId || !branchesByProject.has(projectId)) return;
+      try {
+        const branches = await commands.listBranchesForProject(projectId);
+        branchesByProject = new Map(branchesByProject).set(projectId, branches);
+      } catch (e) {
+        console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
+      }
+    }).then((unlisten) => {
+      unlistenSessionStatus = unlisten;
+    });
+
     return () => {
       window.removeEventListener('staged:new-project', onNewProject);
       unlistenDetection?.();
       unlistenProjectRepoAdded?.();
       unlistenPrStatus?.();
+      unlistenSessionStatus?.();
       workspaceLifecycle.stop();
       projectRunActionsStore.stopListening();
     };

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -460,47 +460,45 @@
     };
     window.addEventListener('timeline-invalidated', onTimelineInvalidated);
 
-    let unlistenSession: (() => void) | undefined;
-    listenToEvent<{ sessionId: string; status: string; projectId?: string }>(
-      'session-status-changed',
-      async (payload) => {
-        const { sessionId, status, projectId } = payload;
-        if (projectId !== project.id) return;
+    const unlistenSession = listenToEvent<{
+      sessionId: string;
+      status: string;
+      projectId?: string;
+    }>('session-status-changed', async (payload) => {
+      const { sessionId, status, projectId } = payload;
+      if (projectId !== project.id) return;
 
-        if (status === 'running') {
-          // Bridge: track until the stub (already loaded by startProjectSession) is
-          // updated with an authoritative sessionStatus on the terminal event.
-          activeSessionIds = new Set([...activeSessionIds, sessionId]);
-          return;
-        }
-
-        if (status === 'completed' || status === 'error' || status === 'cancelled') {
-          const next = new Set(activeSessionIds);
-          next.delete(sessionId);
-          activeSessionIds = next;
-
-          // Surgically update just the affected note instead of reloading all
-          const updatedNote = await commands.getProjectNoteBySession(sessionId);
-          if (updatedNote) {
-            projectNotes = projectNotes.map((n) => (n.id === updatedNote.id ? updatedNote : n));
-          } else {
-            // Note was filtered out (e.g. deleted) — remove from local list
-            projectNotes = projectNotes.filter((n) => n.sessionId !== sessionId);
-          }
-
-          // Invalidate timeline caches so hashtag items pick up new commits/notes
-          for (const b of branches) {
-            commands.invalidateBranchTimeline(b.id);
-          }
-          hashtagVersion++;
-        }
+      if (status === 'running') {
+        // Bridge: track until the stub (already loaded by startProjectSession) is
+        // updated with an authoritative sessionStatus on the terminal event.
+        activeSessionIds = new Set([...activeSessionIds, sessionId]);
+        return;
       }
-    ).then((unlisten) => {
-      unlistenSession = unlisten;
+
+      if (status === 'completed' || status === 'error' || status === 'cancelled') {
+        const next = new Set(activeSessionIds);
+        next.delete(sessionId);
+        activeSessionIds = next;
+
+        // Surgically update just the affected note instead of reloading all
+        const updatedNote = await commands.getProjectNoteBySession(sessionId);
+        if (updatedNote) {
+          projectNotes = projectNotes.map((n) => (n.id === updatedNote.id ? updatedNote : n));
+        } else {
+          // Note was filtered out (e.g. deleted) — remove from local list
+          projectNotes = projectNotes.filter((n) => n.sessionId !== sessionId);
+        }
+
+        // Invalidate timeline caches so hashtag items pick up new commits/notes
+        for (const b of branches) {
+          commands.invalidateBranchTimeline(b.id);
+        }
+        hashtagVersion++;
+      }
     });
 
     return () => {
-      unlistenSession?.();
+      unlistenSession();
       window.removeEventListener('timeline-invalidated', onTimelineInvalidated);
     };
   });

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -20,6 +20,7 @@
     ProjectRepo,
     Branch,
     PrStatusChangedEvent,
+    SessionStatusPayload,
     WorkspaceStatus,
   } from '../../types';
   import * as commands from '../../api/commands';
@@ -320,12 +321,31 @@
       unlistenPrStatus = unlisten;
     });
 
+    // Refresh a project's branches when a commit session completes so the
+    // sprout/draft-PR icon flips as soon as the first commit lands.
+    let unlistenSessionStatus: UnlistenFn | undefined;
+    listenToEvent<SessionStatusPayload>('session-status-changed', async (payload) => {
+      if (payload.status !== 'completed') return;
+      if (payload.sessionType !== 'commit') return;
+      const projectId = payload.projectId;
+      if (!projectId || !projectBranches.has(projectId)) return;
+      try {
+        const branches = await commands.listBranchesForProject(projectId);
+        projectBranches = new Map(projectBranches).set(projectId, branches);
+      } catch (e) {
+        console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
+      }
+    }).then((unlisten) => {
+      unlistenSessionStatus = unlisten;
+    });
+
     return () => {
       projectRunActionsStore.stopListening();
       window.removeEventListener('staged:new-project', onNewProject);
       window.removeEventListener('staged:project-delete-start', onProjectDeleteStart);
       window.removeEventListener('staged:project-delete-end', onProjectDeleteEnd);
       unlistenPrStatus?.();
+      unlistenSessionStatus?.();
     };
   });
 

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -6,7 +6,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import { fade } from 'svelte/transition';
-  import { listenToEvent, type UnlistenFn } from '../../transport';
+  import { listenToEvent } from '../../transport';
   import {
     Cloud,
     GitPullRequest,
@@ -295,8 +295,7 @@
     window.addEventListener('staged:project-delete-end', onProjectDeleteEnd);
 
     // Listen for PR status changes to update branch state
-    let unlistenPrStatus: UnlistenFn | undefined;
-    listenToEvent<PrStatusChangedEvent>('pr-status-changed', (payload) => {
+    const unlistenPrStatus = listenToEvent<PrStatusChangedEvent>('pr-status-changed', (payload) => {
       // Find the project that contains this branch
       for (const [projectId, branches] of projectBranches.entries()) {
         const branchIndex = branches.findIndex((b) => b.id === payload.branchId);
@@ -317,35 +316,33 @@
           break;
         }
       }
-    }).then((unlisten) => {
-      unlistenPrStatus = unlisten;
     });
 
     // Refresh a project's branches when a commit session completes so the
     // sprout/draft-PR icon flips as soon as the first commit lands.
-    let unlistenSessionStatus: UnlistenFn | undefined;
-    listenToEvent<SessionStatusPayload>('session-status-changed', async (payload) => {
-      if (payload.status !== 'completed') return;
-      if (payload.sessionType !== 'commit') return;
-      const projectId = payload.projectId;
-      if (!projectId || !projectBranches.has(projectId)) return;
-      try {
-        const branches = await commands.listBranchesForProject(projectId);
-        projectBranches = new Map(projectBranches).set(projectId, branches);
-      } catch (e) {
-        console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
+    const unlistenSessionStatus = listenToEvent<SessionStatusPayload>(
+      'session-status-changed',
+      async (payload) => {
+        if (payload.status !== 'completed') return;
+        if (payload.sessionType !== 'commit') return;
+        const projectId = payload.projectId;
+        if (!projectId || !projectBranches.has(projectId)) return;
+        try {
+          const branches = await commands.listBranchesForProject(projectId);
+          projectBranches = new Map(projectBranches).set(projectId, branches);
+        } catch (e) {
+          console.error(`Failed to refresh branches for project ${projectId} after commit:`, e);
+        }
       }
-    }).then((unlisten) => {
-      unlistenSessionStatus = unlisten;
-    });
+    );
 
     return () => {
       projectRunActionsStore.stopListening();
       window.removeEventListener('staged:new-project', onNewProject);
       window.removeEventListener('staged:project-delete-start', onProjectDeleteStart);
       window.removeEventListener('staged:project-delete-end', onProjectDeleteEnd);
-      unlistenPrStatus?.();
-      unlistenSessionStatus?.();
+      unlistenPrStatus();
+      unlistenSessionStatus();
     };
   });
 

--- a/apps/staged/src/lib/features/sessions/PipelineSteps.svelte
+++ b/apps/staged/src/lib/features/sessions/PipelineSteps.svelte
@@ -61,8 +61,8 @@
 
   let unlisten: UnlistenFn | null = null;
 
-  onMount(async () => {
-    unlisten = await listenToEvent<PipelineStepPayload>('pipeline-step-changed', (payload) => {
+  onMount(() => {
+    unlisten = listenToEvent<PipelineStepPayload>('pipeline-step-changed', (payload) => {
       if (payload.sessionId !== sessionId) return;
       const { stepIndex, status, output, error, startedAt, completedAt } = payload;
       if (stepIndex < steps.length) {

--- a/apps/staged/src/lib/features/sessions/SessionLauncher.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionLauncher.svelte
@@ -46,24 +46,21 @@
   // Lifecycle — listen for status events
   // =========================================================================
 
-  onMount(async () => {
-    unlistenStatus = await listenToEvent<SessionStatusPayload>(
-      'session-status-changed',
-      (payload) => {
-        const { sessionId, status, errorMessage } = payload;
-        sessions = sessions.map((s) => {
-          if (s.id === sessionId) {
-            return {
-              ...s,
-              status: status as SessionStatus,
-              errorMessage: errorMessage ?? s.errorMessage,
-              updatedAt: Date.now(),
-            };
-          }
-          return s;
-        });
-      }
-    );
+  onMount(() => {
+    unlistenStatus = listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
+      const { sessionId, status, errorMessage } = payload;
+      sessions = sessions.map((s) => {
+        if (s.id === sessionId) {
+          return {
+            ...s,
+            status: status as SessionStatus,
+            errorMessage: errorMessage ?? s.errorMessage,
+            updatedAt: Date.now(),
+          };
+        }
+        return s;
+      });
+    });
   });
 
   onDestroy(() => {

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -76,7 +76,7 @@
   let unlistenDetection: (() => void) | undefined;
 
   onMount(async () => {
-    listenToRepoActionsDetection((event) => {
+    unlistenDetection = listenToRepoActionsDetection((event) => {
       const ctx = selectedContext;
       if (!ctx) return;
       if (event.githubRepo !== ctx.githubRepo || event.subpath !== (ctx.subpath ?? null)) return;
@@ -84,8 +84,6 @@
       if (!event.detecting) {
         loadActions();
       }
-    }).then((unlisten) => {
-      unlistenDetection = unlisten;
     });
 
     await repoBadgeStore.loadAll();

--- a/apps/staged/src/lib/listeners/sessionStatusListener.ts
+++ b/apps/staged/src/lib/listeners/sessionStatusListener.ts
@@ -23,7 +23,7 @@ import { pushStateStore } from '../stores/pushState.svelte';
 import { sessionRegistry, type SessionType } from '../stores/sessionRegistry.svelte';
 import type { SessionStatus, SessionStatusPayload } from '../types';
 
-export function listenForSessionStatus(): Promise<UnlistenFn> {
+export function listenForSessionStatus(): UnlistenFn {
   return listenToEvent<SessionStatusPayload>('session-status-changed', async (payload) => {
     const {
       sessionId,

--- a/apps/staged/src/lib/stores/projectRunActions.svelte.ts
+++ b/apps/staged/src/lib/stores/projectRunActions.svelte.ts
@@ -38,18 +38,16 @@ class ProjectRunActionsStore {
 
   private unlisteners: UnlistenFn[] = [];
   private initialized = false;
-  private generation = 0;
 
   /**
    * Start listening to global Tauri events.
    * Called when ProjectsList or ProjectHome mounts.
    */
-  async startListening(): Promise<void> {
+  startListening(): void {
     if (this.initialized) return;
     this.initialized = true;
-    const gen = ++this.generation;
 
-    const unlistenStatus = await listenToActionStatus((event: ActionStatusEvent) => {
+    const unlistenStatus = listenToActionStatus((event: ActionStatusEvent) => {
       if (event.actionType !== 'run') return;
 
       if (event.status === 'running') {
@@ -64,24 +62,12 @@ class ProjectRunActionsStore {
       }
     });
 
-    // If stopListening() was called while we were awaiting, clean up immediately.
-    if (gen !== this.generation) {
-      unlistenStatus();
-      return;
-    }
-
-    const unlistenPhase = await listenToRunPhaseChanged((event: RunPhaseChangedEvent) => {
+    const unlistenPhase = listenToRunPhaseChanged((event: RunPhaseChangedEvent) => {
       const { executionId, branchId, phase } = event;
       // Always use addExecution to replace the map entry and bump version
       // consistently — avoids relying on direct mutation of $state internals.
       this.addExecution(executionId, branchId, phase);
     });
-
-    if (gen !== this.generation) {
-      unlistenStatus();
-      unlistenPhase();
-      return;
-    }
 
     this.unlisteners.push(unlistenStatus, unlistenPhase);
   }
@@ -97,7 +83,6 @@ class ProjectRunActionsStore {
     this.executions = new Map();
     this.branchToProject = new Map();
     this.initialized = false;
-    this.generation++;
     this.version++;
   }
 

--- a/apps/staged/src/lib/transport.ts
+++ b/apps/staged/src/lib/transport.ts
@@ -68,7 +68,9 @@ export function listenToEvent<T>(event: string, callback: (payload: T) => void):
     const u = await listen<T>(event, (e) => callback(e.payload));
     if (cancelled) u();
     else unlisten = u;
-  })();
+  })().catch((e) => {
+    console.error(`[transport] Failed to register listener for event "${event}":`, e);
+  });
 
   return () => {
     cancelled = true;

--- a/apps/staged/src/lib/transport.ts
+++ b/apps/staged/src/lib/transport.ts
@@ -47,19 +47,33 @@ export type UnlistenFn = () => void;
 /**
  * Listen to a backend event. In Tauri mode this delegates to the Tauri event
  * API; in web mode it is stubbed out.
+ *
+ * Returns a synchronous unlisten function. Registration happens asynchronously
+ * in the background; if the unlisten is called before registration finishes,
+ * the eventual listener is torn down on arrival. This makes the helper safe to
+ * use directly in `onMount` cleanup blocks without an intermediate
+ * `Promise<UnlistenFn>` reference that could race the unmount.
  */
-export async function listenToEvent<T>(
-  event: string,
-  callback: (payload: T) => void
-): Promise<UnlistenFn> {
-  if (isTauri) {
-    const { listen } = await import('@tauri-apps/api/event');
-    return listen<T>(event, (e) => callback(e.payload));
-  }
+export function listenToEvent<T>(event: string, callback: (payload: T) => void): UnlistenFn {
+  let cancelled = false;
+  let unlisten: UnlistenFn | undefined;
 
-  // TODO(web): restore WebSocket event transport from the `mobile-web` branch
-  console.warn(`[transport] Web mode event listening stubbed out (event: ${event})`);
-  return () => {};
+  void (async () => {
+    if (!isTauri) {
+      // TODO(web): restore WebSocket event transport from the `mobile-web` branch
+      console.warn(`[transport] Web mode event listening stubbed out (event: ${event})`);
+      return;
+    }
+    const { listen } = await import('@tauri-apps/api/event');
+    const u = await listen<T>(event, (e) => callback(e.payload));
+    if (cancelled) u();
+    else unlisten = u;
+  })();
+
+  return () => {
+    cancelled = true;
+    unlisten?.();
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The project sidebar icon stayed on `Sprout` after a project's first commit because `projectBranches` was only populated at mount and never refreshed when commit counts changed. This branch fixes that, plus tightens up the underlying listener plumbing it relies on.

- **Refresh project icon on commit completion** (`011ee0af`, `0ce585a5`): `ProjectsList.svelte` and `ProjectHome.svelte` both listen for `session-status-changed` and re-fetch the affected project's branches when a commit session completes. `ProjectHome` needed the same treatment because it renders the sidebar with its own `branchesByProject` state when viewing a project page.
- **Make `listenToEvent` race-free** (`e91dd329`): `listenToEvent` now returns a synchronous `UnlistenFn` instead of a `Promise<UnlistenFn>`. The returned unlisten captures cancellation state and tears down the eventual listener if invoked before registration resolves. This makes the previously load-bearing `let unlisten; listenToEvent(...).then(u => unlisten = u)` pattern unrepresentable, so a component unmounting between the call and `.then` firing can no longer leak a listener. All consumers across `App.svelte`, `actions.ts`, `sessionStatusListener.ts`, `projectRunActions.svelte.ts`, and the Svelte component callers are updated to the new shape.
- **Surface listener-registration failures** (`1e279298`): the async IIFE introduced by the refactor above was swallowing rejections from `import('@tauri-apps/api/event')` or the initial `listen()` call. Attach a `.catch` that logs the event name and error so failures surface in DevTools.

## Test plan

- [ ] Create a brand new project and make its first commit; verify the sidebar icon transitions off `Sprout` whether viewing the projects landing page or `ProjectHome`.
- [ ] Navigate between pages with active listeners (branches, sessions, project home) and confirm no listener leaks or duplicate handlers.
- [ ] Trigger an action / commit / pipeline step and confirm all event-driven UI updates still fire as before.