### PR TITLE
fix(staged): restore white context menus via dedicated --menu surface token

### DIFF
--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -132,7 +132,7 @@
   --foreground: var(--text-primary);
   --card: var(--bg-elevated);
   --card-foreground: var(--text-primary);
-  --popover: var(--bg-elevated);
+  --popover: var(--bg-menu);
   --popover-foreground: var(--text-primary);
   --primary: var(--ui-accent);
   --primary-foreground: var(

--- a/apps/staged/src/lib/theme.ts
+++ b/apps/staged/src/lib/theme.ts
@@ -22,7 +22,8 @@ export interface Theme {
     primary: string; // Main background (same as syntax theme) - used for editor islands
     chrome: string; // Unified chrome background (header, sidebar, spine)
     deepest: string; // Deepest level (tab bar) - pure black/white
-    elevated: string; // Floating elements (dropdowns, tooltips)
+    elevated: string; // Floating elements (cards, dialogs)
+    menu: string; // Menu/popover surfaces (context menu, dropdown, select, popover)
     hover: string; // Hover states
   };
 
@@ -390,6 +391,13 @@ export function createAdaptiveTheme(
       // without going gray, with the ring/shadow the shadcn primitives apply
       // carrying the rest of the lift.
       elevated: isDark ? elevate(0.08) : adjust(primaryBg, -0.04),
+      // Menu/popover surfaces (context menu, dropdown, select, popover) sit on
+      // top of content like other floating surfaces, but unlike cards/dialogs
+      // they read best as a crisp panel rather than a tinted one. Dark themes
+      // reuse the elevated lift; light themes paint pure white (the syntax
+      // background) and lean on the shadcn ring/shadow for the lift, restoring
+      // the white menus that predated the elevated-surface tinting.
+      menu: isDark ? elevate(0.08) : primaryBg,
       hover: elevate(0.06), // Hover state
     },
 
@@ -507,6 +515,7 @@ export function themeToVarMap(t: Theme): Record<string, string> {
     '--bg-chrome': t.bg.chrome,
     '--bg-deepest': t.bg.deepest,
     '--bg-elevated': t.bg.elevated,
+    '--bg-menu': t.bg.menu,
     '--bg-hover': t.bg.hover,
 
     '--border-subtle': t.border.subtle,


### PR DESCRIPTION
## Summary

Context menus, dropdowns, selects, and popovers in light themes had picked up the tinted `--bg-elevated` surface color, losing the crisp white look they had before the elevated-surface tinting landed.

This adds a dedicated `menu` background token that's separate from the `elevated` surface used by cards and dialogs:

- New `bg.menu` field on the `Theme` interface, with `bg.elevated` reclarified as cards/dialogs.
- `createAdaptiveTheme` paints `menu` as pure white (the syntax background) in light themes, leaning on the shadcn ring/shadow for lift; dark themes reuse the elevated lift.
- Exposes the value as a `--bg-menu` CSS variable and points `--popover` at it.

## Test plan

- Verify context menus, dropdowns, selects, and popovers render with white surfaces in light themes.
- Verify dark themes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)