### PR TITLE
fix(staged): layer dialogs and floating UI above legacy overlays

### DIFF
--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -333,6 +333,23 @@ mark.search-match-current {
 /*---break---
  */
 
+/* ── Top-layer z-index scale. A non-inline @theme block so the tokens are
+ *    emitted as real :root custom properties — both Tailwind's `z-overlay` /
+ *    `z-floating` utilities and raw `var(--z-index-*)` references (e.g.
+ *    HashtagInput's fixed-positioned dropdown) resolve to the same source.
+ *    `overlay` sits above the legacy full-screen overlay max (9999, e.g.
+ *    .diff-modal-backdrop) so design-system dialogs own the top layer;
+ *    `floating` sits one above `overlay` so portaled primitives (dropdown,
+ *    select, popover, tooltip, context-menu, hashtag dropdown) paint above
+ *    dialog content even when opened from inside a dialog. ── */
+@theme {
+  --z-index-overlay: 10000;
+  --z-index-floating: 10001;
+}
+
+/*---break---
+ */
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -334,9 +334,10 @@ mark.search-match-current {
  */
 
 /* ── Top-layer z-index scale. A non-inline @theme block so the tokens are
- *    emitted as real :root custom properties — both Tailwind's `z-overlay` /
- *    `z-floating` utilities and raw `var(--z-index-*)` references (e.g.
- *    HashtagInput's fixed-positioned dropdown) resolve to the same source.
+ *    emitted as real :root custom properties — both the arbitrary-property
+ *    utilities `z-(--z-index-overlay)` / `z-(--z-index-floating)` and raw
+ *    `var(--z-index-*)` references (e.g. HashtagInput's fixed-positioned
+ *    dropdown) resolve to the same source.
  *    `overlay` sits above the legacy full-screen overlay max (9999, e.g.
  *    .diff-modal-backdrop) so design-system dialogs own the top layer;
  *    `floating` sits one above `overlay` so portaled primitives (dropdown,

--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -24,7 +24,7 @@
     data-slot="alert-dialog-content"
     data-size={size}
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-overlay grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-(--z-index-overlay) grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -24,7 +24,7 @@
     data-slot="alert-dialog-content"
     data-size={size}
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-[10000] grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -24,7 +24,7 @@
     data-slot="alert-dialog-content"
     data-size={size}
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-[10000] grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-overlay grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -13,7 +13,7 @@
   bind:ref
   data-slot="alert-dialog-overlay"
   class={cn(
-    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[10000]',
+    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-overlay',
     className
   )}
   {...restProps}

--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -13,7 +13,7 @@
   bind:ref
   data-slot="alert-dialog-overlay"
   class={cn(
-    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50',
+    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[10000]',
     className
   )}
   {...restProps}

--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -13,7 +13,7 @@
   bind:ref
   data-slot="alert-dialog-overlay"
   class={cn(
-    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-overlay',
+    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-(--z-index-overlay)',
     className
   )}
   {...restProps}

--- a/apps/staged/src/lib/components/ui/context-menu/context-menu-content.svelte
+++ b/apps/staged/src/lib/components/ui/context-menu/context-menu-content.svelte
@@ -20,7 +20,7 @@
     bind:ref
     data-slot="context-menu-content"
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-md p-1 shadow-md ring-1 duration-100 z-50 overflow-x-hidden overflow-y-auto outline-none',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-md p-1 shadow-md ring-1 duration-100 z-floating overflow-x-hidden overflow-y-auto outline-none',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/context-menu/context-menu-content.svelte
+++ b/apps/staged/src/lib/components/ui/context-menu/context-menu-content.svelte
@@ -20,7 +20,7 @@
     bind:ref
     data-slot="context-menu-content"
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-md p-1 shadow-md ring-1 duration-100 z-floating overflow-x-hidden overflow-y-auto outline-none',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-md p-1 shadow-md ring-1 duration-100 z-(--z-index-floating) overflow-x-hidden overflow-y-auto outline-none',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
@@ -28,7 +28,7 @@
     bind:ref
     data-slot="dialog-content"
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-[10000] w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-overlay w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     onOpenAutoFocus={(e) => e.preventDefault()}

--- a/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
@@ -28,7 +28,7 @@
     bind:ref
     data-slot="dialog-content"
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-overlay w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-(--z-index-overlay) w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     onOpenAutoFocus={(e) => e.preventDefault()}

--- a/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
@@ -28,7 +28,7 @@
     bind:ref
     data-slot="dialog-content"
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-[10000] w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     onOpenAutoFocus={(e) => e.preventDefault()}

--- a/apps/staged/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -13,7 +13,7 @@
   bind:ref
   data-slot="dialog-overlay"
   class={cn(
-    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-overlay',
+    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-(--z-index-overlay)',
     className
   )}
   {...restProps}

--- a/apps/staged/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -13,7 +13,7 @@
   bind:ref
   data-slot="dialog-overlay"
   class={cn(
-    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-[10000]',
+    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-overlay',
     className
   )}
   {...restProps}

--- a/apps/staged/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -13,7 +13,7 @@
   bind:ref
   data-slot="dialog-overlay"
   class={cn(
-    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50',
+    'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-[var(--shadow-overlay)] duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-[10000]',
     className
   )}
   {...restProps}

--- a/apps/staged/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/apps/staged/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -23,7 +23,7 @@
     {sideOffset}
     {align}
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-floating w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/apps/staged/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -23,7 +23,7 @@
     {sideOffset}
     {align}
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-floating w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-(--z-index-floating) w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/popover/popover-content.svelte
+++ b/apps/staged/src/lib/components/ui/popover/popover-content.svelte
@@ -23,7 +23,7 @@
     {sideOffset}
     {align}
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-4 rounded-md p-4 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-72 origin-(--transform-origin) outline-hidden',
+      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-4 rounded-md p-4 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-floating w-72 origin-(--transform-origin) outline-hidden',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/popover/popover-content.svelte
+++ b/apps/staged/src/lib/components/ui/popover/popover-content.svelte
@@ -23,7 +23,7 @@
     {sideOffset}
     {align}
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-4 rounded-md p-4 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-floating w-72 origin-(--transform-origin) outline-hidden',
+      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-4 rounded-md p-4 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-(--z-index-floating) w-72 origin-(--transform-origin) outline-hidden',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/select/select-content.svelte
+++ b/apps/staged/src/lib/components/ui/select/select-content.svelte
@@ -27,7 +27,7 @@
     {preventScroll}
     data-slot="select-content"
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-md shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 overflow-x-hidden overflow-y-auto',
+      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-md shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-floating overflow-x-hidden overflow-y-auto',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/select/select-content.svelte
+++ b/apps/staged/src/lib/components/ui/select/select-content.svelte
@@ -27,7 +27,7 @@
     {preventScroll}
     data-slot="select-content"
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-md shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-floating overflow-x-hidden overflow-y-auto',
+      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-md shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-(--z-index-floating) overflow-x-hidden overflow-y-auto',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/apps/staged/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -27,7 +27,7 @@
     {sideOffset}
     {side}
     class={cn(
-      'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm bg-foreground text-background z-floating w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)',
+      'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm bg-foreground text-background z-(--z-index-floating) w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/apps/staged/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -27,7 +27,7 @@
     {sideOffset}
     {side}
     class={cn(
-      'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm bg-foreground text-background z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)',
+      'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm bg-foreground text-background z-floating w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -655,7 +655,7 @@
     border-radius: 8px;
     max-height: 280px;
     overflow-y: auto;
-    z-index: 9999;
+    z-index: var(--z-index-floating);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     padding: 4px;
   }

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -658,6 +658,9 @@
     z-index: var(--z-index-floating);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     padding: 4px;
+    /* bits-ui sets `body { pointer-events: none }` while a dialog is open. The
+       dropdown portals to body, so re-enable pointer events on it explicitly. */
+    pointer-events: auto;
   }
 
   .hashtag-dropdown-section + .hashtag-dropdown-section {


### PR DESCRIPTION
## Summary

Fixes stacking and interaction issues that surfaced after the shadcn-svelte migration, where dialogs and floating primitives could render beneath legacy overlays and the hashtag dropdown became unclickable inside dialogs.

- Introduce a tokenized top-layer z-index in `app.css` and apply it to shadcn dialog, alert-dialog, popover, select, dropdown-menu, context-menu, and tooltip content/overlay components so they render above legacy overlays.
- Re-enable pointer events on the hashtag dropdown (`HashtagInput.svelte`) so it remains interactive when rendered inside dialogs.

## Test plan

- Open dialogs/alert-dialogs and confirm they appear above any legacy overlays.
- Verify popovers, selects, dropdown menus, context menus, and tooltips layer correctly.
- Confirm the hashtag dropdown is clickable when used inside a dialog.