### PR TITLE
perf(timeline): reduce project switch timeline rendering work

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -10,6 +10,24 @@
   - Notes open a markdown viewer
   - Each item shows session + delete actions on hover
 -->
+<script module lang="ts">
+  /**
+   * Last-measured rendered height of each branch card's timeline interior,
+   * keyed by `branch.id`. Module-scoped (not per-instance) so a cached height
+   * survives both the interior unmounting when scrolled off-screen AND the
+   * BranchCard component being destroyed/recreated across project switches —
+   * letting the placeholder preserve scroll position without re-measuring.
+   */
+  const interiorHeightCache = new Map<string, number>();
+
+  /**
+   * Fallback placeholder height for a card whose interior has never been
+   * measured (e.g. below the fold on the first render after a switch). It is
+   * corrected to the real height the first time the interior mounts.
+   */
+  const DEFAULT_INTERIOR_HEIGHT = 160;
+</script>
+
 <script lang="ts">
   import { untrack } from 'svelte';
   import FileDiff from '@lucide/svelte/icons/file-diff';
@@ -1200,6 +1218,14 @@
   let dragOver = $state(false);
   let cardElement: HTMLDivElement | undefined = $state();
 
+  // Lazy-mount the heavy timeline interior only when this card is within ~1.5
+  // viewports of the scroll container. Off-screen cards render just the cheap
+  // shell (header) plus a height-preserving placeholder, so switching projects
+  // doesn't synchronously build every branch's <BranchTimeline> at once (the
+  // dominant project-switch-freeze cost). See Phase 2a of the switch-freeze plan.
+  let shouldMountInterior = $state(false);
+  let interiorEl: HTMLDivElement | undefined = $state();
+
   let pendingDropNotes = $state<{ key: string; title: string }[]>([]);
 
   function handleFileDrop(paths: string[]) {
@@ -1268,6 +1294,55 @@
     );
 
     return unsub;
+  });
+
+  // Drive shouldMountInterior from an IntersectionObserver on the card root.
+  // The observer is created (and disconnected on cleanup) inside this effect,
+  // so switching projects tears it down with the component — no leaked
+  // observers. Depends only on cardElement, so it isn't re-created on every
+  // timeline refresh.
+  $effect(() => {
+    const el = cardElement;
+    if (!el) return;
+    // SSR / unsupported environment: mount eagerly so content is never hidden.
+    if (typeof IntersectionObserver === 'undefined') {
+      shouldMountInterior = true;
+      return;
+    }
+    // Prefer the real scroll container (.main-panel) as the observer root; fall
+    // back to the viewport (null) if the card isn't inside one — the card still
+    // moves within the viewport as .main-panel scrolls, so null works too.
+    const root = el.closest('.main-panel');
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          shouldMountInterior = entry.isIntersecting;
+        }
+      },
+      // ~1.5 viewports of slop so interiors mount just before scrolling into
+      // view (seamless) and brief scroll-bys don't thrash mount/unmount.
+      { root, rootMargin: '150% 0px', threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  });
+
+  // While the interior is mounted, keep its rendered height cached by branch.id
+  // so the placeholder shown after unmount preserves scroll position (no jump).
+  $effect(() => {
+    const el = interiorEl;
+    if (!el) return;
+    if (typeof ResizeObserver === 'undefined') {
+      const height = el.offsetHeight;
+      if (height > 0) interiorHeightCache.set(branch.id, height);
+      return;
+    }
+    const ro = new ResizeObserver(() => {
+      const height = el.offsetHeight;
+      if (height > 0) interiorHeightCache.set(branch.id, height);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
   });
 </script>
 
@@ -1399,109 +1474,122 @@
           <Button variant="outline" size="xs" onclick={() => loadTimeline()}>Retry</Button>
         </div>
       {:else if timeline || isSettingUp}
-        <BranchTimeline
-          timeline={timeline ?? emptyTimeline}
-          repoDir={branch.worktreePath}
-          {hashtagItems}
-          pendingDropNotes={isLocal ? pendingDropNotes : undefined}
-          pendingItems={sessionMgr.pendingSessionItems}
-          {prunedSessionIds}
-          {error}
-          gitActionDisabledReason={branchIdentityWarning}
-          onRetry={() => loadTimeline()}
-          deletingItems={timelineDeletingItems}
-          reviewCommentBreakdown={timelineReviewDetailsById}
-          onSessionClick={(sid) => sessionMgr.handleTimelineSessionClick(sid)}
-          onResumeClick={(sid) => {
-            commands
-              .resumeSession(sid, 'Continue where you left off.', undefined, branch.id)
-              .then(() => loadTimeline())
-              .catch((e) => {
-                console.error('Failed to resume session:', e);
-                toast.error('Resume failed', {
-                  description:
-                    e instanceof Error
-                      ? e.message
-                      : 'Could not resume the session. Please try again.',
-                });
-              });
-          }}
-          onCommitClick={handleCommitClick}
-          onNoteClick={handleNoteClick}
-          onReviewClick={handleReviewClick}
-          onDeleteCommit={handleDeleteCommit}
-          onDeletePendingCommit={handleDeletePendingCommit}
-          onDeleteNote={handleDeleteNote}
-          onDeleteReview={handleDeleteReview}
-          onImageClick={handleImageClick}
-          onDeleteImage={handleDeleteImage}
-          onStartQueued={() => {
-            commands
-              .drainQueuedSessions(branch.id)
-              .catch((e) => console.error('Failed to drain queued sessions:', e));
-          }}
-          onNewNote={() => sessionMgr.openNewSession('note')}
-          onNewCommit={() => sessionMgr.openNewSession('commit')}
-          onNewReview={hasCodeChanges || sessionMgr.hasCommitSessionInProgress
-            ? (e) => sessionMgr.openNewSession('review', e)
-            : undefined}
-          onPullOrigin={handlePullOrigin}
-          onPushOrigin={handlePushOrigin}
-          onOpenPushSession={pushSessionId && pushSessionId !== '__pending__'
-            ? openPushSession
-            : undefined}
-          onRebaseBranch={() => startBranchCommandPipeline('rebase')}
-          onRebaseBranchOntoOrigin={() => startBranchCommandPipeline('rebase', 'origin')}
-          onForcePush={handleForcePush}
-          onOpenForcePushSession={forcePushSessionId && forcePushSessionId !== '__pending__'
-            ? openForcePushSession
-            : undefined}
-          {forcePushingOrigin}
-          rebaseBranchDisabledReason={branchCommandDisabledReason}
-          onViewWorktreeDiff={isLocal ? () => (showWorktreeDiff = true) : undefined}
-          onCommitWorktreeChanges={() =>
-            sessionMgr.startOrQueueSession('commit', 'Commit uncommitted changes')}
-          onDiscardWorktreeChanges={handleDiscardWorktreeChanges}
-          onNewSessionReferring={(ref) => sessionMgr.openNewSessionReferring(ref)}
-          newSessionDisabled={sessionMgr.isNewSessionDisabled || gitUnsafeActionsDisabled}
-          {pullingOrigin}
-          {pushingOrigin}
-          {discardingWorktreeChanges}
-          {provisioningLabel}
-          {provisioningDetail}
-        >
-          {#snippet footerActions()}
-            {#if hasCodeChanges || branch.prNumber}
-              <div class="footer-right-actions">
-                <BranchCardPrButton
-                  bind:this={prButton}
-                  {branch}
-                  {isLocal}
-                  {isRemote}
-                  {hasCodeChanges}
-                  {timeline}
-                  onOpenSession={(sid) => {
-                    sessionMgr.openSessionId = sid;
-                  }}
-                />
-                {#if hasCodeChanges}
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onclick={() => {
-                      reviewDiffTarget = null;
-                      showBranchDiff = true;
-                    }}
-                    class="text-xs"
-                  >
-                    <FileDiff size={13} />
-                    <span>Diff</span>
-                  </Button>
+        {#if shouldMountInterior}
+          <div class="timeline-interior" bind:this={interiorEl}>
+            <BranchTimeline
+              timeline={timeline ?? emptyTimeline}
+              repoDir={branch.worktreePath}
+              {hashtagItems}
+              pendingDropNotes={isLocal ? pendingDropNotes : undefined}
+              pendingItems={sessionMgr.pendingSessionItems}
+              {prunedSessionIds}
+              {error}
+              gitActionDisabledReason={branchIdentityWarning}
+              onRetry={() => loadTimeline()}
+              deletingItems={timelineDeletingItems}
+              reviewCommentBreakdown={timelineReviewDetailsById}
+              onSessionClick={(sid) => sessionMgr.handleTimelineSessionClick(sid)}
+              onResumeClick={(sid) => {
+                commands
+                  .resumeSession(sid, 'Continue where you left off.', undefined, branch.id)
+                  .then(() => loadTimeline())
+                  .catch((e) => {
+                    console.error('Failed to resume session:', e);
+                    toast.error('Resume failed', {
+                      description:
+                        e instanceof Error
+                          ? e.message
+                          : 'Could not resume the session. Please try again.',
+                    });
+                  });
+              }}
+              onCommitClick={handleCommitClick}
+              onNoteClick={handleNoteClick}
+              onReviewClick={handleReviewClick}
+              onDeleteCommit={handleDeleteCommit}
+              onDeletePendingCommit={handleDeletePendingCommit}
+              onDeleteNote={handleDeleteNote}
+              onDeleteReview={handleDeleteReview}
+              onImageClick={handleImageClick}
+              onDeleteImage={handleDeleteImage}
+              onStartQueued={() => {
+                commands
+                  .drainQueuedSessions(branch.id)
+                  .catch((e) => console.error('Failed to drain queued sessions:', e));
+              }}
+              onNewNote={() => sessionMgr.openNewSession('note')}
+              onNewCommit={() => sessionMgr.openNewSession('commit')}
+              onNewReview={hasCodeChanges || sessionMgr.hasCommitSessionInProgress
+                ? (e) => sessionMgr.openNewSession('review', e)
+                : undefined}
+              onPullOrigin={handlePullOrigin}
+              onPushOrigin={handlePushOrigin}
+              onOpenPushSession={pushSessionId && pushSessionId !== '__pending__'
+                ? openPushSession
+                : undefined}
+              onRebaseBranch={() => startBranchCommandPipeline('rebase')}
+              onRebaseBranchOntoOrigin={() => startBranchCommandPipeline('rebase', 'origin')}
+              onForcePush={handleForcePush}
+              onOpenForcePushSession={forcePushSessionId && forcePushSessionId !== '__pending__'
+                ? openForcePushSession
+                : undefined}
+              {forcePushingOrigin}
+              rebaseBranchDisabledReason={branchCommandDisabledReason}
+              onViewWorktreeDiff={isLocal ? () => (showWorktreeDiff = true) : undefined}
+              onCommitWorktreeChanges={() =>
+                sessionMgr.startOrQueueSession('commit', 'Commit uncommitted changes')}
+              onDiscardWorktreeChanges={handleDiscardWorktreeChanges}
+              onNewSessionReferring={(ref) => sessionMgr.openNewSessionReferring(ref)}
+              newSessionDisabled={sessionMgr.isNewSessionDisabled || gitUnsafeActionsDisabled}
+              {pullingOrigin}
+              {pushingOrigin}
+              {discardingWorktreeChanges}
+              {provisioningLabel}
+              {provisioningDetail}
+            >
+              {#snippet footerActions()}
+                {#if hasCodeChanges || branch.prNumber}
+                  <div class="footer-right-actions">
+                    <BranchCardPrButton
+                      bind:this={prButton}
+                      {branch}
+                      {isLocal}
+                      {isRemote}
+                      {hasCodeChanges}
+                      {timeline}
+                      onOpenSession={(sid) => {
+                        sessionMgr.openSessionId = sid;
+                      }}
+                    />
+                    {#if hasCodeChanges}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onclick={() => {
+                          reviewDiffTarget = null;
+                          showBranchDiff = true;
+                        }}
+                        class="text-xs"
+                      >
+                        <FileDiff size={13} />
+                        <span>Diff</span>
+                      </Button>
+                    {/if}
+                  </div>
                 {/if}
-              </div>
-            {/if}
-          {/snippet}
-        </BranchTimeline>
+              {/snippet}
+            </BranchTimeline>
+          </div>
+        {:else}
+          <!-- Off-screen: render a height-preserving placeholder (last-measured
+               interior height, cached by branch.id) instead of the heavy
+               timeline, so the scrollbar/scroll position stay correct. -->
+          <div
+            class="timeline-placeholder"
+            style:min-height="{interiorHeightCache.get(branch.id) ?? DEFAULT_INTERIOR_HEIGHT}px"
+            aria-hidden="true"
+          ></div>
+        {/if}
       {/if}
     </div>
   {/if}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1456,6 +1456,19 @@
       </div>
     </div>
 
+    <BranchCardPrButton
+      bind:this={prButton}
+      {branch}
+      {isLocal}
+      {isRemote}
+      {hasCodeChanges}
+      {timeline}
+      showButton={false}
+      onOpenSession={(sid) => {
+        sessionMgr.openSessionId = sid;
+      }}
+    />
+
     <div class="card-content">
       {#if isRemote && (remoteWorkspaceStatus === 'stopped' || remoteWorkspaceStatus === 'suspended' || remoteWorkspaceStatus === 'error')}
         <RemoteWorkspaceStatusView
@@ -1550,17 +1563,9 @@
               {#snippet footerActions()}
                 {#if hasCodeChanges || branch.prNumber}
                   <div class="footer-right-actions">
-                    <BranchCardPrButton
-                      bind:this={prButton}
-                      {branch}
-                      {isLocal}
-                      {isRemote}
-                      {hasCodeChanges}
-                      {timeline}
-                      onOpenSession={(sid) => {
-                        sessionMgr.openSessionId = sid;
-                      }}
-                    />
+                    {#if prButton}
+                      {@render prButton.renderButton()}
+                    {/if}
                     {#if hasCodeChanges}
                       <Button
                         variant="outline"

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -46,10 +46,21 @@
     isRemote: boolean;
     hasCodeChanges: boolean;
     timeline: BranchTimelineData | null;
+    showButton?: boolean;
     onOpenSession?: (sessionId: string) => void;
   }
 
-  let { branch, isLocal, isRemote, hasCodeChanges, timeline, onOpenSession }: Props = $props();
+  let {
+    branch,
+    isLocal,
+    isRemote,
+    hasCodeChanges,
+    timeline,
+    showButton = true,
+    onOpenSession,
+  }: Props = $props();
+
+  export { renderButton };
 
   // =========================================================================
   // Option-key tracking (for draft PR creation)
@@ -727,19 +738,25 @@
   </span>
 {/snippet}
 
-{#if hasCodeChanges || branch.prNumber}
-  {#if branch.prNumber}
-    <Tooltip.Root>
-      <Tooltip.Trigger>
-        {#snippet child({ props })}
-          {@render prButton(props)}
-        {/snippet}
-      </Tooltip.Trigger>
-      <Tooltip.Content>{prButtonTitle}</Tooltip.Content>
-    </Tooltip.Root>
-  {:else}
-    {@render prButton({})}
+{#snippet renderButton()}
+  {#if hasCodeChanges || branch.prNumber}
+    {#if branch.prNumber}
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          {#snippet child({ props })}
+            {@render prButton(props)}
+          {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content>{prButtonTitle}</Tooltip.Content>
+      </Tooltip.Root>
+    {:else}
+      {@render prButton({})}
+    {/if}
   {/if}
+{/snippet}
+
+{#if showButton}
+  {@render renderButton()}
 {/if}
 
 <AlertDialog.Root bind:open={showPrErrorDialog}>

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -6,40 +6,14 @@
   Bottom git status rows appear below active and queued work.
   Failed sessions appear in chronological order with completed items.
 -->
-<script module lang="ts">
-  /**
-   * Maximum number of `normalItems` rows a collapsed timeline mounts. Older
-   * rows beyond this are deferred behind a "Show N older" expander and are
-   * genuinely not rendered (not merely hidden) until the user opts in. This
-   * bounds the per-row DOM the synchronous project-switch flush must build for
-   * a long-history branch — Phase 2b of the project-switch-freeze plan, which
-   * bounds the inner `rows` term after Phase 1 cut per-row overlays and Phase
-   * 2a stopped mounting off-screen card interiors. Raise it (or set it very
-   * high) to effectively disable the cap if design rejects the truncated UX.
-   */
-  const TIMELINE_ROW_CAP = 20;
-
-  /**
-   * Whether each branch's timeline is expanded to show its older (deferred)
-   * rows, keyed by the timeline's stable id (see `expansionKey` below).
-   * Module-scoped — not per-instance — so the user's choice survives the whole
-   * `<BranchTimeline>` unmounting when its card scrolls >~1.5 viewports
-   * off-screen (Phase 2a) and later remounting. Mirrors BranchCard's
-   * module-scoped `interiorHeightCache`.
-   */
-  const expandedTimelines = new Map<string, boolean>();
-</script>
-
 <script lang="ts">
-  import { onDestroy, untrack } from 'svelte';
+  import { onDestroy } from 'svelte';
   import type { Snippet } from 'svelte';
   import { slide } from 'svelte/transition';
   import FileText from '@lucide/svelte/icons/file-text';
   import GitCommitVertical from '@lucide/svelte/icons/git-commit-vertical';
   import FileSearch from '@lucide/svelte/icons/file-search';
   import Plus from '@lucide/svelte/icons/plus';
-  import ChevronUp from '@lucide/svelte/icons/chevron-up';
-  import ChevronDown from '@lucide/svelte/icons/chevron-down';
   import { isResumableReason } from '../../types';
   import type {
     BranchGitState,
@@ -811,41 +785,6 @@
     !!onNewNote || !!onNewCommit || !!onNewReview || !!footerActions
   );
 
-  // ── Row cap / "show older" expander (Phase 2b) ────────────────────────
-  //
-  // Cap how many `normalItems` rows a collapsed timeline mounts; pinned-style
-  // footer rows (gitFooterItems), pending/drop placeholders, and the action
-  // footer render in their own loops and are never capped.
-  //
-  // `normalItems` is sorted ascending by timestamp (see the sort above), so the
-  // most-recent rows users expect to see are the TAIL and the deferred OLDER
-  // rows are the head. We therefore render the last N and defer the start.
-  //
-  // The expanded flag persists in the module-scoped `expandedTimelines` map so
-  // it survives Phase 2a's off-screen unmount. We key on `repoDir` (the
-  // branch's worktree path): BranchTimeline isn't passed `branch.id` and we
-  // must not modify BranchCard, so the worktree path is the most stable
-  // branch-unique identifier already in scope. When absent (rare cloud-only
-  // branches with no local clone), expansion isn't persisted and resets on
-  // scroll-away — an acceptable UI-only degradation, never a data issue.
-  let expansionKey = $derived(repoDir ?? null);
-  // Snapshot the persisted flag once at mount (untrack: we deliberately want the
-  // initial value, not a live dependency — toggling writes back via toggleShowOlder).
-  let showOlder = $state(
-    untrack(() => (repoDir ? (expandedTimelines.get(repoDir) ?? false) : false))
-  );
-  let hiddenOlderCount = $derived(Math.max(0, normalItems.length - TIMELINE_ROW_CAP));
-  let visibleNormalItems = $derived(
-    showOlder || hiddenOlderCount === 0
-      ? normalItems
-      : normalItems.slice(normalItems.length - TIMELINE_ROW_CAP)
-  );
-
-  function toggleShowOlder() {
-    showOlder = !showOlder;
-    if (expansionKey) expandedTimelines.set(expansionKey, showOlder);
-  }
-
   /** True when the timeline has no content and action buttons should be enlarged. */
   let actionButtonsEnlarged = $derived(
     items.length === 0 && pendingDropNotes.length === 0 && pendingItems.length === 0
@@ -944,32 +883,7 @@
 {:else}
   <!-- Unified timeline (vertical) -->
   <div class="timeline">
-    {#if hiddenOlderCount > 0}
-      <!--
-        Older (deferred) rows live at the head of the ascending list, so the
-        expander sits above the visible rows. Collapsed: mount only the latest
-        TIMELINE_ROW_CAP rows. Clicking mounts the rest; "Show less" returns to
-        the cheap state. The hidden rows are sliced out, not display:none'd.
-      -->
-      <div class="show-older-row">
-        <Button
-          variant="ghost"
-          size="xs"
-          class="gap-1 text-muted-foreground"
-          aria-expanded={showOlder}
-          onclick={toggleShowOlder}
-        >
-          {#if showOlder}
-            <ChevronDown size={13} />
-            Show less
-          {:else}
-            <ChevronUp size={13} />
-            Show {hiddenOlderCount} older
-          {/if}
-        </Button>
-      </div>
-    {/if}
-    {#each visibleNormalItems as item, index (item.key)}
+    {#each normalItems as item, index (item.key)}
       <div in:maybeSlide={{ sessionId: item.sessionId }} out:slide={{ duration: 200 }}>
         <TimelineRow
           type={item.type}
@@ -995,7 +909,7 @@
           onDiscardChangesClick={item.onDiscardChanges}
           discardChangesDisabledReason={item.discardChangesDisabledReason}
           deleting={item.deleting}
-          isLast={index === visibleNormalItems.length - 1 &&
+          isLast={index === normalItems.length - 1 &&
             pendingDropNotes.length === 0 &&
             pendingItems.length === 0 &&
             gitFooterItems.length === 0 &&
@@ -1262,13 +1176,6 @@
     color: var(--text-muted);
     font-style: italic;
     text-align: center;
-  }
-
-  /* ── "Show older" expander (Phase 2b row cap) ───────────────────────── */
-
-  .show-older-row {
-    display: flex;
-    padding: 2px 0 4px;
   }
 
   /* ── Footer row with inline add buttons ─────────────────────────────── */

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -6,14 +6,40 @@
   Bottom git status rows appear below active and queued work.
   Failed sessions appear in chronological order with completed items.
 -->
+<script module lang="ts">
+  /**
+   * Maximum number of `normalItems` rows a collapsed timeline mounts. Older
+   * rows beyond this are deferred behind a "Show N older" expander and are
+   * genuinely not rendered (not merely hidden) until the user opts in. This
+   * bounds the per-row DOM the synchronous project-switch flush must build for
+   * a long-history branch — Phase 2b of the project-switch-freeze plan, which
+   * bounds the inner `rows` term after Phase 1 cut per-row overlays and Phase
+   * 2a stopped mounting off-screen card interiors. Raise it (or set it very
+   * high) to effectively disable the cap if design rejects the truncated UX.
+   */
+  const TIMELINE_ROW_CAP = 20;
+
+  /**
+   * Whether each branch's timeline is expanded to show its older (deferred)
+   * rows, keyed by the timeline's stable id (see `expansionKey` below).
+   * Module-scoped — not per-instance — so the user's choice survives the whole
+   * `<BranchTimeline>` unmounting when its card scrolls >~1.5 viewports
+   * off-screen (Phase 2a) and later remounting. Mirrors BranchCard's
+   * module-scoped `interiorHeightCache`.
+   */
+  const expandedTimelines = new Map<string, boolean>();
+</script>
+
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import type { Snippet } from 'svelte';
   import { slide } from 'svelte/transition';
   import FileText from '@lucide/svelte/icons/file-text';
   import GitCommitVertical from '@lucide/svelte/icons/git-commit-vertical';
   import FileSearch from '@lucide/svelte/icons/file-search';
   import Plus from '@lucide/svelte/icons/plus';
+  import ChevronUp from '@lucide/svelte/icons/chevron-up';
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
   import { isResumableReason } from '../../types';
   import type {
     BranchGitState,
@@ -785,6 +811,41 @@
     !!onNewNote || !!onNewCommit || !!onNewReview || !!footerActions
   );
 
+  // ── Row cap / "show older" expander (Phase 2b) ────────────────────────
+  //
+  // Cap how many `normalItems` rows a collapsed timeline mounts; pinned-style
+  // footer rows (gitFooterItems), pending/drop placeholders, and the action
+  // footer render in their own loops and are never capped.
+  //
+  // `normalItems` is sorted ascending by timestamp (see the sort above), so the
+  // most-recent rows users expect to see are the TAIL and the deferred OLDER
+  // rows are the head. We therefore render the last N and defer the start.
+  //
+  // The expanded flag persists in the module-scoped `expandedTimelines` map so
+  // it survives Phase 2a's off-screen unmount. We key on `repoDir` (the
+  // branch's worktree path): BranchTimeline isn't passed `branch.id` and we
+  // must not modify BranchCard, so the worktree path is the most stable
+  // branch-unique identifier already in scope. When absent (rare cloud-only
+  // branches with no local clone), expansion isn't persisted and resets on
+  // scroll-away — an acceptable UI-only degradation, never a data issue.
+  let expansionKey = $derived(repoDir ?? null);
+  // Snapshot the persisted flag once at mount (untrack: we deliberately want the
+  // initial value, not a live dependency — toggling writes back via toggleShowOlder).
+  let showOlder = $state(
+    untrack(() => (repoDir ? (expandedTimelines.get(repoDir) ?? false) : false))
+  );
+  let hiddenOlderCount = $derived(Math.max(0, normalItems.length - TIMELINE_ROW_CAP));
+  let visibleNormalItems = $derived(
+    showOlder || hiddenOlderCount === 0
+      ? normalItems
+      : normalItems.slice(normalItems.length - TIMELINE_ROW_CAP)
+  );
+
+  function toggleShowOlder() {
+    showOlder = !showOlder;
+    if (expansionKey) expandedTimelines.set(expansionKey, showOlder);
+  }
+
   /** True when the timeline has no content and action buttons should be enlarged. */
   let actionButtonsEnlarged = $derived(
     items.length === 0 && pendingDropNotes.length === 0 && pendingItems.length === 0
@@ -883,7 +944,32 @@
 {:else}
   <!-- Unified timeline (vertical) -->
   <div class="timeline">
-    {#each normalItems as item, index (item.key)}
+    {#if hiddenOlderCount > 0}
+      <!--
+        Older (deferred) rows live at the head of the ascending list, so the
+        expander sits above the visible rows. Collapsed: mount only the latest
+        TIMELINE_ROW_CAP rows. Clicking mounts the rest; "Show less" returns to
+        the cheap state. The hidden rows are sliced out, not display:none'd.
+      -->
+      <div class="show-older-row">
+        <Button
+          variant="ghost"
+          size="xs"
+          class="gap-1 text-muted-foreground"
+          aria-expanded={showOlder}
+          onclick={toggleShowOlder}
+        >
+          {#if showOlder}
+            <ChevronDown size={13} />
+            Show less
+          {:else}
+            <ChevronUp size={13} />
+            Show {hiddenOlderCount} older
+          {/if}
+        </Button>
+      </div>
+    {/if}
+    {#each visibleNormalItems as item, index (item.key)}
       <div in:maybeSlide={{ sessionId: item.sessionId }} out:slide={{ duration: 200 }}>
         <TimelineRow
           type={item.type}
@@ -909,7 +995,7 @@
           onDiscardChangesClick={item.onDiscardChanges}
           discardChangesDisabledReason={item.discardChangesDisabledReason}
           deleting={item.deleting}
-          isLast={index === normalItems.length - 1 &&
+          isLast={index === visibleNormalItems.length - 1 &&
             pendingDropNotes.length === 0 &&
             pendingItems.length === 0 &&
             gitFooterItems.length === 0 &&
@@ -1176,6 +1262,13 @@
     color: var(--text-muted);
     font-style: italic;
     text-align: center;
+  }
+
+  /* ── "Show older" expander (Phase 2b row cap) ───────────────────────── */
+
+  .show-older-row {
+    display: flex;
+    padding: 2px 0 4px;
   }
 
   /* ── Footer row with inline add buttons ─────────────────────────────── */

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -329,36 +329,15 @@
         {#if meta || secondaryMeta || tertiaryMeta || (badges && badges.length > 0)}
           <div class="timeline-meta">
             {#if meta}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  {#snippet child({ props })}
-                    <span class="meta-item" {...props}>{meta}</span>
-                  {/snippet}
-                </Tooltip.Trigger>
-                <Tooltip.Content>{meta}</Tooltip.Content>
-              </Tooltip.Root>
+              <span class="meta-item" title={meta}>{meta}</span>
             {/if}
             {#if secondaryMeta}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  {#snippet child({ props })}
-                    <span class="meta-item meta-sha" class:failed-meta={isFailed} {...props}
-                      >{secondaryMeta}</span
-                    >
-                  {/snippet}
-                </Tooltip.Trigger>
-                <Tooltip.Content>{secondaryMeta}</Tooltip.Content>
-              </Tooltip.Root>
+              <span class="meta-item meta-sha" class:failed-meta={isFailed} title={secondaryMeta}
+                >{secondaryMeta}</span
+              >
             {/if}
             {#if tertiaryMeta}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  {#snippet child({ props })}
-                    <span class="meta-item" {...props}>{tertiaryMeta}</span>
-                  {/snippet}
-                </Tooltip.Trigger>
-                <Tooltip.Content>{tertiaryMeta}</Tooltip.Content>
-              </Tooltip.Root>
+              <span class="meta-item" title={tertiaryMeta}>{tertiaryMeta}</span>
             {/if}
             {#if badges}
               {#each badges as badge}
@@ -395,58 +374,40 @@
           !!discardChangesDisabledReason}
       >
         {#if onStartClick}
-          <Tooltip.Root>
-            <Tooltip.Trigger>
-              {#snippet child({ props })}
-                <Button
-                  {...props}
-                  variant="outline"
-                  size="xs"
-                  onclick={handleStartClick}
-                  class="h-[22px] rounded border-[var(--border-muted)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
-                >
-                  Start
-                </Button>
-              {/snippet}
-            </Tooltip.Trigger>
-            <Tooltip.Content>Start</Tooltip.Content>
-          </Tooltip.Root>
+          <Button
+            variant="outline"
+            size="xs"
+            onclick={handleStartClick}
+            title="Start"
+            aria-label="Start"
+            class="h-[22px] rounded border-[var(--border-muted)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
+          >
+            Start
+          </Button>
         {/if}
         {#if onRetryClick}
-          <Tooltip.Root>
-            <Tooltip.Trigger>
-              {#snippet child({ props })}
-                <Button
-                  {...props}
-                  variant="ghost"
-                  size="xs"
-                  onclick={handleRetryClick}
-                  class="h-[22px] text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
-                >
-                  Retry
-                </Button>
-              {/snippet}
-            </Tooltip.Trigger>
-            <Tooltip.Content>Retry</Tooltip.Content>
-          </Tooltip.Root>
+          <Button
+            variant="ghost"
+            size="xs"
+            onclick={handleRetryClick}
+            title="Retry"
+            aria-label="Retry"
+            class="h-[22px] text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
+          >
+            Retry
+          </Button>
         {/if}
         {#if onResumeClick}
-          <Tooltip.Root>
-            <Tooltip.Trigger>
-              {#snippet child({ props })}
-                <Button
-                  {...props}
-                  variant="outline"
-                  size="xs"
-                  onclick={handleResumeClick}
-                  class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
-                >
-                  Resume
-                </Button>
-              {/snippet}
-            </Tooltip.Trigger>
-            <Tooltip.Content>Resume session</Tooltip.Content>
-          </Tooltip.Root>
+          <Button
+            variant="outline"
+            size="xs"
+            onclick={handleResumeClick}
+            title="Resume session"
+            aria-label="Resume session"
+            class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
+          >
+            Resume
+          </Button>
         {/if}
         {#if onPullClick || pullDisabledReason}
           <Tooltip.Root>
@@ -539,22 +500,16 @@
           </Tooltip.Root>
         {/if}
         {#if onViewDiffClick}
-          <Tooltip.Root>
-            <Tooltip.Trigger>
-              {#snippet child({ props })}
-                <Button
-                  {...props}
-                  variant="outline"
-                  size="xs"
-                  onclick={handleViewDiffClick}
-                  class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
-                >
-                  Diff
-                </Button>
-              {/snippet}
-            </Tooltip.Trigger>
-            <Tooltip.Content>View diff</Tooltip.Content>
-          </Tooltip.Root>
+          <Button
+            variant="outline"
+            size="xs"
+            onclick={handleViewDiffClick}
+            title="View diff"
+            aria-label="View diff"
+            class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
+          >
+            Diff
+          </Button>
         {/if}
         {#if onCommitChangesClick || commitChangesDisabledReason}
           <Tooltip.Root>
@@ -597,22 +552,16 @@
           </Tooltip.Root>
         {/if}
         {#if hasSession && !onStartClick && !isQueued}
-          <Tooltip.Root>
-            <Tooltip.Trigger>
-              {#snippet child({ props })}
-                <Button
-                  {...props}
-                  variant="ghost"
-                  size="icon-xs"
-                  onclick={handleSessionClick}
-                  class="size-[22px] text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-[var(--ui-accent)] [&_svg]:!size-3"
-                >
-                  <MessageSquare size={12} />
-                </Button>
-              {/snippet}
-            </Tooltip.Trigger>
-            <Tooltip.Content>View session</Tooltip.Content>
-          </Tooltip.Root>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onclick={handleSessionClick}
+            title="View session"
+            aria-label="View session"
+            class="size-[22px] text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-[var(--ui-accent)] [&_svg]:!size-3"
+          >
+            <MessageSquare size={12} />
+          </Button>
         {/if}
         {#if onDeleteClick || deleteDisabledReason}
           <Tooltip.Root>


### PR DESCRIPTION
## Summary
- lazy-mount branch timeline interiors only near the scroll viewport while preserving measured heights
- cap collapsed branch timelines to the latest rows with a Show older expander
- replace several per-row tooltip overlays with native title/aria labels to reduce DOM work

## Tests
- Push hooks ran: crates-fmt, crates-test, crates-lint, differ-ci, staged-ci