### PR TITLE
fix: match recent repo subpaths in add repo search

### DIFF
--- a/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
+++ b/apps/staged/src/lib/features/projects/RepoSearchInput.svelte
@@ -19,6 +19,7 @@
   import * as commands from '../../api/commands';
   import type { GitHubRepo, RecentRepo } from '../../types';
   import { parseGitHubUrl, type RepoSelection } from '../../shared/githubUrl';
+  import { matchesRepoSearch } from '../../shared/repoSearch';
   import { viewport } from '../../shared/viewport.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { darkMode } from '../../stores/isDark.svelte';
@@ -101,11 +102,11 @@
   });
 
   let filteredRecentRepos = $derived.by(() => {
-    const q = query.toLowerCase().trim();
+    const q = query.trim();
     const base = recentRepos.filter(
       (r) => !excludeRepos.has(`${r.githubRepo}\x00${r.subpath ?? ''}`)
     );
-    return q ? base.filter((r) => r.githubRepo.toLowerCase().includes(q)) : base;
+    return q ? base.filter((r) => matchesRepoSearch(r.githubRepo, r.subpath, q)) : base;
   });
 
   const dark = $derived(darkMode.value);

--- a/apps/staged/src/lib/features/settings/repoContextSearch.ts
+++ b/apps/staged/src/lib/features/settings/repoContextSearch.ts
@@ -1,27 +1,8 @@
 import type { ActionContext } from '../../api/commands';
+import { matchesRepoSearch } from '../../shared/repoSearch';
 
-function searchTerms(githubRepo: string, subpath: string | null | undefined): string[] {
-  const repo = githubRepo.toLowerCase();
-  const [org = '', repoName = ''] = repo.split('/');
-  const sub = subpath?.toLowerCase() ?? '';
-  const subpathParts = sub.split('/').filter(Boolean);
-
-  return [repo, org, repoName, sub, ...subpathParts].filter(Boolean);
-}
+export { matchesRepoSearch };
 
 export function matchesRepoContextSearch(context: ActionContext, query: string): boolean {
   return matchesRepoSearch(context.githubRepo, context.subpath, query);
-}
-
-export function matchesRepoSearch(
-  githubRepo: string,
-  subpath: string | null | undefined,
-  query: string
-): boolean {
-  const tokens = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
-
-  if (tokens.length === 0) return true;
-
-  const terms = searchTerms(githubRepo, subpath);
-  return tokens.every((token) => terms.some((term) => term.includes(token)));
 }

--- a/apps/staged/src/lib/shared/repoSearch.test.ts
+++ b/apps/staged/src/lib/shared/repoSearch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { matchesRepoSearch } from './repoSearch';
+
+describe('matchesRepoSearch', () => {
+  it('matches subpath-only queries', () => {
+    expect(matchesRepoSearch('squareup/cash-server', 'kgoose', 'kgoose')).toBe(true);
+  });
+
+  it('matches mixed repo and subpath queries', () => {
+    expect(matchesRepoSearch('squareup/cash-server', 'kgoose', 'cash kgoose')).toBe(true);
+  });
+
+  it('matches joined repo and subpath queries', () => {
+    expect(matchesRepoSearch('squareup/cash-server', 'kgoose', 'cash-server/kgoose')).toBe(true);
+  });
+
+  it('matches tokens regardless of order', () => {
+    expect(matchesRepoSearch('squareup/cash-server', 'kgoose', 'kgoose cash')).toBe(true);
+  });
+
+  it('handles missing subpaths', () => {
+    expect(matchesRepoSearch('squareup/cash-server', null, 'cash-server')).toBe(true);
+    expect(matchesRepoSearch('squareup/cash-server', null, 'kgoose')).toBe(false);
+  });
+
+  it('requires every token to match some repo term', () => {
+    expect(matchesRepoSearch('squareup/cash-server', 'kgoose', 'cash unknown')).toBe(false);
+  });
+});

--- a/apps/staged/src/lib/shared/repoSearch.ts
+++ b/apps/staged/src/lib/shared/repoSearch.ts
@@ -1,0 +1,29 @@
+function searchTerms(githubRepo: string, subpath: string | null | undefined): string[] {
+  const repo = githubRepo.toLowerCase();
+  const [owner = '', repoName = ''] = repo.split('/');
+  const subpathParts = subpath?.toLowerCase().split('/').filter(Boolean) ?? [];
+  const normalizedSubpath = subpathParts.join('/');
+
+  return [
+    repo,
+    owner,
+    repoName,
+    normalizedSubpath,
+    ...subpathParts,
+    normalizedSubpath ? `${repo}/${normalizedSubpath}` : '',
+    normalizedSubpath && repoName ? `${repoName}/${normalizedSubpath}` : '',
+  ].filter(Boolean);
+}
+
+export function matchesRepoSearch(
+  githubRepo: string,
+  subpath: string | null | undefined,
+  query: string
+): boolean {
+  const tokens = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+
+  if (tokens.length === 0) return true;
+
+  const terms = searchTerms(githubRepo, subpath);
+  return tokens.every((token) => terms.some((term) => term.includes(token)));
+}


### PR DESCRIPTION
## Summary
- Share repo search matching between add-repo recent results and repo context settings
- Match subpath-only, mixed token, and repo/subpath queries for recent repos
- Add coverage for the shared repo search helper