### PR TITLE
fix(staged): branch card footer styling and dialog/hashtag dropdown fixes

### DIFF
--- a/apps/staged/src-tauri/Cargo.lock
+++ b/apps/staged/src-tauri/Cargo.lock
@@ -1276,10 +1276,12 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "futures",
+ "nix",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -224,6 +224,7 @@ mark.search-match-current {
 }
 
 .hashtag-badge svg {
+  display: inline-block; /* override Tailwind preflight's `svg { display: block }` */
   width: 12px;
   height: 12px;
   vertical-align: middle;

--- a/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
@@ -31,6 +31,7 @@
       'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
+    onOpenAutoFocus={(e) => e.preventDefault()}
     {...restProps}
   >
     {@render children?.()}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1485,26 +1485,18 @@
                   }}
                 />
                 {#if hasCodeChanges}
-                  <Tooltip.Root>
-                    <Tooltip.Trigger>
-                      {#snippet child({ props })}
-                        <Button
-                          {...props}
-                          variant="outline"
-                          size="sm"
-                          onclick={() => {
-                            reviewDiffTarget = null;
-                            showBranchDiff = true;
-                          }}
-                          class="text-xs"
-                        >
-                          <FileDiff size={13} />
-                          <span>Diff</span>
-                        </Button>
-                      {/snippet}
-                    </Tooltip.Trigger>
-                    <Tooltip.Content>View diff</Tooltip.Content>
-                  </Tooltip.Root>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onclick={() => {
+                      reviewDiffTarget = null;
+                      showBranchDiff = true;
+                    }}
+                    class="text-xs"
+                  >
+                    <FileDiff size={13} />
+                    <span>Diff</span>
+                  </Button>
                 {/if}
               </div>
             {/if}

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -657,83 +657,89 @@
   }
 </script>
 
+{#snippet prButton(props: Record<string, unknown>)}
+  <span {...props} class="inline-flex">
+    <Button
+      variant="outline"
+      size="sm"
+      class={[
+        'gap-1.5 whitespace-nowrap text-xs font-medium [&_svg]:!size-3.5',
+        prState === 'creating' && 'border-[var(--border-muted)]',
+        (prState === 'error' || pushState === 'error') &&
+          'border-destructive text-destructive hover:bg-[var(--ui-danger-bg)] hover:text-destructive',
+        pushState === 'pushing' && 'cursor-default border-[var(--border-muted)]',
+        prState === 'created' && prStatusState === 'MERGED' && '[&_svg]:text-[var(--status-added)]',
+      ]}
+      onclick={handlePrButtonClick}
+      disabled={showPushErrorDialog || showForcePushDialog || showPrErrorDialog}
+    >
+      {#if pushState === 'pushing'}
+        <Spinner size={13} />
+      {:else if pushState === 'error'}
+        <AlertCircle size={13} />
+      {:else if prState === 'creating'}
+        <Spinner size={13} />
+      {:else if prState === 'error'}
+        <AlertCircle size={13} />
+      {:else if prState === 'created' && prStatusState === 'MERGED'}
+        <GitMerge size={13} />
+      {:else if prState === 'created' && hasUnpushed}
+        <GitPullRequestDraft size={13} />
+      {:else if prState === 'created'}
+        <GitPullRequestArrow size={13} />
+      {:else}
+        <GitPullRequestCreateArrow size={13} />
+      {/if}
+      <span>
+        {#if pushState === 'pushing'}
+          Pushing…
+        {:else if pushState === 'error'}
+          Push failed
+        {:else if prState === 'created' && hasUnpushed}
+          {pushAction === 'forcePush' || optionHeld ? 'Force push' : 'Push changes'}
+        {:else if prState === 'created'}
+          {#if prStatusText}
+            {prStatusText}
+          {:else}
+            View PR{#if branch.prNumber}&nbsp;#{branch.prNumber}{/if}
+          {/if}
+        {:else if prState === 'creating'}
+          Creating PR…
+        {:else if prState === 'error'}
+          PR failed
+        {:else}
+          {optionHeld ? 'Create draft PR' : 'Create PR'}
+        {/if}
+      </span>
+      {#if prStatusStale}
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            {#snippet child({ props: staleProps })}
+              <span class="pr-status-stale" {...staleProps}>!</span>
+            {/snippet}
+          </Tooltip.Trigger>
+          <Tooltip.Content>PR status may be outdated</Tooltip.Content>
+        </Tooltip.Root>
+      {:else if prStatusIndicator}
+        <span class="pr-status-indicator {prStatusIndicator}"></span>
+      {/if}
+    </Button>
+  </span>
+{/snippet}
+
 {#if hasCodeChanges || branch.prNumber}
-  <Tooltip.Root>
-    <Tooltip.Trigger>
-      {#snippet child({ props })}
-        <span {...props} class="inline-flex">
-          <Button
-            variant="outline"
-            size="sm"
-            class={[
-              'gap-1.5 whitespace-nowrap text-xs font-medium [&_svg]:!size-3.5',
-              prState === 'creating' && 'border-[var(--border-muted)]',
-              (prState === 'error' || pushState === 'error') &&
-                'border-destructive text-destructive hover:bg-[var(--ui-danger-bg)] hover:text-destructive',
-              pushState === 'pushing' && 'cursor-default border-[var(--border-muted)]',
-              prState === 'created' &&
-                prStatusState === 'MERGED' &&
-                '[&_svg]:text-[var(--status-added)]',
-            ]}
-            onclick={handlePrButtonClick}
-            disabled={showPushErrorDialog || showForcePushDialog || showPrErrorDialog}
-          >
-            {#if pushState === 'pushing'}
-              <Spinner size={13} />
-            {:else if pushState === 'error'}
-              <AlertCircle size={13} />
-            {:else if prState === 'creating'}
-              <Spinner size={13} />
-            {:else if prState === 'error'}
-              <AlertCircle size={13} />
-            {:else if prState === 'created' && prStatusState === 'MERGED'}
-              <GitMerge size={13} />
-            {:else if prState === 'created' && hasUnpushed}
-              <GitPullRequestDraft size={13} />
-            {:else if prState === 'created'}
-              <GitPullRequestArrow size={13} />
-            {:else}
-              <GitPullRequestCreateArrow size={13} />
-            {/if}
-            <span>
-              {#if pushState === 'pushing'}
-                Pushing…
-              {:else if pushState === 'error'}
-                Push failed
-              {:else if prState === 'created' && hasUnpushed}
-                {pushAction === 'forcePush' || optionHeld ? 'Force push' : 'Push changes'}
-              {:else if prState === 'created'}
-                {#if prStatusText}
-                  {prStatusText}
-                {:else}
-                  View PR{#if branch.prNumber}&nbsp;#{branch.prNumber}{/if}
-                {/if}
-              {:else if prState === 'creating'}
-                Creating PR…
-              {:else if prState === 'error'}
-                PR failed
-              {:else}
-                {optionHeld ? 'Create draft PR' : 'Create PR'}
-              {/if}
-            </span>
-            {#if prStatusStale}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  {#snippet child({ props })}
-                    <span class="pr-status-stale" {...props}>!</span>
-                  {/snippet}
-                </Tooltip.Trigger>
-                <Tooltip.Content>PR status may be outdated</Tooltip.Content>
-              </Tooltip.Root>
-            {:else if prStatusIndicator}
-              <span class="pr-status-indicator {prStatusIndicator}"></span>
-            {/if}
-          </Button>
-        </span>
-      {/snippet}
-    </Tooltip.Trigger>
-    <Tooltip.Content>{prButtonTitle}</Tooltip.Content>
-  </Tooltip.Root>
+  {#if branch.prNumber}
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          {@render prButton(props)}
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content>{prButtonTitle}</Tooltip.Content>
+    </Tooltip.Root>
+  {:else}
+    {@render prButton({})}
+  {/if}
 {/if}
 
 <AlertDialog.Root bind:open={showPrErrorDialog}>

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -27,6 +27,7 @@
   import ImageLucide from '@lucide/svelte/icons/image';
   import { HASHTAG_TOKEN_RE, hashtagTypeIconSvg, escapeHtml } from './hashtagItems';
   import { focusAtEndSync } from '../../shared/focusAtEnd';
+  import { portal } from '../../shared/portal';
   import RepoLabel from '../../shared/RepoLabel.svelte';
 
   type DropdownIconComponent = typeof FileText;
@@ -539,12 +540,18 @@
 
     <!-- Dropdown -->
     {#if showDropdown && filteredItems.length > 0}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <!-- Portaled to <body> so position:fixed escapes the dialog's transformed
+           containing block; pointerdown is stopped so selecting an item doesn't
+           trip bits-ui's dismiss-on-interact-outside and close the dialog. -->
       <div
         class="hashtag-dropdown"
         class:above={dropdownPosition === 'above'}
         class:below={dropdownPosition === 'below'}
         style={dropdownStyle}
         bind:this={dropdownEl}
+        use:portal
+        onpointerdown={(e) => e.stopPropagation()}
       >
         {#each filteredSections as section (section.key)}
           <div class="hashtag-dropdown-section">
@@ -584,11 +591,14 @@
         {/each}
       </div>
     {:else if showDropdown && filterText.length > 0}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="hashtag-dropdown"
         class:above={dropdownPosition === 'above'}
         class:below={dropdownPosition === 'below'}
         style={dropdownStyle}
+        use:portal
+        onpointerdown={(e) => e.stopPropagation()}
       >
         <div class="hashtag-dropdown-empty">No matching items</div>
       </div>

--- a/apps/staged/src/lib/features/sessions/PipelineSteps.svelte
+++ b/apps/staged/src/lib/features/sessions/PipelineSteps.svelte
@@ -125,7 +125,7 @@
               {...props}
               variant="ghost"
               type="button"
-              class="flex h-auto w-full items-center justify-start gap-2 rounded px-0 py-1 text-[13px] font-normal text-foreground shadow-none hover:bg-[var(--bg-hover)] hover:text-foreground"
+              class="flex h-auto w-full items-center justify-start gap-2 rounded px-0 py-1 text-left text-[13px] font-normal text-foreground shadow-none hover:bg-[var(--bg-hover)] hover:text-foreground"
               onclick={() => toggleStep(idx)}
             >
               <span class="step-icon">

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -1048,8 +1048,8 @@
                         'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
                         '[&_svg]:transition-all [&_svg]:duration-300',
                         actionButtonsEnlarged
-                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px]'
-                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
+                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--note-color)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
                       ]}
                     >
                       <FileText
@@ -1098,8 +1098,8 @@
                         'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
                         '[&_svg]:transition-all [&_svg]:duration-300',
                         actionButtonsEnlarged
-                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px]'
-                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--commit-color)]'
+                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--commit-color)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
                       ]}
                     >
                       <GitCommitVertical
@@ -1148,8 +1148,8 @@
                         'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
                         '[&_svg]:transition-all [&_svg]:duration-300',
                         actionButtonsEnlarged
-                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px]'
-                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--review-color)]'
+                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--review-color)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
                       ]}
                     >
                       <FileSearch

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -23,7 +23,6 @@
   import type { NoteClickInfo } from '../sessions/noteFreshness';
   import TimelineRow from './TimelineRow.svelte';
   import { Button } from '$lib/components/ui/button';
-  import * as Tooltip from '$lib/components/ui/tooltip';
   import type { TimelineItemType, TimelineBadge } from './TimelineRow.svelte';
   import { escapeHtml, hasHashtagTokens, renderHashtagTokens } from '../sessions/hashtagItems';
   import {
@@ -1032,154 +1031,124 @@
       <div class="footer-row" class:footer-row-enlarged={actionButtonsEnlarged}>
         <div class="footer-left-actions" class:footer-left-actions-enlarged={actionButtonsEnlarged}>
           {#if onNewNote}
-            <Tooltip.Root>
-              <Tooltip.Trigger>
-                {#snippet child({ props })}
-                  <span
-                    {...props}
-                    class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}
-                  >
-                    <Button
-                      variant="ghost"
-                      onclick={onNewNote}
-                      disabled={newSessionDisabled}
-                      aria-label="New note"
-                      class={[
-                        'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                        '[&_svg]:transition-all [&_svg]:duration-300',
-                        actionButtonsEnlarged
-                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
-                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--note-color)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
-                      ]}
-                    >
-                      <FileText
-                        class={actionButtonsEnlarged
-                          ? ''
-                          : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
-                        size={18}
-                      />
-                      <Plus
-                        class={actionButtonsEnlarged
-                          ? 'hidden'
-                          : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
-                        size={18}
-                      />
-                      <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
-                        >New note</span
-                      >
-                      <span
-                        class={[
-                          'hidden',
-                          !actionButtonsEnlarged &&
-                            '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
-                        ]}>Note</span
-                      >
-                    </Button>
-                  </span>
-                {/snippet}
-              </Tooltip.Trigger>
-              <Tooltip.Content>New note</Tooltip.Content>
-            </Tooltip.Root>
+            <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
+              <Button
+                variant="ghost"
+                onclick={onNewNote}
+                disabled={newSessionDisabled}
+                aria-label="New note"
+                class={[
+                  'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                  '[&_svg]:transition-all [&_svg]:duration-300',
+                  actionButtonsEnlarged
+                    ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
+                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--note-color)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                ]}
+              >
+                <FileText
+                  class={actionButtonsEnlarged
+                    ? ''
+                    : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
+                  size={18}
+                />
+                <Plus
+                  class={actionButtonsEnlarged
+                    ? 'hidden'
+                    : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
+                  size={18}
+                />
+                <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
+                  >New note</span
+                >
+                <span
+                  class={[
+                    'hidden',
+                    !actionButtonsEnlarged &&
+                      '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
+                  ]}>Note</span
+                >
+              </Button>
+            </span>
           {/if}
           {#if onNewCommit}
-            <Tooltip.Root>
-              <Tooltip.Trigger>
-                {#snippet child({ props })}
-                  <span
-                    {...props}
-                    class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}
-                  >
-                    <Button
-                      variant="ghost"
-                      onclick={onNewCommit}
-                      disabled={newSessionDisabled}
-                      aria-label="New commit"
-                      class={[
-                        'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                        '[&_svg]:transition-all [&_svg]:duration-300',
-                        actionButtonsEnlarged
-                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--commit-color)]'
-                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--commit-color)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
-                      ]}
-                    >
-                      <GitCommitVertical
-                        class={actionButtonsEnlarged
-                          ? ''
-                          : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
-                        size={18}
-                      />
-                      <Plus
-                        class={actionButtonsEnlarged
-                          ? 'hidden'
-                          : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
-                        size={18}
-                      />
-                      <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
-                        >New commit</span
-                      >
-                      <span
-                        class={[
-                          'hidden',
-                          !actionButtonsEnlarged &&
-                            '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
-                        ]}>Commit</span
-                      >
-                    </Button>
-                  </span>
-                {/snippet}
-              </Tooltip.Trigger>
-              <Tooltip.Content>New commit</Tooltip.Content>
-            </Tooltip.Root>
+            <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
+              <Button
+                variant="ghost"
+                onclick={onNewCommit}
+                disabled={newSessionDisabled}
+                aria-label="New commit"
+                class={[
+                  'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                  '[&_svg]:transition-all [&_svg]:duration-300',
+                  actionButtonsEnlarged
+                    ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--commit-color)]'
+                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--commit-color)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                ]}
+              >
+                <GitCommitVertical
+                  class={actionButtonsEnlarged
+                    ? ''
+                    : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
+                  size={18}
+                />
+                <Plus
+                  class={actionButtonsEnlarged
+                    ? 'hidden'
+                    : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
+                  size={18}
+                />
+                <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
+                  >New commit</span
+                >
+                <span
+                  class={[
+                    'hidden',
+                    !actionButtonsEnlarged &&
+                      '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
+                  ]}>Commit</span
+                >
+              </Button>
+            </span>
           {/if}
           {#if onNewReview}
-            <Tooltip.Root>
-              <Tooltip.Trigger>
-                {#snippet child({ props })}
-                  <span
-                    {...props}
-                    class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}
-                  >
-                    <Button
-                      variant="ghost"
-                      onclick={(e) => onNewReview?.(e)}
-                      disabled={newSessionDisabled}
-                      aria-label="New code review"
-                      class={[
-                        'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                        '[&_svg]:transition-all [&_svg]:duration-300',
-                        actionButtonsEnlarged
-                          ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--review-color)]'
-                          : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--review-color)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
-                      ]}
-                    >
-                      <FileSearch
-                        class={actionButtonsEnlarged
-                          ? ''
-                          : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
-                        size={18}
-                      />
-                      <Plus
-                        class={actionButtonsEnlarged
-                          ? 'hidden'
-                          : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
-                        size={18}
-                      />
-                      <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
-                        >New code review</span
-                      >
-                      <span
-                        class={[
-                          'hidden',
-                          !actionButtonsEnlarged &&
-                            '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
-                        ]}>Code review</span
-                      >
-                    </Button>
-                  </span>
-                {/snippet}
-              </Tooltip.Trigger>
-              <Tooltip.Content>New code review</Tooltip.Content>
-            </Tooltip.Root>
+            <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
+              <Button
+                variant="ghost"
+                onclick={(e) => onNewReview?.(e)}
+                disabled={newSessionDisabled}
+                aria-label="New code review"
+                class={[
+                  'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                  '[&_svg]:transition-all [&_svg]:duration-300',
+                  actionButtonsEnlarged
+                    ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--review-color)]'
+                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--review-color)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                ]}
+              >
+                <FileSearch
+                  class={actionButtonsEnlarged
+                    ? ''
+                    : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
+                  size={18}
+                />
+                <Plus
+                  class={actionButtonsEnlarged
+                    ? 'hidden'
+                    : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
+                  size={18}
+                />
+                <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
+                  >New code review</span
+                >
+                <span
+                  class={[
+                    'hidden',
+                    !actionButtonsEnlarged &&
+                      '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
+                  ]}>Code review</span
+                >
+              </Button>
+            </span>
           {/if}
         </div>
         {#if footerActions && !actionButtonsEnlarged}

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -1042,7 +1042,7 @@
                   '[&_svg]:transition-all [&_svg]:duration-300',
                   actionButtonsEnlarged
                     ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
-                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--note-color)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
                 ]}
               >
                 <FileText
@@ -1082,7 +1082,7 @@
                   '[&_svg]:transition-all [&_svg]:duration-300',
                   actionButtonsEnlarged
                     ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--commit-color)]'
-                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--commit-color)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
                 ]}
               >
                 <GitCommitVertical
@@ -1122,7 +1122,7 @@
                   '[&_svg]:transition-all [&_svg]:duration-300',
                   actionButtonsEnlarged
                     ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--review-color)]'
-                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--review-color)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
                 ]}
               >
                 <FileSearch

--- a/apps/staged/src/lib/shared/portal.ts
+++ b/apps/staged/src/lib/shared/portal.ts
@@ -1,0 +1,17 @@
+/**
+ * Svelte action that relocates an element to `document.body`.
+ *
+ * A `position: fixed` element is positioned relative to its nearest ancestor
+ * that establishes a containing block — which any ancestor with a `transform`
+ * does (e.g. shadcn's `Dialog.Content`, centred with `-translate-*`). Moving the
+ * node to `<body>` removes it from such ancestors so its viewport-relative
+ * coordinates are honoured. Also escapes any `overflow: hidden/auto` clipping.
+ */
+export function portal(node: HTMLElement) {
+  document.body.appendChild(node);
+  return {
+    destroy() {
+      node.remove();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

UI fixes and refactors for the branch card footer and hashtag/dialog interactions in Staged.

- Adjust branch card footer button styling: drop redundant tooltips and revert the themed border, while restoring the themed icon (see `BranchCard.svelte`, `BranchCardPrButton.svelte`, `BranchTimeline.svelte`).
- Add a `portal` Svelte action that relocates dropdowns to `<body>`, so `position: fixed` elements escape the dialog's transformed containing block. This restores the hashtag dropdown inside shadcn dialogs (`portal.ts`, `HashtagInput.svelte`).
- Stop the hashtag dropdown's `pointerdown` from tripping bits-ui's dismiss-on-interact-outside, which previously closed the dialog when selecting an item.
- Restore the inline hashtag capsule icon by overriding Tailwind preflight's `svg { display: block }` (`app.css`).
- Prevent dialogs from auto-focusing their first control via `onOpenAutoFocus` (`dialog-content.svelte`).
- Sync `Cargo.lock` with doctor subprocess deps.