### PR TITLE
fix(staged): auto-increment note title on branch-scoped collision

### DIFF
--- a/apps/staged/src-tauri/src/note_commands.rs
+++ b/apps/staged/src-tauri/src/note_commands.rs
@@ -13,8 +13,10 @@ pub fn create_note(
     content: String,
 ) -> Result<NoteTimelineItem, String> {
     let store = crate::get_store(&store)?;
-    let note = crate::store::models::Note::new(&branch_id, &title, &content);
-    store.create_note(&note).map_err(|e| e.to_string())?;
+    let mut note = crate::store::models::Note::new(&branch_id, &title, &content);
+    store
+        .create_note_with_unique_title(&mut note)
+        .map_err(|e| e.to_string())?;
     Ok(NoteTimelineItem {
         id: note.id,
         title: note.title,

--- a/apps/staged/src-tauri/src/store/notes.rs
+++ b/apps/staged/src-tauri/src/store/notes.rs
@@ -8,6 +8,26 @@ use super::{now_timestamp, Store, StoreError};
 impl Store {
     pub fn create_note(&self, note: &Note) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        Self::insert_note(&conn, note)
+    }
+
+    /// Like [`Store::create_note`], but if the requested title collides with
+    /// an existing note on the same branch, append ` (2)`, ` (3)`, … to make
+    /// it unique (filesystem "Untitled (2).txt" convention). Lookup and
+    /// insert run under one connection lock so concurrent saves can't pick
+    /// the same suffix.
+    ///
+    /// Empty titles are left untouched — those are session stubs that get
+    /// their title filled in later by the runner.
+    pub fn create_note_with_unique_title(&self, note: &mut Note) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        if !note.title.is_empty() {
+            note.title = Self::resolve_unique_note_title(&conn, &note.branch_id, &note.title)?;
+        }
+        Self::insert_note(&conn, note)
+    }
+
+    fn insert_note(conn: &rusqlite::Connection, note: &Note) -> Result<(), StoreError> {
         conn.execute(
             "INSERT INTO notes (id, branch_id, session_id, title, content, created_at, updated_at, completed_at, suggested_next_commit_step, suggested_next_note_step)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
@@ -25,6 +45,35 @@ impl Store {
             ],
         )?;
         Ok(())
+    }
+
+    fn resolve_unique_note_title(
+        conn: &rusqlite::Connection,
+        branch_id: &str,
+        base: &str,
+    ) -> Result<String, StoreError> {
+        let mut stmt = conn.prepare("SELECT title FROM notes WHERE branch_id = ?1")?;
+        let titles: Vec<String> = stmt
+            .query_map(params![branch_id], |row| row.get(0))?
+            .collect::<Result<_, _>>()?;
+
+        if !titles.iter().any(|t| t == base) {
+            return Ok(base.to_string());
+        }
+
+        let prefix = format!("{base} (");
+        let max_n = titles
+            .iter()
+            .filter_map(|t| {
+                let rest = t.strip_prefix(&prefix)?;
+                let num = rest.strip_suffix(')')?;
+                let n = num.parse::<u32>().ok()?;
+                (n >= 2).then_some(n)
+            })
+            .max()
+            .unwrap_or(1);
+
+        Ok(format!("{base} ({})", max_n + 1))
     }
 
     pub fn get_note(&self, id: &str) -> Result<Option<Note>, StoreError> {

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -1261,6 +1261,95 @@ fn test_update_note_title_and_content_is_noop_when_unchanged() {
     assert!(after_third.updated_at > after_first.updated_at);
 }
 
+#[test]
+fn test_create_note_with_unique_title_appends_increment_on_collision() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let branch = Branch::new(&project.id, "feature", "main");
+    store.create_branch(&branch).unwrap();
+
+    let mut first = Note::new(&branch.id, "Build log", "first");
+    store.create_note_with_unique_title(&mut first).unwrap();
+    assert_eq!(first.title, "Build log");
+
+    let mut second = Note::new(&branch.id, "Build log", "second");
+    store.create_note_with_unique_title(&mut second).unwrap();
+    assert_eq!(second.title, "Build log (2)");
+
+    let mut third = Note::new(&branch.id, "Build log", "third");
+    store.create_note_with_unique_title(&mut third).unwrap();
+    assert_eq!(third.title, "Build log (3)");
+
+    // Each insert actually landed, with the disambiguated titles persisted.
+    let titles: Vec<_> = store
+        .list_notes_for_branch(&branch.id)
+        .unwrap()
+        .into_iter()
+        .map(|n| n.title)
+        .collect();
+    assert!(titles.contains(&"Build log".to_string()));
+    assert!(titles.contains(&"Build log (2)".to_string()));
+    assert!(titles.contains(&"Build log (3)".to_string()));
+}
+
+#[test]
+fn test_create_note_with_unique_title_picks_max_plus_one_with_gaps() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let branch = Branch::new(&project.id, "feature", "main");
+    store.create_branch(&branch).unwrap();
+
+    // Seed a non-contiguous set: "Build log" and "Build log (5)" exist, but
+    // (2)–(4) do not. macOS-Finder convention says the next pick is (6).
+    let mut base = Note::new(&branch.id, "Build log", "");
+    store.create_note_with_unique_title(&mut base).unwrap();
+    let manual = Note::new(&branch.id, "Build log (5)", "");
+    store.create_note(&manual).unwrap();
+
+    let mut next = Note::new(&branch.id, "Build log", "");
+    store.create_note_with_unique_title(&mut next).unwrap();
+    assert_eq!(next.title, "Build log (6)");
+}
+
+#[test]
+fn test_create_note_with_unique_title_is_scoped_to_branch() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let branch_a = Branch::new(&project.id, "feature-a", "main");
+    let branch_b = Branch::new(&project.id, "feature-b", "main");
+    store.create_branch(&branch_a).unwrap();
+    store.create_branch(&branch_b).unwrap();
+
+    let mut on_a = Note::new(&branch_a.id, "Build log", "");
+    store.create_note_with_unique_title(&mut on_a).unwrap();
+
+    // Same title on a different branch must not trigger a suffix.
+    let mut on_b = Note::new(&branch_b.id, "Build log", "");
+    store.create_note_with_unique_title(&mut on_b).unwrap();
+    assert_eq!(on_b.title, "Build log");
+}
+
+#[test]
+fn test_create_note_with_unique_title_skips_empty_titles() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let branch = Branch::new(&project.id, "feature", "main");
+    store.create_branch(&branch).unwrap();
+
+    // Empty-titled session stubs must stay empty — the runner fills them in
+    // later via update_note_title_and_content.
+    let mut first = Note::new(&branch.id, "", "").with_session("session-1");
+    store.create_note_with_unique_title(&mut first).unwrap();
+    let mut second = Note::new(&branch.id, "", "").with_session("session-2");
+    store.create_note_with_unique_title(&mut second).unwrap();
+    assert_eq!(first.title, "");
+    assert_eq!(second.title, "");
+}
+
 // =============================================================================
 // Repo Actions
 // =============================================================================

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2233,8 +2233,10 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
             let branch_id: String = arg(&args, "branchId")?;
             let title: String = arg(&args, "title")?;
             let content: String = arg(&args, "content")?;
-            let note = crate::store::models::Note::new(&branch_id, &title, &content);
-            store.create_note(&note).map_err(|e| e.to_string())?;
+            let mut note = crate::store::models::Note::new(&branch_id, &title, &content);
+            store
+                .create_note_with_unique_title(&mut note)
+                .map_err(|e| e.to_string())?;
             let item = crate::NoteTimelineItem {
                 id: note.id,
                 title: note.title,


### PR DESCRIPTION
## Summary

When creating a note on a branch, if the requested title collides with an existing note on that same branch, append ` (2)`, ` (3)`, … to disambiguate (matching the macOS-Finder convention). Empty titles are left untouched so session stubs still get their title filled in later by the runner.

- New `Store::create_note_with_unique_title` resolves the suffix and inserts under a single connection lock so concurrent saves can't pick the same number.
- Suffix resolution scans existing titles on the branch only — collisions on other branches don't trigger a bump.
- With non-contiguous gaps (e.g. `Build log` and `Build log (5)` exist), the next pick is `max + 1`.
- Both the Tauri `create_note` command and the web-server `create_note` dispatcher now route through the new path.

## Test plan

- [x] `cargo test` — added unit coverage for collision, gaps, branch scoping, and empty-title bypass