### PR TITLE
feat(staged): hover parent-branch capsule to preview upstream commits

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -2193,6 +2193,7 @@ pub fn run() {
             // Timeline
             timeline::get_branch_timeline,
             timeline::refresh_branch_git_state,
+            timeline::list_parent_branch_commits,
             timeline::pull_branch_ff_only,
             // Notes
             note_commands::create_note,

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -144,6 +144,38 @@ struct GitStateUpdatedPayload {
     git_state: git::BranchGitState,
 }
 
+/// A single commit on the parent branch that hasn't yet been merged into the
+/// current branch — returned by `list_parent_branch_commits` for the hover
+/// popover on the parent-branch capsule.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParentBranchCommit {
+    pub sha: String,
+    pub short_sha: String,
+    pub subject: String,
+    pub author: String,
+    pub author_email: String,
+    pub timestamp: i64,
+}
+
+fn parse_parent_commit_lines(lines: &[String]) -> Vec<ParentBranchCommit> {
+    let mut commits = Vec::new();
+    for line in lines {
+        let parts: Vec<&str> = line.splitn(6, '|').collect();
+        if parts.len() >= 6 {
+            commits.push(ParentBranchCommit {
+                sha: parts[0].to_string(),
+                short_sha: parts[1].to_string(),
+                subject: parts[2].to_string(),
+                author: parts[3].to_string(),
+                author_email: parts[4].to_string(),
+                timestamp: parts[5].parse().unwrap_or(0),
+            });
+        }
+    }
+    commits
+}
+
 /// Parse `%H|%h|%s|%an|%ae|%ct` formatted commit lines into timeline items,
 /// looking up DB metadata for session linkage.
 fn parse_commit_lines(
@@ -620,6 +652,83 @@ pub async fn refresh_branch_git_state(
     })
     .await
     .map_err(|e| format!("Git state refresh task failed: {e}"))?
+}
+
+/// Return the commits on the parent branch that aren't yet in this branch's
+/// ancestry — i.e. the same `merge-base(HEAD, origin/{base})..origin/{base}`
+/// range that `commitsSinceFork` counts. Read-only against locally cached
+/// refs; the count's own fetch round-trip is what keeps `origin/{base}`
+/// current.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn list_parent_branch_commits(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    branch_id: String,
+) -> Result<Vec<ParentBranchCommit>, String> {
+    let store = crate::get_store(&store)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let branch = store
+            .get_branch(&branch_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+        let base_ref = git::origin_ref_for_branch(&branch.base_branch);
+        let format_arg = "--format=%H|%h|%s|%an|%ae|%ct";
+
+        if let Some(ref ws_name) = branch.workspace_name {
+            let repo_subpath = branches::resolve_branch_workspace_subpath(&store, &branch)?;
+            let range = match branches::run_workspace_git(
+                ws_name,
+                repo_subpath.as_deref(),
+                &["merge-base", &base_ref, "HEAD"],
+            ) {
+                Ok(mb_output) => format!("{}..{base_ref}", mb_output.trim()),
+                Err(_) => base_ref.clone(),
+            };
+            let output = match branches::run_workspace_git(
+                ws_name,
+                repo_subpath.as_deref(),
+                &["log", format_arg, &range],
+            ) {
+                Ok(o) => o,
+                Err(_) => return Ok(Vec::new()),
+            };
+            let lines: Vec<String> = output
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| l.to_string())
+                .collect();
+            return Ok(parse_parent_commit_lines(&lines));
+        }
+
+        let workdir = store
+            .get_workdir_for_branch(&branch_id)
+            .map_err(|e| e.to_string())?;
+        let Some(wd) = workdir else {
+            return Ok(Vec::new());
+        };
+        let worktree_path = Path::new(&wd.path);
+        if !worktree_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let range = match git::cli_run_smart(worktree_path, &["merge-base", &base_ref, "HEAD"]) {
+            Ok(mb_output) => format!("{}..{base_ref}", mb_output.trim()),
+            Err(_) => base_ref.clone(),
+        };
+        let output = match git::cli_run_smart(worktree_path, &["log", format_arg, &range]) {
+            Ok(o) => o,
+            Err(_) => return Ok(Vec::new()),
+        };
+        let lines: Vec<String> = output
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect();
+        Ok(parse_parent_commit_lines(&lines))
+    })
+    .await
+    .map_err(|e| format!("List parent branch commits task failed: {e}"))?
 }
 
 #[tauri::command(rename_all = "camelCase")]

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -688,7 +688,7 @@ pub async fn list_parent_branch_commits(
             let output = match branches::run_workspace_git(
                 ws_name,
                 repo_subpath.as_deref(),
-                &["log", format_arg, &range],
+                &["log", "--max-count=26", format_arg, &range],
             ) {
                 Ok(o) => o,
                 Err(_) => return Ok(Vec::new()),
@@ -716,7 +716,10 @@ pub async fn list_parent_branch_commits(
             Ok(mb_output) => format!("{}..{base_ref}", mb_output.trim()),
             Err(_) => base_ref.clone(),
         };
-        let output = match git::cli_run_smart(worktree_path, &["log", format_arg, &range]) {
+        let output = match git::cli_run_smart(
+            worktree_path,
+            &["log", "--max-count=26", format_arg, &range],
+        ) {
             Ok(o) => o,
             Err(_) => return Ok(Vec::new()),
         };

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -417,6 +417,19 @@ export function refreshBranchGitState(
   });
 }
 
+export interface ParentBranchCommit {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  author: string;
+  authorEmail: string;
+  timestamp: number;
+}
+
+export function listParentBranchCommits(branchId: string): Promise<ParentBranchCommit[]> {
+  return invokeCommand('list_parent_branch_commits', { branchId });
+}
+
 export function invalidateProjectBranchTimelines(branchIds: string[]): void {
   for (const id of branchIds) {
     timelineCache.delete(id);

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1308,6 +1308,7 @@
   {:else if isLocal && !branch.worktreePath && worktreeError}
     <div class="card-header">
       <BranchCardHeaderInfo
+        branchId={branch.id}
         branchName={branch.branchName}
         {repoLabel}
         baseBranch={formatBaseBranch(branch.baseBranch)}
@@ -1347,6 +1348,7 @@
         <Sprout size={14} class="header-icon pr-status-clean" />
       {/if}
       <BranchCardHeaderInfo
+        branchId={branch.id}
         branchName={branch.branchName}
         {repoLabel}
         baseBranch={isRemote

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -3,9 +3,11 @@
   import { AlertTriangle, ChevronRight } from 'lucide-svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
+  import ParentBranchCommitsHover from './ParentBranchCommitsHover.svelte';
   import type { ProjectRepo } from '../../types';
 
   interface Props {
+    branchId?: string;
     branchName: string;
     repoLabel?: ProjectRepo | null;
     baseBranch?: string | null;
@@ -18,6 +20,7 @@
   }
 
   let {
+    branchId,
     branchName,
     repoLabel = null,
     baseBranch = null,
@@ -30,16 +33,26 @@
   }: Props = $props();
 </script>
 
+{#snippet capsule()}
+  <span class="branch-capsule" title={baseBranch}>
+    {baseBranch}{#if parentAheadCount > 0}<span
+        class="ahead-count"
+        transition:fade={{ duration: 150 }}
+      >
+        +{parentAheadCount}</span
+      >{/if}
+  </span>
+{/snippet}
+
 {#snippet parentPill()}
   {#if baseBranch}
-    <span class="branch-capsule" title={baseBranch}>
-      {baseBranch}{#if parentAheadCount > 0}<span
-          class="ahead-count"
-          transition:fade={{ duration: 150 }}
-        >
-          +{parentAheadCount}</span
-        >{/if}
-    </span>
+    {#if parentAheadCount > 0 && branchId}
+      <ParentBranchCommitsHover {branchId} {baseBranch} count={parentAheadCount}>
+        {@render capsule()}
+      </ParentBranchCommitsHover>
+    {:else}
+      {@render capsule()}
+    {/if}
     {#if parentAheadCount > 0 && onRebase}
       <button
         class="rebase-btn"

--- a/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
+++ b/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
@@ -68,18 +68,24 @@
     if (commits !== null || loading) return;
     loading = true;
     error = null;
-    const version = ++loadVersion;
     try {
-      const result = await listParentBranchCommits(branchId);
-      if (version !== loadVersion) return;
-      commits = result;
-    } catch (e) {
-      if (version !== loadVersion) return;
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      if (version === loadVersion) {
-        loading = false;
+      while (open) {
+        const version = ++loadVersion;
+        try {
+          const result = await listParentBranchCommits(branchId);
+          if (version === loadVersion) {
+            commits = result;
+            return;
+          }
+        } catch (e) {
+          if (version === loadVersion) {
+            error = e instanceof Error ? e.message : String(e);
+            return;
+          }
+        }
       }
+    } finally {
+      loading = false;
       await placePopover();
     }
   }

--- a/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
+++ b/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
@@ -188,7 +188,7 @@
     onmouseleave={scheduleClose}
   >
     <div class="popover-header">
-      <span class="popover-title">{baseBranch}</span>
+      <span class="popover-title">Upstream changes in <strong>{baseBranch}</strong></span>
       <span class="popover-count">+{count}</span>
     </div>
     {#if loading && commits === null}
@@ -225,6 +225,7 @@
     display: inline-flex;
     align-items: center;
     min-width: 0;
+    cursor: default;
   }
 
   .commits-popover {

--- a/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
+++ b/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
@@ -102,7 +102,6 @@
   }
 
   function scheduleOpen() {
-    if (count <= 0) return;
     if (closeTimer) {
       clearTimeout(closeTimer);
       closeTimer = null;

--- a/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
+++ b/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
@@ -1,0 +1,348 @@
+<script lang="ts">
+  import { onDestroy, tick } from 'svelte';
+  import type { Snippet } from 'svelte';
+  import { listenToEvent } from '../../transport';
+  import { listParentBranchCommits, type ParentBranchCommit } from '../../commands';
+  import { formatRelativeTimeSeconds } from '../../shared/relativeTime.svelte';
+  import type { BranchGitState } from '../../types';
+
+  interface Props {
+    branchId: string;
+    baseBranch: string;
+    count: number;
+    children: Snippet;
+  }
+
+  let { branchId, baseBranch, count, children }: Props = $props();
+
+  const MAX_ROWS = 25;
+  const OPEN_DELAY_MS = 150;
+  const CLOSE_DELAY_MS = 120;
+  const VIEWPORT_PADDING = 8;
+  const ANCHOR_GAP = 6;
+
+  let open = $state(false);
+  let commits = $state<ParentBranchCommit[] | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+
+  let anchorEl = $state<HTMLSpanElement | null>(null);
+  let popoverEl = $state<HTMLDivElement | null>(null);
+  let left = $state(0);
+  let top = $state(0);
+  let positioned = $state(false);
+
+  let openTimer: ReturnType<typeof setTimeout> | null = null;
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+  let loadVersion = 0;
+
+  function clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(value, max));
+  }
+
+  async function placePopover() {
+    if (!open || !anchorEl) return;
+    await tick();
+    if (!popoverEl) return;
+    const anchorRect = anchorEl.getBoundingClientRect();
+    const popoverRect = popoverEl.getBoundingClientRect();
+    left = clamp(
+      anchorRect.left,
+      VIEWPORT_PADDING,
+      window.innerWidth - popoverRect.width - VIEWPORT_PADDING
+    );
+    const preferredTop = anchorRect.bottom + ANCHOR_GAP;
+    const maxTop = window.innerHeight - popoverRect.height - VIEWPORT_PADDING;
+    if (
+      preferredTop > maxTop &&
+      anchorRect.top - popoverRect.height - ANCHOR_GAP >= VIEWPORT_PADDING
+    ) {
+      top = anchorRect.top - popoverRect.height - ANCHOR_GAP;
+    } else {
+      top = clamp(preferredTop, VIEWPORT_PADDING, Math.max(VIEWPORT_PADDING, maxTop));
+    }
+    positioned = true;
+  }
+
+  async function loadCommits() {
+    if (commits !== null || loading) return;
+    loading = true;
+    error = null;
+    const version = ++loadVersion;
+    try {
+      const result = await listParentBranchCommits(branchId);
+      if (version !== loadVersion) return;
+      commits = result;
+    } catch (e) {
+      if (version !== loadVersion) return;
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      if (version === loadVersion) {
+        loading = false;
+      }
+      await placePopover();
+    }
+  }
+
+  function cancelTimers() {
+    if (openTimer) {
+      clearTimeout(openTimer);
+      openTimer = null;
+    }
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+  }
+
+  function scheduleOpen() {
+    if (count <= 0) return;
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+    if (open || openTimer) return;
+    openTimer = setTimeout(() => {
+      openTimer = null;
+      open = true;
+      positioned = false;
+      void loadCommits();
+      void placePopover();
+    }, OPEN_DELAY_MS);
+  }
+
+  function scheduleClose() {
+    if (openTimer) {
+      clearTimeout(openTimer);
+      openTimer = null;
+    }
+    if (!open || closeTimer) return;
+    closeTimer = setTimeout(() => {
+      closeTimer = null;
+      open = false;
+      positioned = false;
+    }, CLOSE_DELAY_MS);
+  }
+
+  $effect(() => {
+    const unlisten = listenToEvent<{ branchId: string; gitState: BranchGitState }>(
+      'git-state-updated',
+      (payload) => {
+        if (payload.branchId !== branchId) return;
+        commits = null;
+        loadVersion++;
+        if (open) {
+          void loadCommits();
+        }
+      }
+    );
+    return () => unlisten();
+  });
+
+  $effect(() => {
+    if (!open) return;
+    const handler = () => {
+      if (open) void placePopover();
+    };
+    window.addEventListener('resize', handler);
+    window.addEventListener('scroll', handler, true);
+    return () => {
+      window.removeEventListener('resize', handler);
+      window.removeEventListener('scroll', handler, true);
+    };
+  });
+
+  onDestroy(() => {
+    cancelTimers();
+  });
+
+  const visibleCommits = $derived(commits?.slice(0, MAX_ROWS) ?? []);
+  const overflowCount = $derived(commits ? Math.max(0, count - visibleCommits.length) : 0);
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<span
+  class="hover-anchor"
+  bind:this={anchorEl}
+  onmouseenter={scheduleOpen}
+  onmouseleave={scheduleClose}
+>
+  {@render children()}
+</span>
+
+{#if open}
+  <div
+    class="commits-popover"
+    role="tooltip"
+    aria-label="Upstream commits on {baseBranch}"
+    bind:this={popoverEl}
+    style:left={`${left}px`}
+    style:top={`${top}px`}
+    style:visibility={positioned ? 'visible' : 'hidden'}
+    onmouseenter={() => {
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+        closeTimer = null;
+      }
+    }}
+    onmouseleave={scheduleClose}
+  >
+    <div class="popover-header">
+      <span class="popover-title">{baseBranch}</span>
+      <span class="popover-count">+{count}</span>
+    </div>
+    {#if loading && commits === null}
+      <div class="popover-status">Loading…</div>
+    {:else if error}
+      <div class="popover-status popover-error">{error}</div>
+    {:else if commits && commits.length === 0}
+      <div class="popover-status">No upstream commits available.</div>
+    {:else}
+      <ul class="commit-list">
+        {#each visibleCommits as commit (commit.sha)}
+          <li class="commit-row">
+            <div class="commit-main">
+              <div class="commit-subject" title={commit.subject}>{commit.subject}</div>
+              <div class="commit-meta">
+                <span class="commit-author" title={commit.authorEmail}>{commit.author}</span>
+                <span class="commit-dot">·</span>
+                <span class="commit-time">{formatRelativeTimeSeconds(commit.timestamp)}</span>
+              </div>
+            </div>
+            <span class="commit-sha">{commit.shortSha}</span>
+          </li>
+        {/each}
+      </ul>
+      {#if overflowCount > 0}
+        <div class="popover-more">… +{overflowCount} more</div>
+      {/if}
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .hover-anchor {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .commits-popover {
+    position: fixed;
+    z-index: 1100;
+    min-width: 280px;
+    max-width: min(420px, calc(100vw - 16px));
+    max-height: min(360px, calc(100vh - 16px));
+    overflow-y: auto;
+    padding: 6px;
+    border: 1px solid var(--border-muted);
+    border-radius: 8px;
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-elevated);
+    color: var(--text-primary);
+    font-size: var(--size-xs);
+  }
+
+  .popover-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 4px 8px 6px;
+    border-bottom: 1px solid var(--border-subtle);
+    margin-bottom: 4px;
+  }
+
+  .popover-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .popover-count {
+    font-weight: 600;
+    color: var(--ui-accent);
+    flex-shrink: 0;
+  }
+
+  .popover-status {
+    padding: 8px;
+    color: var(--text-muted);
+  }
+
+  .popover-error {
+    color: var(--ui-warning, var(--status-modified));
+  }
+
+  .commit-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .commit-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 6px;
+  }
+
+  .commit-row + .commit-row {
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  .commit-main {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .commit-subject {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .commit-meta {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    color: var(--text-faint);
+    font-size: var(--size-xxs, 11px);
+    margin-top: 2px;
+  }
+
+  .commit-author {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .commit-dot {
+    flex-shrink: 0;
+  }
+
+  .commit-time {
+    flex-shrink: 0;
+  }
+
+  .commit-sha {
+    flex-shrink: 0;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    color: var(--text-faint);
+    font-size: var(--size-xxs, 11px);
+    padding-top: 2px;
+  }
+
+  .popover-more {
+    padding: 6px 8px;
+    color: var(--text-faint);
+    border-top: 1px solid var(--border-subtle);
+    margin-top: 2px;
+  }
+</style>


### PR DESCRIPTION
## Summary

Adds a hover popover on the parent-branch capsule that previews the upstream commits powering the `+N` badge (`merge-base(HEAD, origin/{base})..origin/{base}`).

- New `list_parent_branch_commits` Tauri command that returns the same range as the badge count, capped at 26 rows (MAX_ROWS + 1) on both workspace and worktree paths to bound the IPC payload and defang the `origin/<base>` fallback if `merge-base` fails.
- `ParentBranchCommitsHover` Svelte component that lazy-loads the range on hover, renders up to 25 rows + a `+N more` summary, and invalidates on `git-state-updated`.
- Stale-version retries: if `git-state-updated` fires mid-fetch, the in-flight call would previously leave `loading` set forever; now we loop while open and always clear `loading` in `finally`.
- Polish: no I-beam cursor on the capsule; header reads "Upstream changes in <baseBranch>" so it doesn't repeat the capsule label.

## Test plan

- [ ] Hover the parent-branch capsule on a branch with `+N > 0`; verify the popover lists the same upstream commits.
- [ ] Trigger a `git-state-updated` (e.g. fetch) while the popover is open; verify it refreshes instead of getting stuck on "Loading…".
- [ ] Open on a branch hundreds of commits behind base; verify only 26 rows cross IPC and the popover shows 25 + "more" summary.