### PR TITLE
fix(staged): detach env-capture shell from user TTY

### DIFF
--- a/apps/staged/src-tauri/src/shell_env.rs
+++ b/apps/staged/src-tauri/src/shell_env.rs
@@ -484,7 +484,6 @@ async fn capture_shell_env(
     // dies with EIO on read.
     #[cfg(unix)]
     unsafe {
-        use std::os::unix::process::CommandExt;
         // SAFETY: `setsid()` is async-signal-safe.
         cmd.pre_exec(|| {
             libc::setsid();

--- a/apps/staged/src-tauri/src/shell_env.rs
+++ b/apps/staged/src-tauri/src/shell_env.rs
@@ -476,6 +476,22 @@ async fn capture_shell_env(
         .stderr(Stdio::null())
         .kill_on_drop(true);
 
+    // Detach from the parent's controlling TTY so an interactive `$SHELL -ils`
+    // can't `tcsetpgrp` onto the user's terminal or mutate its modes via
+    // rcfiles. Without this, the spawned shell inherits the staged binary's
+    // ctty (the user's real /dev/tty up the chain), and on exit leaves the
+    // user's TTY foreground-PG pointing at a dead PGID — the outer zsh later
+    // dies with EIO on read.
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `setsid()` is async-signal-safe.
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+
     let mut child = cmd.spawn()?;
     {
         let mut stdin = child
@@ -533,6 +549,17 @@ fn capture_shell_env_blocking(
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
+
+    // See `capture_shell_env` for why this is required.
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `setsid()` is async-signal-safe.
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
 
     let mut child = cmd.spawn()?;
     {


### PR DESCRIPTION
## Summary

The interactive `$SHELL -ils` spawned for environment capture inherited the staged binary's controlling TTY (the user's real `/dev/tty`). On exit, the shell could `tcsetpgrp` or mutate terminal modes against that TTY, leaving the foreground process group pointing at a dead PGID — which caused the outer zsh to later die with EIO on read ("terminal killed").

Fix: call `setsid()` in `pre_exec` to detach the spawned shell into its own session with no controlling terminal. Applied to both the async (`capture_shell_env`) and blocking (`capture_shell_env_blocking`) paths.

## Test plan

- [ ] Run staged from a terminal, trigger env capture (e.g. add a repo / open a project), then continue using the parent shell — confirm it no longer dies with EIO.
- [ ] Verify env capture still returns the expected variables.