### PR TITLE
perf(staged): centralize branch event listeners

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -41,7 +41,6 @@
   import Spinner from '../../shared/Spinner.svelte';
   import { isSessionActive } from '../../shared/sessionStatus';
   import { deleteSessionLinkedItem } from '../../shared/deleteSessionLinkedItem';
-  import { listenToEvent } from '../../transport';
   import { subscribeDragDrop } from './dragDrop';
   import type {
     Branch,
@@ -49,7 +48,6 @@
     BranchTimeline as BranchTimelineData,
     HashtagItem,
     ProjectRepo,
-    SessionStatusPayload,
     WorkspaceStatus,
   } from '../../types';
   import * as commands from '../../api/commands';
@@ -81,6 +79,11 @@
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { pushStateStore } from '../../stores/pushState.svelte';
+  import {
+    onBranchGitStateUpdated,
+    onBranchSetupProgress,
+    onSessionStatusChanged,
+  } from '../../services/branchEventService';
   import type { WorktreeChangesPreview } from '../../commands';
   import type { LinkedNoteContext, NoteClickInfo } from '../sessions/noteFreshness';
 
@@ -217,22 +220,12 @@
   let setupDetail: string | null = $state(null);
 
   $effect(() => {
-    const eventNames = ['worktree-setup-progress', 'workspace-setup-progress'] as const;
-    const unlisteners = eventNames.map((eventName) =>
-      listenToEvent<{ branchId: string; phase: string; detail: string | null }>(
-        eventName,
-        (payload) => {
-          if (payload.branchId === branch.id) {
-            setupPhase = payload.phase;
-            setupDetail = payload.detail;
-          }
-        }
-      )
-    );
+    const unlisten = onBranchSetupProgress(branch.id, (payload) => {
+      setupPhase = payload.phase;
+      setupDetail = payload.detail;
+    });
 
-    return () => {
-      for (const fn of unlisteners) fn();
-    };
+    return () => unlisten();
   });
 
   // Reset setup state when provisioning completes
@@ -605,71 +598,63 @@
   $effect(() => {
     const branchId = branch.id;
 
-    const unlistenStatus = listenToEvent<SessionStatusPayload>(
-      'session-status-changed',
-      (payload) => {
-        const {
-          sessionId: eventSessionId,
-          status,
-          branchId: eventBranchId,
-          isAutoReview,
-        } = payload;
-        if (status === 'completed' || status === 'error' || status === 'cancelled') {
-          // If this is the auto review session completing, just clear tracking
-          if (eventSessionId === sessionMgr.autoReviewSessionId) {
-            sessionMgr.autoReviewSessionId = null;
-            return;
-          }
+    const unlistenStatus = onSessionStatusChanged((payload) => {
+      const { sessionId: eventSessionId, status, branchId: eventBranchId, isAutoReview } = payload;
+      if (status === 'completed' || status === 'error' || status === 'cancelled') {
+        // If this is the auto review session completing, just clear tracking
+        if (eventSessionId === sessionMgr.autoReviewSessionId) {
+          sessionMgr.autoReviewSessionId = null;
+          return;
+        }
 
-          // Push/force-push session tracking lives in pushStateStore and is
-          // cleared centrally by sessionStatusListener.handlePushCompletion.
+        // Push/force-push session tracking lives in pushStateStore and is
+        // cleared centrally by sessionStatusListener.handlePushCompletion.
 
-          // Skip normal completion handling for any auto review session
-          if (isAutoReview) {
-            return;
-          }
+        // Skip normal completion handling for any auto review session
+        if (isAutoReview) {
+          return;
+        }
 
-          // Skip reload for the adopted auto-review session completing —
-          // the timeline was already updated optimistically during adoption.
-          if (eventSessionId === sessionMgr.adoptedSessionId) {
-            sessionMgr.adoptedSessionId = null;
-            return;
-          }
+        // Skip reload for the adopted auto-review session completing —
+        // the timeline was already updated optimistically during adoption.
+        if (eventSessionId === sessionMgr.adoptedSessionId) {
+          sessionMgr.adoptedSessionId = null;
+          return;
+        }
 
-          // Only reload if this session belongs to our branch
-          if (eventBranchId && eventBranchId !== branchId) return;
+        // Only reload if this session belongs to our branch
+        if (eventBranchId && eventBranchId !== branchId) return;
 
-          commands.invalidateBranchTimeline(branch.id);
+        commands.invalidateBranchTimeline(branch.id);
+        loadTimeline();
+        // Handle PR session completion
+        if (prButton && eventSessionId === prButton.getPrSessionId()) {
+          prButton.handlePrSessionComplete(status);
+        }
+        // Handle push session completion
+        if (prButton && eventSessionId === prButton.getPushSessionId()) {
+          prButton.handlePushSessionComplete(status);
+        }
+      } else if (status === 'running' && eventBranchId === branchId) {
+        // Track auto review sessions started by the backend
+        if (isAutoReview) {
+          sessionMgr.autoReviewSessionId = eventSessionId;
+          commands.findFreshAutoReview(branchId).then((review) => {
+            if (review) {
+              sessionMgr.autoReviewId = review.id;
+            }
+          });
+        }
+        // Refresh the timeline so the pending note/commit stub appears immediately.
+        // Skip if a session start is in-flight (pending item has no sessionId yet),
+        // because startBranchSessionWithPendingItem will call loadTimeline after
+        // it gets the sessionId — otherwise pruning can't match the pending item
+        // and both the pending and real items briefly render simultaneously.
+        if (!isAutoReview && !sessionMgr.isSessionStartPending) {
           loadTimeline();
-          // Handle PR session completion
-          if (prButton && eventSessionId === prButton.getPrSessionId()) {
-            prButton.handlePrSessionComplete(status);
-          }
-          // Handle push session completion
-          if (prButton && eventSessionId === prButton.getPushSessionId()) {
-            prButton.handlePushSessionComplete(status);
-          }
-        } else if (status === 'running' && eventBranchId === branchId) {
-          // Track auto review sessions started by the backend
-          if (isAutoReview) {
-            sessionMgr.autoReviewSessionId = eventSessionId;
-            commands.findFreshAutoReview(branchId).then((review) => {
-              if (review) {
-                sessionMgr.autoReviewId = review.id;
-              }
-            });
-          }
-          // Refresh the timeline so the pending note/commit stub appears immediately.
-          // Skip if a session start is in-flight (pending item has no sessionId yet),
-          // because startBranchSessionWithPendingItem will call loadTimeline after
-          // it gets the sessionId — otherwise pruning can't match the pending item
-          // and both the pending and real items briefly render simultaneously.
-          if (!isAutoReview && !sessionMgr.isSessionStartPending) {
-            loadTimeline();
-          }
         }
       }
-    );
+    });
 
     return () => {
       unlistenStatus();
@@ -681,16 +666,12 @@
   $effect(() => {
     const branchId = branch.id;
 
-    const unlistenGitState = listenToEvent<{ branchId: string; gitState: BranchGitState }>(
-      'git-state-updated',
-      (payload) => {
-        if (payload.branchId !== branchId) return;
-        if (timeline) {
-          timeline = { ...timeline, gitState: payload.gitState };
-        }
-        refreshingGitState = false;
+    const unlistenGitState = onBranchGitStateUpdated(branchId, (payload) => {
+      if (timeline) {
+        timeline = { ...timeline, gitState: payload.gitState };
       }
-    );
+      refreshingGitState = false;
+    });
 
     return () => {
       unlistenGitState();

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -26,7 +26,7 @@
   import Spinner from '../../shared/Spinner.svelte';
   import SineWave from '../../shared/SineWave.svelte';
   import ActionOutputModal from '../actions/ActionOutputModal.svelte';
-  import { listenToEvent, type UnlistenFn } from '../../transport';
+  import type { UnlistenFn } from '../../transport';
   import type { Branch, ProjectRepo } from '../../types';
   import * as commands from '../../api/commands';
   import type { ProjectAction } from '../../api/commands';
@@ -36,7 +36,6 @@
     clearActionExecution,
     stopBranchAction,
     getRunPhase,
-    listenToRunPhaseChanged,
     listenToRepoActionsDetection,
     type ActionStatusEvent,
     type ActionType,
@@ -54,6 +53,7 @@
   import { bloxEnv } from '../../stores/bloxEnv.svelte';
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState } from '../agents/agent.svelte';
+  import { onBranchActionStatus, onBranchRunPhaseChanged } from '../../services/branchEventService';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
   import { Button } from '$lib/components/ui/button';
 
@@ -225,12 +225,7 @@
   $effect(() => {
     const branchId = branch.id;
 
-    const unlistenActionStatus = listenToEvent<ActionStatusEvent>('action_status', (payload) => {
-      // Only process events for this branch
-      if (payload.branchId !== branchId) {
-        return;
-      }
-
+    const unlistenActionStatus = onBranchActionStatus(branchId, (payload: ActionStatusEvent) => {
       const existingIndex = runningActions.findIndex((a) => a.executionId === payload.executionId);
 
       if (payload.status === 'running') {
@@ -298,11 +293,9 @@
       }
     });
 
-    const unlistenRunPhaseChanged = listenToRunPhaseChanged((event) => {
-      if (event.branchId === branchId) {
-        runPhases.set(event.executionId, event.phase);
-        runPhases = new Map(runPhases);
-      }
+    const unlistenRunPhaseChanged = onBranchRunPhaseChanged(branchId, (event) => {
+      runPhases.set(event.executionId, event.phase);
+      runPhases = new Map(runPhases);
     });
 
     return () => {

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -15,12 +15,10 @@
   import * as AlertDialog from '$lib/components/ui/alert-dialog';
   import { Button } from '$lib/components/ui/button';
   import { minuteNow, secondNow } from '../../shared/relativeTime.svelte';
-  import { listenToEvent } from '../../transport';
   import type {
     Branch,
     BranchTimeline as BranchTimelineData,
     PrFailedCheck,
-    PrStatusChangedEvent,
     Session,
   } from '../../types';
   import * as commands from '../../api/commands';
@@ -38,6 +36,10 @@
   import { prStateStore, type PrState } from '../../stores/prState.svelte';
   import { pushStateStore, type PushState } from '../../stores/pushState.svelte';
   import * as prPollingService from '../../services/prPollingService';
+  import {
+    onBranchPrStatusChanged,
+    onBranchPrStatusCleared,
+  } from '../../services/branchEventService';
 
   interface Props {
     branch: Branch;
@@ -170,39 +172,35 @@
   $effect(() => {
     const branchId = branch.id;
 
-    const unlistenStatus = listenToEvent<PrStatusChangedEvent>('pr-status-changed', (payload) => {
-      if (payload.branchId === branchId) {
-        prStatusState = payload.prState;
-        prStatusChecks = payload.prChecksStatus;
-        prStatusReviewDecision = payload.prReviewDecision;
-        prStatusMergeable = payload.prMergeable;
-        prStatusDraft = payload.prDraft;
-        prHeadSha = payload.prHeadSha;
-        prFetchedAt = payload.prFetchedAt;
-        failedChecks = payload.failedChecks ?? [];
-        prStatusCleared = false;
-        // Update the polling service with the new checks status
-        prPollingService.updateChecksStatus(
-          branchId,
-          branch.projectId,
-          payload.prChecksStatus === 'PENDING'
-        );
-      }
+    const unlistenStatus = onBranchPrStatusChanged(branchId, (payload) => {
+      prStatusState = payload.prState;
+      prStatusChecks = payload.prChecksStatus;
+      prStatusReviewDecision = payload.prReviewDecision;
+      prStatusMergeable = payload.prMergeable;
+      prStatusDraft = payload.prDraft;
+      prHeadSha = payload.prHeadSha;
+      prFetchedAt = payload.prFetchedAt;
+      failedChecks = payload.failedChecks ?? [];
+      prStatusCleared = false;
+      // Update the polling service with the new checks status
+      prPollingService.updateChecksStatus(
+        branchId,
+        branch.projectId,
+        payload.prChecksStatus === 'PENDING'
+      );
     });
 
-    const unlistenCleared = listenToEvent<string>('pr-status-cleared', (clearedBranchId) => {
-      if (clearedBranchId === branchId) {
-        prStatusState = null;
-        prStatusChecks = null;
-        prStatusReviewDecision = null;
-        prStatusMergeable = null;
-        prStatusDraft = null;
-        prHeadSha = null;
-        prFetchedAt = null;
-        failedChecks = [];
-        prStatusCleared = true;
-        prPollingService.updateChecksStatus(branchId, branch.projectId, false);
-      }
+    const unlistenCleared = onBranchPrStatusCleared(branchId, () => {
+      prStatusState = null;
+      prStatusChecks = null;
+      prStatusReviewDecision = null;
+      prStatusMergeable = null;
+      prStatusDraft = null;
+      prHeadSha = null;
+      prFetchedAt = null;
+      failedChecks = [];
+      prStatusCleared = true;
+      prPollingService.updateChecksStatus(branchId, branch.projectId, false);
     });
 
     return () => {

--- a/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
+++ b/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { onDestroy, tick } from 'svelte';
   import type { Snippet } from 'svelte';
-  import { listenToEvent } from '../../transport';
   import { listParentBranchCommits, type ParentBranchCommit } from '../../commands';
   import { formatRelativeTimeSeconds } from '../../shared/relativeTime.svelte';
-  import type { BranchGitState } from '../../types';
+  import * as Tooltip from '$lib/components/ui/tooltip';
+  import { onBranchGitStateUpdated } from '../../services/branchEventService';
 
   interface Props {
     branchId: string;
@@ -130,17 +130,13 @@
   }
 
   $effect(() => {
-    const unlisten = listenToEvent<{ branchId: string; gitState: BranchGitState }>(
-      'git-state-updated',
-      (payload) => {
-        if (payload.branchId !== branchId) return;
-        commits = null;
-        loadVersion++;
-        if (open) {
-          void loadCommits();
-        }
+    const unlisten = onBranchGitStateUpdated(branchId, () => {
+      commits = null;
+      loadVersion++;
+      if (open) {
+        void loadCommits();
       }
-    );
+    });
     return () => unlisten();
   });
 

--- a/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
+++ b/apps/staged/src/lib/features/branches/ParentBranchCommitsHover.svelte
@@ -3,7 +3,6 @@
   import type { Snippet } from 'svelte';
   import { listParentBranchCommits, type ParentBranchCommit } from '../../commands';
   import { formatRelativeTimeSeconds } from '../../shared/relativeTime.svelte';
-  import * as Tooltip from '$lib/components/ui/tooltip';
   import { onBranchGitStateUpdated } from '../../services/branchEventService';
 
   interface Props {

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { listenToEvent } from '../../transport';
   import Send from '@lucide/svelte/icons/send';
   import Spinner from '../../shared/Spinner.svelte';
   import { Button } from '$lib/components/ui/button';
   import { toast } from 'svelte-sonner';
   import * as commands from '../../api/commands';
   import { getCommitPrefillFromReviewComments } from '../branches/commitSessionPrefill';
-  import type { SessionStatusPayload, HashtagItem } from '../../types';
+  import type { HashtagItem } from '../../types';
   import HashtagInput from '../sessions/HashtagInput.svelte';
   import { buildBranchHashtagItems } from '../sessions/hashtagItems';
   import { getPreferredAgent } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { viewport } from '../../shared/viewport.svelte';
+  import { onBranchSessionStatus } from '../../services/branchEventService';
 
   interface Props {
     branchId: string;
@@ -103,8 +103,7 @@
 
     document.addEventListener('keydown', handleGlobalKeydown);
 
-    const unlisten = listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
-      if (payload.branchId !== branchId) return;
+    const unlisten = onBranchSessionStatus(branchId, () => {
       void refreshQueueState(true);
     });
 

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -74,6 +74,11 @@
   let loading = $state(true);
   let error = $state<string | null>(null);
   let loadGeneration = 0;
+  let initialLoadComplete = $state(false);
+  let lastSelectedProjectId: string | null = null;
+  let backgroundHydrationCancel: (() => void) | null = null;
+  let queuedSessionDrainCancel: (() => void) | null = null;
+  const queuedSessionDrainBranchIds = new Set<string>();
 
   // Store health — if non-null the DB needs a reset before we can proceed
   let storeIncompat = $state<StoreIncompatibility | null>(null);
@@ -201,11 +206,14 @@
     );
 
     return () => {
+      loadGeneration++;
       window.removeEventListener('staged:new-project', onNewProject);
       unlistenDetection();
       unlistenProjectRepoAdded();
       unlistenPrStatus();
       unlistenSessionStatus();
+      cancelBackgroundHydration();
+      cancelQueuedSessionDrain();
       workspaceLifecycle.stop();
       projectRunActionsStore.stopListening();
     };
@@ -244,8 +252,186 @@
     getWindowSync().close();
   }
 
+  function scheduleDeferredTask(callback: () => void, timeout = 1500): () => void {
+    const schedule =
+      typeof requestIdleCallback === 'function'
+        ? (cb: () => void) => requestIdleCallback(cb, { timeout })
+        : (cb: () => void) => setTimeout(cb, 0) as unknown as number;
+    const cancel =
+      typeof cancelIdleCallback === 'function'
+        ? (handle: number) => cancelIdleCallback(handle)
+        : (handle: number) => clearTimeout(handle);
+
+    const handle = schedule(callback);
+    return () => cancel(handle);
+  }
+
+  function cancelBackgroundHydration() {
+    backgroundHydrationCancel?.();
+    backgroundHydrationCancel = null;
+  }
+
+  function cancelQueuedSessionDrain() {
+    queuedSessionDrainCancel?.();
+    queuedSessionDrainCancel = null;
+    queuedSessionDrainBranchIds.clear();
+  }
+
+  function scheduleQueuedSessionDrain(branches: Branch[]) {
+    for (const branch of branches) {
+      const isLocalReady = branch.branchType === 'local' && branch.worktreePath;
+      const isRemoteReady = branch.branchType === 'remote' && branch.workspaceStatus === 'running';
+      if (isLocalReady || isRemoteReady) {
+        queuedSessionDrainBranchIds.add(branch.id);
+      }
+    }
+
+    if (queuedSessionDrainBranchIds.size === 0 || queuedSessionDrainCancel) return;
+
+    queuedSessionDrainCancel = scheduleDeferredTask(() => {
+      queuedSessionDrainCancel = null;
+      const branchIds = Array.from(queuedSessionDrainBranchIds);
+      queuedSessionDrainBranchIds.clear();
+      for (const branchId of branchIds) {
+        commands.drainQueuedSessions(branchId).catch((e) => {
+          console.error('[ProjectHome] Failed to drain queued sessions on startup:', e);
+        });
+      }
+    }, 3000);
+  }
+
+  async function hydrateProject(
+    project: Project,
+    generation: number,
+    options: { drainQueuedSessions?: boolean } = {}
+  ): Promise<Branch[] | null> {
+    const [branches, repos] = await Promise.all([
+      commands.listBranchesForProject(project.id),
+      commands.listProjectRepos(project.id),
+    ]);
+    if (generation !== loadGeneration) return null;
+
+    const mergedBranches = mergeBranchesPreservingWorktree(
+      branchesByProject.get(project.id) || [],
+      branches
+    );
+    branchesByProject = new Map(branchesByProject).set(project.id, mergedBranches);
+    workspaceLifecycle.enqueueInitialSetup(project.id, mergedBranches);
+    replaceProjectRepos(project.id, repos);
+    void repoBadgeStore.ensureForRepos(
+      repos.map((r) => ({ githubRepo: r.githubRepo, subpath: r.subpath }))
+    );
+    projectRunActionsStore
+      .hydrateFromProjectBranches(branchesByProject, {
+        branchIds: mergedBranches.map((b) => b.id),
+      })
+      .catch(console.error);
+
+    if (options.drainQueuedSessions) {
+      scheduleQueuedSessionDrain(mergedBranches);
+    }
+
+    return mergedBranches;
+  }
+
+  async function hydrateAllProjects(projectList: Project[], generation: number) {
+    await Promise.all(
+      projectList.map(async (project) => {
+        try {
+          await hydrateProject(project, generation, { drainQueuedSessions: true });
+        } catch (e) {
+          console.error(`[ProjectHome] Failed to hydrate project '${project.id}':`, e);
+        }
+      })
+    );
+  }
+
+  function scheduleBackgroundHydration(
+    projectList: Project[],
+    foregroundProjectId: string | null,
+    generation: number
+  ) {
+    cancelBackgroundHydration();
+
+    const queue = projectList.filter((project) => project.id !== foregroundProjectId);
+    if (queue.length === 0) return;
+
+    let cancelled = false;
+    let cancelScheduledTask: (() => void) | null = null;
+
+    const hydrateNext = () => {
+      cancelScheduledTask = null;
+      if (cancelled || generation !== loadGeneration) return;
+
+      const project = queue.shift();
+      if (!project) return;
+
+      hydrateProject(project, generation, { drainQueuedSessions: true })
+        .catch((e) => {
+          console.error(`[ProjectHome] Failed to background hydrate project '${project.id}':`, e);
+        })
+        .finally(() => {
+          if (cancelled || generation !== loadGeneration || queue.length === 0) return;
+          cancelScheduledTask = scheduleDeferredTask(hydrateNext, 3000);
+        });
+    };
+
+    cancelScheduledTask = scheduleDeferredTask(hydrateNext, 3000);
+    backgroundHydrationCancel = () => {
+      cancelled = true;
+      cancelScheduledTask?.();
+    };
+  }
+
+  async function hydrateActionDetection(projectList: Project[], generation: number) {
+    try {
+      const contexts = await commands.listActionContexts();
+      if (generation !== loadGeneration) return;
+      detectingProjectIds = new Set(
+        projectList
+          .filter((project) =>
+            contexts.some(
+              (context) =>
+                context.detectingActions &&
+                context.githubRepo === project.githubRepo &&
+                context.subpath === project.subpath
+            )
+          )
+          .map((project) => project.id)
+      );
+    } catch (e) {
+      console.error('[ProjectHome] Failed to load action contexts:', e);
+    }
+  }
+
+  async function hydrateForCurrentSelection(projectId: string | null) {
+    const generation = ++loadGeneration;
+    cancelBackgroundHydration();
+    error = null;
+
+    const projectList = projects;
+    if (projectId) {
+      const project = projectList.find((p) => p.id === projectId);
+      if (!project) return;
+      try {
+        await hydrateProject(project, generation, { drainQueuedSessions: true });
+      } catch (e) {
+        if (generation !== loadGeneration) return;
+        console.error(`[ProjectHome] Failed to hydrate selected project '${project.id}':`, e);
+      }
+      if (generation !== loadGeneration) return;
+      scheduleBackgroundHydration(projectList, projectId, generation);
+    } else {
+      await hydrateAllProjects(projectList, generation);
+    }
+
+    void hydrateActionDetection(projectList, generation);
+  }
+
   async function loadData() {
     const generation = ++loadGeneration;
+    initialLoadComplete = false;
+    cancelBackgroundHydration();
     if (projects.length === 0) {
       loading = true;
     }
@@ -273,62 +459,27 @@
       }
       reposById = prunedRepos;
 
-      await Promise.all(
-        projectList.map(async (project) => {
+      if (selectedProjectId) {
+        const selectedProject = projectList.find((project) => project.id === selectedProjectId);
+        if (selectedProject) {
           try {
-            const [branches, repos] = await Promise.all([
-              commands.listBranchesForProject(project.id),
-              commands.listProjectRepos(project.id),
-            ]);
-            if (generation !== loadGeneration) return;
-            branchesByProject = new Map(branchesByProject).set(project.id, branches);
-            workspaceLifecycle.enqueueInitialSetup(project.id, branches);
-            replaceProjectRepos(project.id, repos);
-
-            // On startup, drain queued sessions for branches that are already ready.
-            for (const branch of branches) {
-              const isLocalReady = branch.branchType === 'local' && branch.worktreePath;
-              const isRemoteReady =
-                branch.branchType === 'remote' && branch.workspaceStatus === 'running';
-              if (isLocalReady || isRemoteReady) {
-                commands.drainQueuedSessions(branch.id).catch((e) => {
-                  console.error('[ProjectHome] Failed to drain queued sessions on startup:', e);
-                });
-              }
-            }
+            await hydrateProject(selectedProject, generation, { drainQueuedSessions: true });
           } catch (e) {
-            console.error(`[ProjectHome] Failed to hydrate project '${project.id}':`, e);
+            console.error(
+              `[ProjectHome] Failed to hydrate selected project '${selectedProject.id}':`,
+              e
+            );
           }
-        })
-      );
-
-      projectRunActionsStore.hydrateFromProjectBranches(branchesByProject).catch(console.error);
-
-      // Ensure badges exist for all loaded repos
-      const allRepos = [...reposById.values()].map((r) => ({
-        githubRepo: r.githubRepo,
-        subpath: r.subpath,
-      }));
-      void repoBadgeStore.ensureForRepos(allRepos);
-
-      try {
-        const contexts = await commands.listActionContexts();
+        }
         if (generation !== loadGeneration) return;
-        detectingProjectIds = new Set(
-          projectList
-            .filter((project) =>
-              contexts.some(
-                (context) =>
-                  context.detectingActions &&
-                  context.githubRepo === project.githubRepo &&
-                  context.subpath === project.subpath
-              )
-            )
-            .map((project) => project.id)
-        );
-      } catch (e) {
-        console.error('[ProjectHome] Failed to load action contexts:', e);
+        scheduleBackgroundHydration(projectList, selectedProjectId, generation);
+      } else {
+        await hydrateAllProjects(projectList, generation);
       }
+
+      lastSelectedProjectId = selectedProjectId;
+      initialLoadComplete = true;
+      void hydrateActionDetection(projectList, generation);
     } catch (e) {
       if (generation !== loadGeneration) return;
       error = e instanceof Error ? e.message : String(e);
@@ -338,6 +489,14 @@
       }
     }
   }
+
+  $effect(() => {
+    const projectId = selectedProjectId;
+    if (!initialLoadComplete) return;
+    if (projectId === lastSelectedProjectId) return;
+    lastSelectedProjectId = projectId;
+    void hydrateForCurrentSelection(projectId);
+  });
 
   let visibleProjects = $derived(
     selectedProjectId ? projects.filter((project) => project.id === selectedProjectId) : projects

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -34,6 +34,7 @@
   import * as commands from '../../api/commands';
   import HashtagInput from '../sessions/HashtagInput.svelte';
   import { buildProjectHashtagItems } from '../sessions/hashtagItems';
+  import { branchTimelineReadyKey } from '../branches/branchTimelineReady';
   import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
   import { projectStateStore } from '../../stores/projectState.svelte';
   import BranchCard from '../branches/BranchCard.svelte';
@@ -44,6 +45,9 @@
   import SuggestedRepos from './SuggestedRepos.svelte';
   import type { RepoSelection as RepoPickerSelection } from '../../shared/githubUrl';
   import TimelineRow from '../timeline/TimelineRow.svelte';
+  import TimelineContextMenu, {
+    type TimelineContextMenuAction,
+  } from '../timeline/TimelineContextMenu.svelte';
   import NoteModal from '../notes/NoteModal.svelte';
   import SessionModal from '../sessions/SessionModal.svelte';
   import AgentSelector from '../agents/AgentSelector.svelte';
@@ -200,19 +204,65 @@
   // Hashtag reference items
   let hashtagItems = $state<HashtagItem[]>([]);
   let hashtagVersion = $state(0);
+  let hashtagInputFocused = $state(false);
+  let hashtagLoadGeneration = 0;
+  let loadedHashtagSignature: string | null = null;
+  let loadingHashtagSignature: string | null = null;
+  let hashtagSignature = $derived.by(() => {
+    const readyBranchParts = branches.map((branch) => {
+      const readyKey = branchTimelineReadyKey(branch) ?? '';
+      const repo = branch.projectRepoId ? reposById.get(branch.projectRepoId) : null;
+      return [
+        branch.id,
+        readyKey,
+        branch.branchName,
+        branch.projectRepoId ?? '',
+        repo?.githubRepo ?? '',
+        repo?.subpath ?? '',
+      ].join(':');
+    });
+    const noteParts = projectNotes.map((note) =>
+      [note.id, note.title, note.updatedAt, note.completedAt ?? ''].join(':')
+    );
+
+    return [project.id, hashtagVersion, readyBranchParts.join('|'), noteParts.join('|')].join(';');
+  });
+
+  async function ensureHashtagItems() {
+    const signature = hashtagSignature;
+    if (signature === loadedHashtagSignature) return;
+    if (signature === loadingHashtagSignature) return;
+
+    const generation = ++hashtagLoadGeneration;
+    loadingHashtagSignature = signature;
+    const branchesSnapshot = [...branches];
+    const reposSnapshot = new Map(reposById);
+    const notesSnapshot = [...projectNotes];
+
+    try {
+      const items = await buildProjectHashtagItems(
+        project.id,
+        branchesSnapshot,
+        reposSnapshot,
+        notesSnapshot
+      );
+      if (generation !== hashtagLoadGeneration) return;
+      if (signature !== hashtagSignature) return;
+      hashtagItems = items;
+      loadedHashtagSignature = signature;
+    } catch (err) {
+      console.error('[ProjectSection] Failed to build hashtag items:', err);
+    } finally {
+      if (loadingHashtagSignature === signature) {
+        loadingHashtagSignature = null;
+      }
+    }
+  }
+
   $effect(() => {
-    const _v = hashtagVersion; // reactive dependency for manual invalidation
-    let stale = false;
-    buildProjectHashtagItems(project.id, branches, reposById)
-      .then((items) => {
-        if (!stale) hashtagItems = items;
-      })
-      .catch((err) => {
-        console.error('[ProjectSection] Failed to build hashtag items:', err);
-      });
-    return () => {
-      stale = true;
-    };
+    const _signature = hashtagSignature;
+    if (!hashtagInputFocused) return;
+    void ensureHashtagItems();
   });
 
   // Image attachment state
@@ -247,6 +297,8 @@
 
   function handlePromptFocusIn() {
     promptExpanded = true;
+    hashtagInputFocused = true;
+    void ensureHashtagItems();
   }
 
   function handlePromptFocusOut(e: FocusEvent) {
@@ -258,6 +310,7 @@
       return;
     }
     promptExpanded = false;
+    hashtagInputFocused = false;
   }
 
   async function handleImageFileSelect(e: Event) {
@@ -434,6 +487,16 @@
       return (a.completedAt ?? a.createdAt) - (b.completedAt ?? b.createdAt);
     })
   );
+  let projectNoteContextMenuActions = $derived.by(() => {
+    const actions: TimelineContextMenuAction[] = [];
+    for (const note of timelineNotes) {
+      const key = projectNoteContextMenuKey(note);
+      if (key) {
+        actions.push({ key, hashtagRef: `#project-note:${note.id}` });
+      }
+    }
+    return actions;
+  });
 
   let openNote = $state<{
     title: string;
@@ -442,6 +505,21 @@
     noteUpdatedAt?: number;
   } | null>(null);
   let openSessionId = $state<string | null>(null);
+
+  function isCompletedProjectNote(note: ProjectNote): boolean {
+    const isRunning = isSessionActive(note.sessionStatus);
+    const isFailed = !isRunning && !!note.sessionId && !note.content.trim();
+    return !isRunning && !isFailed;
+  }
+
+  function projectNoteContextMenuKey(note: ProjectNote): string | undefined {
+    return isCompletedProjectNote(note) ? `project-note-${note.id}` : undefined;
+  }
+
+  function handleProjectNoteNewSessionReferring(ref: string) {
+    promptText = buildReferringPrompt(promptText, ref);
+    focusAtEnd(promptTextarea);
+  }
 
   function linkedNoteContext(note: ProjectNote | undefined): LinkedNoteContext | null {
     if (!note) return null;
@@ -729,50 +807,51 @@
         <FileText size={13} />
         <span>Project Notes</span>
       </div>
-      <div class="notes-timeline">
-        {#each timelineNotes as note, index (note.id)}
-          {@const isRunning = isSessionActive(note.sessionStatus)}
-          {@const isFailed = !isRunning && !!note.sessionId && !note.content.trim()}
-          {@const noteType = isRunning ? 'generating-note' : isFailed ? 'failed-note' : 'note'}
-          {@const liveHint =
-            isRunning && note.sessionId ? liveSessionHints[note.sessionId] : undefined}
-          <TimelineRow
-            type={noteType}
-            title={isRunning
-              ? 'Generating note…'
-              : isFailed
-                ? 'Session finished — no note created'
-                : note.title || 'Untitled note'}
-            secondaryMeta={isRunning
-              ? (liveHint ?? 'Generating note')
-              : isFailed
+      <TimelineContextMenu
+        actions={projectNoteContextMenuActions}
+        onNewSessionReferring={handleProjectNoteNewSessionReferring}
+      >
+        <div class="notes-timeline">
+          {#each timelineNotes as note, index (note.id)}
+            {@const isRunning = isSessionActive(note.sessionStatus)}
+            {@const isFailed = !isRunning && !!note.sessionId && !note.content.trim()}
+            {@const noteType = isRunning ? 'generating-note' : isFailed ? 'failed-note' : 'note'}
+            {@const liveHint =
+              isRunning && note.sessionId ? liveSessionHints[note.sessionId] : undefined}
+            <TimelineRow
+              type={noteType}
+              title={isRunning
+                ? 'Generating note…'
+                : isFailed
+                  ? 'Session finished — no note created'
+                  : note.title || 'Untitled note'}
+              secondaryMeta={isRunning
+                ? (liveHint ?? 'Generating note')
+                : isFailed
+                  ? undefined
+                  : formatRelativeTime(note.completedAt ?? note.createdAt, nowMs)}
+              deleting={deletingNoteIds.has(note.id)}
+              isLast={index === timelineNotes.length - 1}
+              sessionId={note.sessionId ?? undefined}
+              onItemClick={isRunning || isFailed
                 ? undefined
-                : formatRelativeTime(note.completedAt ?? note.createdAt, nowMs)}
-            deleting={deletingNoteIds.has(note.id)}
-            isLast={index === timelineNotes.length - 1}
-            sessionId={note.sessionId ?? undefined}
-            onItemClick={isRunning || isFailed
-              ? undefined
-              : () => {
-                  openNote = {
-                    title: note.title,
-                    content: note.content,
-                    sessionId: note.sessionId ?? undefined,
-                    noteUpdatedAt: note.updatedAt,
-                  };
-                }}
-            onSessionClick={(sid) => {
-              openSessionId = sid;
-            }}
-            onDeleteClick={() => handleDeleteNote(note.id)}
-            hashtagRef={noteType === 'note' ? `#project-note:${note.id}` : undefined}
-            onNewSessionReferring={(ref) => {
-              promptText = buildReferringPrompt(promptText, ref);
-              focusAtEnd(promptTextarea);
-            }}
-          />
-        {/each}
-      </div>
+                : () => {
+                    openNote = {
+                      title: note.title,
+                      content: note.content,
+                      sessionId: note.sessionId ?? undefined,
+                      noteUpdatedAt: note.updatedAt,
+                    };
+                  }}
+              onSessionClick={(sid) => {
+                openSessionId = sid;
+              }}
+              onDeleteClick={() => handleDeleteNote(note.id)}
+              contextMenuKey={projectNoteContextMenuKey(note)}
+            />
+          {/each}
+        </div>
+      </TimelineContextMenu>
     </div>
   {/if}
 

--- a/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
@@ -263,4 +263,21 @@ describe('buildProjectHashtagItems', () => {
     expect(getBranchTimeline).toHaveBeenNthCalledWith(1, 'local-ready');
     expect(getBranchTimeline).toHaveBeenNthCalledWith(2, 'remote-ready');
   });
+
+  it('reuses provided project notes instead of fetching them again', async () => {
+    vi.mocked(getBranchTimeline).mockResolvedValue(emptyTimeline());
+
+    const items = await buildProjectHashtagItems('project-1', [], undefined, [
+      projectNote({ id: 'provided-note', title: 'Provided note' }),
+    ]);
+
+    expect(listProjectNotes).not.toHaveBeenCalled();
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        type: 'project-note',
+        id: 'provided-note',
+        title: 'Provided note',
+      })
+    );
+  });
 });

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -125,7 +125,8 @@ export async function buildBranchHashtagItems(
 export async function buildProjectHashtagItems(
   projectId: string,
   branches: Branch[],
-  reposById?: Map<string, ProjectRepo>
+  reposById?: Map<string, ProjectRepo>,
+  knownProjectNotes?: ProjectNote[]
 ): Promise<HashtagItem[]> {
   const readyBranches = branches.filter((branch) => branchTimelineReadyKey(branch) !== null);
 
@@ -133,7 +134,7 @@ export async function buildProjectHashtagItems(
     Promise.allSettled(
       readyBranches.map((b) => getBranchTimeline(b.id).then((t) => ({ branch: b, timeline: t })))
     ),
-    listProjectNotes(projectId),
+    knownProjectNotes ? Promise.resolve(knownProjectNotes) : listProjectNotes(projectId),
   ]);
 
   const timelines = timelineResults

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -22,6 +22,9 @@
   } from '../../types';
   import type { NoteClickInfo } from '../sessions/noteFreshness';
   import TimelineRow from './TimelineRow.svelte';
+  import TimelineContextMenu, {
+    type TimelineContextMenuAction,
+  } from './TimelineContextMenu.svelte';
   import { Button } from '$lib/components/ui/button';
   import type { TimelineItemType, TimelineBadge } from './TimelineRow.svelte';
   import { escapeHtml, hasHashtagTokens, renderHashtagTokens } from '../sessions/hashtagItems';
@@ -781,6 +784,18 @@
 
   let normalItems = $derived(items.filter((item) => item.placement !== 'git-footer'));
   let gitFooterItems = $derived(items.filter((item) => item.placement === 'git-footer'));
+  let timelineContextMenuActions = $derived.by(() => {
+    const actions: TimelineContextMenuAction[] = [];
+    for (const item of normalItems) {
+      const action = contextMenuActionForItem(item);
+      if (action) actions.push(action);
+    }
+    for (const item of gitFooterItems) {
+      const action = contextMenuActionForItem(item);
+      if (action) actions.push(action);
+    }
+    return actions;
+  });
   let actionFooterVisible = $derived(
     !!onNewNote || !!onNewCommit || !!onNewReview || !!footerActions
   );
@@ -812,6 +827,19 @@
 
   function isResumable(item: DisplayItem): boolean {
     return !!item.sessionId && isResumableReason(item.completionReason) && !item.deleting;
+  }
+
+  function hasContextMenuAction(item: DisplayItem): boolean {
+    return !!item.commitSha || (!!item.hashtagRef && !!onNewSessionReferring);
+  }
+
+  function contextMenuActionForItem(item: DisplayItem): TimelineContextMenuAction | null {
+    if (!hasContextMenuAction(item)) return null;
+    return {
+      key: item.key,
+      commitSha: item.commitSha,
+      hashtagRef: item.hashtagRef,
+    };
   }
 
   function handleDeleteClick(item: DisplayItem, opts?: { altKey: boolean }) {
@@ -882,281 +910,282 @@
   <p class="no-items">No commits or notes yet</p>
 {:else}
   <!-- Unified timeline (vertical) -->
-  <div class="timeline">
-    {#each normalItems as item, index (item.key)}
-      <div in:maybeSlide={{ sessionId: item.sessionId }} out:slide={{ duration: 200 }}>
-        <TimelineRow
-          type={item.type}
-          title={item.title}
-          titleHtml={item.titleHtml}
-          meta={item.meta}
-          secondaryMeta={item.secondaryMeta}
-          tertiaryMeta={item.tertiaryMeta}
-          badges={item.badges}
-          onPullClick={item.onPull}
-          pullDisabledReason={item.pullDisabledReason}
-          onPushClick={item.onPush}
-          pushDisabledReason={item.pushDisabledReason}
-          onRebaseClick={item.onRebase}
-          rebaseDisabledReason={item.rebaseDisabledReason}
-          onForcePushClick={item.onForcePush}
-          forcePushDisabledReason={item.forcePushDisabledReason}
-          forcePushing={item.forcePushing}
-          pushing={item.pushing}
-          onViewDiffClick={item.onViewDiff}
-          onCommitChangesClick={item.onCommitChanges}
-          commitChangesDisabledReason={item.commitChangesDisabledReason}
-          onDiscardChangesClick={item.onDiscardChanges}
-          discardChangesDisabledReason={item.discardChangesDisabledReason}
-          deleting={item.deleting}
-          isLast={index === normalItems.length - 1 &&
-            pendingDropNotes.length === 0 &&
-            pendingItems.length === 0 &&
-            gitFooterItems.length === 0 &&
-            !error &&
-            !actionFooterVisible}
-          sessionId={item.sessionId}
-          deleteDisabledReason={isDeletable(item) ? item.deleteDisabledReason : undefined}
-          commitSha={item.commitSha}
-          hashtagRef={item.hashtagRef}
-          showConnector={item.showConnector}
-          {onNewSessionReferring}
-          {onSessionClick}
-          onItemClick={() => handleItemClick(item)}
-          onDeleteClick={!isDeletable(item) || item.deleteDisabledReason
-            ? undefined
-            : (opts) => handleDeleteClick(item, opts)}
-          onStartClick={item.type.startsWith('queued-') && !hasActiveSession
-            ? onStartQueued
-            : undefined}
-          onResumeClick={isResumable(item) && onResumeClick && item.sessionId && !hasActiveSession
-            ? () => onResumeClick!(item.sessionId!)
-            : undefined}
-        />
-      </div>
-    {/each}
-    {#each pendingDropNotes as drop, index (drop.key)}
-      <div transition:slide={{ duration: 200 }}>
-        <TimelineRow
-          type="generating-note"
-          title={drop.title}
-          secondaryMeta="adding..."
-          isLast={index === pendingDropNotes.length - 1 &&
-            pendingItems.length === 0 &&
-            gitFooterItems.length === 0 &&
-            !error &&
-            !actionFooterVisible}
-        />
-      </div>
-    {/each}
-    {#each pendingItems as item, index (item.key)}
-      <div in:slide={{ duration: 200 }} out:maybeSlide={{ sessionId: item.sessionId }}>
-        <TimelineRow
-          type={item.type}
-          title={item.title}
-          titleHtml={hashtagItems.length > 0 && hasHashtagTokens(item.title)
-            ? renderHashtagTokens(item.title, hashtagItems)
-            : undefined}
-          secondaryMeta={item.sessionId
-            ? (liveSessionHints[item.sessionId] ??
-              item.secondaryMeta ??
-              fallbackHintForPendingType(item.type))
-            : item.secondaryMeta}
-          isLast={index === pendingItems.length - 1 &&
-            gitFooterItems.length === 0 &&
-            !error &&
-            !actionFooterVisible}
-        />
-      </div>
-    {/each}
-    {#each gitFooterItems as item, index (item.key)}
-      <div transition:slide={{ duration: 200 }}>
-        <TimelineRow
-          type={item.type}
-          title={item.title}
-          titleHtml={item.titleHtml}
-          meta={item.meta}
-          secondaryMeta={item.secondaryMeta}
-          tertiaryMeta={item.tertiaryMeta}
-          badges={item.badges}
-          onPullClick={item.onPull}
-          pullDisabledReason={item.pullDisabledReason}
-          onPushClick={item.onPush}
-          pushDisabledReason={item.pushDisabledReason}
-          onRebaseClick={item.onRebase}
-          rebaseDisabledReason={item.rebaseDisabledReason}
-          onForcePushClick={item.onForcePush}
-          forcePushDisabledReason={item.forcePushDisabledReason}
-          forcePushing={item.forcePushing}
-          pushing={item.pushing}
-          onViewDiffClick={item.onViewDiff}
-          onCommitChangesClick={item.onCommitChanges}
-          commitChangesDisabledReason={item.commitChangesDisabledReason}
-          onDiscardChangesClick={item.onDiscardChanges}
-          discardChangesDisabledReason={item.discardChangesDisabledReason}
-          deleting={item.deleting}
-          isLast={index === gitFooterItems.length - 1 && !error}
-          sessionId={item.sessionId}
-          deleteDisabledReason={isDeletable(item) ? item.deleteDisabledReason : undefined}
-          commitSha={item.commitSha}
-          hashtagRef={item.hashtagRef}
-          showConnector={item.showConnector}
-          {onNewSessionReferring}
-          {onSessionClick}
-          onItemClick={() => handleItemClick(item)}
-          onDeleteClick={!isDeletable(item) || item.deleteDisabledReason
-            ? undefined
-            : (opts) => handleDeleteClick(item, opts)}
-          onStartClick={item.type.startsWith('queued-') && !hasActiveSession
-            ? onStartQueued
-            : undefined}
-          onResumeClick={isResumable(item) && onResumeClick && item.sessionId && !hasActiveSession
-            ? () => onResumeClick!(item.sessionId!)
-            : undefined}
-        />
-      </div>
-    {/each}
-    {#if error}
-      <div transition:slide={{ duration: 200 }}>
-        <TimelineRow
-          type="load-error"
-          title="Failed to load commits"
-          secondaryMeta={error}
-          isLast={!actionFooterVisible}
-          onRetryClick={onRetry}
-        />
-      </div>
-    {/if}
-    {#if actionFooterVisible}
-      <div class="footer-row" class:footer-row-enlarged={actionButtonsEnlarged}>
-        <div class="footer-left-actions" class:footer-left-actions-enlarged={actionButtonsEnlarged}>
-          {#if onNewNote}
-            <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
-              <Button
-                variant="ghost"
-                onclick={onNewNote}
-                disabled={newSessionDisabled}
-                aria-label="New note"
-                class={[
-                  'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                  '[&_svg]:transition-all [&_svg]:duration-300',
-                  actionButtonsEnlarged
-                    ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
-                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
-                ]}
-              >
-                <FileText
-                  class={actionButtonsEnlarged
-                    ? ''
-                    : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
-                  size={18}
-                />
-                <Plus
-                  class={actionButtonsEnlarged
-                    ? 'hidden'
-                    : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
-                  size={18}
-                />
-                <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
-                  >New note</span
-                >
-                <span
+  <TimelineContextMenu actions={timelineContextMenuActions} {onNewSessionReferring}>
+    <div class="timeline">
+      {#each normalItems as item, index (item.key)}
+        <div>
+          <TimelineRow
+            type={item.type}
+            title={item.title}
+            titleHtml={item.titleHtml}
+            meta={item.meta}
+            secondaryMeta={item.secondaryMeta}
+            tertiaryMeta={item.tertiaryMeta}
+            badges={item.badges}
+            onPullClick={item.onPull}
+            pullDisabledReason={item.pullDisabledReason}
+            onPushClick={item.onPush}
+            pushDisabledReason={item.pushDisabledReason}
+            onRebaseClick={item.onRebase}
+            rebaseDisabledReason={item.rebaseDisabledReason}
+            onForcePushClick={item.onForcePush}
+            forcePushDisabledReason={item.forcePushDisabledReason}
+            forcePushing={item.forcePushing}
+            pushing={item.pushing}
+            onViewDiffClick={item.onViewDiff}
+            onCommitChangesClick={item.onCommitChanges}
+            commitChangesDisabledReason={item.commitChangesDisabledReason}
+            onDiscardChangesClick={item.onDiscardChanges}
+            discardChangesDisabledReason={item.discardChangesDisabledReason}
+            deleting={item.deleting}
+            isLast={index === normalItems.length - 1 &&
+              pendingDropNotes.length === 0 &&
+              pendingItems.length === 0 &&
+              gitFooterItems.length === 0 &&
+              !error &&
+              !actionFooterVisible}
+            sessionId={item.sessionId}
+            deleteDisabledReason={isDeletable(item) ? item.deleteDisabledReason : undefined}
+            contextMenuKey={hasContextMenuAction(item) ? item.key : undefined}
+            showConnector={item.showConnector}
+            {onSessionClick}
+            onItemClick={() => handleItemClick(item)}
+            onDeleteClick={!isDeletable(item) || item.deleteDisabledReason
+              ? undefined
+              : (opts) => handleDeleteClick(item, opts)}
+            onStartClick={item.type.startsWith('queued-') && !hasActiveSession
+              ? onStartQueued
+              : undefined}
+            onResumeClick={isResumable(item) && onResumeClick && item.sessionId && !hasActiveSession
+              ? () => onResumeClick!(item.sessionId!)
+              : undefined}
+          />
+        </div>
+      {/each}
+      {#each pendingDropNotes as drop, index (drop.key)}
+        <div transition:slide={{ duration: 200 }}>
+          <TimelineRow
+            type="generating-note"
+            title={drop.title}
+            secondaryMeta="adding..."
+            isLast={index === pendingDropNotes.length - 1 &&
+              pendingItems.length === 0 &&
+              gitFooterItems.length === 0 &&
+              !error &&
+              !actionFooterVisible}
+          />
+        </div>
+      {/each}
+      {#each pendingItems as item, index (item.key)}
+        <div in:slide={{ duration: 200 }} out:maybeSlide={{ sessionId: item.sessionId }}>
+          <TimelineRow
+            type={item.type}
+            title={item.title}
+            titleHtml={hashtagItems.length > 0 && hasHashtagTokens(item.title)
+              ? renderHashtagTokens(item.title, hashtagItems)
+              : undefined}
+            secondaryMeta={item.sessionId
+              ? (liveSessionHints[item.sessionId] ??
+                item.secondaryMeta ??
+                fallbackHintForPendingType(item.type))
+              : item.secondaryMeta}
+            isLast={index === pendingItems.length - 1 &&
+              gitFooterItems.length === 0 &&
+              !error &&
+              !actionFooterVisible}
+          />
+        </div>
+      {/each}
+      {#each gitFooterItems as item, index (item.key)}
+        <div>
+          <TimelineRow
+            type={item.type}
+            title={item.title}
+            titleHtml={item.titleHtml}
+            meta={item.meta}
+            secondaryMeta={item.secondaryMeta}
+            tertiaryMeta={item.tertiaryMeta}
+            badges={item.badges}
+            onPullClick={item.onPull}
+            pullDisabledReason={item.pullDisabledReason}
+            onPushClick={item.onPush}
+            pushDisabledReason={item.pushDisabledReason}
+            onRebaseClick={item.onRebase}
+            rebaseDisabledReason={item.rebaseDisabledReason}
+            onForcePushClick={item.onForcePush}
+            forcePushDisabledReason={item.forcePushDisabledReason}
+            forcePushing={item.forcePushing}
+            pushing={item.pushing}
+            onViewDiffClick={item.onViewDiff}
+            onCommitChangesClick={item.onCommitChanges}
+            commitChangesDisabledReason={item.commitChangesDisabledReason}
+            onDiscardChangesClick={item.onDiscardChanges}
+            discardChangesDisabledReason={item.discardChangesDisabledReason}
+            deleting={item.deleting}
+            isLast={index === gitFooterItems.length - 1 && !error}
+            sessionId={item.sessionId}
+            deleteDisabledReason={isDeletable(item) ? item.deleteDisabledReason : undefined}
+            contextMenuKey={hasContextMenuAction(item) ? item.key : undefined}
+            showConnector={item.showConnector}
+            {onSessionClick}
+            onItemClick={() => handleItemClick(item)}
+            onDeleteClick={!isDeletable(item) || item.deleteDisabledReason
+              ? undefined
+              : (opts) => handleDeleteClick(item, opts)}
+            onStartClick={item.type.startsWith('queued-') && !hasActiveSession
+              ? onStartQueued
+              : undefined}
+            onResumeClick={isResumable(item) && onResumeClick && item.sessionId && !hasActiveSession
+              ? () => onResumeClick!(item.sessionId!)
+              : undefined}
+          />
+        </div>
+      {/each}
+      {#if error}
+        <div>
+          <TimelineRow
+            type="load-error"
+            title="Failed to load commits"
+            secondaryMeta={error}
+            isLast={!actionFooterVisible}
+            onRetryClick={onRetry}
+          />
+        </div>
+      {/if}
+      {#if actionFooterVisible}
+        <div class="footer-row" class:footer-row-enlarged={actionButtonsEnlarged}>
+          <div
+            class="footer-left-actions"
+            class:footer-left-actions-enlarged={actionButtonsEnlarged}
+          >
+            {#if onNewNote}
+              <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
+                <Button
+                  variant="ghost"
+                  onclick={onNewNote}
+                  disabled={newSessionDisabled}
+                  aria-label="New note"
                   class={[
-                    'hidden',
-                    !actionButtonsEnlarged &&
-                      '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
-                  ]}>Note</span
+                    'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                    '[&_svg]:transition-all [&_svg]:duration-300',
+                    actionButtonsEnlarged
+                      ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
+                      : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                  ]}
                 >
-              </Button>
-            </span>
-          {/if}
-          {#if onNewCommit}
-            <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
-              <Button
-                variant="ghost"
-                onclick={onNewCommit}
-                disabled={newSessionDisabled}
-                aria-label="New commit"
-                class={[
-                  'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                  '[&_svg]:transition-all [&_svg]:duration-300',
-                  actionButtonsEnlarged
-                    ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--commit-color)]'
-                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
-                ]}
-              >
-                <GitCommitVertical
-                  class={actionButtonsEnlarged
-                    ? ''
-                    : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
-                  size={18}
-                />
-                <Plus
-                  class={actionButtonsEnlarged
-                    ? 'hidden'
-                    : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
-                  size={18}
-                />
-                <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
-                  >New commit</span
-                >
-                <span
+                  <FileText
+                    class={actionButtonsEnlarged
+                      ? ''
+                      : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
+                    size={18}
+                  />
+                  <Plus
+                    class={actionButtonsEnlarged
+                      ? 'hidden'
+                      : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
+                    size={18}
+                  />
+                  <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
+                    >New note</span
+                  >
+                  <span
+                    class={[
+                      'hidden',
+                      !actionButtonsEnlarged &&
+                        '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
+                    ]}>Note</span
+                  >
+                </Button>
+              </span>
+            {/if}
+            {#if onNewCommit}
+              <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
+                <Button
+                  variant="ghost"
+                  onclick={onNewCommit}
+                  disabled={newSessionDisabled}
+                  aria-label="New commit"
                   class={[
-                    'hidden',
-                    !actionButtonsEnlarged &&
-                      '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
-                  ]}>Commit</span
+                    'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                    '[&_svg]:transition-all [&_svg]:duration-300',
+                    actionButtonsEnlarged
+                      ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--commit-color)]'
+                      : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                  ]}
                 >
-              </Button>
-            </span>
-          {/if}
-          {#if onNewReview}
-            <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
-              <Button
-                variant="ghost"
-                onclick={(e) => onNewReview?.(e)}
-                disabled={newSessionDisabled}
-                aria-label="New code review"
-                class={[
-                  'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                  '[&_svg]:transition-all [&_svg]:duration-300',
-                  actionButtonsEnlarged
-                    ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--review-color)]'
-                    : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
-                ]}
-              >
-                <FileSearch
-                  class={actionButtonsEnlarged
-                    ? ''
-                    : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
-                  size={18}
-                />
-                <Plus
-                  class={actionButtonsEnlarged
-                    ? 'hidden'
-                    : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
-                  size={18}
-                />
-                <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
-                  >New code review</span
-                >
-                <span
+                  <GitCommitVertical
+                    class={actionButtonsEnlarged
+                      ? ''
+                      : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
+                    size={18}
+                  />
+                  <Plus
+                    class={actionButtonsEnlarged
+                      ? 'hidden'
+                      : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
+                    size={18}
+                  />
+                  <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
+                    >New commit</span
+                  >
+                  <span
+                    class={[
+                      'hidden',
+                      !actionButtonsEnlarged &&
+                        '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
+                    ]}>Commit</span
+                  >
+                </Button>
+              </span>
+            {/if}
+            {#if onNewReview}
+              <span class={actionButtonsEnlarged ? 'inline-flex flex-1' : 'inline-flex'}>
+                <Button
+                  variant="ghost"
+                  onclick={(e) => onNewReview?.(e)}
+                  disabled={newSessionDisabled}
+                  aria-label="New code review"
                   class={[
-                    'hidden',
-                    !actionButtonsEnlarged &&
-                      '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
-                  ]}>Code review</span
+                    'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                    '[&_svg]:transition-all [&_svg]:duration-300',
+                    actionButtonsEnlarged
+                      ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--review-color)]'
+                      : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
+                  ]}
                 >
-              </Button>
-            </span>
+                  <FileSearch
+                    class={actionButtonsEnlarged
+                      ? ''
+                      : '@max-3xl/timeline:hidden @max-[480px]/timeline:inline-block'}
+                    size={18}
+                  />
+                  <Plus
+                    class={actionButtonsEnlarged
+                      ? 'hidden'
+                      : 'hidden @max-3xl/timeline:inline-block @max-[480px]/timeline:!size-[10px]'}
+                    size={18}
+                  />
+                  <span class={!actionButtonsEnlarged ? '@max-3xl/timeline:hidden' : ''}
+                    >New code review</span
+                  >
+                  <span
+                    class={[
+                      'hidden',
+                      !actionButtonsEnlarged &&
+                        '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
+                    ]}>Code review</span
+                  >
+                </Button>
+              </span>
+            {/if}
+          </div>
+          {#if footerActions && !actionButtonsEnlarged}
+            {@render footerActions()}
           {/if}
         </div>
-        {#if footerActions && !actionButtonsEnlarged}
-          {@render footerActions()}
-        {/if}
-      </div>
-    {/if}
-  </div>
+      {/if}
+    </div>
+  </TimelineContextMenu>
 {/if}
 
 <style>

--- a/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import Copy from '@lucide/svelte/icons/copy';
+  import MessageSquarePlus from '@lucide/svelte/icons/message-square-plus';
+  import * as ContextMenu from '$lib/components/ui/context-menu';
+
+  export type TimelineContextMenuAction = {
+    key: string;
+    commitSha?: string;
+    hashtagRef?: string;
+  };
+
+  interface Props {
+    actions?: TimelineContextMenuAction[];
+    onNewSessionReferring?: (hashtagRef: string) => void;
+    children?: Snippet;
+  }
+
+  let { actions = [], onNewSessionReferring, children }: Props = $props();
+
+  let open = $state(false);
+  let activeActionKey = $state<string | null>(null);
+
+  function hasVisibleAction(action: TimelineContextMenuAction): boolean {
+    return !!action.commitSha || (!!action.hashtagRef && !!onNewSessionReferring);
+  }
+
+  let actionByKey = $derived.by(() => {
+    const map = new Map<string, TimelineContextMenuAction>();
+    for (const action of actions) {
+      if (hasVisibleAction(action)) {
+        map.set(action.key, action);
+      }
+    }
+    return map;
+  });
+  let hasActions = $derived(actionByKey.size > 0);
+  let activeAction = $derived(activeActionKey ? (actionByKey.get(activeActionKey) ?? null) : null);
+
+  function actionForEvent(event: Event): TimelineContextMenuAction | null {
+    const currentTarget = event.currentTarget;
+    const target = event.target;
+    if (!(currentTarget instanceof Element) || !(target instanceof Element)) return null;
+
+    const row = target.closest('[data-timeline-context-menu-key]');
+    if (!(row instanceof HTMLElement) || !currentTarget.contains(row)) return null;
+
+    const key = row.dataset.timelineContextMenuKey;
+    if (!key) return null;
+    return actionByKey.get(key) ?? null;
+  }
+
+  function handleContextMenu(event: MouseEvent) {
+    const action = actionForEvent(event);
+    if (!action) {
+      activeActionKey = null;
+      open = false;
+      event.preventDefault();
+      return;
+    }
+
+    activeActionKey = action.key;
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (event.pointerType === 'mouse') return;
+
+    const action = actionForEvent(event);
+    if (!action) {
+      activeActionKey = null;
+      open = false;
+      event.preventDefault();
+      return;
+    }
+
+    activeActionKey = action.key;
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      activeActionKey = null;
+    }
+  }
+
+  function handleCopySha() {
+    const sha = activeAction?.commitSha;
+    if (sha) {
+      navigator.clipboard.writeText(sha).catch(() => {});
+    }
+  }
+
+  function handleNewSessionReferring() {
+    const ref = activeAction?.hashtagRef;
+    if (ref) {
+      onNewSessionReferring?.(ref);
+    }
+  }
+
+  $effect(() => {
+    if (activeActionKey && !actionByKey.has(activeActionKey)) {
+      activeActionKey = null;
+      open = false;
+    }
+  });
+</script>
+
+{#if hasActions}
+  <ContextMenu.Root bind:open onOpenChange={handleOpenChange}>
+    <ContextMenu.Trigger
+      class="contents"
+      oncontextmenu={handleContextMenu}
+      onpointerdown={handlePointerDown}
+    >
+      {@render children?.()}
+    </ContextMenu.Trigger>
+    <ContextMenu.Content class="min-w-[180px]">
+      {#if activeAction}
+        {#if activeAction.commitSha}
+          <ContextMenu.Item onSelect={handleCopySha}>
+            <Copy size={14} /> Copy SHA
+          </ContextMenu.Item>
+        {/if}
+        {#if activeAction.hashtagRef && onNewSessionReferring}
+          <ContextMenu.Item onSelect={handleNewSessionReferring}>
+            <MessageSquarePlus size={14} /> New session referring to this
+          </ContextMenu.Item>
+        {/if}
+      {/if}
+    </ContextMenu.Content>
+  </ContextMenu.Root>
+{:else}
+  {@render children?.()}
+{/if}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -11,16 +11,13 @@
   import FileSearch from '@lucide/svelte/icons/file-search';
   import ImageLucide from '@lucide/svelte/icons/image';
   import MessageSquare from '@lucide/svelte/icons/message-square';
-  import MessageSquarePlus from '@lucide/svelte/icons/message-square-plus';
   import Trash2 from '@lucide/svelte/icons/trash-2';
   import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
   import Clock from '@lucide/svelte/icons/clock';
   import GitBranch from '@lucide/svelte/icons/git-branch';
   import GitMerge from '@lucide/svelte/icons/git-merge';
   import ChevronsDown from '@lucide/svelte/icons/chevrons-down';
-  import Copy from '@lucide/svelte/icons/copy';
   import Spinner from '../../shared/Spinner.svelte';
-  import * as ContextMenu from '$lib/components/ui/context-menu';
   import { Button } from '$lib/components/ui/button';
 
   export type TimelineItemType =
@@ -89,12 +86,8 @@
     onDiscardChangesClick?: () => void;
     discardChangesDisabledReason?: string;
     showConnector?: boolean;
-    /** Full commit SHA for the context menu "Copy SHA" action. */
-    commitSha?: string;
-    /** Hashtag reference token (e.g. "#commit:abc123") for "New session referring to this". */
-    hashtagRef?: string;
-    /** Callback invoked when the user picks "New session referring to this" from the context menu. */
-    onNewSessionReferring?: (hashtagRef: string) => void;
+    /** Key used by the parent timeline context menu to look up row actions. */
+    contextMenuKey?: string;
   }
 
   let {
@@ -131,9 +124,7 @@
     onDiscardChangesClick,
     discardChangesDisabledReason,
     showConnector = true,
-    commitSha,
-    hashtagRef,
-    onNewSessionReferring,
+    contextMenuKey,
   }: Props = $props();
 
   let isNote = $derived(
@@ -178,6 +169,16 @@
   );
   let isClickable = $derived(!!onItemClick && !isPending && !isFailed);
   let hasSession = $derived(!!sessionId && !deleting);
+  let pullTitle = $derived(pullDisabledReason ?? 'Pull');
+  let pushTitle = $derived(pushDisabledReason ?? (pushing ? 'View push session' : 'Push'));
+  let forcePushTitle = $derived(
+    forcePushDisabledReason ??
+      (forcePushing ? 'View push session' : 'Force push local branch to origin')
+  );
+  let rebaseTitle = $derived(rebaseDisabledReason ?? 'Rebase');
+  let commitChangesTitle = $derived(commitChangesDisabledReason ?? 'Commit changes');
+  let discardChangesTitle = $derived(discardChangesDisabledReason ?? 'Discard changes');
+  let deleteTitle = $derived(deleteDisabledReason ?? 'Delete');
 
   function handleRowClick() {
     if (isClickable) {
@@ -247,8 +248,13 @@
     onDiscardChangesClick?.();
   }
 
-  // ── Context menu ────────────────────────────────────────────────────
-  let hasContextMenu = $derived(!!commitSha || (!!hashtagRef && !!onNewSessionReferring));
+  function handleRowContextMenu(e: MouseEvent) {
+    if (!contextMenuKey) e.stopPropagation();
+  }
+
+  function handleRowPointerDown(e: PointerEvent) {
+    if (!contextMenuKey && e.pointerType !== 'mouse') e.stopPropagation();
+  }
 </script>
 
 {#snippet rowBody()}
@@ -262,6 +268,9 @@
     class:git-state={isGitState}
     class:compact={type === 'load-error'}
     onclick={handleRowClick}
+    oncontextmenu={handleRowContextMenu}
+    onpointerdown={handleRowPointerDown}
+    data-timeline-context-menu-key={contextMenuKey}
   >
     <div class="timeline-marker">
       <div
@@ -409,12 +418,14 @@
           </Button>
         {/if}
         {#if onPullClick || pullDisabledReason}
-          <span class="inline-flex" title={pullDisabledReason}>
+          <span class="inline-flex" title={pullTitle}>
             <Button
               variant="outline"
               size="xs"
               onclick={handlePullClick}
               disabled={!!pullDisabledReason}
+              title={pullTitle}
+              aria-label={pullTitle}
               class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
             >
               Pull
@@ -422,15 +433,14 @@
           </span>
         {/if}
         {#if onPushClick || pushDisabledReason}
-          <span
-            class="inline-flex"
-            title={pushDisabledReason ?? (pushing ? 'View push session' : undefined)}
-          >
+          <span class="inline-flex" title={pushTitle}>
             <Button
               variant="outline"
               size="xs"
               onclick={handlePushClick}
               disabled={!!pushDisabledReason}
+              title={pushTitle}
+              aria-label={pushTitle}
               class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
             >
               {pushing ? 'Pushing\u2026' : 'Push'}
@@ -438,16 +448,14 @@
           </span>
         {/if}
         {#if onForcePushClick || forcePushDisabledReason}
-          <span
-            class="inline-flex"
-            title={forcePushDisabledReason ??
-              (forcePushing ? 'View push session' : 'Force push local branch to origin')}
-          >
+          <span class="inline-flex" title={forcePushTitle}>
             <Button
               variant="outline"
               size="xs"
               onclick={handleForcePushClick}
               disabled={!!forcePushDisabledReason}
+              title={forcePushTitle}
+              aria-label={forcePushTitle}
               class={[
                 'h-[22px] rounded-md bg-transparent shadow-none',
                 forcePushing
@@ -460,12 +468,14 @@
           </span>
         {/if}
         {#if onRebaseClick || rebaseDisabledReason}
-          <span class="inline-flex" title={rebaseDisabledReason}>
+          <span class="inline-flex" title={rebaseTitle}>
             <Button
               variant="outline"
               size="xs"
               onclick={handleRebaseClick}
               disabled={!!rebaseDisabledReason}
+              title={rebaseTitle}
+              aria-label={rebaseTitle}
               class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
             >
               Rebase
@@ -485,12 +495,14 @@
           </Button>
         {/if}
         {#if onCommitChangesClick || commitChangesDisabledReason}
-          <span class="inline-flex" title={commitChangesDisabledReason ?? 'Commit changes'}>
+          <span class="inline-flex" title={commitChangesTitle}>
             <Button
               variant="outline"
               size="xs"
               onclick={handleCommitChangesClick}
               disabled={!!commitChangesDisabledReason}
+              title={commitChangesTitle}
+              aria-label={commitChangesTitle}
               class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
             >
               Commit
@@ -498,12 +510,14 @@
           </span>
         {/if}
         {#if onDiscardChangesClick || discardChangesDisabledReason}
-          <span class="inline-flex" title={discardChangesDisabledReason ?? 'Discard changes'}>
+          <span class="inline-flex" title={discardChangesTitle}>
             <Button
               variant="outline"
               size="xs"
               onclick={handleDiscardChangesClick}
               disabled={!!discardChangesDisabledReason}
+              title={discardChangesTitle}
+              aria-label={discardChangesTitle}
               class="h-[22px] rounded-md border-[var(--border-subtle)] bg-transparent text-[var(--text-muted)] shadow-none hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
             >
               Discard
@@ -523,13 +537,14 @@
           </Button>
         {/if}
         {#if onDeleteClick || deleteDisabledReason}
-          <span class="inline-flex" title={deleteDisabledReason ?? 'Delete'}>
+          <span class="inline-flex" title={deleteTitle}>
             <Button
               variant="ghost"
               size="icon-xs"
-              aria-label="Delete"
               onclick={handleDeleteClick}
               disabled={!!deleteDisabledReason}
+              title={deleteTitle}
+              aria-label={deleteTitle}
               class="size-[22px] text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-destructive [&_svg]:!size-3"
             >
               <Trash2 size={12} />
@@ -541,29 +556,7 @@
   </div>
 {/snippet}
 
-{#if hasContextMenu}
-  <ContextMenu.Root>
-    <ContextMenu.Trigger class="contents">
-      {@render rowBody()}
-    </ContextMenu.Trigger>
-    <ContextMenu.Content class="min-w-[140px]">
-      {#if commitSha}
-        <ContextMenu.Item
-          onSelect={() => navigator.clipboard.writeText(commitSha!).catch(() => {})}
-        >
-          <Copy size={14} /> Copy SHA
-        </ContextMenu.Item>
-      {/if}
-      {#if hashtagRef && onNewSessionReferring}
-        <ContextMenu.Item onSelect={() => onNewSessionReferring!(hashtagRef!)}>
-          <MessageSquarePlus size={14} /> New session referring to this
-        </ContextMenu.Item>
-      {/if}
-    </ContextMenu.Content>
-  </ContextMenu.Root>
-{:else}
-  {@render rowBody()}
-{/if}
+{@render rowBody()}
 
 <style>
   .timeline-row {

--- a/apps/staged/src/lib/services/branchEventService.ts
+++ b/apps/staged/src/lib/services/branchEventService.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared branch event subscriptions.
+ *
+ * Branch cards mount in bulk during project navigation. This service keeps one
+ * Tauri listener per backend event and fans events out to lightweight local
+ * subscribers so navigation does not repeatedly register/unregister listeners.
+ */
+
+import { listenToEvent, type UnlistenFn } from '../transport';
+import type { ActionStatusEvent, RunPhaseChangedEvent } from '../features/actions/actions';
+import type { BranchGitState, PrStatusChangedEvent, SessionStatusPayload } from '../types';
+
+type EventCallback<T> = (payload: T) => void;
+
+interface SharedEventEntry<T> {
+  callbacks: Set<EventCallback<T>>;
+  unlisten: UnlistenFn | null;
+}
+
+export interface BranchSetupProgressEvent {
+  branchId: string;
+  phase: string;
+  detail: string | null;
+}
+
+export interface BranchGitStateUpdatedEvent {
+  branchId: string;
+  gitState: BranchGitState;
+}
+
+const sharedEvents = new Map<string, SharedEventEntry<unknown>>();
+
+function getSharedEventEntry<T>(eventName: string): SharedEventEntry<T> {
+  let entry = sharedEvents.get(eventName) as SharedEventEntry<T> | undefined;
+  if (!entry) {
+    entry = {
+      callbacks: new Set<EventCallback<T>>(),
+      unlisten: null,
+    };
+    sharedEvents.set(eventName, entry as SharedEventEntry<unknown>);
+  }
+  return entry;
+}
+
+function subscribeSharedEvent<T>(eventName: string, callback: EventCallback<T>): UnlistenFn {
+  const entry = getSharedEventEntry<T>(eventName);
+  entry.callbacks.add(callback);
+
+  if (!entry.unlisten) {
+    entry.unlisten = listenToEvent<T>(eventName, (payload) => {
+      for (const subscriber of [...entry.callbacks]) {
+        try {
+          subscriber(payload);
+        } catch (error) {
+          console.error(`[branchEventService] subscriber failed for ${eventName}:`, error);
+        }
+      }
+    });
+  }
+
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    entry.callbacks.delete(callback);
+  };
+}
+
+function combineUnlisteners(unlisteners: UnlistenFn[]): UnlistenFn {
+  return () => {
+    for (const unlisten of unlisteners) {
+      unlisten();
+    }
+  };
+}
+
+function subscribeBranchPayload<T extends { branchId: string }>(
+  eventName: string,
+  branchId: string,
+  callback: EventCallback<T>
+): UnlistenFn {
+  return subscribeSharedEvent<T>(eventName, (payload) => {
+    if (payload.branchId === branchId) {
+      callback(payload);
+    }
+  });
+}
+
+export function onBranchSetupProgress(
+  branchId: string,
+  callback: EventCallback<BranchSetupProgressEvent>
+): UnlistenFn {
+  return combineUnlisteners([
+    subscribeBranchPayload('worktree-setup-progress', branchId, callback),
+    subscribeBranchPayload('workspace-setup-progress', branchId, callback),
+  ]);
+}
+
+export function onSessionStatusChanged(callback: EventCallback<SessionStatusPayload>): UnlistenFn {
+  return subscribeSharedEvent('session-status-changed', callback);
+}
+
+export function onBranchSessionStatus(
+  branchId: string,
+  callback: EventCallback<SessionStatusPayload>
+): UnlistenFn {
+  return subscribeSharedEvent<SessionStatusPayload>('session-status-changed', (payload) => {
+    if (payload.branchId === branchId) {
+      callback(payload);
+    }
+  });
+}
+
+export function onBranchGitStateUpdated(
+  branchId: string,
+  callback: EventCallback<BranchGitStateUpdatedEvent>
+): UnlistenFn {
+  return subscribeBranchPayload('git-state-updated', branchId, callback);
+}
+
+export function onBranchPrStatusChanged(
+  branchId: string,
+  callback: EventCallback<PrStatusChangedEvent>
+): UnlistenFn {
+  return subscribeBranchPayload('pr-status-changed', branchId, callback);
+}
+
+export function onBranchPrStatusCleared(
+  branchId: string,
+  callback: EventCallback<string>
+): UnlistenFn {
+  return subscribeSharedEvent<string>('pr-status-cleared', (clearedBranchId) => {
+    if (clearedBranchId === branchId) {
+      callback(clearedBranchId);
+    }
+  });
+}
+
+export function onBranchActionStatus(
+  branchId: string,
+  callback: EventCallback<ActionStatusEvent>
+): UnlistenFn {
+  return subscribeBranchPayload('action_status', branchId, callback);
+}
+
+export function onBranchRunPhaseChanged(
+  branchId: string,
+  callback: EventCallback<RunPhaseChangedEvent>
+): UnlistenFn {
+  return subscribeBranchPayload('action:run-phase-changed', branchId, callback);
+}

--- a/apps/staged/src/lib/stores/projectRunActions.svelte.ts
+++ b/apps/staged/src/lib/stores/projectRunActions.svelte.ts
@@ -36,6 +36,9 @@ class ProjectRunActionsStore {
   /** Manual reactivity version counter */
   private version = $state(0);
 
+  /** Branches whose current running-action state has already been queried. */
+  private hydratedBranchIds = new Set<string>();
+
   private unlisteners: UnlistenFn[] = [];
   private initialized = false;
 
@@ -82,6 +85,7 @@ class ProjectRunActionsStore {
     this.unlisteners = [];
     this.executions = new Map();
     this.branchToProject = new Map();
+    this.hydratedBranchIds.clear();
     this.initialized = false;
     this.version++;
   }
@@ -105,7 +109,10 @@ class ProjectRunActionsStore {
    * project→branches map. Convenience wrapper used by both ProjectsList
    * and ProjectHome after loading branch data.
    */
-  async hydrateFromProjectBranches(branchesByProject: Map<string, Branch[]>): Promise<void> {
+  async hydrateFromProjectBranches(
+    branchesByProject: Map<string, Branch[]>,
+    options: { branchIds?: Iterable<string>; force?: boolean } = {}
+  ): Promise<void> {
     const branchProjectMap = new Map<string, string[]>();
     const allBranchIds: string[] = [];
     for (const [projectId, branches] of branchesByProject) {
@@ -118,15 +125,21 @@ class ProjectRunActionsStore {
       }
     }
     this.updateBranchProjectMap(branchProjectMap);
-    await this.hydrateFromBranches(allBranchIds);
+    await this.hydrateFromBranches(options.branchIds ?? allBranchIds, options.force ?? false);
   }
 
   /**
    * Hydrate initial state by querying running actions for all known branches.
    */
-  private async hydrateFromBranches(branchIds: string[]): Promise<void> {
+  private async hydrateFromBranches(branchIds: Iterable<string>, force: boolean): Promise<void> {
+    const uniqueBranchIds = Array.from(new Set(branchIds));
+    const branchIdsToHydrate = force
+      ? uniqueBranchIds
+      : uniqueBranchIds.filter((branchId) => !this.hydratedBranchIds.has(branchId));
+    if (branchIdsToHydrate.length === 0) return;
+
     const results = await Promise.allSettled(
-      branchIds.map(async (branchId) => {
+      branchIdsToHydrate.map(async (branchId) => {
         const actions = await getRunningBranchActions(branchId);
         return { branchId, actions };
       })
@@ -136,6 +149,7 @@ class ProjectRunActionsStore {
     const runActions: { executionId: string; branchId: string }[] = [];
     for (const result of results) {
       if (result.status !== 'fulfilled') continue;
+      this.hydratedBranchIds.add(result.value.branchId);
       for (const action of result.value.actions) {
         if (action.actionType !== 'run') continue;
         runActions.push({ executionId: action.executionId, branchId: action.branchId });


### PR DESCRIPTION
Summary:
- Adds a shared branch event service that keeps one Tauri listener per backend event and fans out to branch-scoped subscribers.
- Moves branch card, PR status, setup progress, git state, action status, and diff launcher subscriptions onto the shared service.

Tests:
- Pre-push checks passed during git push.