### PR TITLE
fix(staged): stop timeline hover jitter via scrollbar-gutter and icon layer hint

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -888,6 +888,9 @@
     min-width: 0;
     min-height: 0;
     overflow: auto;
+    /* Reserve the scrollbar gutter so the centered column never re-centers
+       when the vertical scrollbar appears/disappears (avoids a ~4px jog). */
+    scrollbar-gutter: stable;
     display: flex;
     flex-direction: column;
   }

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -736,6 +736,11 @@
     flex-shrink: 0;
     background-color: var(--bg-elevated);
     border: 1px solid var(--border-subtle);
+    /* Pin the icon onto its own compositing layer so it rasterizes at integer
+       pixels and stays put during the row's hover background-color transition.
+       Restores the layer hint #775 dropped from .timeline-row, but on the tiny
+       icon rather than the full-width row to keep that commit's memory win. */
+    transform: translateZ(0);
   }
 
   .timeline-icon.commit-icon {


### PR DESCRIPTION
## Summary

Fixes a small visual jitter that occurred when hovering over timeline rows.

- **`ProjectHome.svelte`**: Set `scrollbar-gutter: stable` on the scrollable column so the centered content no longer re-centers (a ~4px jog) when the vertical scrollbar appears/disappears.
- **`TimelineRow.svelte`**: Add `transform: translateZ(0)` to the timeline icon so it rasterizes on its own compositing layer at integer pixels and stays put during the row's hover `background-color` transition. This restores the layer hint #775 dropped from `.timeline-row`, but scopes it to the tiny icon instead of the full-width row to preserve that commit's memory win.

## Test plan

- Hover timeline rows and confirm the icon and centered column no longer shift.