### PR TITLE
fix(staged): reset Add Repo dialog state on open

### DIFF
--- a/apps/staged/src/lib/features/projects/AddRepoModal.svelte
+++ b/apps/staged/src/lib/features/projects/AddRepoModal.svelte
@@ -34,9 +34,30 @@
     | {
         waitForSubpathValidation: () => Promise<boolean>;
         selectRepo: (selection: RepoSelection) => void;
+        reset: () => void;
       }
     | undefined
   >(undefined);
+
+  // The modal stays mounted across open/close cycles, so its state survives.
+  // Reset everything on the rising edge of `open` (false -> true) — not on
+  // close — so the dialog's exit animation still plays with its final contents.
+  let wasOpen = false;
+  $effect(() => {
+    if (open && !wasOpen) {
+      selectedRepo = null;
+      headRepo = null;
+      subpath = '';
+      branchName = '';
+      isNewBranch = false;
+      matchedPr = null;
+      defaultBranch = null;
+      saving = false;
+      error = null;
+      repoConfigApi?.reset();
+    }
+    wasOpen = open;
+  });
 
   // Clear error when user edits the subpath
   $effect(() => {

--- a/apps/staged/src/lib/features/projects/NewProjectForm.svelte
+++ b/apps/staged/src/lib/features/projects/NewProjectForm.svelte
@@ -52,6 +52,7 @@
     | {
         waitForSubpathValidation: () => Promise<boolean>;
         selectRepo: (selection: RepoSelection) => void;
+        reset: () => void;
       }
     | undefined
   >(undefined);

--- a/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
+++ b/apps/staged/src/lib/features/projects/RepoConfigForm.svelte
@@ -60,6 +60,7 @@
     api?: {
       waitForSubpathValidation: () => Promise<boolean>;
       selectRepo: (selection: RepoSelection) => void;
+      reset: () => void;
     };
   }
 
@@ -80,6 +81,7 @@
       | {
           waitForSubpathValidation: () => Promise<boolean>;
           selectRepo: (selection: RepoSelection) => void;
+          reset: () => void;
         }
       | undefined
     >(undefined),
@@ -170,6 +172,26 @@
     }
   }
 
+  /** Clear all form state, including internal-only fields the parent can't bind.
+   *  Mirrors the Clear button's reset plus the deferred-picker/PR-resolution state. */
+  function reset() {
+    if (branchPickerTimer) clearTimeout(branchPickerTimer);
+    selectedRepo = null;
+    headRepo = null;
+    subpath = '';
+    branchName = '';
+    isNewBranch = false;
+    matchedPr = null;
+    defaultBranch = null;
+    displayRepo = null;
+    isMonorepo = false;
+    checkingMonorepo = false;
+    showBranchPicker = false;
+    resolvingPr = false;
+    pendingPrNumber = null;
+    pendingBranchName = null;
+  }
+
   // Expose validation API to parent
   $effect(() => {
     api = {
@@ -177,6 +199,7 @@
         ? () => subpathApi!.waitForValidation()
         : () => Promise.resolve(true),
       selectRepo: handleRepoSelected,
+      reset,
     };
   });
 


### PR DESCRIPTION
## Summary

The Add Repo modal stays mounted across open/close cycles, so stale state from a previous session persisted when reopening it — leaving the dialog in a confusing state (e.g. a previously selected repo, branch, or error still showing).

This resets all form state on the rising edge of `open` (false → true), rather than on close, so the dialog's exit animation still plays with its final contents.

## Changes

- **AddRepoModal.svelte**: Reset all local state and call the new `repoConfigApi.reset()` when the modal transitions from closed to open.
- **RepoConfigForm.svelte**: Add a `reset()` method to the exposed API that clears all form state, including internal-only fields the parent can't bind (deferred branch-picker timer, PR-resolution state, monorepo detection).
- **NewProjectForm.svelte**: Add `reset` to the API type definition.