### PR TITLE
feat(staged): add Doctor tool update controls

### DIFF
--- a/apps/staged/src-tauri/src/doctor.rs
+++ b/apps/staged/src-tauri/src/doctor.rs
@@ -69,7 +69,11 @@ pub async fn run_doctor_update(
              that does not match the backend-derived update command."
         ));
     }
-    doctor::execute_fix_with_options(check_id, fix_type, Some(command), None).await
+    // Run the backend-derived `expected`, not the frontend-supplied `command`.
+    // They are equal past the guard above, but executing `expected` makes the
+    // command that runs provably the one the backend derived — no dependence on
+    // the equality check surviving future edits.
+    doctor::execute_fix_with_options(check_id, fix_type, Some(expected), None).await
 }
 
 /// Re-run freshness and return the authoritative update command for the given

--- a/apps/staged/src-tauri/src/doctor.rs
+++ b/apps/staged/src-tauri/src/doctor.rs
@@ -1,11 +1,38 @@
 //! Tauri command wrappers for the doctor health-check system.
 
-pub use doctor::{CheckStatus, DoctorCheck, DoctorReport, FixType};
+pub use doctor::types::{AuthStatus, InstallSource};
+pub use doctor::{
+    AgentVersionInfo, CheckStatus, DoctorCheck, DoctorReport, FixType, RunChecksOptions,
+};
 
 /// Run all health checks and return the report.
+///
+/// This is the cheap, no-network path: it resolves binaries and reports
+/// install/auth status but does not probe registries for version freshness.
+/// The frontend calls this first for an instant paint, then follows up with
+/// [`run_doctor_freshness`] to fill in version/update information.
 #[tauri::command]
 pub async fn run_doctor() -> DoctorReport {
     doctor::run_checks().await
+}
+
+/// Run all health checks with version freshness enabled.
+///
+/// This is the slower second pass: it probes each readout's installed version
+/// and looks up the latest version from the relevant registry (npm, brew,
+/// crates.io, GitHub releases), populating `installedVersion`, `latestVersion`,
+/// `updateAvailable`, and the source-aware `updateCommand`/`updateFixType` on
+/// each readout. Hits the network, so it must never block first paint.
+#[tauri::command]
+pub async fn run_doctor_freshness() -> DoctorReport {
+    doctor::run_checks_with_options(RunChecksOptions {
+        check_freshness: true,
+        offline: false,
+        // Use the default public registries — Staged installs these agents
+        // from public npm/brew/crates.io, not an internal mirror.
+        npm_registry: None,
+    })
+    .await
 }
 
 /// Run a fix for a doctor check, identified by check ID and fix type.
@@ -15,4 +42,60 @@ pub async fn run_doctor() -> DoctorReport {
 #[tauri::command]
 pub async fn run_doctor_fix(check_id: String, fix_type: FixType) -> Result<(), String> {
     doctor::execute_fix(check_id, fix_type).await
+}
+
+/// Run a source-aware update for a single readout (main CLI or ACP bridge).
+///
+/// Unlike [`run_doctor_fix`], update commands (`UpdateMain`/`UpdateBridge`) are
+/// derived per-readout at freshness time rather than living in the static check
+/// table, so the executor needs the command passed in as an override.
+///
+/// **Trust boundary:** we do not execute the frontend-supplied `command`
+/// blindly. We re-run freshness, re-derive the expected `updateCommand` for
+/// `(check_id, fix_type)` backend-side, and only proceed if the two match. This
+/// keeps `run_doctor_update` from becoming an arbitrary-shell-exec hole — the
+/// `command` argument is effectively a confirmation of what the UI displayed,
+/// validated against the authoritative backend derivation.
+#[tauri::command]
+pub async fn run_doctor_update(
+    check_id: String,
+    fix_type: FixType,
+    command: String,
+) -> Result<(), String> {
+    let expected = expected_update_command(&check_id, &fix_type).await?;
+    if expected != command {
+        return Err(format!(
+            "Update command mismatch for {check_id}: refusing to run a command \
+             that does not match the backend-derived update command."
+        ));
+    }
+    doctor::execute_fix_with_options(check_id, fix_type, Some(command), None).await
+}
+
+/// Re-run freshness and return the authoritative update command for the given
+/// check + slot, or an error if no actionable update is derivable.
+async fn expected_update_command(check_id: &str, fix_type: &FixType) -> Result<String, String> {
+    let report = doctor::run_checks_with_options(RunChecksOptions {
+        check_freshness: true,
+        offline: false,
+        npm_registry: None,
+    })
+    .await;
+
+    let check = report
+        .checks
+        .iter()
+        .find(|c| c.id == check_id)
+        .ok_or_else(|| format!("No such check: {check_id}"))?;
+
+    // The fix type selects which readout's update applies.
+    let readout = match fix_type {
+        FixType::UpdateMain => check.main.as_ref(),
+        FixType::UpdateBridge => check.bridge.as_ref(),
+        _ => return Err(format!("{fix_type:?} is not an update fix type")),
+    };
+
+    readout
+        .and_then(|r| r.update_command.clone())
+        .ok_or_else(|| format!("No actionable update available for {check_id}"))
 }

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -2313,7 +2313,9 @@ pub fn run() {
             review_commands::remove_reference_file,
             // Doctor
             doctor::run_doctor,
+            doctor::run_doctor_freshness,
             doctor::run_doctor_fix,
+            doctor::run_doctor_update,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -3654,10 +3654,21 @@ Begin the note with a markdown H1 heading as the title.\n\n"
             let report = doctor::run_checks().await;
             Ok(serde_json::to_value(report).unwrap())
         }
+        "run_doctor_freshness" => {
+            let report = crate::doctor::run_doctor_freshness().await;
+            Ok(serde_json::to_value(report).unwrap())
+        }
         "run_doctor_fix" => {
             let check_id: String = arg(&args, "checkId")?;
             let fix_type: doctor::FixType = arg(&args, "fixType")?;
             doctor::execute_fix(check_id, fix_type).await?;
+            Ok(Value::Null)
+        }
+        "run_doctor_update" => {
+            let check_id: String = arg(&args, "checkId")?;
+            let fix_type: doctor::FixType = arg(&args, "fixType")?;
+            let command: String = arg(&args, "command")?;
+            crate::doctor::run_doctor_update(check_id, fix_type, command).await?;
             Ok(Value::Null)
         }
 

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -1024,6 +1024,39 @@ export function squashCommits(branchId: string, provider?: string): Promise<stri
 // Doctor (Health Check)
 // =============================================================================
 
+export type DoctorFixType = 'command' | 'bridge' | 'auth' | 'updateMain' | 'updateBridge';
+
+export type DoctorInstallSource =
+  | 'brew'
+  | 'npm'
+  | 'cargo'
+  | 'mise'
+  | 'asdf'
+  | 'curlPipe'
+  | 'system'
+  | 'unknown';
+
+/**
+ * Version + install-source readout for one binary behind an agent check.
+ *
+ * An AI-agent check may front two distinct binaries — the agent's own CLI
+ * (`main`) and its ACP bridge (`bridge`) — each versioned independently. Only
+ * `installSource` is populated on the cheap path; the freshness pass fills in
+ * the rest. Note `updateAvailable` is suppressed (null) for self-updating
+ * tools, so treat null as "no actionable update", never as "up to date".
+ */
+export interface AgentVersionInfo {
+  installSource: DoctorInstallSource | null;
+  installedVersion: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean | null;
+  selfUpdating: boolean | null;
+  /** Source-aware update command. Non-null only when an update is actionable. */
+  updateCommand: string | null;
+  /** 'updateMain' or 'updateBridge', matching this readout's slot. */
+  updateFixType: 'updateMain' | 'updateBridge' | null;
+}
+
 export interface DoctorCheck {
   id: string;
   label: string;
@@ -1031,24 +1064,61 @@ export interface DoctorCheck {
   message: string;
   fixUrl: string | null;
   fixCommand: string | null;
-  fixType: 'command' | 'bridge' | null;
+  fixType: DoctorFixType | null;
   path: string | null;
   bridgePath: string | null;
   rawOutput: string | null;
+  authStatus: 'authenticated' | 'notAuthenticated' | 'notApplicable' | 'unknown' | null;
+  /** Flat version fields mirror the bridge readout (else main) for compat. */
+  installedVersion: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean | null;
+  installSource: DoctorInstallSource | null;
+  selfUpdating: boolean | null;
+  /** Independent readout for the agent's own CLI (e.g. `claude`, `codex`). */
+  main: AgentVersionInfo | null;
+  /** Independent readout for the agent's ACP bridge (e.g. `claude-agent-acp`). */
+  bridge: AgentVersionInfo | null;
 }
 
 export interface DoctorReport {
   checks: DoctorCheck[];
 }
 
-/** Run all system health checks. */
+/** Run all system health checks (cheap path — no version freshness). */
 export function runDoctor(): Promise<DoctorReport> {
   return invokeCommand('run_doctor');
 }
 
+/**
+ * Re-run all checks with version freshness enabled. Slower (hits npm/brew/
+ * crates.io/GitHub) — call this as a second pass after `runDoctor` so the base
+ * report paints instantly while version/update info fills in.
+ */
+export function runDoctorFreshness(): Promise<DoctorReport> {
+  return invokeCommand('run_doctor_freshness');
+}
+
 /** Run a fix for a doctor check, identified by check ID and fix type. */
-export function runDoctorFix(checkId: string, fixType: 'command' | 'bridge'): Promise<void> {
+export function runDoctorFix(
+  checkId: string,
+  fixType: 'command' | 'bridge' | 'auth'
+): Promise<void> {
   return invokeCommand('run_doctor_fix', { checkId, fixType });
+}
+
+/**
+ * Run a source-aware update for a single readout (main CLI or ACP bridge).
+ *
+ * The backend re-derives the expected command for `(checkId, fixType)` and only
+ * runs it if `command` matches, so this is not a raw-shell-exec path.
+ */
+export function runDoctorUpdate(
+  checkId: string,
+  fixType: 'updateMain' | 'updateBridge',
+  command: string
+): Promise<void> {
+  return invokeCommand('run_doctor_update', { checkId, fixType, command });
 }
 
 // =============================================================================

--- a/apps/staged/src/lib/features/doctor/DoctorCheckRow.svelte
+++ b/apps/staged/src/lib/features/doctor/DoctorCheckRow.svelte
@@ -11,8 +11,16 @@
   import XCircle from '@lucide/svelte/icons/x-circle';
   import ExternalLink from '@lucide/svelte/icons/external-link';
   import Wrench from '@lucide/svelte/icons/wrench';
+  import ArrowUpCircle from '@lucide/svelte/icons/arrow-up-circle';
   import { openUrl, runDoctorFix } from '../../api/commands';
-  import type { DoctorCheck } from '../../api/commands';
+  import type { AgentVersionInfo, DoctorCheck } from '../../api/commands';
+  import {
+    doctorState,
+    updateCheck,
+    refreshFreshness,
+    isReadoutActionable,
+    hasActionableUpdate,
+  } from './doctor.svelte';
   import { Button } from '$lib/components/ui/button';
   import * as AlertDialog from '$lib/components/ui/alert-dialog';
   import AgentIcon from '../agents/AgentIcon.svelte';
@@ -31,6 +39,41 @@
   let fixError = $state<string | null>(null);
   let showFixDialog = $state(false);
 
+  // The "Fix" button never handles updates — those use update commands that are
+  // derived per-readout, not the static fix command.
+  const FIX_TYPES = ['command', 'bridge', 'auth'] as const;
+  const canFix = $derived(
+    !!check.fixType &&
+      (FIX_TYPES as readonly string[]).includes(check.fixType) &&
+      !!check.fixCommand &&
+      check.status !== 'pass'
+  );
+
+  /** Readouts (main + bridge) that have any version info worth surfacing. */
+  interface ReadoutEntry {
+    slot: 'main' | 'bridge';
+    info: AgentVersionInfo;
+  }
+  const readouts = $derived(
+    (
+      [
+        { slot: 'main', info: check.main },
+        { slot: 'bridge', info: check.bridge },
+      ] as { slot: 'main' | 'bridge'; info: AgentVersionInfo | null }[]
+    ).filter((r): r is ReadoutEntry => r.info?.updateAvailable === true)
+  );
+
+  /** Update commands that will run when the user confirms (actionable only). */
+  const updateCommands = $derived(
+    [check.main, check.bridge].filter((r) => isReadoutActionable(r)).map((r) => r!.updateCommand!)
+  );
+
+  const canUpdate = $derived(hasActionableUpdate(check));
+  const updating = $derived(doctorState.updating.includes(check.id));
+
+  let showUpdateDialog = $state(false);
+  let updateError = $state<string | null>(null);
+
   function promptFix() {
     if (!check.fixType) return;
     fixError = null;
@@ -43,7 +86,8 @@
     fixing = true;
     fixError = null;
     try {
-      await runDoctorFix(check.id, check.fixType);
+      // canFix guarantees fixType is one of the non-update kinds here.
+      await runDoctorFix(check.id, check.fixType as 'command' | 'bridge' | 'auth');
       showFixDialog = false;
       onFixed?.();
     } catch (e) {
@@ -56,6 +100,30 @@
   function cancelFix() {
     if (fixing) return;
     showFixDialog = false;
+  }
+
+  function promptUpdate() {
+    if (!canUpdate) return;
+    updateError = null;
+    showUpdateDialog = true;
+  }
+
+  async function confirmUpdate() {
+    updateError = null;
+    try {
+      await updateCheck(check);
+      // Re-probe freshness so the just-cleared badges disappear.
+      await refreshFreshness();
+      showUpdateDialog = false;
+      onFixed?.();
+    } catch (e) {
+      updateError = String(e);
+    }
+  }
+
+  function cancelUpdate() {
+    if (updating) return;
+    showUpdateDialog = false;
   }
 </script>
 
@@ -89,9 +157,23 @@
     {#if check.bridgePath}
       <span class="check-path">{check.bridgePath}</span>
     {/if}
+    {#each readouts as readout (readout.slot)}
+      <span class="update-badge" class:info-only={!readout.info.updateCommand}>
+        <ArrowUpCircle size={11} />
+        {readout.slot === 'bridge' ? 'Bridge update' : 'Update'} available:
+        {readout.info.installedVersion ?? '?'} → {readout.info.latestVersion ?? '?'}
+      </span>
+    {/each}
   </div>
 
-  {#if check.fixType && check.fixCommand && check.status !== 'pass'}
+  {#if canUpdate}
+    <Button variant="outline" size="sm" disabled={updating} onclick={promptUpdate}>
+      <ArrowUpCircle size={14} />
+      {updating ? 'Updating' : 'Update'}
+    </Button>
+  {/if}
+
+  {#if canFix}
     <Button variant="outline" size="sm" onclick={promptFix}>
       <Wrench size={14} />
       Fix
@@ -127,6 +209,35 @@
         }}
       >
         {fixing ? 'Running' : fixError ? 'Retry' : 'Run'}
+      </AlertDialog.Action>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>
+
+<AlertDialog.Root bind:open={showUpdateDialog}>
+  <AlertDialog.Content>
+    <AlertDialog.Header>
+      <AlertDialog.Title
+        >Run update command{updateCommands.length > 1 ? 's' : ''}?</AlertDialog.Title
+      >
+      <AlertDialog.Description class="max-h-[42vh] overflow-auto whitespace-pre-line">
+        {updateCommands.join('\n')}
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+    {#if updateError}
+      <p class="text-destructive text-sm">{updateError}</p>
+    {/if}
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel disabled={updating} onclick={cancelUpdate}>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action
+        variant="outline"
+        disabled={updating}
+        onclick={(e) => {
+          e.preventDefault();
+          confirmUpdate();
+        }}
+      >
+        {updating ? 'Updating' : updateError ? 'Retry' : 'Update'}
       </AlertDialog.Action>
     </AlertDialog.Footer>
   </AlertDialog.Content>
@@ -191,5 +302,20 @@
     font-family: monospace;
     overflow-wrap: break-word;
     word-wrap: break-word;
+  }
+
+  .update-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    align-self: flex-start;
+    margin-top: 2px;
+    font-size: 10px;
+    color: var(--color-warning, #d29922);
+  }
+
+  /* When there's no runnable command, the badge is informational only. */
+  .update-badge.info-only {
+    color: var(--text-muted);
   }
 </style>

--- a/apps/staged/src/lib/features/doctor/DoctorCheckRow.svelte
+++ b/apps/staged/src/lib/features/doctor/DoctorCheckRow.svelte
@@ -17,12 +17,12 @@
   import {
     doctorState,
     updateCheck,
-    refreshFreshness,
     isReadoutActionable,
     hasActionableUpdate,
   } from './doctor.svelte';
   import { Button } from '$lib/components/ui/button';
   import * as AlertDialog from '$lib/components/ui/alert-dialog';
+  import Spinner from '../../shared/Spinner.svelte';
   import AgentIcon from '../agents/AgentIcon.svelte';
 
   let {
@@ -71,6 +71,14 @@
   const canUpdate = $derived(hasActionableUpdate(check));
   const updating = $derived(doctorState.updating.includes(check.id));
 
+  // Show a per-row spinner while the (global, batched) freshness pass runs.
+  // Skip `fail` rows — the tool isn't installed, so "checking for an update"
+  // is noise — and skip rows that already surface a result (Update button or
+  // badge) so the spinner and the result never display together.
+  const showFreshnessSpinner = $derived(
+    doctorState.freshnessLoading && check.status !== 'fail' && !canUpdate && readouts.length === 0
+  );
+
   let showUpdateDialog = $state(false);
   let updateError = $state<string | null>(null);
 
@@ -112,9 +120,10 @@
     updateError = null;
     try {
       await updateCheck(check);
-      // Re-probe freshness so the just-cleared badges disappear.
-      await refreshFreshness();
       showUpdateDialog = false;
+      // onFixed (runChecksAndRefresh) is the single full re-run: a base scan
+      // that re-derives status/message, a chained freshness pass that clears
+      // the badges, and a provider refresh. No separate freshness call needed.
       onFixed?.();
     } catch (e) {
       updateError = String(e);
@@ -165,6 +174,10 @@
       </span>
     {/each}
   </div>
+
+  {#if showFreshnessSpinner}
+    <Spinner size={14} />
+  {/if}
 
   {#if canUpdate}
     <Button variant="outline" size="sm" disabled={updating} onclick={promptUpdate}>

--- a/apps/staged/src/lib/features/doctor/DoctorCheckRow.svelte
+++ b/apps/staged/src/lib/features/doctor/DoctorCheckRow.svelte
@@ -71,6 +71,11 @@
   const canUpdate = $derived(hasActionableUpdate(check));
   const updating = $derived(doctorState.updating.includes(check.id));
 
+  // A panel-wide "Update all" run serializes its installs; while it's in flight
+  // this row's actions must stay disabled, or a user could fire a second update
+  // for a check the batch hasn't reached yet and race two global installs.
+  const batchUpdating = $derived(doctorState.updatingAll);
+
   // Show a per-row spinner while the (global, batched) freshness pass runs.
   // Skip `fail` rows — the tool isn't installed, so "checking for an update"
   // is noise — and skip rows that already surface a result (Update button or
@@ -180,14 +185,14 @@
   {/if}
 
   {#if canUpdate}
-    <Button variant="outline" size="sm" disabled={updating} onclick={promptUpdate}>
+    <Button variant="outline" size="sm" disabled={updating || batchUpdating} onclick={promptUpdate}>
       <ArrowUpCircle size={14} />
       {updating ? 'Updating' : 'Update'}
     </Button>
   {/if}
 
   {#if canFix}
-    <Button variant="outline" size="sm" onclick={promptFix}>
+    <Button variant="outline" size="sm" disabled={batchUpdating} onclick={promptFix}>
       <Wrench size={14} />
       Fix
     </Button>

--- a/apps/staged/src/lib/features/doctor/doctor.svelte.ts
+++ b/apps/staged/src/lib/features/doctor/doctor.svelte.ts
@@ -114,6 +114,15 @@ export async function runChecks(): Promise<void> {
 }
 
 /**
+ * Monotonic token identifying the most recently started freshness pass.
+ *
+ * Passes can overlap (a re-run or an update fires while one is in flight) and
+ * resolve out of order. Each pass captures the value here at the start; only
+ * the latest pass is allowed to merge its result or own `freshnessLoading`.
+ */
+let freshnessGeneration = 0;
+
+/**
  * Run the freshness pass and merge its version fields into the current report.
  *
  * Patches per-check rather than replacing the whole report, so the visible rows
@@ -121,14 +130,21 @@ export async function runChecks(): Promise<void> {
  */
 export async function refreshFreshness(): Promise<void> {
   if (!doctorState.report) return;
+  const generation = ++freshnessGeneration;
   doctorState.freshnessLoading = true;
   try {
     const fresh = await runDoctorFreshness();
+    // A newer pass started while this one was in flight: discard this result
+    // entirely. Merging would patch stale version data, and the newer pass
+    // already owns `freshnessLoading`.
+    if (generation !== freshnessGeneration) return;
     mergeFreshness(fresh);
   } catch (e) {
     console.error('[Doctor] Failed to run freshness pass:', e);
   } finally {
-    doctorState.freshnessLoading = false;
+    // Only the latest pass clears the flag, so a superseded pass resolving late
+    // can't switch the spinner off while a newer pass is still running.
+    if (generation === freshnessGeneration) doctorState.freshnessLoading = false;
   }
 }
 
@@ -180,7 +196,8 @@ export async function updateCheck(check: DoctorCheck): Promise<boolean> {
  * Update every check that has an actionable readout, one check at a time.
  *
  * Serialized across checks (and within each check) to avoid concurrent global
- * installs. Runs a single freshness refresh at the end so all badges clear.
+ * installs. The caller is responsible for the single full re-run afterwards
+ * (a freshness-only pass would leave updated tools showing stale status/message).
  */
 export async function updateAll(): Promise<void> {
   const checks = doctorState.report?.checks.filter(hasActionableUpdate) ?? [];
@@ -191,5 +208,4 @@ export async function updateAll(): Promise<void> {
       console.error(`[Doctor] Failed to update ${check.id}:`, e);
     }
   }
-  await refreshFreshness();
 }

--- a/apps/staged/src/lib/features/doctor/doctor.svelte.ts
+++ b/apps/staged/src/lib/features/doctor/doctor.svelte.ts
@@ -22,6 +22,8 @@ interface DoctorState {
   freshnessLoading: boolean;
   /** IDs of checks with an update currently in flight (blocks double-clicks). */
   updating: string[];
+  /** True while a panel-wide "Update all" run is in progress. */
+  updatingAll: boolean;
 }
 
 export const doctorState: DoctorState = $state({
@@ -29,6 +31,7 @@ export const doctorState: DoctorState = $state({
   loading: false,
   freshnessLoading: false,
   updating: [],
+  updatingAll: false,
 });
 
 /** Version fields the freshness pass fills in; merged onto the base report. */
@@ -196,16 +199,26 @@ export async function updateCheck(check: DoctorCheck): Promise<boolean> {
  * Update every check that has an actionable readout, one check at a time.
  *
  * Serialized across checks (and within each check) to avoid concurrent global
- * installs. The caller is responsible for the single full re-run afterwards
- * (a freshness-only pass would leave updated tools showing stale status/message).
+ * installs. Sets `doctorState.updatingAll` for the duration so the UI can
+ * disable every per-row Update/Fix button — otherwise a user could confirm an
+ * individual update for a check this batch hasn't reached yet, racing a second
+ * global install against the one in flight. The caller is responsible for the
+ * single full re-run afterwards (a freshness-only pass would leave updated
+ * tools showing stale status/message).
  */
 export async function updateAll(): Promise<void> {
-  const checks = doctorState.report?.checks.filter(hasActionableUpdate) ?? [];
-  for (const check of checks) {
-    try {
-      await updateCheck(check);
-    } catch (e) {
-      console.error(`[Doctor] Failed to update ${check.id}:`, e);
+  if (doctorState.updatingAll) return;
+  doctorState.updatingAll = true;
+  try {
+    const checks = doctorState.report?.checks.filter(hasActionableUpdate) ?? [];
+    for (const check of checks) {
+      try {
+        await updateCheck(check);
+      } catch (e) {
+        console.error(`[Doctor] Failed to update ${check.id}:`, e);
+      }
     }
+  } finally {
+    doctorState.updatingAll = false;
   }
 }

--- a/apps/staged/src/lib/features/doctor/doctor.svelte.ts
+++ b/apps/staged/src/lib/features/doctor/doctor.svelte.ts
@@ -4,19 +4,53 @@
  * Exposes `doctorState` (report + loading flag) and an action helper
  * that calls the Tauri `run_doctor` command.
  */
-import { runDoctor, type DoctorCheck, type DoctorReport } from '../../api/commands';
+import {
+  runDoctor,
+  runDoctorFreshness,
+  runDoctorUpdate,
+  type AgentVersionInfo,
+  type DoctorCheck,
+  type DoctorReport,
+} from '../../api/commands';
 
 interface DoctorState {
   /** The most recent report, or null if not yet run. */
   report: DoctorReport | null;
   /** True while the initial scan is running. */
   loading: boolean;
+  /** True while the async version-freshness pass is running. */
+  freshnessLoading: boolean;
+  /** IDs of checks with an update currently in flight (blocks double-clicks). */
+  updating: string[];
 }
 
 export const doctorState: DoctorState = $state({
   report: null,
   loading: false,
+  freshnessLoading: false,
+  updating: [],
 });
+
+/** Version fields the freshness pass fills in; merged onto the base report. */
+const FRESHNESS_FIELDS: (keyof DoctorCheck)[] = [
+  'installedVersion',
+  'latestVersion',
+  'updateAvailable',
+  'installSource',
+  'selfUpdating',
+  'main',
+  'bridge',
+];
+
+/** A readout is actionable when it has both an update and a command to run it. */
+export function isReadoutActionable(readout: AgentVersionInfo | null | undefined): boolean {
+  return !!readout && readout.updateAvailable === true && !!readout.updateCommand;
+}
+
+/** True when either readout of a check has an actionable update available. */
+export function hasActionableUpdate(check: DoctorCheck): boolean {
+  return isReadoutActionable(check.main) || isReadoutActionable(check.bridge);
+}
 
 const STATUS_ICONS: Record<DoctorCheck['status'], string> = {
   pass: '✓',
@@ -72,4 +106,90 @@ export async function runChecks(): Promise<void> {
   } finally {
     doctorState.loading = false;
   }
+
+  // Second pass: probe registries for version freshness and merge the version
+  // fields onto the already-painted report. Don't await — let the base report
+  // render immediately while this fills in update badges in the background.
+  void refreshFreshness();
+}
+
+/**
+ * Run the freshness pass and merge its version fields into the current report.
+ *
+ * Patches per-check rather than replacing the whole report, so the visible rows
+ * never blank out (the freshness report can lag or differ in transient ways).
+ */
+export async function refreshFreshness(): Promise<void> {
+  if (!doctorState.report) return;
+  doctorState.freshnessLoading = true;
+  try {
+    const fresh = await runDoctorFreshness();
+    mergeFreshness(fresh);
+  } catch (e) {
+    console.error('[Doctor] Failed to run freshness pass:', e);
+  } finally {
+    doctorState.freshnessLoading = false;
+  }
+}
+
+/** Merge version fields from a freshness report into the cached base report. */
+function mergeFreshness(fresh: DoctorReport): void {
+  const report = doctorState.report;
+  if (!report) return;
+  const byId = new Map(fresh.checks.map((c) => [c.id, c]));
+  for (const check of report.checks) {
+    const updated = byId.get(check.id);
+    if (!updated) continue;
+    for (const field of FRESHNESS_FIELDS) {
+      // Assign through a loosely-typed view: every field is independently
+      // optional and we're copying like-for-like from the same shape.
+      (check as unknown as Record<string, unknown>)[field] = updated[field];
+    }
+  }
+}
+
+/**
+ * Update a single check's actionable readouts (main CLI + ACP bridge).
+ *
+ * Runs the readouts' update commands **sequentially** — never race two global
+ * npm/brew installs, they can clobber each other. After the updates land, the
+ * caller is expected to refresh freshness so the badges clear. Guards against
+ * double-clicks via the per-check in-flight set.
+ *
+ * Returns true if at least one update ran successfully.
+ */
+export async function updateCheck(check: DoctorCheck): Promise<boolean> {
+  if (doctorState.updating.includes(check.id)) return false;
+  doctorState.updating = [...doctorState.updating, check.id];
+  let ranAny = false;
+  try {
+    for (const readout of [check.main, check.bridge]) {
+      if (!isReadoutActionable(readout) || !readout?.updateFixType || !readout.updateCommand) {
+        continue;
+      }
+      await runDoctorUpdate(check.id, readout.updateFixType, readout.updateCommand);
+      ranAny = true;
+    }
+  } finally {
+    doctorState.updating = doctorState.updating.filter((id) => id !== check.id);
+  }
+  return ranAny;
+}
+
+/**
+ * Update every check that has an actionable readout, one check at a time.
+ *
+ * Serialized across checks (and within each check) to avoid concurrent global
+ * installs. Runs a single freshness refresh at the end so all badges clear.
+ */
+export async function updateAll(): Promise<void> {
+  const checks = doctorState.report?.checks.filter(hasActionableUpdate) ?? [];
+  for (const check of checks) {
+    try {
+      await updateCheck(check);
+    } catch (e) {
+      console.error(`[Doctor] Failed to update ${check.id}:`, e);
+    }
+  }
+  await refreshFreshness();
 }

--- a/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
@@ -4,9 +4,16 @@
   import Stethoscope from '@lucide/svelte/icons/stethoscope';
   import ClipboardCopy from '@lucide/svelte/icons/clipboard-copy';
   import Check from '@lucide/svelte/icons/check';
+  import ArrowUpCircle from '@lucide/svelte/icons/arrow-up-circle';
   import Spinner from '../../shared/Spinner.svelte';
   import DoctorCheckRow from '../doctor/DoctorCheckRow.svelte';
-  import { doctorState, runChecks, formatDebugReport } from '../doctor/doctor.svelte';
+  import {
+    doctorState,
+    runChecks,
+    updateAll,
+    hasActionableUpdate,
+    formatDebugReport,
+  } from '../doctor/doctor.svelte';
   import { refreshProviders } from '../agents/agent.svelte';
   import { Button } from '$lib/components/ui/button';
 
@@ -38,6 +45,23 @@
   const agentChecks = $derived(
     doctorState.report?.checks.filter((c) => c.id.startsWith('ai-agent-')) ?? []
   );
+
+  /** True when any check has an actionable update across its readouts. */
+  const anyUpdatable = $derived(doctorState.report?.checks.some(hasActionableUpdate) ?? false);
+
+  /** True while a panel-wide update run is in progress. */
+  let updatingAll = $state(false);
+
+  async function runUpdateAll() {
+    if (updatingAll) return;
+    updatingAll = true;
+    try {
+      await updateAll();
+      if (mounted) refreshProviders();
+    } finally {
+      updatingAll = false;
+    }
+  }
 
   let copied = $state(false);
 
@@ -73,8 +97,15 @@
         </Button>
       {/if}
 
+      {#if anyUpdatable && !doctorState.loading}
+        <Button variant="outline" size="sm" disabled={updatingAll} onclick={runUpdateAll}>
+          <ArrowUpCircle size={14} />
+          {updatingAll ? 'Updating all' : 'Update all'}
+        </Button>
+      {/if}
+
       {#if !doctorState.loading}
-        <Button variant="outline" size="sm" onclick={runChecksAndRefresh}>
+        <Button variant="outline" size="sm" disabled={updatingAll} onclick={runChecksAndRefresh}>
           <RefreshCw size={14} />
           Re-run
         </Button>

--- a/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
@@ -49,21 +49,15 @@
   /** True when any check has an actionable update across its readouts. */
   const anyUpdatable = $derived(doctorState.report?.checks.some(hasActionableUpdate) ?? false);
 
-  /** True while a panel-wide update run is in progress. */
-  let updatingAll = $state(false);
-
   async function runUpdateAll() {
-    if (updatingAll) return;
-    updatingAll = true;
-    try {
-      await updateAll();
-      // One full re-run after the batch: re-derives each check's status/message
-      // (so updated tools drop their stale warnings), chains a freshness pass to
-      // clear the badges, and re-discovers providers.
-      if (mounted) await runChecksAndRefresh();
-    } finally {
-      updatingAll = false;
-    }
+    if (doctorState.updatingAll) return;
+    // updateAll owns `doctorState.updatingAll` for its duration, which disables
+    // every per-row Update/Fix button so no individual update can race the batch.
+    await updateAll();
+    // One full re-run after the batch: re-derives each check's status/message
+    // (so updated tools drop their stale warnings), chains a freshness pass to
+    // clear the badges, and re-discovers providers.
+    if (mounted) await runChecksAndRefresh();
   }
 
   let copied = $state(false);
@@ -101,14 +95,24 @@
       {/if}
 
       {#if anyUpdatable && !doctorState.loading}
-        <Button variant="outline" size="sm" disabled={updatingAll} onclick={runUpdateAll}>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={doctorState.updatingAll}
+          onclick={runUpdateAll}
+        >
           <ArrowUpCircle size={14} />
-          {updatingAll ? 'Updating all' : 'Update all'}
+          {doctorState.updatingAll ? 'Updating all' : 'Update all'}
         </Button>
       {/if}
 
       {#if !doctorState.loading}
-        <Button variant="outline" size="sm" disabled={updatingAll} onclick={runChecksAndRefresh}>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={doctorState.updatingAll}
+          onclick={runChecksAndRefresh}
+        >
           <RefreshCw size={14} />
           Re-run
         </Button>

--- a/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/DoctorSettingsPanel.svelte
@@ -57,7 +57,10 @@
     updatingAll = true;
     try {
       await updateAll();
-      if (mounted) refreshProviders();
+      // One full re-run after the batch: re-derives each check's status/message
+      // (so updated tools drop their stale warnings), chains a freshness pass to
+      // clear the badges, and re-discovers providers.
+      if (mounted) await runChecksAndRefresh();
     } finally {
       updatingAll = false;
     }


### PR DESCRIPTION
Summary:
- Add Doctor support for detecting tool update availability and running individual or bulk updates.
- Expose backend-derived update commands through Tauri commands and the web server.
- Refresh Doctor state after updates while avoiding stale per-row update actions during bulk runs.