### PR TITLE
feat: allow parallel branch note sessions

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -2278,6 +2278,7 @@ pub fn run() {
             session_commands::cancel_session,
             session_commands::delete_session,
             session_commands::start_branch_session,
+            session_commands::start_or_queue_branch_session,
             session_commands::queue_branch_session,
             session_commands::drain_queued_sessions,
             session_commands::start_project_session,

--- a/apps/staged/src-tauri/src/prs.rs
+++ b/apps/staged/src-tauri/src/prs.rs
@@ -489,7 +489,7 @@ pub(crate) async fn start_queued_commit_pipeline_for_branch(
     let effective_provider = session.provider.clone().or(provider);
 
     let transitioned = store
-        .transition_to_running(&session.id)
+        .transition_queued_to_running(&session.id)
         .map_err(|e| e.to_string())?;
     if !transitioned {
         return Ok(false);

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -7,7 +7,7 @@
 //!
 //! Only commands the frontend legitimately needs are exposed here:
 //! - `start_session` / `resume_session` — kick off agent work
-//! - `start_branch_session` — kick off branch-scoped agent work (note/commit)
+//! - `start_or_queue_branch_session` — start or enqueue branch-scoped agent work
 //! - `cancel_session` / `delete_session` — lifecycle control
 //! - `get_session` / `get_session_messages` / `get_session_messages_since` — reads for polling
 //!
@@ -16,9 +16,9 @@
 //! only by the backend (`session_runner` / `agent` modules) via the
 //! `Store` directly.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -474,6 +474,24 @@ pub enum BranchSessionType {
     Review,
 }
 
+impl BranchSessionType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            BranchSessionType::Commit => "commit",
+            BranchSessionType::Note => "note",
+            BranchSessionType::Review => "review",
+        }
+    }
+
+    fn schedule_kind(&self) -> BranchSessionScheduleKind {
+        match self {
+            BranchSessionType::Commit => BranchSessionScheduleKind::Commit,
+            BranchSessionType::Note => BranchSessionScheduleKind::Note,
+            BranchSessionType::Review => BranchSessionScheduleKind::Review,
+        }
+    }
+}
+
 fn extra_env_for_branch_session(session_type: &BranchSessionType) -> Vec<(String, String)> {
     if matches!(session_type, BranchSessionType::Commit) {
         session_runner::git_identity_env_from_global_config()
@@ -634,6 +652,52 @@ fn running_branch_session_kinds(
     Ok(active)
 }
 
+fn branch_session_launch_locks() -> &'static Mutex<HashMap<String, Arc<Mutex<()>>>> {
+    static LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+    LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn branch_session_launch_lock_for(branch_id: &str) -> Arc<Mutex<()>> {
+    let mut locks = branch_session_launch_locks().lock().unwrap();
+    Arc::clone(
+        locks
+            .entry(branch_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(()))),
+    )
+}
+
+fn has_queued_user_branch_session(store: &Store, branch_id: &str) -> Result<bool, String> {
+    let queued = store
+        .get_queued_sessions_for_branch(branch_id)
+        .map_err(|e| e.to_string())?;
+
+    for session in queued {
+        if let Some(schedule) = resolve_branch_session_schedule(store, branch_id, &session, true)? {
+            if schedule.blocks_queue {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+fn should_queue_branch_session_start(
+    store: &Store,
+    branch_id: &str,
+    session_type: &BranchSessionType,
+) -> Result<bool, String> {
+    if has_queued_user_branch_session(store, branch_id)? {
+        return Ok(true);
+    }
+
+    let active = running_branch_session_kinds(store, branch_id)?;
+    Ok(!can_start_with_active_branch_sessions(
+        session_type.schedule_kind(),
+        &active,
+    ))
+}
+
 #[cfg(test)]
 fn drainable_session_ids_for_active_set(
     queued: &[(String, BranchSessionSchedule)],
@@ -662,6 +726,13 @@ pub struct BranchSessionLaunchContext {
     pub review_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BranchSessionLaunchStatus {
+    Running,
+    Queued,
+}
+
 /// Response from starting a branch session.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -669,6 +740,7 @@ pub struct BranchSessionResponse {
     pub session_id: String,
     /// The ID of the artifact created (commit or note).
     pub artifact_id: String,
+    pub session_status: BranchSessionLaunchStatus,
 }
 
 /// Response from starting a project session.
@@ -831,39 +903,55 @@ Begin the note with a markdown H1 heading as the title.\n\n"
     })
 }
 
-/// Start a branch-scoped session (note or commit).
-///
-/// This builds the full prompt (action tag + branch history + user prompt),
-/// creates the artifact stub, and kicks off the agent in the branch's workdir.
-///
-/// For remote branches (those with a `workspace_name`), the session runs via
-/// `blox acp` instead of a local agent binary. Branch context and commit
-/// detection are skipped since there is no local worktree.
-#[allow(clippy::too_many_arguments)]
-#[tauri::command(rename_all = "camelCase")]
-pub async fn start_branch_session(
-    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
-    registry: tauri::State<'_, Arc<session_runner::SessionRegistry>>,
-    app_handle: tauri::AppHandle,
-    branch_id: String,
-    prompt: String,
+struct PreparedBranchSessionStart {
+    branch: store::Branch,
     session_type: BranchSessionType,
     provider: Option<String>,
-    image_ids: Option<Vec<String>>,
-    launch_context: Option<BranchSessionLaunchContext>,
-) -> Result<BranchSessionResponse, String> {
-    let store = get_store(&store)?;
+    working_dir: PathBuf,
+    full_prompt: String,
+    pre_head_sha: Option<String>,
+    review_tip_sha: Option<String>,
+    remote_working_dir: Option<PathBuf>,
+}
 
-    if matches!(
-        session_type,
-        BranchSessionType::Commit | BranchSessionType::Review
-    ) {
-        cancel_in_flight_auto_review_for_branch(&store, &registry, &branch_id)?;
-    }
+struct CreatedBranchSession {
+    session: store::Session,
+    artifact_id: String,
+}
 
-    // Resolve branch → project
+fn resolve_branch_session_provider(
+    store: &Arc<Store>,
+    branch_id: &str,
+    session_type: &BranchSessionType,
+    provider: Option<String>,
+) -> Result<Option<String>, String> {
     let branch = store
-        .get_branch(&branch_id)
+        .get_branch(branch_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+    if matches!(session_type, BranchSessionType::Review) {
+        Some(resolve_review_provider(
+            provider,
+            branch.workspace_name.is_some(),
+        ))
+        .transpose()
+    } else {
+        Ok(provider)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn prepare_branch_session_start(
+    store: &Arc<Store>,
+    branch_id: &str,
+    prompt: &str,
+    session_type: BranchSessionType,
+    provider: Option<String>,
+    launch_context: Option<&BranchSessionLaunchContext>,
+) -> Result<PreparedBranchSessionStart, String> {
+    let branch = store
+        .get_branch(branch_id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
 
@@ -873,24 +961,19 @@ pub async fn start_branch_session(
         .ok_or_else(|| format!("Project not found: {}", branch.project_id))?;
 
     let is_remote = branch.workspace_name.is_some();
-    let provider = if matches!(session_type, BranchSessionType::Review) {
-        Some(resolve_review_provider(provider, is_remote)?)
-    } else {
-        provider
-    };
 
     // Resolve working directory and branch context.
     // Remote branches use ws_exec for git operations; local branches use the worktree directly.
     let (working_dir, branch_context) = if is_remote {
         // For remote branches, use the derived clone path as a fallback working dir.
         // The actual work happens via ws_exec, not local filesystem.
-        let fallback_dir = resolve_branch_repo_slug(&store, &project, &branch)
+        let fallback_dir = resolve_branch_repo_slug(store, &project, &branch)
             .and_then(|repo| crate::paths::repos_dir().map(|d| d.join(repo)))
             .unwrap_or_else(|| PathBuf::from("/tmp"));
         let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
         let base_branch = branch.base_branch.clone();
-        let store_for_context = Arc::clone(&store);
-        let branch_id_for_context = branch_id.clone();
+        let store_for_context = Arc::clone(store);
+        let branch_id_for_context = branch_id.to_string();
         let project_id_for_context = branch.project_id.clone();
         let ctx = tauri::async_runtime::spawn_blocking(move || {
             build_remote_branch_context(
@@ -906,7 +989,7 @@ pub async fn start_branch_session(
         (fallback_dir, ctx)
     } else {
         let workdir = store
-            .get_workdir_for_branch(&branch_id)
+            .get_workdir_for_branch(branch_id)
             .map_err(|e| e.to_string())?
             .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
 
@@ -930,110 +1013,68 @@ pub async fn start_branch_session(
         let ctx = build_branch_context(
             &worktree_path,
             &branch.base_branch,
-            &store,
-            &branch_id,
+            store,
+            branch_id,
             &branch.project_id,
         );
         (worktree_path, ctx)
     };
 
-    // Build the full prompt with action instructions + project information + branch context.
-    let project_information = build_project_context(&store, &project, &branch);
-    let full_prompt = build_full_prompt(
-        &prompt,
-        &project_information,
-        &branch_context,
-        &session_type,
-        launch_context.as_ref(),
-        Some(&branch.base_branch),
-    );
-
-    // Create the session
-    let mut session = store::Session::new_running(&full_prompt, &working_dir);
-    if let Some(ref p) = provider {
-        session = session.with_provider(p);
-    }
-    store.create_session(&session).map_err(|e| e.to_string())?;
-
-    // Emit a "running" event so the frontend can register the session in its
-    // state stores (project list spinner, unread badges, etc.) regardless of
-    // which UI surface started the session.
-    let session_type_str = match session_type {
-        BranchSessionType::Commit => "commit",
-        BranchSessionType::Note => "note",
-        BranchSessionType::Review => "review",
-    };
-    session_runner::emit_session_running(
-        &app_handle,
-        &session.id,
-        &branch_id,
-        &branch.project_id,
-        session_type_str,
-    );
-
-    // Create artifact stub and compute pre-head SHA
-    let (artifact_id, pre_head_sha) = match session_type {
-        BranchSessionType::Note => {
-            let note = store::Note::new(&branch_id, &prompt, "").with_session(&session.id);
-            store.create_note(&note).map_err(|e| e.to_string())?;
-            (note.id, None)
-        }
-        BranchSessionType::Commit => {
-            let commit = store::Commit::new_pending(&branch_id).with_session(&session.id);
-            store.create_commit(&commit).map_err(|e| e.to_string())?;
-            // For remote branches, get HEAD via ws_exec; for local, use git directly.
-            let head_sha = if is_remote {
-                let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
-                match run_blox_blocking(move || {
-                    blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"])
-                })
-                .await
-                {
-                    Ok(sha) => Some(sha.trim().to_string()),
-                    Err(e) => {
-                        log::warn!("Failed to get remote HEAD SHA via ws_exec: {e}");
-                        None
-                    }
+    let pre_head_sha = if matches!(session_type, BranchSessionType::Commit) {
+        if is_remote {
+            let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
+            match run_blox_blocking(move || {
+                blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"])
+            })
+            .await
+            {
+                Ok(sha) => Some(sha.trim().to_string()),
+                Err(e) => {
+                    log::warn!("Failed to get remote HEAD SHA via ws_exec: {e}");
+                    None
                 }
-            } else {
-                Some(
-                    git::get_head_sha(&working_dir)
-                        .map_err(|e| format!("Failed to get HEAD SHA: {e}"))?,
-                )
-            };
-            (commit.id, head_sha)
+            }
+        } else {
+            Some(
+                git::get_head_sha(&working_dir)
+                    .map_err(|e| format!("Failed to get HEAD SHA: {e}"))?,
+            )
         }
-        BranchSessionType::Review => {
-            // Get the current tip SHA for the review anchor
-            let tip_sha = if is_remote {
-                let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
-                run_blox_blocking(move || {
-                    blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"])
-                })
+    } else {
+        None
+    };
+
+    let review_tip_sha = if matches!(session_type, BranchSessionType::Review) {
+        let tip_sha = if is_remote {
+            let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
+            run_blox_blocking(move || blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"]))
                 .await
                 .map(|s| s.trim().to_string())
                 .unwrap_or_else(|_| "unknown".to_string())
-            } else {
-                git::get_head_sha(&working_dir)
-                    .map_err(|e| format!("Failed to get HEAD SHA: {e}"))?
-            };
-
-            let review = store::Review::new(&branch_id, &tip_sha, store::ReviewScope::Branch)
-                .with_session(&session.id);
-            store.create_review(&review).map_err(|e| e.to_string())?;
-            (review.id, None)
-        }
+        } else {
+            git::get_head_sha(&working_dir).map_err(|e| format!("Failed to get HEAD SHA: {e}"))?
+        };
+        Some(tip_sha)
+    } else {
+        None
     };
 
-    // Review sessions have a required provider by this point; other session
-    // types keep the caller's optional selection.
-    let effective_provider = provider;
+    // Build the full prompt with action instructions + project information + branch context.
+    let project_information = build_project_context(store, &project, &branch);
+    let full_prompt = build_full_prompt(
+        prompt,
+        &project_information,
+        &branch_context,
+        &session_type,
+        launch_context,
+        Some(&branch.base_branch),
+    );
 
     // Resolve the actual workspace path for remote branches so the remote agent
     // starts in the correct repo directory (not the workspace default).
     let remote_working_dir = if is_remote {
         let ws_name = branch.workspace_name.as_deref().unwrap().to_string();
-        let store_for_resolve = Arc::clone(&store);
+        let store_for_resolve = Arc::clone(store);
         let branch_for_resolve = branch.clone();
         match tauri::async_runtime::spawn_blocking(move || {
             crate::branches::resolve_branch_workspace_subpath(
@@ -1055,23 +1096,145 @@ pub async fn start_branch_session(
         None
     };
 
+    Ok(PreparedBranchSessionStart {
+        branch,
+        session_type,
+        provider,
+        working_dir,
+        full_prompt,
+        pre_head_sha,
+        review_tip_sha,
+        remote_working_dir,
+    })
+}
+
+fn insert_running_branch_session(
+    store: &Arc<Store>,
+    prepared: &PreparedBranchSessionStart,
+    prompt: &str,
+) -> Result<CreatedBranchSession, String> {
+    let mut session = store::Session::new_running(&prepared.full_prompt, &prepared.working_dir);
+    if let Some(ref p) = prepared.provider {
+        session = session.with_provider(p);
+    }
+    store.create_session(&session).map_err(|e| e.to_string())?;
+
+    let artifact_id = match &prepared.session_type {
+        BranchSessionType::Note => {
+            let note = store::Note::new(&prepared.branch.id, prompt, "").with_session(&session.id);
+            store.create_note(&note).map_err(|e| e.to_string())?;
+            note.id
+        }
+        BranchSessionType::Commit => {
+            let commit = store::Commit::new_pending(&prepared.branch.id).with_session(&session.id);
+            store.create_commit(&commit).map_err(|e| e.to_string())?;
+            commit.id
+        }
+        BranchSessionType::Review => {
+            let review = store::Review::new(
+                &prepared.branch.id,
+                prepared.review_tip_sha.as_deref().unwrap_or("unknown"),
+                store::ReviewScope::Branch,
+            )
+            .with_session(&session.id);
+            store.create_review(&review).map_err(|e| e.to_string())?;
+            review.id
+        }
+    };
+
+    Ok(CreatedBranchSession {
+        session,
+        artifact_id,
+    })
+}
+
+fn insert_queued_branch_session(
+    store: &Arc<Store>,
+    branch_id: &str,
+    prompt: &str,
+    session_type: &BranchSessionType,
+    provider: Option<String>,
+    image_ids: &[String],
+    launch_context: Option<&BranchSessionLaunchContext>,
+) -> Result<BranchSessionResponse, String> {
+    let queued_prompt = embed_launch_context(prompt, launch_context)?;
+    let mut session = store::Session::new_queued(&queued_prompt);
+    if let Some(ref p) = provider {
+        session = session.with_provider(p);
+    }
+    store.create_session(&session).map_err(|e| e.to_string())?;
+
+    store
+        .set_images_session_id(image_ids, &session.id)
+        .map_err(|e| e.to_string())?;
+
+    let artifact_id = match session_type {
+        BranchSessionType::Note => {
+            let note = store::Note::new(branch_id, prompt, "").with_session(&session.id);
+            store.create_note(&note).map_err(|e| e.to_string())?;
+            note.id
+        }
+        BranchSessionType::Commit => {
+            let commit = store::Commit::new_pending(branch_id).with_session(&session.id);
+            store.create_commit(&commit).map_err(|e| e.to_string())?;
+            commit.id
+        }
+        BranchSessionType::Review => {
+            let review = store::Review::new(branch_id, "", store::ReviewScope::Branch)
+                .with_session(&session.id);
+            store.create_review(&review).map_err(|e| e.to_string())?;
+            review.id
+        }
+    };
+
+    Ok(BranchSessionResponse {
+        session_id: session.id,
+        artifact_id,
+        session_status: BranchSessionLaunchStatus::Queued,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_running_branch_session(
+    store: Arc<Store>,
+    registry: Arc<session_runner::SessionRegistry>,
+    app_handle: tauri::AppHandle,
+    prepared: PreparedBranchSessionStart,
+    created: CreatedBranchSession,
+    image_ids: Vec<String>,
+) -> Result<BranchSessionResponse, String> {
+    let session_type = prepared.session_type;
+    let branch = prepared.branch;
+    let session_type_str = session_type.as_str();
+    let branch_id = branch.id.clone();
+    let project_id = branch.project_id.clone();
+    let workspace_name = branch.workspace_name.clone();
+
+    session_runner::emit_session_running(
+        &app_handle,
+        &created.session.id,
+        &branch_id,
+        &project_id,
+        session_type_str,
+    );
+
     session_runner::start_session(
         SessionConfig {
-            session_id: session.id.clone(),
-            prompt: full_prompt,
-            working_dir,
+            session_id: created.session.id.clone(),
+            prompt: prepared.full_prompt,
+            working_dir: prepared.working_dir,
             agent_session_id: None,
-            pre_head_sha,
-            provider: effective_provider,
-            workspace_name: branch.workspace_name.clone(),
+            pre_head_sha: prepared.pre_head_sha,
+            provider: prepared.provider,
+            workspace_name,
             extra_env: extra_env_for_branch_session(&session_type),
             mcp_project_id: None,
             action_executor: None,
             action_registry: None,
-            remote_working_dir,
-            image_ids: image_ids.unwrap_or_default(),
+            remote_working_dir: prepared.remote_working_dir,
+            image_ids,
             branch_id: Some(branch_id),
-            project_id: Some(branch.project_id.clone()),
+            project_id: Some(project_id),
         },
         store,
         app_handle,
@@ -1079,9 +1242,172 @@ pub async fn start_branch_session(
     )?;
 
     Ok(BranchSessionResponse {
-        session_id: session.id,
-        artifact_id,
+        session_id: created.session.id,
+        artifact_id: created.artifact_id,
+        session_status: BranchSessionLaunchStatus::Running,
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn start_or_queue_branch_session_for_store(
+    store: Arc<Store>,
+    registry: Arc<session_runner::SessionRegistry>,
+    app_handle: tauri::AppHandle,
+    branch_id: String,
+    prompt: String,
+    session_type: BranchSessionType,
+    provider: Option<String>,
+    image_ids: Option<Vec<String>>,
+    launch_context: Option<BranchSessionLaunchContext>,
+) -> Result<BranchSessionResponse, String> {
+    let image_ids = image_ids.unwrap_or_default();
+
+    if matches!(
+        session_type,
+        BranchSessionType::Commit | BranchSessionType::Review
+    ) {
+        cancel_in_flight_auto_review_for_branch(&store, &registry, &branch_id)?;
+    }
+
+    let provider = resolve_branch_session_provider(&store, &branch_id, &session_type, provider)?;
+    let launch_lock = branch_session_launch_lock_for(&branch_id);
+
+    {
+        let _guard = launch_lock.lock().unwrap();
+        if should_queue_branch_session_start(&store, &branch_id, &session_type)? {
+            return insert_queued_branch_session(
+                &store,
+                &branch_id,
+                &prompt,
+                &session_type,
+                provider,
+                &image_ids,
+                launch_context.as_ref(),
+            );
+        }
+    }
+
+    let prepared = prepare_branch_session_start(
+        &store,
+        &branch_id,
+        &prompt,
+        session_type.clone(),
+        provider.clone(),
+        launch_context.as_ref(),
+    )
+    .await?;
+
+    let created = {
+        let _guard = launch_lock.lock().unwrap();
+        if should_queue_branch_session_start(&store, &branch_id, &session_type)? {
+            return insert_queued_branch_session(
+                &store,
+                &branch_id,
+                &prompt,
+                &session_type,
+                provider,
+                &image_ids,
+                launch_context.as_ref(),
+            );
+        }
+        insert_running_branch_session(&store, &prepared, &prompt)?
+    };
+
+    launch_running_branch_session(store, registry, app_handle, prepared, created, image_ids)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn queue_branch_session_for_store(
+    store: Arc<Store>,
+    registry: Arc<session_runner::SessionRegistry>,
+    branch_id: String,
+    prompt: String,
+    session_type: BranchSessionType,
+    provider: Option<String>,
+    image_ids: Option<Vec<String>>,
+    launch_context: Option<BranchSessionLaunchContext>,
+) -> Result<BranchSessionResponse, String> {
+    let image_ids = image_ids.unwrap_or_default();
+
+    if matches!(
+        session_type,
+        BranchSessionType::Commit | BranchSessionType::Review
+    ) {
+        cancel_in_flight_auto_review_for_branch(&store, &registry, &branch_id)?;
+    }
+
+    let provider = resolve_branch_session_provider(&store, &branch_id, &session_type, provider)?;
+    let launch_lock = branch_session_launch_lock_for(&branch_id);
+    let _guard = launch_lock.lock().unwrap();
+    insert_queued_branch_session(
+        &store,
+        &branch_id,
+        &prompt,
+        &session_type,
+        provider,
+        &image_ids,
+        launch_context.as_ref(),
+    )
+}
+
+/// Start or queue a branch-scoped session.
+///
+/// Kept for compatibility with older callers; it now delegates to the backend
+/// scheduling guard rather than unconditionally starting work.
+#[allow(clippy::too_many_arguments)]
+#[tauri::command(rename_all = "camelCase")]
+pub async fn start_branch_session(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    registry: tauri::State<'_, Arc<session_runner::SessionRegistry>>,
+    app_handle: tauri::AppHandle,
+    branch_id: String,
+    prompt: String,
+    session_type: BranchSessionType,
+    provider: Option<String>,
+    image_ids: Option<Vec<String>>,
+    launch_context: Option<BranchSessionLaunchContext>,
+) -> Result<BranchSessionResponse, String> {
+    let store = get_store(&store)?;
+    start_or_queue_branch_session_for_store(
+        store,
+        Arc::clone(&registry),
+        app_handle,
+        branch_id,
+        prompt,
+        session_type,
+        provider,
+        image_ids,
+        launch_context,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+#[tauri::command(rename_all = "camelCase")]
+pub async fn start_or_queue_branch_session(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    registry: tauri::State<'_, Arc<session_runner::SessionRegistry>>,
+    app_handle: tauri::AppHandle,
+    branch_id: String,
+    prompt: String,
+    session_type: BranchSessionType,
+    provider: Option<String>,
+    image_ids: Option<Vec<String>>,
+    launch_context: Option<BranchSessionLaunchContext>,
+) -> Result<BranchSessionResponse, String> {
+    let store = get_store(&store)?;
+    start_or_queue_branch_session_for_store(
+        store,
+        Arc::clone(&registry),
+        app_handle,
+        branch_id,
+        prompt,
+        session_type,
+        provider,
+        image_ids,
+        launch_context,
+    )
+    .await
 }
 
 // =============================================================================
@@ -1106,66 +1432,16 @@ pub fn queue_branch_session(
     launch_context: Option<BranchSessionLaunchContext>,
 ) -> Result<BranchSessionResponse, String> {
     let store = get_store(&store)?;
-
-    if matches!(
+    queue_branch_session_for_store(
+        store,
+        Arc::clone(&registry),
+        branch_id,
+        prompt,
         session_type,
-        BranchSessionType::Commit | BranchSessionType::Review
-    ) {
-        cancel_in_flight_auto_review_for_branch(&store, &registry, &branch_id)?;
-    }
-
-    // Validate that the branch exists.
-    let branch = store
-        .get_branch(&branch_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
-    let is_remote = branch.workspace_name.is_some();
-    let provider = if matches!(session_type, BranchSessionType::Review) {
-        Some(resolve_review_provider(provider, is_remote)?)
-    } else {
-        provider
-    };
-
-    // Create the queued session — prompt is stored raw (not enriched with
-    // context) since context will be built when the session is drained.
-    let queued_prompt = embed_launch_context(&prompt, launch_context.as_ref())?;
-    let mut session = store::Session::new_queued(&queued_prompt);
-    if let Some(ref p) = provider {
-        session = session.with_provider(p);
-    }
-    store.create_session(&session).map_err(|e| e.to_string())?;
-
-    // Link any attached images to the queued session so they are available at drain time.
-    if let Some(ref ids) = image_ids {
-        store
-            .set_images_session_id(ids, &session.id)
-            .map_err(|e| e.to_string())?;
-    }
-
-    // Create the artifact stub, following the same pattern as start_branch_session.
-    let artifact_id = match session_type {
-        BranchSessionType::Note => {
-            let note = store::Note::new(&branch_id, &prompt, "").with_session(&session.id);
-            store.create_note(&note).map_err(|e| e.to_string())?;
-            note.id
-        }
-        BranchSessionType::Commit => {
-            let commit = store::Commit::new_pending(&branch_id).with_session(&session.id);
-            store.create_commit(&commit).map_err(|e| e.to_string())?;
-            commit.id
-        }
-        BranchSessionType::Review => {
-            let review = store::Review::new(&branch_id, "", store::ReviewScope::Branch)
-                .with_session(&session.id);
-            store.create_review(&review).map_err(|e| e.to_string())?;
-            review.id
-        }
-    };
-
-    Ok(BranchSessionResponse {
-        session_id: session.id,
-        artifact_id,
-    })
+        provider,
+        image_ids,
+        launch_context,
+    )
 }
 
 /// Drain queued sessions for a branch by starting compatible work.
@@ -1785,6 +2061,7 @@ pub async fn trigger_auto_review(
     Ok(BranchSessionResponse {
         session_id: session.id,
         artifact_id: review.id,
+        session_status: BranchSessionLaunchStatus::Running,
     })
 }
 
@@ -3340,6 +3617,69 @@ mod tests {
     }
 
     #[test]
+    fn branch_start_decision_queues_all_user_modes_behind_running_commit() {
+        let (store, branch) = setup_branch_store();
+        create_branch_commit_session(&store, &branch.id, store::SessionStatus::Running);
+
+        for session_type in [
+            BranchSessionType::Note,
+            BranchSessionType::Review,
+            BranchSessionType::Commit,
+        ] {
+            assert!(should_queue_branch_session_start(&store, &branch.id, &session_type).unwrap());
+        }
+    }
+
+    #[test]
+    fn branch_start_decision_allows_note_and_review_to_overlap_but_not_match() {
+        let (store, branch) = setup_branch_store();
+        create_branch_note_session(&store, &branch.id, store::SessionStatus::Running);
+
+        assert!(
+            !should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Review)
+                .unwrap()
+        );
+        assert!(
+            should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Note)
+                .unwrap()
+        );
+        assert!(
+            should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Commit)
+                .unwrap()
+        );
+
+        let (store, branch) = setup_branch_store();
+        create_branch_review_session(&store, &branch.id, store::SessionStatus::Running);
+
+        assert!(
+            !should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Note)
+                .unwrap()
+        );
+        assert!(
+            should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Review)
+                .unwrap()
+        );
+        assert!(
+            should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Commit)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn branch_start_decision_queues_behind_existing_queued_user_session() {
+        let (store, branch) = setup_branch_store();
+        create_branch_note_session(&store, &branch.id, store::SessionStatus::Queued);
+
+        for session_type in [
+            BranchSessionType::Note,
+            BranchSessionType::Review,
+            BranchSessionType::Commit,
+        ] {
+            assert!(should_queue_branch_session_start(&store, &branch.id, &session_type).unwrap());
+        }
+    }
+
+    #[test]
     fn running_commit_pipeline_blocks_queued_note_and_review() {
         let (store, branch) = setup_branch_store();
         create_branch_commit_pipeline_session(&store, &branch.id);
@@ -3394,6 +3734,43 @@ mod tests {
         ] {
             assert!(can_start_with_active_branch_sessions(kind, &active));
         }
+    }
+
+    #[test]
+    fn branch_start_decision_ignores_auto_review_barriers() {
+        let (store, branch) = setup_branch_store();
+        create_auto_review(&store, &branch.id, store::SessionStatus::Running);
+        create_auto_review(&store, &branch.id, store::SessionStatus::Queued);
+
+        for session_type in [
+            BranchSessionType::Note,
+            BranchSessionType::Review,
+            BranchSessionType::Commit,
+        ] {
+            assert!(!should_queue_branch_session_start(&store, &branch.id, &session_type).unwrap());
+        }
+    }
+
+    #[test]
+    fn explicit_queue_response_reports_queued_status() {
+        let (store, branch) = setup_branch_store();
+        let registry = Arc::new(session_runner::SessionRegistry::new());
+
+        let response = queue_branch_session_for_store(
+            Arc::clone(&store),
+            registry,
+            branch.id.clone(),
+            "capture a note".to_string(),
+            BranchSessionType::Note,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(response.session_status, BranchSessionLaunchStatus::Queued);
+        let session = store.get_session(&response.session_id).unwrap().unwrap();
+        assert_eq!(session.status, store::SessionStatus::Queued);
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -686,11 +686,35 @@ fn has_queued_user_branch_session(store: &Store, branch_id: &str) -> Result<bool
     Ok(false)
 }
 
+fn branch_session_start_waits_for_provisioning(
+    store: &Store,
+    branch_id: &str,
+) -> Result<bool, String> {
+    let branch = store
+        .get_branch(branch_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+    match branch.branch_type {
+        store::BranchType::Local => store
+            .get_workdir_for_branch(branch_id)
+            .map(|workdir| workdir.is_none())
+            .map_err(|e| e.to_string()),
+        store::BranchType::Remote => {
+            Ok(branch.workspace_status != Some(store::WorkspaceStatus::Running))
+        }
+    }
+}
+
 fn should_queue_branch_session_start(
     store: &Store,
     branch_id: &str,
     session_type: &BranchSessionType,
 ) -> Result<bool, String> {
+    if branch_session_start_waits_for_provisioning(store, branch_id)? {
+        return Ok(true);
+    }
+
     if has_queued_user_branch_session(store, branch_id)? {
         return Ok(true);
     }
@@ -3475,6 +3499,27 @@ mod tests {
         (store, branch)
     }
 
+    fn setup_branch_store_with_workdir() -> (Arc<Store>, store::Branch) {
+        let (store, branch) = setup_branch_store();
+        let workdir_path = format!("/tmp/staged-test-workdir-{}", branch.id);
+        let workdir =
+            store::Workdir::new(&branch.project_id, &workdir_path).with_branch(&branch.id);
+        store.create_workdir(&workdir).unwrap();
+        (store, branch)
+    }
+
+    fn setup_remote_branch_store(status: store::WorkspaceStatus) -> (Arc<Store>, store::Branch) {
+        let store = Arc::new(Store::in_memory().unwrap());
+        let mut project = store::Project::new("test-owner/test-repo");
+        project.location = store::ProjectLocation::Remote;
+        store.create_project(&project).unwrap();
+        let mut branch =
+            store::Branch::new_remote(&project.id, "feature", "main", "test-workspace");
+        branch.workspace_status = Some(status);
+        store.create_branch(&branch).unwrap();
+        (store, branch)
+    }
+
     fn ids(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
     }
@@ -3647,8 +3692,53 @@ mod tests {
     }
 
     #[test]
-    fn branch_start_decision_queues_all_user_modes_behind_running_commit() {
+    fn branch_start_decision_queues_local_branch_without_workdir() {
         let (store, branch) = setup_branch_store();
+
+        for session_type in [
+            BranchSessionType::Note,
+            BranchSessionType::Review,
+            BranchSessionType::Commit,
+        ] {
+            assert!(should_queue_branch_session_start(&store, &branch.id, &session_type).unwrap());
+        }
+    }
+
+    #[test]
+    fn branch_start_decision_queues_remote_branch_until_workspace_running() {
+        let (store, branch) = setup_remote_branch_store(store::WorkspaceStatus::Starting);
+
+        for session_type in [
+            BranchSessionType::Note,
+            BranchSessionType::Review,
+            BranchSessionType::Commit,
+        ] {
+            assert!(should_queue_branch_session_start(&store, &branch.id, &session_type).unwrap());
+        }
+    }
+
+    #[test]
+    fn branch_start_decision_uses_compatibility_for_running_remote_branch() {
+        let (store, branch) = setup_remote_branch_store(store::WorkspaceStatus::Running);
+        create_branch_note_session(&store, &branch.id, store::SessionStatus::Running);
+
+        assert!(
+            !should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Review)
+                .unwrap()
+        );
+        assert!(
+            !should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Note)
+                .unwrap()
+        );
+        assert!(
+            should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Commit)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn branch_start_decision_queues_all_user_modes_behind_running_commit() {
+        let (store, branch) = setup_branch_store_with_workdir();
         create_branch_commit_session(&store, &branch.id, store::SessionStatus::Running);
 
         for session_type in [
@@ -3662,7 +3752,7 @@ mod tests {
 
     #[test]
     fn branch_start_decision_allows_parallel_notes_and_note_review_overlap() {
-        let (store, branch) = setup_branch_store();
+        let (store, branch) = setup_branch_store_with_workdir();
         create_branch_note_session(&store, &branch.id, store::SessionStatus::Running);
 
         assert!(
@@ -3678,7 +3768,7 @@ mod tests {
                 .unwrap()
         );
 
-        let (store, branch) = setup_branch_store();
+        let (store, branch) = setup_branch_store_with_workdir();
         create_branch_review_session(&store, &branch.id, store::SessionStatus::Running);
 
         assert!(
@@ -3697,7 +3787,7 @@ mod tests {
 
     #[test]
     fn branch_start_decision_queues_behind_existing_queued_user_session() {
-        let (store, branch) = setup_branch_store();
+        let (store, branch) = setup_branch_store_with_workdir();
         create_branch_note_session(&store, &branch.id, store::SessionStatus::Queued);
 
         for session_type in [
@@ -3795,7 +3885,7 @@ mod tests {
 
     #[test]
     fn branch_start_decision_ignores_auto_review_barriers() {
-        let (store, branch) = setup_branch_store();
+        let (store, branch) = setup_branch_store_with_workdir();
         create_auto_review(&store, &branch.id, store::SessionStatus::Running);
         create_auto_review(&store, &branch.id, store::SessionStatus::Queued);
 

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -516,6 +516,10 @@ impl BranchSessionScheduleKind {
         )
     }
 
+    fn allows_parallel_instances(self) -> bool {
+        matches!(self, BranchSessionScheduleKind::Note)
+    }
+
     fn branch_session_type(self) -> Option<BranchSessionType> {
         match self {
             BranchSessionScheduleKind::Commit => Some(BranchSessionType::Commit),
@@ -545,7 +549,7 @@ fn can_start_with_active_branch_sessions(
         return false;
     }
 
-    !active.contains(&candidate)
+    candidate.allows_parallel_instances() || !active.contains(&candidate)
 }
 
 fn note_session_schedule() -> BranchSessionSchedule {
@@ -3587,6 +3591,19 @@ mod tests {
     }
 
     #[test]
+    fn running_note_allows_queued_note() {
+        let (store, branch) = setup_branch_store();
+        create_branch_note_session(&store, &branch.id, store::SessionStatus::Running);
+
+        let active = running_branch_session_kinds(&store, &branch.id).unwrap();
+
+        assert!(can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Note,
+            &active
+        ));
+    }
+
+    #[test]
     fn running_review_allows_queued_note() {
         let (store, branch) = setup_branch_store();
         create_branch_review_session(&store, &branch.id, store::SessionStatus::Running);
@@ -3595,6 +3612,19 @@ mod tests {
 
         assert!(can_start_with_active_branch_sessions(
             BranchSessionScheduleKind::Note,
+            &active
+        ));
+    }
+
+    #[test]
+    fn running_review_blocks_queued_review() {
+        let (store, branch) = setup_branch_store();
+        create_branch_review_session(&store, &branch.id, store::SessionStatus::Running);
+
+        let active = running_branch_session_kinds(&store, &branch.id).unwrap();
+
+        assert!(!can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Review,
             &active
         ));
     }
@@ -3631,7 +3661,7 @@ mod tests {
     }
 
     #[test]
-    fn branch_start_decision_allows_note_and_review_to_overlap_but_not_match() {
+    fn branch_start_decision_allows_parallel_notes_and_note_review_overlap() {
         let (store, branch) = setup_branch_store();
         create_branch_note_session(&store, &branch.id, store::SessionStatus::Running);
 
@@ -3640,7 +3670,7 @@ mod tests {
                 .unwrap()
         );
         assert!(
-            should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Note)
+            !should_queue_branch_session_start(&store, &branch.id, &BranchSessionType::Note)
                 .unwrap()
         );
         assert!(
@@ -3720,6 +3750,33 @@ mod tests {
     }
 
     #[test]
+    fn drain_scan_starts_multiple_queued_notes_before_commit_barrier() {
+        let mut active = HashSet::new();
+        let queued = vec![
+            (
+                "note-1".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+            (
+                "note-2".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+            (
+                "commit".to_string(),
+                schedule(BranchSessionScheduleKind::Commit),
+            ),
+            (
+                "note-3".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+        ];
+
+        let drainable = drainable_session_ids_for_active_set(&queued, &mut active);
+
+        assert_eq!(drainable, vec!["note-1".to_string(), "note-2".to_string()]);
+    }
+
+    #[test]
     fn running_auto_review_does_not_block_queued_user_sessions() {
         let (store, branch) = setup_branch_store();
         create_auto_review(&store, &branch.id, store::SessionStatus::Running);
@@ -3786,11 +3843,15 @@ mod tests {
                 schedule(BranchSessionScheduleKind::Review),
             ),
             (
+                "note-2".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+            (
                 "commit".to_string(),
                 schedule(BranchSessionScheduleKind::Commit),
             ),
             (
-                "note-2".to_string(),
+                "note-3".to_string(),
                 schedule(BranchSessionScheduleKind::Note),
             ),
         ];
@@ -3799,8 +3860,35 @@ mod tests {
 
         assert_eq!(
             drainable,
-            vec!["note-1".to_string(), "review-1".to_string()]
+            vec![
+                "note-1".to_string(),
+                "review-1".to_string(),
+                "note-2".to_string()
+            ]
         );
+    }
+
+    #[test]
+    fn drain_scan_does_not_skip_over_manual_review_blocker() {
+        let mut active = HashSet::new();
+        let queued = vec![
+            (
+                "review-1".to_string(),
+                schedule(BranchSessionScheduleKind::Review),
+            ),
+            (
+                "review-2".to_string(),
+                schedule(BranchSessionScheduleKind::Review),
+            ),
+            (
+                "note-1".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+        ];
+
+        let drainable = drainable_session_ids_for_active_set(&queued, &mut active);
+
+        assert_eq!(drainable, vec!["review-1".to_string()]);
     }
 
     fn create_branch_review(

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -3380,17 +3380,20 @@ mod tests {
     }
 
     #[test]
-    fn running_auto_review_does_not_block_queued_note() {
+    fn running_auto_review_does_not_block_queued_user_sessions() {
         let (store, branch) = setup_branch_store();
         create_auto_review(&store, &branch.id, store::SessionStatus::Running);
 
         let active = running_branch_session_kinds(&store, &branch.id).unwrap();
 
         assert!(active.is_empty());
-        assert!(can_start_with_active_branch_sessions(
+        for kind in [
             BranchSessionScheduleKind::Note,
-            &active
-        ));
+            BranchSessionScheduleKind::Review,
+            BranchSessionScheduleKind::Commit,
+        ] {
+            assert!(can_start_with_active_branch_sessions(kind, &active));
+        }
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1643,7 +1643,7 @@ async fn start_queued_session_for_branch(
     // Atomically transition session from queued to running.
     // If another drain call already claimed this session, bail out.
     let transitioned = store
-        .transition_to_running(&session_id)
+        .transition_queued_to_running(&session_id)
         .map_err(|e| e.to_string())?;
     if !transitioned {
         return Ok(false);

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -482,6 +482,177 @@ fn extra_env_for_branch_session(session_type: &BranchSessionType) -> Vec<(String
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum BranchSessionScheduleKind {
+    Commit,
+    Note,
+    Review,
+    CommitPipeline,
+}
+
+impl BranchSessionScheduleKind {
+    fn is_exclusive(self) -> bool {
+        matches!(
+            self,
+            BranchSessionScheduleKind::Commit | BranchSessionScheduleKind::CommitPipeline
+        )
+    }
+
+    fn branch_session_type(self) -> Option<BranchSessionType> {
+        match self {
+            BranchSessionScheduleKind::Commit => Some(BranchSessionType::Commit),
+            BranchSessionScheduleKind::Note => Some(BranchSessionType::Note),
+            BranchSessionScheduleKind::Review => Some(BranchSessionType::Review),
+            BranchSessionScheduleKind::CommitPipeline => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BranchSessionSchedule {
+    kind: BranchSessionScheduleKind,
+    review_id: Option<String>,
+    blocks_queue: bool,
+}
+
+fn can_start_with_active_branch_sessions(
+    candidate: BranchSessionScheduleKind,
+    active: &HashSet<BranchSessionScheduleKind>,
+) -> bool {
+    if candidate.is_exclusive() {
+        return active.is_empty();
+    }
+
+    if active.iter().any(|kind| kind.is_exclusive()) {
+        return false;
+    }
+
+    !active.contains(&candidate)
+}
+
+fn note_session_schedule() -> BranchSessionSchedule {
+    BranchSessionSchedule {
+        kind: BranchSessionScheduleKind::Note,
+        review_id: None,
+        blocks_queue: true,
+    }
+}
+
+fn review_session_schedule(review: &store::Review) -> BranchSessionSchedule {
+    BranchSessionSchedule {
+        kind: BranchSessionScheduleKind::Review,
+        review_id: Some(review.id.clone()),
+        blocks_queue: !review.is_auto,
+    }
+}
+
+fn commit_session_schedule(kind: BranchSessionScheduleKind) -> BranchSessionSchedule {
+    BranchSessionSchedule {
+        kind,
+        review_id: None,
+        blocks_queue: true,
+    }
+}
+
+fn is_commit_pipeline_session(session: &store::Session) -> bool {
+    session
+        .pipeline
+        .as_ref()
+        .and_then(|pipeline| pipeline.kind.as_ref())
+        .is_some()
+}
+
+fn resolve_branch_session_schedule(
+    store: &Store,
+    branch_id: &str,
+    session: &store::Session,
+    require_artifact: bool,
+) -> Result<Option<BranchSessionSchedule>, String> {
+    if is_commit_pipeline_session(session) {
+        let commit = store
+            .get_commit_by_session(&session.id)
+            .map_err(|e| e.to_string())?;
+        return match commit {
+            Some(commit) if commit.branch_id == branch_id => Ok(Some(commit_session_schedule(
+                BranchSessionScheduleKind::CommitPipeline,
+            ))),
+            Some(_) => Ok(None),
+            None if require_artifact => Err(format!(
+                "Queued pipeline session {} has no linked commit",
+                session.id
+            )),
+            None => Ok(None),
+        };
+    }
+
+    if let Some(commit) = store
+        .get_commit_by_session(&session.id)
+        .map_err(|e| e.to_string())?
+    {
+        return Ok((commit.branch_id == branch_id)
+            .then(|| commit_session_schedule(BranchSessionScheduleKind::Commit)));
+    }
+
+    if let Some(note) = store
+        .get_note_by_session(&session.id)
+        .map_err(|e| e.to_string())?
+    {
+        return Ok((note.branch_id == branch_id).then(note_session_schedule));
+    }
+
+    if let Some(review) = store
+        .get_review_by_session(&session.id)
+        .map_err(|e| e.to_string())?
+    {
+        return Ok((review.branch_id == branch_id).then(|| review_session_schedule(&review)));
+    }
+
+    if require_artifact {
+        Err(format!(
+            "Queued session {} has no linked artifact",
+            session.id
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+fn running_branch_session_kinds(
+    store: &Store,
+    branch_id: &str,
+) -> Result<HashSet<BranchSessionScheduleKind>, String> {
+    let running = store.get_running_sessions().map_err(|e| e.to_string())?;
+    let mut active = HashSet::new();
+    for session in running {
+        if let Some(schedule) = resolve_branch_session_schedule(store, branch_id, &session, false)?
+        {
+            if schedule.blocks_queue {
+                active.insert(schedule.kind);
+            }
+        }
+    }
+    Ok(active)
+}
+
+#[cfg(test)]
+fn drainable_session_ids_for_active_set(
+    queued: &[(String, BranchSessionSchedule)],
+    active: &mut HashSet<BranchSessionScheduleKind>,
+) -> Vec<String> {
+    let mut drainable = Vec::new();
+    for (session_id, schedule) in queued {
+        if !can_start_with_active_branch_sessions(schedule.kind, active) {
+            break;
+        }
+
+        drainable.push(session_id.clone());
+        if schedule.blocks_queue {
+            active.insert(schedule.kind);
+        }
+    }
+    drainable
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchSessionLaunchContext {
@@ -997,10 +1168,11 @@ pub fn queue_branch_session(
     })
 }
 
-/// Drain the oldest queued session for a branch by starting it.
+/// Drain queued sessions for a branch by starting compatible work.
 ///
-/// Queries all queued sessions for the given branch and starts only the first
-/// one (oldest by `created_at`). Returns whether a session was started.
+/// Queries queued sessions for the given branch oldest-first, starts compatible
+/// note/review pairs, and stops at the first FIFO barrier. Returns whether at
+/// least one session was started.
 #[tauri::command(rename_all = "camelCase")]
 #[allow(clippy::too_many_arguments)]
 pub async fn drain_queued_sessions(
@@ -1021,7 +1193,7 @@ pub async fn drain_queued_sessions(
     .await
 }
 
-/// Start the oldest queued branch session if one exists and the branch is idle.
+/// Start queued branch sessions while they can safely run together.
 ///
 /// This is shared by the Tauri command and backend lifecycle hooks so queue
 /// progression remains owned by the backend.
@@ -1032,62 +1204,70 @@ pub async fn drain_queued_sessions_for_branch(
     branch_id: String,
     provider: Option<String>,
 ) -> Result<bool, String> {
-    // Bail out if the branch already has a running session to prevent
-    // concurrent sessions on the same branch.
-    if store
-        .has_running_session_for_branch(&branch_id)
-        .unwrap_or(false)
-    {
-        return Ok(false);
-    }
-
     let queued = store
         .get_queued_sessions_for_branch(&branch_id)
         .map_err(|e| e.to_string())?;
 
-    let session = match queued.into_iter().next() {
-        Some(s) => s,
-        None => return Ok(false),
-    };
+    let mut active = running_branch_session_kinds(&store, &branch_id)?;
+    let mut started_any = false;
 
-    if session
-        .pipeline
-        .as_ref()
-        .and_then(|pipeline| pipeline.kind.as_ref())
-        .is_some()
-    {
-        if store
-            .get_commit_by_session(&session.id)
-            .map_err(|e| e.to_string())?
-            .is_none()
-        {
-            return Err(format!(
-                "Queued pipeline session {} has no linked commit",
-                session.id
-            ));
+    for session in queued {
+        let schedule = match resolve_branch_session_schedule(&store, &branch_id, &session, true)? {
+            Some(schedule) => schedule,
+            None => continue,
+        };
+
+        if !can_start_with_active_branch_sessions(schedule.kind, &active) {
+            break;
         }
 
+        let started = start_queued_session_for_branch(
+            Arc::clone(&store),
+            Arc::clone(&registry),
+            app_handle.clone(),
+            branch_id.clone(),
+            session,
+            schedule.clone(),
+            provider.clone(),
+        )
+        .await?;
+
+        if started {
+            started_any = true;
+            if schedule.blocks_queue {
+                active.insert(schedule.kind);
+            }
+        } else {
+            active = running_branch_session_kinds(&store, &branch_id)?;
+        }
+    }
+
+    Ok(started_any)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start_queued_session_for_branch(
+    store: Arc<Store>,
+    registry: Arc<session_runner::SessionRegistry>,
+    app_handle: tauri::AppHandle,
+    branch_id: String,
+    session: store::Session,
+    schedule: BranchSessionSchedule,
+    provider: Option<String>,
+) -> Result<bool, String> {
+    if matches!(schedule.kind, BranchSessionScheduleKind::CommitPipeline) {
         return crate::prs::start_queued_commit_pipeline_for_branch(
             store, registry, app_handle, branch_id, session, provider,
         )
         .await;
     }
 
-    // Look up which artifact type is linked to this session so we know
-    // what kind of branch session to start.
-    let (session_type, review_id) =
-        if let Ok(Some(_commit)) = store.get_commit_by_session(&session.id) {
-            (BranchSessionType::Commit, None)
-        } else if let Ok(Some(_note)) = store.get_note_by_session(&session.id) {
-            (BranchSessionType::Note, None)
-        } else if let Ok(Some(review)) = store.get_review_by_session(&session.id) {
-            (BranchSessionType::Review, Some(review.id))
-        } else {
-            return Err(format!(
-                "Queued session {} has no linked artifact",
-                session.id
-            ));
-        };
+    let session_type = schedule.kind.branch_session_type().ok_or_else(|| {
+        format!(
+            "Queued session {} cannot start as an agent session",
+            session.id
+        )
+    })?;
 
     // Use the original prompt from the queued session.
     let (prompt, launch_context) = extract_launch_context(&session.prompt)?;
@@ -1201,7 +1381,7 @@ pub async fn drain_queued_sessions_for_branch(
     // Update the review's commit_sha now that we have the working directory.
     // At queue time, reviews are created with an empty commit_sha since the
     // workspace may not exist yet.
-    if let Some(ref review_id) = review_id {
+    if let Some(ref review_id) = schedule.review_id {
         let tip_sha = if is_remote {
             let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
             run_blox_blocking(move || blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"]))
@@ -3045,6 +3225,202 @@ mod tests {
             .with_auto();
         store.create_review(&review).unwrap();
         (session, review)
+    }
+
+    fn create_session_with_status(
+        store: &Arc<Store>,
+        prompt: &str,
+        status: store::SessionStatus,
+    ) -> store::Session {
+        let session = match status {
+            store::SessionStatus::Queued => store::Session::new_queued(prompt),
+            store::SessionStatus::Running => store::Session::new_running(prompt, Path::new("/tmp")),
+            other => panic!("unsupported scheduler test status: {}", other.as_str()),
+        };
+        store.create_session(&session).unwrap();
+        session
+    }
+
+    fn create_branch_note_session(
+        store: &Arc<Store>,
+        branch_id: &str,
+        status: store::SessionStatus,
+    ) -> store::Session {
+        let session = create_session_with_status(store, "note", status);
+        let note = store::Note::new(branch_id, "note", "").with_session(&session.id);
+        store.create_note(&note).unwrap();
+        session
+    }
+
+    fn create_branch_review_session(
+        store: &Arc<Store>,
+        branch_id: &str,
+        status: store::SessionStatus,
+    ) -> store::Session {
+        let session = create_session_with_status(store, "review", status);
+        let review = store::Review::new(branch_id, "abc123", store::ReviewScope::Branch)
+            .with_session(&session.id);
+        store.create_review(&review).unwrap();
+        session
+    }
+
+    fn create_branch_commit_session(
+        store: &Arc<Store>,
+        branch_id: &str,
+        status: store::SessionStatus,
+    ) -> store::Session {
+        let session = create_session_with_status(store, "commit", status);
+        let commit = store::Commit::new_pending(branch_id).with_session(&session.id);
+        store.create_commit(&commit).unwrap();
+        session
+    }
+
+    fn create_branch_commit_pipeline_session(
+        store: &Arc<Store>,
+        branch_id: &str,
+    ) -> store::Session {
+        let mut session = store::Session::new_running("rebase", Path::new("/tmp"));
+        session.pipeline =
+            Some(store::PipelineExecution::from_steps(&[]).with_kind(store::PipelineKind::Rebase));
+        store.create_session(&session).unwrap();
+        let commit = store::Commit::new_pending(branch_id).with_session(&session.id);
+        store.create_commit(&commit).unwrap();
+        session
+    }
+
+    fn schedule(kind: BranchSessionScheduleKind) -> BranchSessionSchedule {
+        BranchSessionSchedule {
+            kind,
+            review_id: None,
+            blocks_queue: true,
+        }
+    }
+
+    #[test]
+    fn running_note_allows_queued_review() {
+        let (store, branch) = setup_branch_store();
+        create_branch_note_session(&store, &branch.id, store::SessionStatus::Running);
+
+        let active = running_branch_session_kinds(&store, &branch.id).unwrap();
+
+        assert!(can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Review,
+            &active
+        ));
+    }
+
+    #[test]
+    fn running_review_allows_queued_note() {
+        let (store, branch) = setup_branch_store();
+        create_branch_review_session(&store, &branch.id, store::SessionStatus::Running);
+
+        let active = running_branch_session_kinds(&store, &branch.id).unwrap();
+
+        assert!(can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Note,
+            &active
+        ));
+    }
+
+    #[test]
+    fn running_commit_blocks_queued_note_and_review() {
+        let (store, branch) = setup_branch_store();
+        create_branch_commit_session(&store, &branch.id, store::SessionStatus::Running);
+
+        let active = running_branch_session_kinds(&store, &branch.id).unwrap();
+
+        assert!(!can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Note,
+            &active
+        ));
+        assert!(!can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Review,
+            &active
+        ));
+    }
+
+    #[test]
+    fn running_commit_pipeline_blocks_queued_note_and_review() {
+        let (store, branch) = setup_branch_store();
+        create_branch_commit_pipeline_session(&store, &branch.id);
+
+        let active = running_branch_session_kinds(&store, &branch.id).unwrap();
+
+        assert!(!can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Note,
+            &active
+        ));
+        assert!(!can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Review,
+            &active
+        ));
+    }
+
+    #[test]
+    fn queued_commit_acts_as_fifo_barrier() {
+        let mut active = HashSet::new();
+        let queued = vec![
+            (
+                "note-1".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+            (
+                "commit".to_string(),
+                schedule(BranchSessionScheduleKind::Commit),
+            ),
+            (
+                "review-1".to_string(),
+                schedule(BranchSessionScheduleKind::Review),
+            ),
+        ];
+
+        let drainable = drainable_session_ids_for_active_set(&queued, &mut active);
+
+        assert_eq!(drainable, vec!["note-1".to_string()]);
+    }
+
+    #[test]
+    fn running_auto_review_does_not_block_queued_note() {
+        let (store, branch) = setup_branch_store();
+        create_auto_review(&store, &branch.id, store::SessionStatus::Running);
+
+        let active = running_branch_session_kinds(&store, &branch.id).unwrap();
+
+        assert!(active.is_empty());
+        assert!(can_start_with_active_branch_sessions(
+            BranchSessionScheduleKind::Note,
+            &active
+        ));
+    }
+
+    #[test]
+    fn drain_scan_starts_compatible_oldest_sessions_and_stops_at_incompatible_session() {
+        let mut active = HashSet::new();
+        let queued = vec![
+            (
+                "note-1".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+            (
+                "review-1".to_string(),
+                schedule(BranchSessionScheduleKind::Review),
+            ),
+            (
+                "commit".to_string(),
+                schedule(BranchSessionScheduleKind::Commit),
+            ),
+            (
+                "note-2".to_string(),
+                schedule(BranchSessionScheduleKind::Note),
+            ),
+        ];
+
+        let drainable = drainable_session_ids_for_active_set(&queued, &mut active);
+
+        assert_eq!(
+            drainable,
+            vec!["note-1".to_string(), "review-1".to_string()]
+        );
     }
 
     fn create_branch_review(

--- a/apps/staged/src-tauri/src/store/sessions.rs
+++ b/apps/staged/src-tauri/src/store/sessions.rs
@@ -148,6 +148,21 @@ impl Store {
         Ok(rows > 0)
     }
 
+    /// Atomically claim a queued session for execution by this process.
+    ///
+    /// Returns `true` if the row was updated, `false` if the session was no
+    /// longer queued, for example because it was cancelled after the queue was
+    /// snapshotted.
+    pub fn transition_queued_to_running(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE sessions SET status = 'running', error_message = NULL, completion_reason = NULL, updated_at = ?1, owner_pid = ?2
+             WHERE id = ?3 AND status = 'queued'",
+            params![now_timestamp(), std::process::id(), id],
+        )?;
+        Ok(rows > 0)
+    }
+
     /// Atomically transition a session to `Running`, but only if it is NOT
     /// already running. Returns `true` if the row was updated, `false` if
     /// the session was already running (or didn't exist).

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -464,6 +464,48 @@ fn test_transition_from_active_does_not_overwrite_completed_session() {
 }
 
 #[test]
+fn test_transition_queued_to_running_claims_queued_session() {
+    let store = Store::in_memory().unwrap();
+
+    let session = Session::new_queued("queued");
+    store.create_session(&session).unwrap();
+
+    let transitioned = store.transition_queued_to_running(&session.id).unwrap();
+    assert!(transitioned);
+
+    let final_state = store.get_session(&session.id).unwrap().unwrap();
+    assert_eq!(final_state.status, SessionStatus::Running);
+    assert_eq!(final_state.owner_pid, Some(std::process::id()));
+}
+
+#[test]
+fn test_transition_queued_to_running_does_not_overwrite_cancelled_session() {
+    let store = Store::in_memory().unwrap();
+
+    let session = Session::new_queued("cancelled before claim");
+    store.create_session(&session).unwrap();
+    store
+        .update_session_status(
+            &session.id,
+            SessionStatus::Cancelled,
+            None,
+            Some(&CompletionReason::Interrupted),
+        )
+        .unwrap();
+
+    let transitioned = store.transition_queued_to_running(&session.id).unwrap();
+    assert!(!transitioned);
+
+    let final_state = store.get_session(&session.id).unwrap().unwrap();
+    assert_eq!(final_state.status, SessionStatus::Cancelled);
+    assert_eq!(
+        final_state.completion_reason,
+        Some(CompletionReason::Interrupted)
+    );
+    assert_eq!(final_state.owner_pid, None);
+}
+
+#[test]
 fn test_queued_pipeline_commit_owns_branch_queue_position() {
     let store = Store::in_memory().unwrap();
     let project = Project::new("test-owner/test-repo");

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2841,7 +2841,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
 
             Ok(Value::Null)
         }
-        "start_branch_session" => {
+        "start_branch_session" | "start_or_queue_branch_session" => {
             let store = get_store(store_mutex)?;
             let branch_id: String = arg(&args, "branchId")?;
             let prompt: String = arg(&args, "prompt")?;
@@ -2851,220 +2851,20 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
             let launch_context: Option<session_commands::BranchSessionLaunchContext> =
                 opt_arg(&args, "launchContext")?;
 
-            if matches!(
-                session_type,
-                session_commands::BranchSessionType::Commit
-                    | session_commands::BranchSessionType::Review
-            ) {
-                session_commands::cancel_in_flight_auto_review_for_branch(
-                    &store,
-                    session_registry,
-                    &branch_id,
-                )?;
-            }
-
-            let branch = store
-                .get_branch(&branch_id)
-                .map_err(|e| e.to_string())?
-                .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
-
-            let project = store
-                .get_project(&branch.project_id)
-                .map_err(|e| e.to_string())?
-                .ok_or_else(|| format!("Project not found: {}", branch.project_id))?;
-
-            let is_remote = branch.workspace_name.is_some();
-
-            let (working_dir, branch_context) = if is_remote {
-                let fallback_dir =
-                    session_commands::resolve_branch_repo_slug(&store, &project, &branch)
-                        .and_then(|repo| crate::paths::repos_dir().map(|d| d.join(repo)))
-                        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
-                let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
-                let base_branch = branch.base_branch.clone();
-                let store_for_context = Arc::clone(&store);
-                let branch_id_for_context = branch_id.clone();
-                let project_id_for_context = branch.project_id.clone();
-                let ctx = tokio::task::spawn_blocking(move || {
-                    session_commands::build_remote_branch_context(
-                        &workspace_name,
-                        &base_branch,
-                        &store_for_context,
-                        &branch_id_for_context,
-                        &project_id_for_context,
-                    )
-                })
-                .await
-                .map_err(|e| format!("Failed to build remote branch context: {e}"))?;
-                (fallback_dir, ctx)
-            } else {
-                let workdir = store
-                    .get_workdir_for_branch(&branch_id)
-                    .map_err(|e| e.to_string())?
-                    .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
-
-                let mut worktree_path = std::path::PathBuf::from(&workdir.path);
-                let effective_subpath = if let Some(repo_id) = branch.project_repo_id.as_deref() {
-                    store
-                        .get_project_repo(repo_id)
-                        .ok()
-                        .flatten()
-                        .and_then(|repo| repo.subpath)
-                } else {
-                    project.subpath.clone()
-                };
-                if let Some(ref subpath) = effective_subpath {
-                    worktree_path = worktree_path.join(subpath);
-                }
-
-                let ctx = session_commands::build_branch_context(
-                    &worktree_path,
-                    &branch.base_branch,
-                    &store,
-                    &branch_id,
-                    &branch.project_id,
-                );
-                (worktree_path, ctx)
-            };
-
-            let project_information =
-                session_commands::build_project_context(&store, &project, &branch);
-            let full_prompt = session_commands::build_full_prompt(
-                &prompt,
-                &project_information,
-                &branch_context,
-                &session_type,
-                launch_context.as_ref(),
-                Some(&branch.base_branch),
-            );
-
-            let mut session = store::Session::new_running(&full_prompt, &working_dir);
-            if let Some(ref p) = provider {
-                session = session.with_provider(p);
-            }
-            store.create_session(&session).map_err(|e| e.to_string())?;
-
-            let session_type_str = match session_type {
-                session_commands::BranchSessionType::Commit => "commit",
-                session_commands::BranchSessionType::Note => "note",
-                session_commands::BranchSessionType::Review => "review",
-            };
-            session_runner::emit_session_running(
-                app_handle,
-                &session.id,
-                &branch_id,
-                &branch.project_id,
-                session_type_str,
-            );
-
-            let (artifact_id, pre_head_sha) = match session_type {
-                session_commands::BranchSessionType::Note => {
-                    let note = store::Note::new(&branch_id, &prompt, "").with_session(&session.id);
-                    store.create_note(&note).map_err(|e| e.to_string())?;
-                    (note.id, None)
-                }
-                session_commands::BranchSessionType::Commit => {
-                    let commit = store::Commit::new_pending(&branch_id).with_session(&session.id);
-                    store.create_commit(&commit).map_err(|e| e.to_string())?;
-                    let head_sha = if is_remote {
-                        let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
-                        match session_commands::run_blox_blocking(move || {
-                            crate::blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"])
-                        })
-                        .await
-                        {
-                            Ok(sha) => Some(sha.trim().to_string()),
-                            Err(e) => {
-                                log::warn!("Failed to get remote HEAD SHA via ws_exec: {e}");
-                                None
-                            }
-                        }
-                    } else {
-                        Some(
-                            crate::git::get_head_sha(&working_dir)
-                                .map_err(|e| format!("Failed to get HEAD SHA: {e}"))?,
-                        )
-                    };
-                    (commit.id, head_sha)
-                }
-                session_commands::BranchSessionType::Review => {
-                    let tip_sha = if is_remote {
-                        let workspace_name = branch.workspace_name.as_deref().unwrap().to_string();
-                        session_commands::run_blox_blocking(move || {
-                            crate::blox::ws_exec(&workspace_name, &["git", "rev-parse", "HEAD"])
-                        })
-                        .await
-                        .map(|s| s.trim().to_string())
-                        .unwrap_or_else(|_| "unknown".to_string())
-                    } else {
-                        crate::git::get_head_sha(&working_dir)
-                            .map_err(|e| format!("Failed to get HEAD SHA: {e}"))?
-                    };
-
-                    let review =
-                        store::Review::new(&branch_id, &tip_sha, store::ReviewScope::Branch)
-                            .with_session(&session.id);
-                    store.create_review(&review).map_err(|e| e.to_string())?;
-                    (review.id, None)
-                }
-            };
-
-            let effective_provider = provider;
-
-            let remote_working_dir = if is_remote {
-                let ws_name = branch.workspace_name.as_deref().unwrap().to_string();
-                let store_for_resolve = Arc::clone(&store);
-                let branch_for_resolve = branch.clone();
-                match tokio::task::spawn_blocking(move || {
-                    crate::branches::resolve_branch_workspace_subpath(
-                        &store_for_resolve,
-                        &branch_for_resolve,
-                    )
-                    .ok()
-                    .flatten()
-                    .and_then(|subpath| {
-                        crate::branches::resolve_workspace_repo_path(&ws_name, &subpath).ok()
-                    })
-                })
-                .await
-                {
-                    Ok(Some(path)) => Some(std::path::PathBuf::from(path)),
-                    _ => None,
-                }
-            } else {
-                None
-            };
-
-            session_runner::start_session(
-                SessionConfig {
-                    session_id: session.id.clone(),
-                    prompt: full_prompt,
-                    working_dir,
-                    agent_session_id: None,
-                    pre_head_sha,
-                    provider: effective_provider,
-                    workspace_name: branch.workspace_name.clone(),
-                    extra_env: vec![],
-                    mcp_project_id: None,
-                    action_executor: None,
-                    action_registry: None,
-                    remote_working_dir,
-                    image_ids: image_ids.unwrap_or_default(),
-                    branch_id: Some(branch_id),
-                    project_id: Some(branch.project_id.clone()),
-                },
+            let result = session_commands::start_or_queue_branch_session_for_store(
                 store,
-                app_handle.clone(),
                 Arc::clone(session_registry),
-            )?;
-
-            Ok(
-                serde_json::to_value(session_commands::BranchSessionResponse {
-                    session_id: session.id,
-                    artifact_id,
-                })
-                .unwrap(),
+                app_handle.clone(),
+                branch_id,
+                prompt,
+                session_type,
+                provider,
+                image_ids,
+                launch_context,
             )
+            .await?;
+
+            Ok(serde_json::to_value(result).unwrap())
         }
         "start_project_session" => {
             let store = get_store(store_mutex)?;
@@ -3201,63 +3001,18 @@ Begin the note with a markdown H1 heading as the title.\n\n"
             let launch_context: Option<session_commands::BranchSessionLaunchContext> =
                 opt_arg(&args, "launchContext")?;
 
-            if matches!(
+            let result = session_commands::queue_branch_session_for_store(
+                store,
+                Arc::clone(session_registry),
+                branch_id,
+                prompt,
                 session_type,
-                session_commands::BranchSessionType::Commit
-                    | session_commands::BranchSessionType::Review
-            ) {
-                session_commands::cancel_in_flight_auto_review_for_branch(
-                    &store,
-                    session_registry,
-                    &branch_id,
-                )?;
-            }
+                provider,
+                image_ids,
+                launch_context,
+            )?;
 
-            let _branch = store
-                .get_branch(&branch_id)
-                .map_err(|e| e.to_string())?
-                .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
-
-            let queued_prompt =
-                session_commands::embed_launch_context(&prompt, launch_context.as_ref())?;
-            let mut session = store::Session::new_queued(&queued_prompt);
-            if let Some(ref p) = provider {
-                session = session.with_provider(p);
-            }
-            store.create_session(&session).map_err(|e| e.to_string())?;
-
-            if let Some(ref ids) = image_ids {
-                store
-                    .set_images_session_id(ids, &session.id)
-                    .map_err(|e| e.to_string())?;
-            }
-
-            let artifact_id = match session_type {
-                session_commands::BranchSessionType::Note => {
-                    let note = store::Note::new(&branch_id, &prompt, "").with_session(&session.id);
-                    store.create_note(&note).map_err(|e| e.to_string())?;
-                    note.id
-                }
-                session_commands::BranchSessionType::Commit => {
-                    let commit = store::Commit::new_pending(&branch_id).with_session(&session.id);
-                    store.create_commit(&commit).map_err(|e| e.to_string())?;
-                    commit.id
-                }
-                session_commands::BranchSessionType::Review => {
-                    let review = store::Review::new(&branch_id, "", store::ReviewScope::Branch)
-                        .with_session(&session.id);
-                    store.create_review(&review).map_err(|e| e.to_string())?;
-                    review.id
-                }
-            };
-
-            Ok(
-                serde_json::to_value(session_commands::BranchSessionResponse {
-                    session_id: session.id,
-                    artifact_id,
-                })
-                .unwrap(),
-            )
+            Ok(serde_json::to_value(result).unwrap())
         }
         "drain_queued_sessions" => {
             let store = get_store(store_mutex)?;

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -661,6 +661,25 @@ export function startBranchSession(
   });
 }
 
+/** Start a branch session immediately when compatible, otherwise queue it. */
+export function startOrQueueBranchSession(
+  branchId: string,
+  prompt: string,
+  sessionType: BranchSessionType,
+  provider?: string,
+  imageIds?: string[],
+  launchContext?: BranchSessionLaunchContext
+): Promise<BranchSessionResponse> {
+  return invokeCommand('start_or_queue_branch_session', {
+    branchId,
+    prompt,
+    sessionType,
+    provider: provider ?? null,
+    imageIds: imageIds ?? null,
+    launchContext: launchContext ?? null,
+  });
+}
+
 /** Queue a branch-scoped session to run after current work completes. */
 export function queueBranchSession(
   branchId: string,

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -647,7 +647,7 @@
         }
         // Refresh the timeline so the pending note/commit stub appears immediately.
         // Skip if a session start is in-flight (pending item has no sessionId yet),
-        // because startBranchSessionWithPendingItem will call loadTimeline after
+        // because startOrQueueSession will call loadTimeline after
         // it gets the sessionId — otherwise pruning can't match the pending item
         // and both the pending and real items briefly render simultaneously.
         if (!isAutoReview && !sessionMgr.isSessionStartPending) {

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1710,6 +1710,7 @@
     {notePrefill}
     remote={isRemote}
     willQueue={sessionMgr.willQueue}
+    willQueueForMode={(mode) => sessionMgr.willQueueForMode(mode)}
     onClose={(draft) => {
       // Don't persist prefilled text as a draft — it should be re-evaluated
       // each time the dialog opens based on the current timeline state.

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -276,32 +276,35 @@ export default class BranchCardSessionManager {
     }
   }
 
-  async startBranchSessionWithPendingItem(
-    mode: BranchSessionType,
-    prompt: string,
-    imageIds: string[] = []
-  ) {
+  async startOrQueueSession(mode: BranchSessionType, prompt: string, imageIds: string[] = []) {
     const branch = this.getBranch();
     const isRemote = this.getIsRemote();
+    const willQueue = this.willQueueForMode(mode);
 
     if (this.autoReviewSessionId && mode !== 'note') {
       this.cancelAutoReview();
     }
 
     const pendingKey = `session-start-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const queueMeta = this.getTimeline()
+      ? 'Queued \u2014 waiting for current session\u2026'
+      : 'Queued \u2014 waiting for workspace\u2026';
+
     this.pendingSessionItems = [
       ...this.pendingSessionItems,
       {
         key: pendingKey,
-        type: this.pendingSessionTypeForMode(mode),
+        type: willQueue
+          ? this.queuedSessionTypeForMode(mode)
+          : this.pendingSessionTypeForMode(mode),
         title: this.pendingSessionTitleForMode(mode, prompt),
-        secondaryMeta: this.pendingSessionMetaForMode(mode),
+        secondaryMeta: willQueue ? queueMeta : this.pendingSessionMetaForMode(mode),
       },
     ];
 
     try {
       const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
-      const result = await commands.startBranchSession(
+      const result = await commands.startOrQueueBranchSession(
         branch.id,
         prompt,
         mode,
@@ -313,12 +316,16 @@ export default class BranchCardSessionManager {
         throw new Error('Failed to start session: no session ID returned');
       }
 
+      const queued = result.sessionStatus === 'queued';
       this.pendingSessionItems = this.pendingSessionItems.map((item) =>
         item.key === pendingKey
           ? {
               ...item,
+              type: queued
+                ? this.queuedSessionTypeForMode(mode)
+                : this.pendingSessionTypeForMode(mode),
               sessionId: result.sessionId,
-              secondaryMeta: undefined,
+              secondaryMeta: queued ? queueMeta : undefined,
             }
           : item
       );
@@ -330,70 +337,6 @@ export default class BranchCardSessionManager {
         description: e instanceof Error ? e.message : String(e),
         duration: Infinity,
       });
-    }
-  }
-
-  async queueBranchSession(mode: BranchSessionType, prompt: string, imageIds: string[] = []) {
-    const branch = this.getBranch();
-    const isRemote = this.getIsRemote();
-
-    if (this.autoReviewSessionId && mode !== 'note') {
-      this.cancelAutoReview();
-    }
-
-    const pendingKey = `session-queue-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const queueMeta = this.getTimeline()
-      ? 'Queued \u2014 waiting for current session\u2026'
-      : 'Queued \u2014 waiting for workspace\u2026';
-
-    this.pendingSessionItems = [
-      ...this.pendingSessionItems,
-      {
-        key: pendingKey,
-        type: this.queuedSessionTypeForMode(mode),
-        title: this.pendingSessionTitleForMode(mode, prompt),
-        secondaryMeta: queueMeta,
-      },
-    ];
-
-    try {
-      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
-      const result = await commands.queueBranchSession(
-        branch.id,
-        prompt,
-        mode,
-        getPreferredAgent(agents) ?? undefined,
-        imageIds.length > 0 ? imageIds : undefined
-      );
-
-      if (!result || !result.sessionId) {
-        throw new Error('Failed to queue session: no session ID returned');
-      }
-
-      this.pendingSessionItems = this.pendingSessionItems.map((item) =>
-        item.key === pendingKey
-          ? {
-              ...item,
-              sessionId: result.sessionId,
-            }
-          : item
-      );
-
-      this.loadTimeline();
-    } catch (e) {
-      this.pendingSessionItems = this.pendingSessionItems.filter((item) => item.key !== pendingKey);
-      toast.error('Unable to queue session', {
-        description: e instanceof Error ? e.message : String(e),
-        duration: Infinity,
-      });
-    }
-  }
-
-  async startOrQueueSession(mode: BranchSessionType, prompt: string, imageIds: string[] = []) {
-    if (this.willQueueForMode(mode)) {
-      await this.queueBranchSession(mode, prompt, imageIds);
-    } else {
-      await this.startBranchSessionWithPendingItem(mode, prompt, imageIds);
     }
   }
 

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -11,13 +11,13 @@
 
 import type { Branch, BranchTimeline as BranchTimelineData, BranchSessionType } from '../../types';
 import * as commands from '../../api/commands';
-import { isSessionActive } from '../../shared/sessionStatus';
 import { getPreferredAgent } from '../settings/preferences.svelte';
 import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
 import { toast } from 'svelte-sonner';
 import { projectStateStore } from '../../stores/projectState.svelte';
 import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
 import { buildReferringPrompt } from '../../shared/buildReferringPrompt';
+import { shouldQueueBranchSession } from './branchSessionQueue';
 
 type PendingSessionItemType =
   | 'pending-commit'
@@ -51,6 +51,14 @@ export default class BranchCardSessionManager {
   draftImageIds = $state<string[]>([]);
   pendingSessionItems = $state<PendingSessionItem[]>([]);
   isSessionStartPending = $derived(this.pendingSessionItems.some((item) => !item.sessionId));
+  private hasPendingQueuedSession = $derived(
+    this.pendingSessionItems.some(
+      (item) =>
+        item.type === 'queued-commit' ||
+        item.type === 'queued-note' ||
+        item.type === 'queued-review'
+    )
+  );
 
   // Auto review state — tracks a background review started after each commit
   autoReviewSessionId = $state<string | null>(null);
@@ -62,23 +70,8 @@ export default class BranchCardSessionManager {
   // Session modal (opened after starting a branch session, or from timeline)
   openSessionId = $state<string | null>(null);
 
-  /** True when any session is actively generating on this branch's timeline. */
-  hasRunningSession = $derived.by(() => {
-    const tl = this.getTimeline();
-    if (!tl) return false;
-    return (
-      tl.commits.some((c) => isSessionActive(c.sessionStatus)) ||
-      tl.notes.some((n) => isSessionActive(n.sessionStatus)) ||
-      tl.reviews.some((r) => isSessionActive(r.sessionStatus) && !r.isAuto)
-    );
-  });
-
   /** True when a new session will be queued rather than started immediately. */
-  willQueue = $derived(
-    !this.getTimeline() || // provisioning — no timeline yet
-      this.hasRunningSession || // another session is active
-      this.isSessionStartPending // a session start is already in flight
-  );
+  willQueue = $derived.by(() => this.willQueueForMode(this.newSessionMode));
 
   /** True when new session actions (new commit, note, review) should be disabled. */
   isNewSessionDisabled = $derived(this.showNewSession || this.isSessionStartPending);
@@ -110,6 +103,15 @@ export default class BranchCardSessionManager {
     this.loadTimeline = opts.loadTimeline;
     this.getTimeline = opts.getTimeline;
     this.setTimeline = opts.setTimeline;
+  }
+
+  willQueueForMode(mode: BranchSessionType): boolean {
+    return shouldQueueBranchSession({
+      mode,
+      timeline: this.getTimeline(),
+      hasPendingSessionStart: this.isSessionStartPending,
+      hasPendingQueuedSession: this.hasPendingQueuedSession,
+    });
   }
 
   prunePendingSessionItems(nextTimeline: BranchTimelineData): Set<string> {
@@ -388,7 +390,7 @@ export default class BranchCardSessionManager {
   }
 
   async startOrQueueSession(mode: BranchSessionType, prompt: string, imageIds: string[] = []) {
-    if (this.willQueue) {
+    if (this.willQueueForMode(mode)) {
       await this.queueBranchSession(mode, prompt, imageIds);
     } else {
       await this.startBranchSessionWithPendingItem(mode, prompt, imageIds);

--- a/apps/staged/src/lib/features/branches/branchSessionQueue.test.ts
+++ b/apps/staged/src/lib/features/branches/branchSessionQueue.test.ts
@@ -51,23 +51,27 @@ describe('shouldQueueBranchSession', () => {
   });
 
   it('queues new work behind any queued user session', () => {
-    for (const mode of ['commit', 'note', 'review'] satisfies BranchSessionType[]) {
-      expect(
-        shouldQueueBranchSession({
-          mode,
-          timeline: timeline({ review: 'queued' }),
-        })
-      ).toBe(true);
+    for (const queuedMode of ['commit', 'note', 'review'] satisfies BranchSessionType[]) {
+      for (const mode of ['commit', 'note', 'review'] satisfies BranchSessionType[]) {
+        expect(
+          shouldQueueBranchSession({
+            mode,
+            timeline: timeline({ [queuedMode]: 'queued' }),
+          })
+        ).toBe(true);
+      }
     }
   });
 
   it('ignores auto reviews when deciding whether user work can start', () => {
-    expect(
-      shouldQueueBranchSession({
-        mode: 'note',
-        timeline: timeline({}, 'running'),
-      })
-    ).toBe(false);
+    for (const mode of ['commit', 'note', 'review'] satisfies BranchSessionType[]) {
+      expect(
+        shouldQueueBranchSession({
+          mode,
+          timeline: timeline({}, 'running'),
+        })
+      ).toBe(false);
+    }
   });
 
   it('queues same-type note or review sessions', () => {

--- a/apps/staged/src/lib/features/branches/branchSessionQueue.test.ts
+++ b/apps/staged/src/lib/features/branches/branchSessionQueue.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { shouldQueueBranchSession, type BranchSessionQueueTimeline } from './branchSessionQueue';
+import type { BranchSessionType } from '../../types';
+
+function timeline(
+  sessions: Partial<Record<BranchSessionType, string | null>> = {},
+  autoReviewStatus: string | null = null
+): BranchSessionQueueTimeline {
+  return {
+    commits: sessions.commit === undefined ? [] : [{ sessionStatus: sessions.commit }],
+    notes: sessions.note === undefined ? [] : [{ sessionStatus: sessions.note }],
+    reviews: [
+      ...(sessions.review === undefined ? [] : [{ sessionStatus: sessions.review, isAuto: false }]),
+      ...(autoReviewStatus === null ? [] : [{ sessionStatus: autoReviewStatus, isAuto: true }]),
+    ],
+  };
+}
+
+describe('shouldQueueBranchSession', () => {
+  it('allows a note to start while a review is running', () => {
+    expect(
+      shouldQueueBranchSession({
+        mode: 'note',
+        timeline: timeline({ review: 'running' }),
+      })
+    ).toBe(false);
+  });
+
+  it('allows a review to start while a note is running', () => {
+    expect(
+      shouldQueueBranchSession({
+        mode: 'review',
+        timeline: timeline({ note: 'running' }),
+      })
+    ).toBe(false);
+  });
+
+  it('queues a commit while a note or review is running', () => {
+    expect(
+      shouldQueueBranchSession({
+        mode: 'commit',
+        timeline: timeline({ note: 'running' }),
+      })
+    ).toBe(true);
+    expect(
+      shouldQueueBranchSession({
+        mode: 'commit',
+        timeline: timeline({ review: 'running' }),
+      })
+    ).toBe(true);
+  });
+
+  it('queues new work behind any queued user session', () => {
+    for (const mode of ['commit', 'note', 'review'] satisfies BranchSessionType[]) {
+      expect(
+        shouldQueueBranchSession({
+          mode,
+          timeline: timeline({ review: 'queued' }),
+        })
+      ).toBe(true);
+    }
+  });
+
+  it('ignores auto reviews when deciding whether user work can start', () => {
+    expect(
+      shouldQueueBranchSession({
+        mode: 'note',
+        timeline: timeline({}, 'running'),
+      })
+    ).toBe(false);
+  });
+
+  it('queues same-type note or review sessions', () => {
+    expect(
+      shouldQueueBranchSession({
+        mode: 'note',
+        timeline: timeline({ note: 'running' }),
+      })
+    ).toBe(true);
+    expect(
+      shouldQueueBranchSession({
+        mode: 'review',
+        timeline: timeline({ review: 'running' }),
+      })
+    ).toBe(true);
+  });
+
+  it('queues while the timeline or an optimistic session start is pending', () => {
+    expect(shouldQueueBranchSession({ mode: 'note', timeline: null })).toBe(true);
+    expect(
+      shouldQueueBranchSession({
+        mode: 'review',
+        timeline: timeline(),
+        hasPendingSessionStart: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldQueueBranchSession({
+        mode: 'review',
+        timeline: timeline(),
+        hasPendingQueuedSession: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/staged/src/lib/features/branches/branchSessionQueue.test.ts
+++ b/apps/staged/src/lib/features/branches/branchSessionQueue.test.ts
@@ -74,13 +74,13 @@ describe('shouldQueueBranchSession', () => {
     }
   });
 
-  it('queues same-type note or review sessions', () => {
+  it('allows same-type notes but queues same-type reviews', () => {
     expect(
       shouldQueueBranchSession({
         mode: 'note',
         timeline: timeline({ note: 'running' }),
       })
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldQueueBranchSession({
         mode: 'review',

--- a/apps/staged/src/lib/features/branches/branchSessionQueue.ts
+++ b/apps/staged/src/lib/features/branches/branchSessionQueue.ts
@@ -65,6 +65,7 @@ export function canStartBranchSession({
 
   const running = runningBranchSessionTypes(timeline);
   if (running.has('commit')) return false;
+  if (mode === 'note') return true;
   if (mode === 'commit') return running.size === 0;
 
   return !running.has(mode);

--- a/apps/staged/src/lib/features/branches/branchSessionQueue.ts
+++ b/apps/staged/src/lib/features/branches/branchSessionQueue.ts
@@ -1,0 +1,75 @@
+import type { BranchSessionType } from '../../types';
+
+type TimelineSessionItem = {
+  sessionStatus: string | null;
+};
+
+type TimelineReviewSessionItem = TimelineSessionItem & {
+  isAuto: boolean;
+};
+
+export interface BranchSessionQueueTimeline {
+  commits: TimelineSessionItem[];
+  notes: TimelineSessionItem[];
+  reviews: TimelineReviewSessionItem[];
+}
+
+export interface BranchSessionQueueOptions {
+  mode: BranchSessionType;
+  timeline: BranchSessionQueueTimeline | null | undefined;
+  hasPendingSessionStart?: boolean;
+  hasPendingQueuedSession?: boolean;
+}
+
+function isQueued(status: string | null | undefined): boolean {
+  return status === 'queued';
+}
+
+function isRunning(status: string | null | undefined): boolean {
+  return status === 'running';
+}
+
+export function hasQueuedBranchSession(timeline: BranchSessionQueueTimeline): boolean {
+  return (
+    timeline.commits.some((commit) => isQueued(commit.sessionStatus)) ||
+    timeline.notes.some((note) => isQueued(note.sessionStatus)) ||
+    timeline.reviews.some((review) => !review.isAuto && isQueued(review.sessionStatus))
+  );
+}
+
+function runningBranchSessionTypes(timeline: BranchSessionQueueTimeline): Set<BranchSessionType> {
+  const running = new Set<BranchSessionType>();
+
+  if (timeline.commits.some((commit) => isRunning(commit.sessionStatus))) {
+    running.add('commit');
+  }
+  if (timeline.notes.some((note) => isRunning(note.sessionStatus))) {
+    running.add('note');
+  }
+  if (timeline.reviews.some((review) => !review.isAuto && isRunning(review.sessionStatus))) {
+    running.add('review');
+  }
+
+  return running;
+}
+
+export function canStartBranchSession({
+  mode,
+  timeline,
+  hasPendingSessionStart = false,
+  hasPendingQueuedSession = false,
+}: BranchSessionQueueOptions): boolean {
+  if (!timeline) return false;
+  if (hasPendingSessionStart || hasPendingQueuedSession) return false;
+  if (hasQueuedBranchSession(timeline)) return false;
+
+  const running = runningBranchSessionTypes(timeline);
+  if (running.has('commit')) return false;
+  if (mode === 'commit') return running.size === 0;
+
+  return !running.has(mode);
+}
+
+export function shouldQueueBranchSession(options: BranchSessionQueueOptions): boolean {
+  return !canStartBranchSession(options);
+}

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -13,6 +13,7 @@
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { viewport } from '../../shared/viewport.svelte';
   import { onBranchSessionStatus } from '../../services/branchEventService';
+  import { shouldQueueBranchSession } from '../branches/branchSessionQueue';
 
   interface Props {
     branchId: string;
@@ -44,7 +45,7 @@
   let isDirty = $state(false);
   let starting = $state(false);
   let timelineLoading = $state(true);
-  let hasRunningSession = $state(false);
+  let shouldQueueCommitSession = $state(true);
   let textareaElement = $state<HTMLElement | null>(null);
 
   // Hashtag reference items
@@ -66,7 +67,7 @@
   const MAX_TEXTAREA_HEIGHT_PX = 260;
 
   let suggestedPrompt = $derived(getCommitPrefillFromReviewComments(visibleCommentCount));
-  let willQueue = $derived(timelineLoading || hasRunningSession);
+  let willQueue = $derived(timelineLoading || shouldQueueCommitSession);
 
   $effect(() => {
     if (!isDirty) {
@@ -79,23 +80,17 @@
     syncTextareaHeight();
   });
 
-  async function refreshQueueState(force = false) {
+  async function refreshQueueState(force = false): Promise<boolean> {
     try {
       const timeline = await commands.getBranchTimeline(branchId, { force });
-      hasRunningSession =
-        timeline.commits.some(
-          (c) => c.sessionStatus === 'running' || c.sessionStatus === 'queued'
-        ) ||
-        timeline.notes.some((n) => n.sessionStatus === 'running' || n.sessionStatus === 'queued') ||
-        timeline.reviews.some(
-          (r) => !r.isAuto && (r.sessionStatus === 'running' || r.sessionStatus === 'queued')
-        );
+      shouldQueueCommitSession = shouldQueueBranchSession({ mode: 'commit', timeline });
     } catch (e) {
       console.error('[DiffCommitSessionLauncher] Failed to load timeline:', e);
-      hasRunningSession = false;
+      shouldQueueCommitSession = true;
     } finally {
       timelineLoading = false;
     }
+    return shouldQueueCommitSession;
   }
 
   onMount(() => {
@@ -155,8 +150,9 @@
     }
 
     starting = true;
+    let shouldQueue = true;
     try {
-      await refreshQueueState(true);
+      shouldQueue = await refreshQueueState(true);
 
       const launchContext = {
         source: 'diff_viewer' as const,
@@ -168,7 +164,7 @@
       const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
       const provider = getPreferredAgent(agents) ?? undefined;
 
-      if (hasRunningSession) {
+      if (shouldQueue) {
         await commands.queueBranchSession(
           branchId,
           finalPrompt,
@@ -191,7 +187,7 @@
       onStarted();
     } catch (e) {
       toast.error(
-        hasRunningSession ? 'Unable to queue commit session' : 'Unable to start commit session',
+        shouldQueue ? 'Unable to queue commit session' : 'Unable to start commit session',
         {
           description: e instanceof Error ? e.message : String(e),
           duration: Infinity,

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -150,9 +150,8 @@
     }
 
     starting = true;
-    let shouldQueue = true;
     try {
-      shouldQueue = await refreshQueueState(true);
+      await refreshQueueState(true);
 
       const launchContext = {
         source: 'diff_viewer' as const,
@@ -164,35 +163,21 @@
       const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
       const provider = getPreferredAgent(agents) ?? undefined;
 
-      if (shouldQueue) {
-        await commands.queueBranchSession(
-          branchId,
-          finalPrompt,
-          'commit',
-          provider,
-          undefined,
-          launchContext
-        );
-      } else {
-        await commands.startBranchSession(
-          branchId,
-          finalPrompt,
-          'commit',
-          provider,
-          undefined,
-          launchContext
-        );
-      }
+      await commands.startOrQueueBranchSession(
+        branchId,
+        finalPrompt,
+        'commit',
+        provider,
+        undefined,
+        launchContext
+      );
 
       onStarted();
     } catch (e) {
-      toast.error(
-        shouldQueue ? 'Unable to queue commit session' : 'Unable to start commit session',
-        {
-          description: e instanceof Error ? e.message : String(e),
-          duration: Infinity,
-        }
-      );
+      toast.error('Unable to start commit session', {
+        description: e instanceof Error ? e.message : String(e),
+        duration: Infinity,
+      });
     } finally {
       starting = false;
     }

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -65,7 +65,6 @@
     type TreeNode,
   } from './diffModalHelpers';
   import { viewport } from '../../shared/viewport.svelte';
-  import { shouldQueueBranchSession } from '../branches/branchSessionQueue';
 
   // ==========================================================================
   // Props
@@ -438,39 +437,23 @@
       commitSha: diffViewer.state.commitSha ?? '',
       reviewId: activeReviewId ?? null,
     };
-    let shouldQueue = true;
 
     try {
-      const timeline = await commands.getBranchTimeline(branchId, { force: true });
-      shouldQueue = shouldQueueBranchSession({ mode, timeline });
-
       const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
       const provider = getPreferredAgent(agents) ?? undefined;
-
-      if (shouldQueue) {
-        await commands.queueBranchSession(
-          branchId,
-          prompt,
-          mode,
-          provider,
-          undefined,
-          launchContext
-        );
-      } else {
-        await commands.startBranchSession(
-          branchId,
-          prompt,
-          mode,
-          provider,
-          undefined,
-          launchContext
-        );
-      }
+      const result = await commands.startOrQueueBranchSession(
+        branchId,
+        prompt,
+        mode,
+        provider,
+        undefined,
+        launchContext
+      );
 
       const label = mode === 'note' ? 'Note' : 'Commit';
-      toast.success(`${label} session ${shouldQueue ? 'queued' : 'started'}`);
+      toast.success(`${label} session ${result.sessionStatus === 'queued' ? 'queued' : 'started'}`);
     } catch (e) {
-      toast.error(`Unable to ${shouldQueue ? 'queue' : 'start'} ${mode} session`, {
+      toast.error(`Unable to start ${mode} session`, {
         description: e instanceof Error ? e.message : String(e),
         duration: Infinity,
       });
@@ -509,39 +492,23 @@
       commitSha: diffViewer.state.commitSha ?? '',
       reviewId: activeReviewId ?? null,
     };
-    let shouldQueue = true;
 
     try {
-      const timeline = await commands.getBranchTimeline(branchId, { force: true });
-      shouldQueue = shouldQueueBranchSession({ mode: data.mode, timeline });
-
       const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
       const provider = getPreferredAgent(agents) ?? undefined;
-
-      if (shouldQueue) {
-        await commands.queueBranchSession(
-          branchId,
-          data.prompt,
-          data.mode,
-          provider,
-          data.imageIds,
-          launchContext
-        );
-      } else {
-        await commands.startBranchSession(
-          branchId,
-          data.prompt,
-          data.mode,
-          provider,
-          data.imageIds,
-          launchContext
-        );
-      }
+      const result = await commands.startOrQueueBranchSession(
+        branchId,
+        data.prompt,
+        data.mode,
+        provider,
+        data.imageIds,
+        launchContext
+      );
 
       const label = data.mode === 'note' ? 'Note' : data.mode === 'commit' ? 'Commit' : 'Review';
-      toast.success(`${label} session ${shouldQueue ? 'queued' : 'started'}`);
+      toast.success(`${label} session ${result.sessionStatus === 'queued' ? 'queued' : 'started'}`);
     } catch (e) {
-      toast.error(`Unable to ${shouldQueue ? 'queue' : 'start'} ${data.mode} session`, {
+      toast.error(`Unable to start ${data.mode} session`, {
         description: e instanceof Error ? e.message : String(e),
         duration: Infinity,
       });

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -65,6 +65,7 @@
     type TreeNode,
   } from './diffModalHelpers';
   import { viewport } from '../../shared/viewport.svelte';
+  import { shouldQueueBranchSession } from '../branches/branchSessionQueue';
 
   // ==========================================================================
   // Props
@@ -437,23 +438,16 @@
       commitSha: diffViewer.state.commitSha ?? '',
       reviewId: activeReviewId ?? null,
     };
+    let shouldQueue = true;
 
     try {
-      // Check if there's a running session to decide queue vs start
       const timeline = await commands.getBranchTimeline(branchId, { force: true });
-      const hasRunning =
-        timeline.commits.some(
-          (c) => c.sessionStatus === 'running' || c.sessionStatus === 'queued'
-        ) ||
-        timeline.notes.some((n) => n.sessionStatus === 'running' || n.sessionStatus === 'queued') ||
-        timeline.reviews.some(
-          (r) => !r.isAuto && (r.sessionStatus === 'running' || r.sessionStatus === 'queued')
-        );
+      shouldQueue = shouldQueueBranchSession({ mode, timeline });
 
       const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
       const provider = getPreferredAgent(agents) ?? undefined;
 
-      if (hasRunning) {
+      if (shouldQueue) {
         await commands.queueBranchSession(
           branchId,
           prompt,
@@ -474,9 +468,9 @@
       }
 
       const label = mode === 'note' ? 'Note' : 'Commit';
-      toast.success(`${label} session ${hasRunning ? 'queued' : 'started'}`);
+      toast.success(`${label} session ${shouldQueue ? 'queued' : 'started'}`);
     } catch (e) {
-      toast.error(`Unable to start ${mode} session`, {
+      toast.error(`Unable to ${shouldQueue ? 'queue' : 'start'} ${mode} session`, {
         description: e instanceof Error ? e.message : String(e),
         duration: Infinity,
       });
@@ -515,22 +509,16 @@
       commitSha: diffViewer.state.commitSha ?? '',
       reviewId: activeReviewId ?? null,
     };
+    let shouldQueue = true;
 
     try {
       const timeline = await commands.getBranchTimeline(branchId, { force: true });
-      const hasRunning =
-        timeline.commits.some(
-          (c) => c.sessionStatus === 'running' || c.sessionStatus === 'queued'
-        ) ||
-        timeline.notes.some((n) => n.sessionStatus === 'running' || n.sessionStatus === 'queued') ||
-        timeline.reviews.some(
-          (r) => !r.isAuto && (r.sessionStatus === 'running' || r.sessionStatus === 'queued')
-        );
+      shouldQueue = shouldQueueBranchSession({ mode: data.mode, timeline });
 
       const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
       const provider = getPreferredAgent(agents) ?? undefined;
 
-      if (hasRunning) {
+      if (shouldQueue) {
         await commands.queueBranchSession(
           branchId,
           data.prompt,
@@ -551,9 +539,9 @@
       }
 
       const label = data.mode === 'note' ? 'Note' : data.mode === 'commit' ? 'Commit' : 'Review';
-      toast.success(`${label} session ${hasRunning ? 'queued' : 'started'}`);
+      toast.success(`${label} session ${shouldQueue ? 'queued' : 'started'}`);
     } catch (e) {
-      toast.error(`Unable to start ${data.mode} session`, {
+      toast.error(`Unable to ${shouldQueue ? 'queue' : 'start'} ${data.mode} session`, {
         description: e instanceof Error ? e.message : String(e),
         duration: Infinity,
       });

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -59,6 +59,8 @@
     remote?: boolean;
     /** When true, the session will be queued rather than started immediately. */
     willQueue?: boolean;
+    /** Mode-aware queue state for callers that allow switching session types. */
+    willQueueForMode?: (mode: BranchSessionType) => boolean;
     onClose: (draft: { prompt: string; mode: BranchSessionType; imageIds: string[] }) => void;
     onSubmit: (data: { prompt: string; mode: BranchSessionType; imageIds: string[] }) => void;
   }
@@ -76,6 +78,7 @@
     notePrefill = '',
     remote = false,
     willQueue = false,
+    willQueueForMode,
     onClose,
     onSubmit,
   }: Props = $props();
@@ -89,6 +92,7 @@
   let isCommit = $derived(currentMode === 'commit');
   let isReview = $derived(currentMode === 'review');
   let isNote = $derived(!isCommit && !isReview);
+  let currentWillQueue = $derived(willQueueForMode?.(currentMode) ?? willQueue);
   const footerControlClass =
     'h-9 gap-1.5 rounded-md border border-[var(--border-muted)] bg-[var(--bg-primary)] px-4 py-2 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-[var(--bg-hover)] hover:text-foreground max-[640px]:h-11 max-[640px]:justify-center';
 
@@ -532,10 +536,10 @@
           >
             {#if starting}
               <Spinner size={14} />
-              {willQueue ? 'Queueing…' : 'Starting…'}
+              {currentWillQueue ? 'Queueing…' : 'Starting…'}
             {:else}
               <Send size={14} />
-              {willQueue ? 'Queue' : 'Start'}
+              {currentWillQueue ? 'Queue' : 'Start'}
             {/if}
           </Button>
         </div>

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -405,6 +405,7 @@ export interface SessionMessage {
 // =============================================================================
 
 export type BranchSessionType = 'note' | 'commit' | 'review';
+export type BranchSessionLaunchStatus = 'running' | 'queued';
 
 export interface BranchSessionLaunchContext {
   source: 'diff_viewer';
@@ -416,6 +417,7 @@ export interface BranchSessionLaunchContext {
 export interface BranchSessionResponse {
   sessionId: string;
   artifactId: string;
+  sessionStatus: BranchSessionLaunchStatus;
 }
 
 // =============================================================================


### PR DESCRIPTION
Summary:
- Add a shared start-or-queue branch session path that reports whether work is running or queued.
- Let compatible branch sessions launch in parallel while preserving FIFO blockers for commits and queued user sessions.
- Centralize frontend queue decisions and add frontend/Rust coverage for scheduling and queued-session claims.

Tests:
- Push hooks ran: crates-fmt, crates-lint, crates-test, differ-ci, staged-ci.