### PR TITLE
fix(staged): restore new project location card spacing

### DIFF
--- a/apps/staged/src/lib/features/projects/NewProjectForm.svelte
+++ b/apps/staged/src/lib/features/projects/NewProjectForm.svelte
@@ -199,7 +199,8 @@
         orientation="vertical"
         bind:value={location}
         disabled={saving}
-        class="w-full gap-0"
+        spacing={2}
+        class="w-full"
       >
         {#each [{ value: 'local', label: 'Local', description: 'Run agents on your machine', icon: Monitor }, { value: 'remote', label: 'Remote', description: 'Run agents in the cloud', icon: Cloud }] as option}
           <ToggleGroup.Item


### PR DESCRIPTION
Summary:
- Restore separated spacing between the Local and Remote location options in the New Project form.
- Keep the toggle group full width while using explicit component spacing.

Tests:
- Push hooks ran successfully.