### PR TITLE
fix(staged): show the requested session in SessionModal

### DIFF
--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -159,37 +159,6 @@
 
   const SLIDE_DURATION = 150;
 
-  // -------------------------------------------------------------------------
-  // Diagnostic logging
-  //
-  // Temporary instrumentation to diagnose the "spinner spins forever / load
-  // takes a long time" report. Logs the load lifecycle (effect fires →
-  // loadSession → each backend await → poll) with monotonic timestamps and the
-  // requested vs. currently-loaded session id, so an out-of-order/stuck load or
-  // a slow backend call is visible in the console.
-  let loadSeq = 0;
-  function slog(msg: string, extra?: Record<string, unknown>) {
-    const t = performance.now().toFixed(1);
-    // Read reactive state via untrack so this diagnostic snapshot never
-    // registers dependencies on the calling effect. Otherwise calling slog()
-    // from within the load effect (directly or through loadSession()'s
-    // synchronous prologue) would subscribe the effect to session/loading,
-    // which loadSession() then mutates — re-triggering the effect in a tight
-    // infinite loop that hammers the backend every reactive flush.
-    const snapshot = untrack(() => ({
-      sessionId,
-      loadedId: session?.id ?? null,
-      closed,
-      open,
-      loading,
-    }));
-    // eslint-disable-next-line no-console
-    console.debug(`[SessionModal +${t}ms] ${msg}`, {
-      ...snapshot,
-      ...extra,
-    });
-  }
-
   $effect(() => {
     const rootCandidates: DisplayRootInput = [repoDir, session?.workingDir];
     const nextKey = displayRootKey(rootCandidates);
@@ -442,9 +411,7 @@
     // retrigger this effect.
     const isOpen = open;
     const id = sessionId;
-    slog('load effect fired', { effectOpen: isOpen, effectId: id });
     if (!isOpen || !id) {
-      slog('load effect bail: not open or no id');
       stopPolling();
       return;
     }
@@ -455,11 +422,7 @@
     closed = false;
     stopPolling();
     loadSession().then(() => {
-      if (closed || !open || sessionId !== id) {
-        slog('post-load bail (stale/closed)', { effectId: id });
-        return;
-      }
-      slog('post-load complete', { status: session?.status, msgs: messages.length });
+      if (closed || !open || sessionId !== id) return;
       if (session?.status === 'running') {
         startPolling();
       }
@@ -478,12 +441,7 @@
 
   /** Initial full load. */
   async function loadSession() {
-    const seq = ++loadSeq;
-    slog('loadSession enter', { seq });
-    if (closed) {
-      slog('loadSession bail: closed', { seq });
-      return;
-    }
+    if (closed) return;
     // Clear prior session state when loading a *different* session so a
     // bail-out or in-flight load can never paint the previously-viewed
     // session — show a clean loading state for the requested id instead. When
@@ -498,22 +456,9 @@
     }
     loading = true;
     error = null;
-    const reqId = sessionId;
-    const startedAt = performance.now();
     try {
-      slog('loadSession awaiting backend', { seq, reqId });
       const [s, msgs] = await Promise.all([getSession(sessionId), getSessionMessages(sessionId)]);
-      slog('loadSession backend resolved', {
-        seq,
-        reqId,
-        elapsedMs: +(performance.now() - startedAt).toFixed(1),
-        gotSession: !!s,
-        gotMsgs: msgs.length,
-      });
-      if (closed) {
-        slog('loadSession bail after await: closed', { seq });
-        return;
-      }
+      if (closed) return;
       if (!s) {
         error = 'Session not found';
         return;
@@ -521,11 +466,9 @@
       session = s;
       messages = msgs;
     } catch (e) {
-      slog('loadSession error', { seq, error: e instanceof Error ? e.message : String(e) });
       error = e instanceof Error ? e.message : String(e);
     } finally {
       loading = false;
-      slog('loadSession finally', { seq, elapsedMs: +(performance.now() - startedAt).toFixed(1) });
       // Wait for Svelte to render the messages (they only mount once loading
       // is false) before enabling intro transitions, so existing messages
       // don't all slide in at once.
@@ -537,21 +480,11 @@
 
   /** Incremental poll — re-fetch last message (may have grown) + any new ones. */
   async function poll() {
-    if (!session || closed || pollInFlight) {
-      slog('poll skip', {
-        reason: !session ? 'no session' : closed ? 'closed' : 'in flight',
-      });
-      return;
-    }
+    if (!session || closed || pollInFlight) return;
     pollInFlight = true;
-    const startedAt = performance.now();
     try {
       // Fetch session status
       const s = await getSession(sessionId);
-      slog('poll status resolved', {
-        elapsedMs: +(performance.now() - startedAt).toFixed(1),
-        status: s?.status,
-      });
       if (closed) return;
       if (s) session = s;
 
@@ -581,9 +514,8 @@
         stopPolling();
         processQueue();
       }
-    } catch (e) {
+    } catch {
       // Polling errors are expected during shutdown — silently ignore
-      slog('poll error', { error: e instanceof Error ? e.message : String(e) });
     } finally {
       pollInFlight = false;
     }

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -170,13 +170,22 @@
   let loadSeq = 0;
   function slog(msg: string, extra?: Record<string, unknown>) {
     const t = performance.now().toFixed(1);
-    // eslint-disable-next-line no-console
-    console.debug(`[SessionModal +${t}ms] ${msg}`, {
+    // Read reactive state via untrack so this diagnostic snapshot never
+    // registers dependencies on the calling effect. Otherwise calling slog()
+    // from within the load effect (directly or through loadSession()'s
+    // synchronous prologue) would subscribe the effect to session/loading,
+    // which loadSession() then mutates — re-triggering the effect in a tight
+    // infinite loop that hammers the backend every reactive flush.
+    const snapshot = untrack(() => ({
       sessionId,
       loadedId: session?.id ?? null,
       closed,
       open,
       loading,
+    }));
+    // eslint-disable-next-line no-console
+    console.debug(`[SessionModal +${t}ms] ${msg}`, {
+      ...snapshot,
       ...extra,
     });
   }

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -159,6 +159,28 @@
 
   const SLIDE_DURATION = 150;
 
+  // -------------------------------------------------------------------------
+  // Diagnostic logging
+  //
+  // Temporary instrumentation to diagnose the "spinner spins forever / load
+  // takes a long time" report. Logs the load lifecycle (effect fires →
+  // loadSession → each backend await → poll) with monotonic timestamps and the
+  // requested vs. currently-loaded session id, so an out-of-order/stuck load or
+  // a slow backend call is visible in the console.
+  let loadSeq = 0;
+  function slog(msg: string, extra?: Record<string, unknown>) {
+    const t = performance.now().toFixed(1);
+    // eslint-disable-next-line no-console
+    console.debug(`[SessionModal +${t}ms] ${msg}`, {
+      sessionId,
+      loadedId: session?.id ?? null,
+      closed,
+      open,
+      loading,
+      ...extra,
+    });
+  }
+
   $effect(() => {
     const rootCandidates: DisplayRootInput = [repoDir, session?.workingDir];
     const nextKey = displayRootKey(rootCandidates);
@@ -411,7 +433,9 @@
     // retrigger this effect.
     const isOpen = open;
     const id = sessionId;
+    slog('load effect fired', { effectOpen: isOpen, effectId: id });
     if (!isOpen || !id) {
+      slog('load effect bail: not open or no id');
       stopPolling();
       return;
     }
@@ -422,7 +446,11 @@
     closed = false;
     stopPolling();
     loadSession().then(() => {
-      if (closed || !open || sessionId !== id) return;
+      if (closed || !open || sessionId !== id) {
+        slog('post-load bail (stale/closed)', { effectId: id });
+        return;
+      }
+      slog('post-load complete', { status: session?.status, msgs: messages.length });
       if (session?.status === 'running') {
         startPolling();
       }
@@ -441,7 +469,12 @@
 
   /** Initial full load. */
   async function loadSession() {
-    if (closed) return;
+    const seq = ++loadSeq;
+    slog('loadSession enter', { seq });
+    if (closed) {
+      slog('loadSession bail: closed', { seq });
+      return;
+    }
     // Clear prior session state when loading a *different* session so a
     // bail-out or in-flight load can never paint the previously-viewed
     // session — show a clean loading state for the requested id instead. When
@@ -453,9 +486,22 @@
     }
     loading = true;
     error = null;
+    const reqId = sessionId;
+    const startedAt = performance.now();
     try {
+      slog('loadSession awaiting backend', { seq, reqId });
       const [s, msgs] = await Promise.all([getSession(sessionId), getSessionMessages(sessionId)]);
-      if (closed) return;
+      slog('loadSession backend resolved', {
+        seq,
+        reqId,
+        elapsedMs: +(performance.now() - startedAt).toFixed(1),
+        gotSession: !!s,
+        gotMsgs: msgs.length,
+      });
+      if (closed) {
+        slog('loadSession bail after await: closed', { seq });
+        return;
+      }
       if (!s) {
         error = 'Session not found';
         return;
@@ -463,9 +509,11 @@
       session = s;
       messages = msgs;
     } catch (e) {
+      slog('loadSession error', { seq, error: e instanceof Error ? e.message : String(e) });
       error = e instanceof Error ? e.message : String(e);
     } finally {
       loading = false;
+      slog('loadSession finally', { seq, elapsedMs: +(performance.now() - startedAt).toFixed(1) });
       // Wait for Svelte to render the messages (they only mount once loading
       // is false) before enabling intro transitions, so existing messages
       // don't all slide in at once.
@@ -477,11 +525,21 @@
 
   /** Incremental poll — re-fetch last message (may have grown) + any new ones. */
   async function poll() {
-    if (!session || closed || pollInFlight) return;
+    if (!session || closed || pollInFlight) {
+      slog('poll skip', {
+        reason: !session ? 'no session' : closed ? 'closed' : 'in flight',
+      });
+      return;
+    }
     pollInFlight = true;
+    const startedAt = performance.now();
     try {
       // Fetch session status
       const s = await getSession(sessionId);
+      slog('poll status resolved', {
+        elapsedMs: +(performance.now() - startedAt).toFixed(1),
+        status: s?.status,
+      });
       if (closed) return;
       if (s) session = s;
 
@@ -511,8 +569,9 @@
         stopPolling();
         processQueue();
       }
-    } catch {
+    } catch (e) {
       // Polling errors are expected during shutdown — silently ignore
+      slog('poll error', { error: e instanceof Error ? e.message : String(e) });
     } finally {
       pollInFlight = false;
     }

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -442,11 +442,15 @@
   /** Initial full load. */
   async function loadSession() {
     if (closed) return;
-    // Clear prior session state so a bail-out or in-flight load can never
-    // paint the previously-viewed session — show a clean loading state for the
-    // requested id instead.
-    session = null;
-    messages = [];
+    // Clear prior session state when loading a *different* session so a
+    // bail-out or in-flight load can never paint the previously-viewed
+    // session — show a clean loading state for the requested id instead. When
+    // reopening the same session, keep the existing transcript so it stays
+    // visible (and correct) rather than flashing a loading state.
+    if (session?.id !== sessionId) {
+      session = null;
+      messages = [];
+    }
     loading = true;
     error = null;
     try {

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -415,6 +415,11 @@
       stopPolling();
       return;
     }
+    // Reset the teardown guard deterministically before loading, in the same
+    // flush. `closed` is a plain (non-reactive) variable, so writing it here
+    // does not retrigger this effect — which is exactly why relying on a
+    // separately-declared reset effect raced ahead of this load.
+    closed = false;
     stopPolling();
     loadSession().then(() => {
       if (closed || !open || sessionId !== id) return;
@@ -437,6 +442,11 @@
   /** Initial full load. */
   async function loadSession() {
     if (closed) return;
+    // Clear prior session state so a bail-out or in-flight load can never
+    // paint the previously-viewed session — show a clean loading state for the
+    // requested id instead.
+    session = null;
+    messages = [];
     loading = true;
     error = null;
     try {
@@ -892,10 +902,6 @@
     stopPolling();
     onClose();
   }
-
-  $effect(() => {
-    if (open) closed = false;
-  });
 
   /** Group consecutive tool_call / tool_result messages into pairs */
   type ToolPair = {

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -488,8 +488,11 @@
     // bail-out or in-flight load can never paint the previously-viewed
     // session — show a clean loading state for the requested id instead. When
     // reopening the same session, keep the existing transcript so it stays
-    // visible (and correct) rather than flashing a loading state.
-    if (session?.id !== sessionId) {
+    // visible (and correct) rather than flashing a loading state. Read the
+    // currently-loaded id via untrack so this synchronous prologue never
+    // subscribes the calling load effect to `session` — which it mutates
+    // below, otherwise re-triggering the effect in a tight infinite loop.
+    if (untrack(() => session?.id) !== sessionId) {
       session = null;
       messages = [];
     }


### PR DESCRIPTION
## Summary

Fixes the SessionModal sometimes painting a previously-viewed session instead of the one that was just requested, and resolves a related infinite load loop.

- Reset the `closed` teardown guard deterministically inside the load effect (same flush) rather than via a separate reset effect that could race ahead of the load.
- When loading a *different* session, clear `session`/`messages` up front so a bail-out or in-flight load can never paint the prior session — a clean loading state shows for the requested id. Reopening the same session keeps the existing transcript visible.
- Read the currently-loaded session id via `untrack` in the synchronous load prologue so the load effect doesn't subscribe to `session` (which it mutates), avoiding a tight infinite re-trigger loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)