### PR TITLE
fix: restore markdown list markers

### DIFF
--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -418,6 +418,22 @@
     padding-left: 1.5em;
   }
 
+  .markdown-content :global(ul) {
+    list-style-type: disc;
+  }
+
+  .markdown-content :global(ol) {
+    list-style-type: decimal;
+  }
+
+  .markdown-content :global(ul ul) {
+    list-style-type: circle;
+  }
+
+  .markdown-content :global(ul ul ul) {
+    list-style-type: square;
+  }
+
   .markdown-content :global(li) {
     margin: 0.25em 0;
   }

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -2110,6 +2110,22 @@
     padding-left: 1.5em;
   }
 
+  .markdown-content :global(ul) {
+    list-style-type: disc;
+  }
+
+  .markdown-content :global(ol) {
+    list-style-type: decimal;
+  }
+
+  .markdown-content :global(ul ul) {
+    list-style-type: circle;
+  }
+
+  .markdown-content :global(ul ul ul) {
+    list-style-type: square;
+  }
+
   .markdown-content :global(li) {
     margin: 0.25em 0;
   }


### PR DESCRIPTION
Summary:
- Restore explicit unordered and ordered list marker styles in note and session markdown renderers.
- Add nested unordered marker styles so markdown hierarchy is visible.

Tests:
- Push hooks passed: crates-fmt, crates-test, crates-lint, differ-ci, staged-ci.