### PR TITLE
feat(staged): show "Force push" on PR button when branch has diverged

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -33,7 +33,7 @@
     type CompletedPushOutcome,
   } from './branchCardHelpers';
   import { buildPrButtonTitle } from './prButtonTooltip';
-  import { shouldShowPushChanges } from './prButtonGitState';
+  import { derivePrPushAction } from './prButtonGitState';
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { prStateStore, type PrState } from '../../stores/prState.svelte';
@@ -107,17 +107,18 @@
   let prStatusDraft = $state<boolean | null>(null);
   let failedChecks = $state<PrFailedCheck[]>([]);
 
-  // Derive hasUnpushed from the git-state upstream relation when available,
+  // Derive push action from the git-state upstream relation when available,
   // falling back to a HEAD/PR SHA comparison only when upstream is missing
   // (e.g. fork PRs without an `origin/<branch>` ref).
-  let hasUnpushed = $derived(
-    shouldShowPushChanges({
+  let pushAction = $derived(
+    derivePrPushAction({
       prNumber: branch.prNumber,
       prState: branch.prState,
       prHeadSha,
       gitState: timeline?.gitState ?? null,
     })
   );
+  let hasUnpushed = $derived(pushAction !== 'none');
 
   // Sync local PR status state when branch prop changes
   let syncedBranchId = $state<string | null>(null);
@@ -357,7 +358,9 @@
     if (pushState === 'pushing') return 'Pushing… (click to view)';
     if (pushState === 'error') return 'Push failed — click for details';
     if (prState === 'created' && hasUnpushed) {
-      return optionHeld ? 'Force push to remote' : 'Push changes to remote';
+      return pushAction === 'forcePush' || optionHeld
+        ? 'Force push to remote'
+        : 'Push changes to remote';
     }
     if (prState === 'created') {
       if (prStatusState === 'MERGED') return 'Merged';
@@ -596,7 +599,7 @@
       return;
     }
     if (prState === 'created' && hasUnpushed && pushState === 'idle') {
-      handlePush(optionHeld);
+      handlePush(pushAction === 'forcePush' || optionHeld);
     } else if (prState === 'created') {
       const url = prUrl ?? cachedPrUrl;
       if (url) {
@@ -683,7 +686,7 @@
       {:else if pushState === 'error'}
         Push failed
       {:else if prState === 'created' && hasUnpushed}
-        {optionHeld ? 'Force push' : 'Push changes'}
+        {pushAction === 'forcePush' || optionHeld ? 'Force push' : 'Push changes'}
       {:else if prState === 'created'}
         {#if prStatusText}
           {prStatusText}

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -599,7 +599,13 @@
       return;
     }
     if (prState === 'created' && hasUnpushed && pushState === 'idle') {
-      handlePush(pushAction === 'forcePush' || optionHeld);
+      const wantsForcePush = pushAction === 'forcePush' || optionHeld;
+      if (wantsForcePush && !optionHeld) {
+        // Force push without an explicit alt override — confirm first.
+        showForcePushDialog = true;
+      } else {
+        handlePush(wantsForcePush);
+      }
     } else if (prState === 'created') {
       const url = prUrl ?? cachedPrUrl;
       if (url) {

--- a/apps/staged/src/lib/features/branches/prButtonGitState.test.ts
+++ b/apps/staged/src/lib/features/branches/prButtonGitState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { shouldShowPushChanges } from './prButtonGitState';
+import { derivePrPushAction, shouldShowPushChanges } from './prButtonGitState';
 import type { BranchGitState, UpstreamRelation } from '../../types';
 
 function makeGitState(
@@ -177,5 +177,134 @@ describe('shouldShowPushChanges', () => {
         }),
       })
     ).toBe(false);
+  });
+});
+
+describe('derivePrPushAction', () => {
+  it("returns 'push' when local is ahead of upstream", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'prsha',
+        gitState: makeGitState('localAhead'),
+      })
+    ).toBe('push');
+  });
+
+  it("returns 'forcePush' when local has diverged from upstream", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'prsha',
+        gitState: makeGitState('diverged'),
+      })
+    ).toBe('forcePush');
+  });
+
+  it("returns 'none' when local is in sync with upstream", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'prsha',
+        gitState: makeGitState('inSync'),
+      })
+    ).toBe('none');
+  });
+
+  it("returns 'none' when origin is ahead of local", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'prsha',
+        gitState: makeGitState('originAhead'),
+      })
+    ).toBe('none');
+  });
+
+  it("returns 'push' for missing upstream with differing SHAs (fork PR fallback)", () => {
+    // We deliberately don't classify fork PRs as 'forcePush' up-front —
+    // the backend's non-FF rejection still drives that path through
+    // showForcePushDialog.
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'prsha',
+        gitState: makeGitState('missing', { headSha: 'localsha' }),
+      })
+    ).toBe('push');
+  });
+
+  it("returns 'none' for missing upstream when SHAs match", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'samesha',
+        gitState: makeGitState('missing', { headSha: 'samesha' }),
+      })
+    ).toBe('none');
+  });
+
+  it("returns 'none' for missing upstream when prHeadSha is null", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: null,
+        gitState: makeGitState('missing'),
+      })
+    ).toBe('none');
+  });
+
+  it("returns 'none' for merged PRs even when local has diverged", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'MERGED',
+        prHeadSha: 'prsha',
+        gitState: makeGitState('diverged'),
+      })
+    ).toBe('none');
+  });
+
+  it("returns 'none' when the branch has no PR yet", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: null,
+        prState: null,
+        prHeadSha: null,
+        gitState: makeGitState('diverged'),
+      })
+    ).toBe('none');
+  });
+
+  it("returns 'none' when git state has not loaded yet", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'prsha',
+        gitState: null,
+      })
+    ).toBe('none');
+  });
+
+  it("returns 'none' when a different branch is checked out (diverged would otherwise apply)", () => {
+    expect(
+      derivePrPushAction({
+        prNumber: 42,
+        prState: 'OPEN',
+        prHeadSha: 'prsha',
+        gitState: makeGitState('diverged', {
+          expectedBranchMatches: false,
+          currentBranch: 'main',
+        }),
+      })
+    ).toBe('none');
   });
 });

--- a/apps/staged/src/lib/features/branches/prButtonGitState.ts
+++ b/apps/staged/src/lib/features/branches/prButtonGitState.ts
@@ -7,33 +7,43 @@ export interface ShouldShowPushChangesInput {
   gitState: BranchGitState | null | undefined;
 }
 
-export function shouldShowPushChanges(input: ShouldShowPushChangesInput): boolean {
+export type PrPushAction = 'none' | 'push' | 'forcePush';
+
+export function derivePrPushAction(input: ShouldShowPushChangesInput): PrPushAction {
   const { prNumber, prState, prHeadSha, gitState } = input;
-  if (!prNumber) return false;
-  if (prState === 'MERGED') return false;
-  if (!gitState) return false;
+  if (!prNumber) return 'none';
+  if (prState === 'MERGED') return 'none';
+  if (!gitState) return 'none';
   // When a different branch is checked out, neither `upstream.relation`
   // (computed against HEAD's upstream) nor `headSha` reflect this PR's
   // branch, so the comparison would be meaningless.
-  if (!gitState.expectedBranchMatches) return false;
+  if (!gitState.expectedBranchMatches) return 'none';
 
   switch (gitState.upstream.relation) {
     case 'localAhead':
+      return 'push';
     case 'diverged':
-      return true;
+      return 'forcePush';
     case 'inSync':
     case 'originAhead':
-      return false;
+      return 'none';
     case 'missing': {
       // Fork PRs may not have origin/<branch>. Fall back to comparing local
-      // HEAD with the PR head SHA reported by GitHub.
-      if (!gitState.headSha || !prHeadSha) return false;
-      return gitState.headSha !== prHeadSha;
+      // HEAD with the PR head SHA reported by GitHub. We can't tell from
+      // this data alone whether the remote diverged, so classify as 'push'
+      // and rely on the backend's non-fast-forward rejection to surface
+      // the force-push dialog if needed.
+      if (!gitState.headSha || !prHeadSha) return 'none';
+      return gitState.headSha !== prHeadSha ? 'push' : 'none';
     }
     default: {
       const _exhaustive: never = gitState.upstream.relation;
       void _exhaustive;
-      return false;
+      return 'none';
     }
   }
+}
+
+export function shouldShowPushChanges(input: ShouldShowPushChangesInput): boolean {
+  return derivePrPushAction(input) !== 'none';
 }


### PR DESCRIPTION
## Summary

When a branch has diverged from its upstream (e.g. after a rebase or amend), the PR button now shows "Force push" instead of "Push changes" without needing to hold the option key. Holding option still forces a force push when the local state alone wouldn't have triggered it.

## Changes

- Introduce `derivePrPushAction` returning `'none' | 'push' | 'forcePush'`, classifying `diverged` as `forcePush` and `localAhead` as `push`.
- `shouldShowPushChanges` is preserved as a thin wrapper for callers that only need the boolean.
- `BranchCardPrButton` derives `pushAction` and uses it for the label, tooltip, and click handler — option-held still forces force push.
- Fork PRs (no `origin/<branch>`) keep the existing fallback: classified as `push`, with the backend's non-FF rejection driving the force-push dialog.
- Adds unit tests covering each upstream relation, fork PR fallback, merged/no-PR/null gitState, and the wrong-branch guard.

## Test plan
- [ ] Branch with local commits ahead of upstream → button reads "Push changes"
- [ ] Branch that has been rebased/amended (diverged) → button reads "Force push" without holding option
- [ ] In-sync branch → no push action shown
- [ ] Holding option on a `localAhead` branch still triggers force push