### PR TITLE
fix(staged): swap dialogs to bg-card so they use the elevated surface

### DIFF
--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -24,7 +24,7 @@
     data-slot="alert-dialog-content"
     data-size={size}
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-(--z-index-overlay) grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-card text-card-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-(--z-index-overlay) grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
@@ -28,7 +28,7 @@
     bind:ref
     data-slot="dialog-content"
     class={cn(
-      'bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-(--z-index-overlay) w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+      'bg-card text-card-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-(--z-index-overlay) w-full -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
     onOpenAutoFocus={(e) => e.preventDefault()}


### PR DESCRIPTION
Swap the alert dialog and dialog content surfaces to `bg-card` so they render on the elevated surface token rather than the base background.

## Changes
- `alert-dialog-content.svelte`: use `bg-card` for the content surface
- `dialog-content.svelte`: use `bg-card` for the content surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)