### PR TITLE
fix(staged): un-mute agent selector text to text-muted-foreground

### DIFF
--- a/apps/staged/src/lib/features/agents/AgentSelector.svelte
+++ b/apps/staged/src/lib/features/agents/AgentSelector.svelte
@@ -36,7 +36,7 @@
   {#if agents.length > 1}
     <DropdownMenu.Root>
       <DropdownMenu.Trigger
-        class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--text-faint)] transition-colors hover:bg-[var(--bg-hover)] hover:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+        class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         {disabled}
         title="Select AI agent"
       >
@@ -68,7 +68,7 @@
   {:else}
     <button
       type="button"
-      class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--text-faint)] disabled:cursor-not-allowed disabled:opacity-40"
+      class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground disabled:cursor-not-allowed disabled:opacity-40"
       {disabled}
       title={currentLabel}
     >


### PR DESCRIPTION
## Summary

The agent dropdown trigger and the single-agent button rendered their
label with `text-[var(--text-faint)]` — the faintest color in the
palette — which left the agent name hard to read at rest. This switches
both to `text-muted-foreground` so the label is legible without
hovering.

## Changes

- `apps/staged/src/lib/features/agents/AgentSelector.svelte`
  - `DropdownMenu.Trigger` (multi-agent case): `text-[var(--text-faint)]`
    → `text-muted-foreground`. The now-redundant
    `hover:text-muted-foreground` is removed since the rest state already
    matches it.
  - `<button>` (single-agent case): `text-[var(--text-faint)]`
    → `text-muted-foreground`.

Net diff: 1 file changed, 2 insertions(+), 2 deletions(-).

## Before / After

- **Before:** agent name rendered in the faintest text color, low
  contrast and easy to miss.
- **After:** agent name rendered in muted-foreground — clearly legible at
  rest, consistent with other secondary labels in the UI.

## Testing

UI-only styling change; no behavioral changes. Verified the label is
legible at rest and hover/disabled states are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)