### PR TITLE
fix: pin subtitle-badge and action-button icons with translateZ(0)

### DIFF
--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -845,6 +845,10 @@
     font-size: calc(var(--size-xs) - 1px);
     font-weight: 600;
     line-height: 1;
+    /* Pin the review badge onto its own compositing layer (same rationale as
+       .timeline-icon) so its icon stays put during the row's hover
+       background-color transition instead of re-snapping to fractional pixels. */
+    transform: translateZ(0);
   }
 
   /* Actions container — visible on row hover */
@@ -855,6 +859,12 @@
     flex-shrink: 0;
     opacity: 0;
     transition: opacity 0.1s;
+  }
+
+  /* Pin each action-button icon onto its own layer so it doesn't jiggle during
+     the container's opacity fade or the Button's transition-all on hover. */
+  .timeline-actions :global(svg) {
+    transform: translateZ(0);
   }
 
   .timeline-row:hover .timeline-actions,


### PR DESCRIPTION
Stops timeline-row icons from jiggling/re-snapping to fractional pixels during hover transitions by promoting them onto their own compositing layers.

## Changes
- **Review badge** (`.subtitle-badge`): add `transform: translateZ(0)` so its icon stays put during the row's hover `background-color` transition (same rationale as `.timeline-icon`).
- **Action-button icons** (`.timeline-actions :global(svg)`): add `transform: translateZ(0)` so they don't jiggle during the container's opacity fade or the Button's `transition-all` on hover.