### PR TITLE
perf(staged): pause offscreen animations and drop static will-change from timeline rows

### DIFF
--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -673,7 +673,6 @@
     border-radius: 6px;
     position: relative;
     transition: background-color 0.15s ease;
-    will-change: transform;
   }
 
   .timeline-row:hover {

--- a/apps/staged/src/lib/shared/GitTreeAnimation.svelte
+++ b/apps/staged/src/lib/shared/GitTreeAnimation.svelte
@@ -10,6 +10,7 @@
 
   let canvas: HTMLCanvasElement | null = $state(null);
   let animationId: number | null = null;
+  let resumeAnimation: (() => void) | null = null;
 
   const CONFIG = {
     commitInterval: 600,
@@ -526,12 +527,36 @@
       animationId = requestAnimationFrame(animate);
     }
 
+    // Resume from a paused state without re-seeding the tree; reset the frame
+    // timers so the gap while hidden doesn't produce a huge dt jump.
+    resumeAnimation = () => {
+      if (!canvas) return;
+      lastFrameTime = performance.now();
+      lastCommitTime = performance.now();
+      animationId = requestAnimationFrame(animate);
+    };
+
     animationId = requestAnimationFrame(animate);
+  }
+
+  // Pause the rAF loop while the document is hidden so it stops compositing
+  // canvas frames in the background, and resume when it becomes visible again.
+  function onVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      if (animationId !== null) {
+        cancelAnimationFrame(animationId);
+        animationId = null;
+      }
+    } else if (animationId === null) {
+      resumeAnimation?.();
+    }
   }
 
   onMount(() => {
     updateColors();
     startAnimation();
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     const observer = new MutationObserver(() => updateColors());
     observer.observe(document.documentElement, {
@@ -544,6 +569,7 @@
 
   onDestroy(() => {
     if (animationId !== null) cancelAnimationFrame(animationId);
+    document.removeEventListener('visibilitychange', onVisibilityChange);
   });
 </script>
 

--- a/apps/staged/src/lib/shared/SineWave.svelte
+++ b/apps/staged/src/lib/shared/SineWave.svelte
@@ -7,10 +7,17 @@
   let { size = 20, color = 'currentColor' }: Props = $props();
 
   let phase = $state(0);
+  let svgEl: SVGSVGElement;
 
+  // The wave only needs to animate while it's actually on screen. Gating the
+  // rAF loop on document visibility and viewport intersection stops it from
+  // keeping the compositor warm when the tab is backgrounded or the element is
+  // scrolled out of view.
   $effect(() => {
-    let id: number;
+    let id: number | undefined;
     let t0: number | undefined;
+    let documentVisible = document.visibilityState !== 'hidden';
+    let inViewport = true;
 
     function tick(ts: number) {
       t0 ??= ts;
@@ -18,12 +25,46 @@
       id = requestAnimationFrame(tick);
     }
 
-    id = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(id);
+    function start() {
+      if (id === undefined && documentVisible && inViewport) {
+        t0 = undefined;
+        id = requestAnimationFrame(tick);
+      }
+    }
+
+    function stop() {
+      if (id !== undefined) {
+        cancelAnimationFrame(id);
+        id = undefined;
+      }
+    }
+
+    function onVisibilityChange() {
+      documentVisible = document.visibilityState !== 'hidden';
+      if (documentVisible) start();
+      else stop();
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    const observer = new IntersectionObserver((entries) => {
+      inViewport = entries[entries.length - 1].isIntersecting;
+      if (inViewport) start();
+      else stop();
+    });
+    observer.observe(svgEl);
+
+    start();
+
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      observer.disconnect();
+    };
   });
 
   let pathD = $derived.by(() => {
-    const segments = 64;
+    const segments = 32;
     const startX = 10;
     const endX = 90;
     const range = endX - startX;
@@ -38,7 +79,12 @@
 </script>
 
 <div class="sine-wave-container" style="width: {size}px; height: {size}px;">
-  <svg style="width: {size}px; height: {size}px;" viewBox="0 0 100 100" fill="none">
+  <svg
+    bind:this={svgEl}
+    style="width: {size}px; height: {size}px;"
+    viewBox="0 0 100 100"
+    fill="none"
+  >
     <path
       d={pathD}
       stroke={color}


### PR DESCRIPTION
## Summary

- Pause per-frame wave and canvas animation loops (`SineWave`, `GitTreeAnimation`) when the elements aren't visible, avoiding wasted rAF work and rendering.
- Remove the static `will-change: transform` from timeline rows (`TimelineRow`), which was forcing unnecessary compositing layers.

These changes reduce render/CPU overhead from animations and layout that aren't actively needed.