### PR TITLE
fix(staged): force-bypass fetch TTL when refreshing git state after push

### DIFF
--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -520,16 +520,24 @@ pub async fn get_branch_timeline(
         .map_err(|e| format!("Timeline task failed: {e}"))?
 }
 
-/// Run a TTL-gated `git fetch` + git state recomputation for a branch,
-/// then emit a `git-state-updated` event so the frontend can merge the
-/// fresh state into the existing timeline.
+/// Run a `git fetch` + git state recomputation for a branch, then emit
+/// a `git-state-updated` event so the frontend can merge the fresh state
+/// into the existing timeline. Defaults to TTL-gated fetching; pass
+/// `force = true` to bypass the TTL (e.g. right after a successful push,
+/// where the caller knows the remote has moved).
 #[tauri::command(rename_all = "camelCase")]
 pub async fn refresh_branch_git_state(
     app: tauri::AppHandle,
     store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
     branch_id: String,
+    force: Option<bool>,
 ) -> Result<(), String> {
     let store = crate::get_store(&store)?;
+    let fetch_mode = if force.unwrap_or(false) {
+        git::FetchMode::Force
+    } else {
+        git::FetchMode::Ttl
+    };
 
     tauri::async_runtime::spawn_blocking(move || {
         let branch = store
@@ -559,7 +567,7 @@ pub async fn refresh_branch_git_state(
                 &resolved_path,
                 &branch.branch_name,
                 &branch.base_branch,
-                git::FetchMode::Ttl,
+                fetch_mode,
             ))
         } else if let Some(ref wd) = workdir {
             let worktree_path = Path::new(&wd.path);
@@ -568,7 +576,7 @@ pub async fn refresh_branch_git_state(
                     worktree_path,
                     &branch.branch_name,
                     &branch.base_branch,
-                    git::FetchMode::Ttl,
+                    fetch_mode,
                 ))
             } else {
                 None

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -404,8 +404,14 @@ export function getBranchTimelineWithRevalidation(branchId: string): {
   };
 }
 
-export function refreshBranchGitState(branchId: string): Promise<void> {
-  return invokeCommand('refresh_branch_git_state', { branchId });
+export function refreshBranchGitState(
+  branchId: string,
+  options: { force?: boolean } = {}
+): Promise<void> {
+  return invokeCommand('refresh_branch_git_state', {
+    branchId,
+    force: options.force ?? false,
+  });
 }
 
 export function invalidateProjectBranchTimelines(branchIds: string[]): void {

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -539,8 +539,10 @@
           pushStateStore.setPushDone(branch.id);
           // Refresh local git state so `upstream.relation` settles back to
           // `inSync` (driving hasUnpushed to false) without optimistically
-          // mutating prHeadSha here.
-          commands.refreshBranchGitState(branch.id).catch((e) => {
+          // mutating prHeadSha here. Force-bypass the TTL: a recent
+          // window-focus or timeline-mount refresh can otherwise short-circuit
+          // the `git fetch` and leave `refs/remotes/origin/<branch>` stale.
+          commands.refreshBranchGitState(branch.id, { force: true }).catch((e) => {
             console.warn('[Staged] Failed to refresh git state after push:', e);
           });
           // Immediately refresh PR status so checks update right away


### PR DESCRIPTION
## Summary

After a successful push from the PR button, the frontend refreshes the branch's git state so `upstream.relation` settles back to `inSync` (clearing `hasUnpushed`). Previously this used the TTL-gated fetch path, so a recent window-focus or timeline-mount refresh could short-circuit the `git fetch` and leave `refs/remotes/origin/<branch>` stale — making the PR button appear unsynced until the next TTL window expired.

This change adds an optional `force` flag to `refresh_branch_git_state` that bypasses the TTL, and the post-push refresh in `BranchCardPrButton` opts in. Other callers continue to use the TTL-gated default.

## Test plan

- [ ] Push a branch via the PR button and verify the button transitions out of "unpushed" without needing a window focus or wait
- [ ] Confirm unrelated refresh paths (window focus, timeline mount) still respect the TTL