### PR TITLE
feat: add reset to origin for diverged branches

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -2209,6 +2209,7 @@ pub fn run() {
             timeline::refresh_branch_git_state,
             timeline::list_parent_branch_commits,
             timeline::pull_branch_ff_only,
+            timeline::reset_branch_to_remote,
             // Notes
             note_commands::create_note,
             note_commands::delete_note,

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -858,6 +858,111 @@ fn ensure_worktree_discardable(state: &git::BranchGitState) -> Result<(), String
     Ok(())
 }
 
+fn ensure_reset_to_remote_allowed(state: &git::BranchGitState) -> Result<(), String> {
+    if state.detached_head {
+        return Err("Cannot reset while HEAD is detached".to_string());
+    }
+    if !state.expected_branch_matches {
+        let current = state
+            .current_branch
+            .as_deref()
+            .unwrap_or("an unknown branch");
+        return Err(format!("Cannot reset while checked out on {current}"));
+    }
+    if state.fetch.status == git::FetchStatus::Failed {
+        let detail = state
+            .fetch
+            .error
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or("latest origin state could not be fetched");
+        return Err(format!("Cannot reset to origin: {detail}"));
+    }
+    if !state.upstream.exists {
+        return Err(format!(
+            "Cannot reset because {} does not exist",
+            state.upstream.r#ref
+        ));
+    }
+    if state.upstream.relation != git::UpstreamRelation::Diverged {
+        return Err(
+            "Reset to Origin is only available when the branch has diverged from origin"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn reset_branch_to_remote_impl(store: &Arc<Store>, branch_id: &str) -> Result<(), String> {
+    let branch = store
+        .get_branch(branch_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Branch not found: {branch_id}"))?;
+
+    if let Some(ref ws_name) = branch.workspace_name {
+        let repo_subpath = branches::resolve_branch_workspace_subpath(store, &branch)?;
+        let resolved_path = resolve_repo_path(ws_name, repo_subpath.as_deref())?;
+        let cache_key = remote_git_state_cache_key(
+            ws_name,
+            repo_subpath.as_deref(),
+            &branch.branch_name,
+            &branch.base_branch,
+        );
+        let state = git::compute_branch_git_state_batched(
+            &cache_key,
+            |script, args| {
+                branches::run_workspace_shell(ws_name, script, args).map_err(|e| e.to_string())
+            },
+            &resolved_path,
+            &branch.branch_name,
+            &branch.base_branch,
+            git::FetchMode::Force,
+            git::WorktreeStatusScope::Full,
+        );
+        ensure_reset_to_remote_allowed(&state)?;
+        branches::run_workspace_git(
+            ws_name,
+            repo_subpath.as_deref(),
+            &["reset", "--hard", &state.upstream.r#ref],
+        )
+        .map_err(|e| e.to_string())?;
+        branches::run_workspace_git(ws_name, repo_subpath.as_deref(), &["clean", "-fd"])
+            .map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+
+    let workdir = store
+        .get_workdir_for_branch(branch_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("No worktree for branch: {branch_id}"))?;
+    let worktree = Path::new(&workdir.path);
+    let state = git::compute_local_branch_git_state(
+        worktree,
+        &branch.branch_name,
+        &branch.base_branch,
+        git::FetchMode::Force,
+        git::WorktreeStatusScope::Full,
+        git::EnvSource::Captured,
+    );
+    ensure_reset_to_remote_allowed(&state)?;
+    git::cli_run(worktree, &["reset", "--hard", &state.upstream.r#ref])
+        .map_err(|e| e.to_string())?;
+    git::cli_run(worktree, &["clean", "-fd"]).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn reset_branch_to_remote(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    branch_id: String,
+) -> Result<(), String> {
+    let store = crate::get_store(&store)?;
+
+    tauri::async_runtime::spawn_blocking(move || reset_branch_to_remote_impl(&store, &branch_id))
+        .await
+        .map_err(|e| format!("Reset task failed: {e}"))?
+}
+
 fn remote_worktree_change_paths(
     workspace_name: &str,
     repo_subpath: Option<&str>,
@@ -1228,6 +1333,82 @@ mod tests {
     use crate::git::Span;
     use crate::store::models::{Branch, Comment, Project, ReviewScope, Workdir};
     use crate::test_utils::TempGitRepo;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use uuid::Uuid;
+
+    struct TempPath {
+        path: PathBuf,
+    }
+
+    impl TempPath {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!("staged-{label}-{}", Uuid::new_v4()));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempPath {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) -> String {
+        let mut command = Command::new("git");
+        command
+            .arg("-c")
+            .arg("core.hooksPath=/dev/null")
+            .arg("-C")
+            .arg(repo)
+            .args(args);
+        crate::git::strip_git_env(&mut command);
+
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap()
+    }
+
+    fn clone_repo(origin: &TempGitRepo) -> TempPath {
+        let clone_dir = TempPath::new("clone");
+        let mut command = Command::new("git");
+        command.arg("clone").arg(origin.path()).arg(&clone_dir.path);
+        crate::git::strip_git_env(&mut command);
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "git clone failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        run_git(
+            &clone_dir.path,
+            &["config", "user.email", "test@example.com"],
+        );
+        run_git(&clone_dir.path, &["config", "user.name", "Test"]);
+        clone_dir
+    }
+
+    fn remote_backed_feature() -> (TempGitRepo, TempPath) {
+        let origin = TempGitRepo::new();
+        origin.write_file("file.txt", "base\n");
+        origin.commit("base");
+
+        let clone = clone_repo(&origin);
+        run_git(&clone.path, &["checkout", "-b", "feature"]);
+        fs::write(clone.path.join("file.txt"), "base\nfeature\n").unwrap();
+        run_git(&clone.path, &["add", "."]);
+        run_git(&clone.path, &["commit", "-m", "feature"]);
+        run_git(&clone.path, &["push", "origin", "feature:feature"]);
+        run_git(&clone.path, &["fetch", "origin", "main", "feature"]);
+        (origin, clone)
+    }
 
     fn repo_with_visible_and_stale_commit() -> (TempGitRepo, String, String) {
         let repo = TempGitRepo::new();
@@ -1244,17 +1425,113 @@ mod tests {
         (repo, visible_sha, stale_sha)
     }
 
-    fn store_with_branch(repo: &TempGitRepo) -> (Arc<Store>, Branch) {
+    fn store_with_branch_path(path: &Path) -> (Arc<Store>, Branch) {
         let store = Arc::new(Store::in_memory().unwrap());
         let project = Project::new("test-owner/test-repo");
         store.create_project(&project).unwrap();
         let branch = Branch::new(&project.id, "feature", "main");
         store.create_branch(&branch).unwrap();
-        let workdir =
-            Workdir::new(&project.id, repo.path().to_str().unwrap()).with_branch(&branch.id);
+        let workdir = Workdir::new(&project.id, path.to_str().unwrap()).with_branch(&branch.id);
         store.create_workdir(&workdir).unwrap();
 
         (store, branch)
+    }
+
+    fn store_with_branch(repo: &TempGitRepo) -> (Arc<Store>, Branch) {
+        store_with_branch_path(repo.path())
+    }
+
+    #[test]
+    fn reset_branch_to_remote_resets_diverged_branch_and_cleans_worktree() {
+        let (origin, clone) = remote_backed_feature();
+        fs::write(clone.path.join("local.txt"), "local\n").unwrap();
+        run_git(&clone.path, &["add", "."]);
+        run_git(&clone.path, &["commit", "-m", "local"]);
+
+        origin.run_git(&["checkout", "feature"]);
+        origin.write_file("origin.txt", "origin\n");
+        let origin_sha = origin.commit("origin");
+
+        fs::write(clone.path.join("file.txt"), "dirty\n").unwrap();
+        fs::write(clone.path.join("untracked.txt"), "untracked\n").unwrap();
+        let (store, branch) = store_with_branch_path(&clone.path);
+
+        reset_branch_to_remote_impl(&store, &branch.id).unwrap();
+
+        let head = run_git(&clone.path, &["rev-parse", "HEAD"])
+            .trim()
+            .to_string();
+        let upstream = run_git(&clone.path, &["rev-parse", "origin/feature"])
+            .trim()
+            .to_string();
+        assert_eq!(head, upstream);
+        assert_eq!(head, origin_sha);
+        assert!(!clone.path.join("local.txt").exists());
+        assert!(!clone.path.join("untracked.txt").exists());
+        assert!(clone.path.join("origin.txt").exists());
+        assert_eq!(run_git(&clone.path, &["status", "--porcelain"]).trim(), "");
+    }
+
+    #[test]
+    fn reset_branch_to_remote_rejects_local_ahead_branch() {
+        let (_origin, clone) = remote_backed_feature();
+        fs::write(clone.path.join("local.txt"), "local\n").unwrap();
+        run_git(&clone.path, &["add", "."]);
+        run_git(&clone.path, &["commit", "-m", "local"]);
+        let local_sha = run_git(&clone.path, &["rev-parse", "HEAD"])
+            .trim()
+            .to_string();
+        let (store, branch) = store_with_branch_path(&clone.path);
+
+        let err = reset_branch_to_remote_impl(&store, &branch.id).unwrap_err();
+
+        assert!(err.contains("only available when the branch has diverged"));
+        assert_eq!(
+            run_git(&clone.path, &["rev-parse", "HEAD"])
+                .trim()
+                .to_string(),
+            local_sha
+        );
+    }
+
+    #[test]
+    fn reset_branch_to_remote_rejects_missing_upstream() {
+        let origin = TempGitRepo::new();
+        origin.write_file("file.txt", "base\n");
+        origin.commit("base");
+        let clone = clone_repo(&origin);
+        run_git(&clone.path, &["checkout", "-b", "feature"]);
+        fs::write(clone.path.join("file.txt"), "base\nfeature\n").unwrap();
+        run_git(&clone.path, &["add", "."]);
+        run_git(&clone.path, &["commit", "-m", "feature"]);
+        let (store, branch) = store_with_branch_path(&clone.path);
+
+        let err = reset_branch_to_remote_impl(&store, &branch.id).unwrap_err();
+
+        assert!(err.contains("origin/feature does not exist"));
+    }
+
+    #[test]
+    fn reset_branch_to_remote_rejects_wrong_checked_out_branch() {
+        let (_origin, clone) = remote_backed_feature();
+        run_git(&clone.path, &["checkout", "-b", "other"]);
+        let (store, branch) = store_with_branch_path(&clone.path);
+
+        let err = reset_branch_to_remote_impl(&store, &branch.id).unwrap_err();
+
+        assert!(err.contains("checked out on other"));
+    }
+
+    #[test]
+    fn reset_branch_to_remote_rejects_detached_head() {
+        let (_origin, clone) = remote_backed_feature();
+        let head = run_git(&clone.path, &["rev-parse", "HEAD"]);
+        run_git(&clone.path, &["checkout", "--detach", head.trim()]);
+        let (store, branch) = store_with_branch_path(&clone.path);
+
+        let err = reset_branch_to_remote_impl(&store, &branch.id).unwrap_err();
+
+        assert!(err.contains("HEAD is detached"));
     }
 
     #[test]

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -438,6 +438,10 @@ export function pullBranchFastForward(branchId: string): Promise<void> {
   return invokeCommand('pull_branch_ff_only', { branchId });
 }
 
+export function resetBranchToRemote(branchId: string): Promise<void> {
+  return invokeCommand('reset_branch_to_remote', { branchId });
+}
+
 // =============================================================================
 // Actions
 // =============================================================================

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -149,7 +149,9 @@
   let refreshingGitState = $state(false);
   let error = $state<string | null>(null);
   let pullingOrigin = $state(false);
+  let resettingToOrigin = $state(false);
   let discardingWorktreeChanges = $state(false);
+  let showResetToOriginDialog = $state(false);
   let loadedTimelineKey = $state<string | null>(null);
   type TimelineFullReview = NonNullable<Awaited<ReturnType<typeof commands.getReview>>>;
   type TimelineReviewDetails = {
@@ -934,6 +936,48 @@
     }
   }
 
+  function formatCommitCount(count: number, noun = 'commit'): string {
+    return `${count} ${noun}${count === 1 ? '' : 's'}`;
+  }
+
+  let resetToOriginTarget = $derived(`origin/${branch.branchName}`);
+  let resetToOriginDescription = $derived.by(() => {
+    const state = timeline?.gitState;
+    if (state?.upstream.relation === 'diverged') {
+      return (
+        `Origin has ${formatCommitCount(state.upstream.behind)} that your local branch does not. ` +
+        `Resetting will discard ${formatCommitCount(state.upstream.ahead, 'local commit')} ` +
+        `and make this branch match ${resetToOriginTarget}. This will also discard ` +
+        'uncommitted changes and remove untracked files.'
+      );
+    }
+
+    return (
+      `Reset ${branch.branchName} to ${resetToOriginTarget}? This will discard local commits ` +
+      'that are not on origin, discard uncommitted changes, and remove untracked files.'
+    );
+  });
+
+  function handleResetToOrigin() {
+    if (timeline?.gitState?.upstream.relation !== 'diverged') return;
+    showResetToOriginDialog = true;
+  }
+
+  async function confirmResetToOrigin() {
+    if (resettingToOrigin || commandPipelinePending || branchSessionBusy) return;
+    showResetToOriginDialog = false;
+    resettingToOrigin = true;
+    try {
+      await commands.resetBranchToRemote(branch.id);
+      commands.invalidateBranchTimeline(branch.id);
+      await loadTimeline({ force: true });
+    } catch (e) {
+      notifyError('Reset to Origin failed', e);
+    } finally {
+      resettingToOrigin = false;
+    }
+  }
+
   // Push state is sourced from the global pushStateStore so it survives the
   // BranchCard remount that happens when the user switches projects and back.
   // The store is shared with BranchCardPrButton (single entry per branch.id),
@@ -1558,6 +1602,7 @@
               onRebaseBranch={() => startBranchCommandPipeline('rebase')}
               onRebaseBranchOntoOrigin={() => startBranchCommandPipeline('rebase', 'origin')}
               onForcePush={handleForcePush}
+              onResetToOrigin={handleResetToOrigin}
               onOpenForcePushSession={forcePushSessionId && forcePushSessionId !== '__pending__'
                 ? openForcePushSession
                 : undefined}
@@ -1579,6 +1624,7 @@
               newSessionDisabled={sessionMgr.isNewSessionDisabled || gitUnsafeActionsDisabled}
               {pullingOrigin}
               {pushingOrigin}
+              {resettingToOrigin}
               {discardingWorktreeChanges}
               {provisioningLabel}
               {provisioningDetail}
@@ -1780,6 +1826,21 @@
       <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
       <AlertDialog.Action variant="destructive" onclick={confirmForcePush}>
         Force Push
+      </AlertDialog.Action>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>
+
+<AlertDialog.Root bind:open={showResetToOriginDialog}>
+  <AlertDialog.Content>
+    <AlertDialog.Header>
+      <AlertDialog.Title>Reset to Origin</AlertDialog.Title>
+      <AlertDialog.Description>{resetToOriginDescription}</AlertDialog.Description>
+    </AlertDialog.Header>
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action variant="destructive" onclick={confirmResetToOrigin}>
+        Reset to Origin
       </AlertDialog.Action>
     </AlertDialog.Footer>
   </AlertDialog.Content>

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1600,7 +1600,6 @@
                 ? openPushSession
                 : undefined}
               onRebaseBranch={() => startBranchCommandPipeline('rebase')}
-              onRebaseBranchOntoOrigin={() => startBranchCommandPipeline('rebase', 'origin')}
               onForcePush={handleForcePush}
               onResetToOrigin={handleResetToOrigin}
               onOpenForcePushSession={forcePushSessionId && forcePushSessionId !== '__pending__'

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -91,6 +91,7 @@
     onRebaseBranch?: () => void;
     onRebaseBranchOntoOrigin?: () => void;
     onForcePush?: () => void;
+    onResetToOrigin?: () => void;
     onOpenForcePushSession?: () => void;
     forcePushingOrigin?: boolean;
     onOpenPushSession?: () => void;
@@ -102,6 +103,7 @@
     newSessionDisabled?: boolean;
     pullingOrigin?: boolean;
     pushingOrigin?: boolean;
+    resettingToOrigin?: boolean;
     discardingWorktreeChanges?: boolean;
     /** Error message from a failed load/revalidation. */
     error?: string | null;
@@ -146,6 +148,7 @@
     onRebaseBranch,
     onRebaseBranchOntoOrigin,
     onForcePush,
+    onResetToOrigin,
     onOpenForcePushSession,
     forcePushingOrigin = false,
     onOpenPushSession,
@@ -157,6 +160,7 @@
     newSessionDisabled = false,
     pullingOrigin = false,
     pushingOrigin = false,
+    resettingToOrigin = false,
     discardingWorktreeChanges = false,
     error,
     gitActionDisabledReason,
@@ -256,6 +260,9 @@
     onForcePush?: () => void;
     forcePushDisabledReason?: string;
     forcePushing?: boolean;
+    onResetToOrigin?: () => void;
+    resetToOriginDisabledReason?: string;
+    resettingToOrigin?: boolean;
     pushing?: boolean;
     onViewDiff?: () => void;
     onCommitChanges?: () => void;
@@ -461,6 +468,13 @@
             : onRebaseBranchOntoOrigin
               ? (rebaseBranchDisabledReason ?? undefined)
               : undefined;
+        const resetToOriginReason = resettingToOrigin
+          ? 'Resetting...'
+          : forcePushingOrigin
+            ? 'Push in progress'
+            : onResetToOrigin
+              ? (rebaseBranchDisabledReason ?? undefined)
+              : undefined;
         rows.push({
           key: 'git-diverged',
           type: 'git-merge-warning',
@@ -481,6 +495,9 @@
               ? (rebaseBranchDisabledReason ?? undefined)
               : undefined,
           forcePushing: forcePushingOrigin,
+          onResetToOrigin: resetToOriginReason ? undefined : onResetToOrigin,
+          resetToOriginDisabledReason: resetToOriginReason,
+          resettingToOrigin,
         });
         break;
       }
@@ -931,6 +948,9 @@
             onForcePushClick={item.onForcePush}
             forcePushDisabledReason={item.forcePushDisabledReason}
             forcePushing={item.forcePushing}
+            onResetToOriginClick={item.onResetToOrigin}
+            resetToOriginDisabledReason={item.resetToOriginDisabledReason}
+            resettingToOrigin={item.resettingToOrigin}
             pushing={item.pushing}
             onViewDiffClick={item.onViewDiff}
             onCommitChangesClick={item.onCommitChanges}
@@ -1015,6 +1035,9 @@
             onForcePushClick={item.onForcePush}
             forcePushDisabledReason={item.forcePushDisabledReason}
             forcePushing={item.forcePushing}
+            onResetToOriginClick={item.onResetToOrigin}
+            resetToOriginDisabledReason={item.resetToOriginDisabledReason}
+            resettingToOrigin={item.resettingToOrigin}
             pushing={item.pushing}
             onViewDiffClick={item.onViewDiff}
             onCommitChangesClick={item.onCommitChanges}

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -89,7 +89,6 @@
     onPullOrigin?: () => void;
     onPushOrigin?: () => void;
     onRebaseBranch?: () => void;
-    onRebaseBranchOntoOrigin?: () => void;
     onForcePush?: () => void;
     onResetToOrigin?: () => void;
     onOpenForcePushSession?: () => void;
@@ -146,7 +145,6 @@
     onPullOrigin,
     onPushOrigin,
     onRebaseBranch,
-    onRebaseBranchOntoOrigin,
     onForcePush,
     onResetToOrigin,
     onOpenForcePushSession,
@@ -444,30 +442,14 @@
           2
         );
         const behindCount = state.upstream.behind;
-        // When `origin/{branch}` is itself behind `origin/{base}` rebasing onto
-        // origin would replay branch commits over a stale tip — almost never
-        // what the user wants. Surface that fact and disable the action; the
-        // companion "rebase onto base" action remains available via onRebase
-        // wired on other rows.
         const baseRefShort = state.base.ref.replace(/^origin\//, '') || state.base.ref;
         const upstreamBehindBase = state.upstream.behindBase;
-        const originBehindBaseReason =
-          upstreamBehindBase > 0
-            ? `origin/${state.currentBranch ?? 'branch'} is ${plural(upstreamBehindBase, 'commit')} behind ${baseRefShort}; rebase onto ${baseRefShort} instead`
-            : undefined;
         const baseSummary =
           upstreamBehindBase > 0
             ? ` and is ${plural(upstreamBehindBase, 'commit')} behind ${baseRefShort}`
             : '';
         const divergedTitle = `origin diverges here and has ${plural(behindCount, 'more commit')}${baseSummary}`;
         const divergedTitleHtml = `<span class="git-ref-badge">origin</span> diverges here and has ${escapeHtml(plural(behindCount, 'more commit'))}${escapeHtml(baseSummary)}`;
-        const rebaseReason = forcePushingOrigin
-          ? 'Force push in progress'
-          : originBehindBaseReason
-            ? originBehindBaseReason
-            : onRebaseBranchOntoOrigin
-              ? (rebaseBranchDisabledReason ?? undefined)
-              : undefined;
         const resetToOriginReason = resettingToOrigin
           ? 'Resetting...'
           : forcePushingOrigin
@@ -482,8 +464,6 @@
           titleHtml: divergedTitleHtml,
           timestamp: placement.timestamp,
           order: placement.order,
-          onRebase: rebaseReason ? undefined : onRebaseBranchOntoOrigin,
-          rebaseDisabledReason: rebaseReason,
           onForcePush: forcePushingOrigin
             ? onOpenForcePushSession
             : rebaseBranchDisabledReason

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -464,26 +464,6 @@
             </Button>
           </span>
         {/if}
-        {#if onForcePushClick || forcePushDisabledReason}
-          <span class="inline-flex" title={forcePushTitle}>
-            <Button
-              variant="outline"
-              size="xs"
-              onclick={handleForcePushClick}
-              disabled={!!forcePushDisabledReason}
-              title={forcePushTitle}
-              aria-label={forcePushTitle}
-              class={[
-                'h-[22px] rounded-md bg-transparent shadow-none',
-                forcePushing
-                  ? 'border-[var(--border-subtle)] text-[var(--text-muted)] hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground'
-                  : 'border-[var(--ui-danger-bg)] font-medium text-[var(--ui-danger)] hover:border-[var(--ui-danger)] hover:bg-[var(--ui-danger-bg)] hover:text-[var(--ui-danger)]',
-              ]}
-            >
-              {forcePushing ? 'Pushing\u2026' : 'Force Push'}
-            </Button>
-          </span>
-        {/if}
         {#if onResetToOriginClick || resetToOriginDisabledReason}
           <span class="inline-flex" title={resetToOriginTitle}>
             <Button
@@ -501,6 +481,26 @@
               ]}
             >
               {resettingToOrigin ? 'Resetting\u2026' : 'Reset to Origin'}
+            </Button>
+          </span>
+        {/if}
+        {#if onForcePushClick || forcePushDisabledReason}
+          <span class="inline-flex" title={forcePushTitle}>
+            <Button
+              variant="outline"
+              size="xs"
+              onclick={handleForcePushClick}
+              disabled={!!forcePushDisabledReason}
+              title={forcePushTitle}
+              aria-label={forcePushTitle}
+              class={[
+                'h-[22px] rounded-md bg-transparent shadow-none',
+                forcePushing
+                  ? 'border-[var(--border-subtle)] text-[var(--text-muted)] hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground'
+                  : 'border-[var(--ui-danger-bg)] font-medium text-[var(--ui-danger)] hover:border-[var(--ui-danger)] hover:bg-[var(--ui-danger-bg)] hover:text-[var(--ui-danger)]',
+              ]}
+            >
+              {forcePushing ? 'Pushing\u2026' : 'Force Push'}
             </Button>
           </span>
         {/if}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -79,6 +79,9 @@
     onForcePushClick?: () => void;
     forcePushDisabledReason?: string;
     forcePushing?: boolean;
+    onResetToOriginClick?: () => void;
+    resetToOriginDisabledReason?: string;
+    resettingToOrigin?: boolean;
     pushing?: boolean;
     onViewDiffClick?: () => void;
     onCommitChangesClick?: () => void;
@@ -117,6 +120,9 @@
     onForcePushClick,
     forcePushDisabledReason,
     forcePushing = false,
+    onResetToOriginClick,
+    resetToOriginDisabledReason,
+    resettingToOrigin = false,
     pushing = false,
     onViewDiffClick,
     onCommitChangesClick,
@@ -175,6 +181,10 @@
     forcePushDisabledReason ??
       (forcePushing ? 'View push session' : 'Force push local branch to origin')
   );
+  let resetToOriginTitle = $derived(
+    resetToOriginDisabledReason ??
+      (resettingToOrigin ? 'Resetting to origin' : 'Reset local branch to origin')
+  );
   let rebaseTitle = $derived(rebaseDisabledReason ?? 'Rebase');
   let commitChangesTitle = $derived(commitChangesDisabledReason ?? 'Commit changes');
   let discardChangesTitle = $derived(discardChangesDisabledReason ?? 'Discard changes');
@@ -231,6 +241,11 @@
   function handleForcePushClick(e: MouseEvent) {
     e.stopPropagation();
     onForcePushClick?.();
+  }
+
+  function handleResetToOriginClick(e: MouseEvent) {
+    e.stopPropagation();
+    onResetToOriginClick?.();
   }
 
   function handleViewDiffClick(e: MouseEvent) {
@@ -375,6 +390,8 @@
           !!rebaseDisabledReason ||
           !!onForcePushClick ||
           !!forcePushDisabledReason ||
+          !!onResetToOriginClick ||
+          !!resetToOriginDisabledReason ||
           !!onViewDiffClick ||
           !!onCommitChangesClick ||
           !!commitChangesDisabledReason ||
@@ -464,6 +481,26 @@
               ]}
             >
               {forcePushing ? 'Pushing\u2026' : 'Force Push'}
+            </Button>
+          </span>
+        {/if}
+        {#if onResetToOriginClick || resetToOriginDisabledReason}
+          <span class="inline-flex" title={resetToOriginTitle}>
+            <Button
+              variant="outline"
+              size="xs"
+              onclick={handleResetToOriginClick}
+              disabled={!!resetToOriginDisabledReason}
+              title={resetToOriginTitle}
+              aria-label={resetToOriginTitle}
+              class={[
+                'h-[22px] rounded-md bg-transparent shadow-none',
+                resettingToOrigin
+                  ? 'border-[var(--border-subtle)] text-[var(--text-muted)] hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground'
+                  : 'border-[var(--ui-danger-bg)] font-medium text-[var(--ui-danger)] hover:border-[var(--ui-danger)] hover:bg-[var(--ui-danger-bg)] hover:text-[var(--ui-danger)]',
+              ]}
+            >
+              {resettingToOrigin ? 'Resetting\u2026' : 'Reset to Origin'}
             </Button>
           </span>
         {/if}


### PR DESCRIPTION
## Summary
- add a Reset to Origin action for diverged branches with destructive confirmation
- hard-reset and clean local/workspace branches only after verifying origin state
- update timeline row controls and cover reset eligibility with backend tests