### PR TITLE
fix(staged): stabilize timeline footer controls

### DIFF
--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -1218,6 +1218,9 @@
     margin: 0 -8px;
     position: relative;
     z-index: 1;
+    /* Keep footer controls on a tiny stable layer while row hover backgrounds
+       repaint above, without restoring a compositor layer on every row. */
+    transform: translateZ(0);
     transition:
       gap 0.3s ease,
       padding 0.3s ease,


### PR DESCRIPTION
Summary:
- Promote timeline footer controls to a stable compositor layer so hover repaints do not make the bottom controls wobble.
- Keep the change scoped to the footer controls instead of restoring compositor layers on every row.

Testing:
- Push hooks ran crates-fmt, crates-lint, crates-test, differ-ci, and staged-ci.