### PR TITLE
feat(slack-bridge): add Slack Socket Mode bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,15 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -484,6 +493,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -518,12 +536,28 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "derive_more"
@@ -563,13 +597,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -807,6 +851,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2144,14 +2198,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2181,6 +2246,22 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slack-bridge"
+version = "0.1.0"
+dependencies = [
+ "acp-client",
+ "anyhow",
+ "async-trait",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+]
 
 [[package]]
 name = "smallvec"
@@ -2429,6 +2510,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,6 +2535,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2515,6 +2613,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,6 +2680,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2713,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -2757,6 +2886,24 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 resolver = "2"
-members = ["crates/*"]
+members = ["crates/*", "apps/slack-bridge"]
 exclude = ["apps/staged/src-tauri", "apps/differ/src-tauri"]

--- a/apps/slack-bridge/.env.example
+++ b/apps/slack-bridge/.env.example
@@ -1,0 +1,20 @@
+# slack-bridge configuration — copy to `.env` and fill in. Never commit real values.
+
+# App-level token for Socket Mode (Basic Information → App-Level Tokens).
+# Must have the `connections:write` scope. Starts with `xapp-`.
+SLACK_APP_TOKEN=xapp-...
+
+# Bot token (OAuth & Permissions → Bot User OAuth Token). Starts with `xoxb-`.
+SLACK_BOT_TOKEN=xoxb-...
+
+# Optional. Only needed if you later add an HTTP Events API endpoint; Socket
+# Mode does not verify request signatures, so the bridge does not require this.
+# SLACK_SIGNING_SECRET=...
+
+# ACP agent provider id. One of: codex, claude, goose, pi, amp.
+# `codex-acp` is also accepted and normalized to `codex`.
+BUILDERBOT_AGENT=codex
+
+# Working directory the agent runs in. Defaults to the current directory.
+# Point this at the repo you want the agent to operate on (e.g. this monorepo).
+# BUILDERBOT_WORKDIR=/path/to/repo

--- a/apps/slack-bridge/Cargo.toml
+++ b/apps/slack-bridge/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "slack-bridge"
+version = "0.1.0"
+edition = "2021"
+description = "Minimal Slack Socket Mode bridge that turns @builderbot mentions into ACP agent tasks"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+async-trait = "0.1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "io-util", "net"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+acp-client = { path = "../../crates/acp-client" }
+reqwest = { version = "0.13", features = ["json", "rustls"], default-features = false }
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
+
+[dev-dependencies]

--- a/apps/slack-bridge/README.md
+++ b/apps/slack-bridge/README.md
@@ -1,0 +1,108 @@
+# slack-bridge
+
+A minimal Slack bridge for builderbot. Mention `@builderbot` in a channel and it
+starts an ACP agent task, then streams progress back into the same thread.
+
+- **Socket Mode** — no public webhook URL required.
+- **Secrets via environment** — nothing is hard-coded; see [`.env.example`](.env.example).
+- **Reuses builderbot primitives** — runs agents through `crates/acp-client`
+  (`AcpDriver` + `MessageWriter`), so any installed ACP agent (Codex, Claude,
+  Goose, Pi, Amp) works.
+
+## How it works
+
+```
+Slack app_mention  ──▶  events::parse_app_mention  ──▶  AgentTask
+                                                          │
+                                  runner::run_task (AcpDriver)
+                                                          │
+   StreamingWriter (impl MessageWriter)  ──▶  ProgressState ──render──▶ SlackSink
+                                                          │
+                          chat.postMessage (once) + chat.update (throttled)
+```
+
+The agent's streamed text and tool calls are folded into a single thread message
+that is edited as work progresses (throttled to respect Slack rate limits).
+
+## Prerequisites
+
+- An ACP agent on your `PATH`. Default is Codex (`codex-acp`); override with
+  `BUILDERBOT_AGENT`. Others: `claude` (`claude-agent-acp`), `goose`, `pi`, `amp`.
+- Rust toolchain via the repo's hermit environment (`source ./bin/activate-hermit`).
+
+## Slack app setup
+
+1. **Create an app** at <https://api.slack.com/apps> → *From scratch*.
+2. **Socket Mode**: *Settings → Socket Mode* → enable. When prompted, generate an
+   **App-Level Token** with the `connections:write` scope. This is your
+   `SLACK_APP_TOKEN` (`xapp-…`).
+3. **Bot token scopes**: *Features → OAuth & Permissions → Scopes → Bot Token
+   Scopes*, add:
+   - `app_mentions:read` — receive `@builderbot` mentions
+   - `chat:write` — post and edit thread messages
+   - `channels:history` — read message context (add `groups:history`,
+     `im:history`, `mpim:history` if you use the bot in those surfaces)
+4. **Event subscriptions**: *Features → Event Subscriptions* → enable. Under
+   *Subscribe to bot events*, add `app_mention`. (No Request URL is needed in
+   Socket Mode.)
+5. **Install**: *Settings → Install App* → install to your workspace. Copy the
+   **Bot User OAuth Token** (`xoxb-…`) into `SLACK_BOT_TOKEN`.
+6. **Invite** the bot to a channel: `/invite @builderbot`.
+
+> `SLACK_SIGNING_SECRET` is **not** required for Socket Mode (it verifies HTTP
+> request signatures). It is accepted for forward-compatibility only.
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill in the tokens, or export the variables in
+your shell:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `SLACK_APP_TOKEN` | yes | Socket Mode connection (`xapp-…`) |
+| `SLACK_BOT_TOKEN` | yes | Web API calls (`xoxb-…`) |
+| `SLACK_SIGNING_SECRET` | no | Reserved; unused in Socket Mode |
+| `BUILDERBOT_AGENT` | no | ACP provider id, default `codex` |
+| `BUILDERBOT_WORKDIR` | no | Agent working dir, default current dir |
+
+This binary reads variables already present in the environment. To load a `.env`
+file, source it first (e.g. `set -a; source apps/slack-bridge/.env; set +a`).
+
+## Running
+
+```bash
+source ./bin/activate-hermit
+
+# Offline check — no tokens, no network. Runs a captured event through the
+# parser + progress formatter and prints what would be posted.
+cargo run -p slack-bridge -- dev apps/slack-bridge/fixtures/app_mention.json
+
+# Live dry-run — connects to Slack, echoes the parsed prompt and a canned
+# progress sequence into the thread, but does NOT invoke an agent.
+cargo run -p slack-bridge -- run --dry-run
+
+# Live — mentions start real agent tasks.
+cargo run -p slack-bridge -- run
+```
+
+## Tests
+
+```bash
+cargo test -p slack-bridge
+```
+
+Focused unit tests cover:
+- **Slack event parsing** (`src/events.rs`) — mention stripping, thread vs.
+  root replies, multiline prompts, and ignored events (bot-authored,
+  non-mention, empty, missing fields).
+- **Progress formatting** (`src/progress.rs`) — tool-call lines, headers,
+  truncation to Slack limits, char-boundary safety, and chunk coalescing.
+- **Streaming writer** (`src/runner.rs`) — tool calls flush immediately, text
+  chunks are throttled, and `finalize` forces a flush.
+
+## Dependencies
+
+Socket Mode is implemented directly over `tokio-tungstenite` (WebSocket) plus a
+few `reqwest` Web API calls, rather than a full Slack framework — the envelope
+loop is small and this keeps the dependency tree minimal. Agent execution reuses
+`crates/acp-client`.

--- a/apps/slack-bridge/fixtures/app_mention.json
+++ b/apps/slack-bridge/fixtures/app_mention.json
@@ -1,0 +1,13 @@
+{
+  "type": "events_api",
+  "envelope_id": "abc-123",
+  "payload": {
+    "event": {
+      "type": "app_mention",
+      "channel": "C0123ABCD",
+      "user": "U07USER",
+      "text": "<@U07BOT> please run the test suite and report failures",
+      "ts": "1718800000.000100"
+    }
+  }
+}

--- a/apps/slack-bridge/src/config.rs
+++ b/apps/slack-bridge/src/config.rs
@@ -1,0 +1,107 @@
+//! Runtime configuration, sourced entirely from environment variables.
+//!
+//! No secrets are ever hard-coded or written to disk. See `.env.example` and
+//! the README for the full list and Slack app setup.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+/// Environment variable names, in one place.
+pub mod env {
+    pub const APP_TOKEN: &str = "SLACK_APP_TOKEN";
+    pub const BOT_TOKEN: &str = "SLACK_BOT_TOKEN";
+    pub const SIGNING_SECRET: &str = "SLACK_SIGNING_SECRET";
+    pub const AGENT: &str = "BUILDERBOT_AGENT";
+    pub const WORKDIR: &str = "BUILDERBOT_WORKDIR";
+}
+
+/// Validated configuration for a live Socket Mode session.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// App-level token (`xapp-…`) used to open the Socket Mode connection.
+    pub app_token: String,
+    /// Bot token (`xoxb-…`) used for Web API calls.
+    pub bot_token: String,
+    /// ACP provider id (e.g. `codex`, `claude`).
+    pub agent: String,
+    /// Working directory the agent runs in (defaults to the current dir).
+    pub workdir: PathBuf,
+}
+
+/// Default agent when `BUILDERBOT_AGENT` is unset.
+pub const DEFAULT_AGENT: &str = "codex";
+
+impl Config {
+    /// Load and validate configuration from the process environment.
+    pub fn from_env() -> Result<Self> {
+        let app_token = require(env::APP_TOKEN)?;
+        let bot_token = require(env::BOT_TOKEN)?;
+
+        if !app_token.starts_with("xapp-") {
+            anyhow::bail!(
+                "{} must be an app-level token starting with 'xapp-'",
+                env::APP_TOKEN
+            );
+        }
+        if !bot_token.starts_with("xoxb-") {
+            anyhow::bail!(
+                "{} must be a bot token starting with 'xoxb-'",
+                env::BOT_TOKEN
+            );
+        }
+
+        Ok(Self {
+            app_token,
+            bot_token,
+            agent: agent_from_env(),
+            workdir: workdir_from_env()?,
+        })
+    }
+}
+
+/// Resolve the agent id from the environment, falling back to [`DEFAULT_AGENT`].
+pub fn agent_from_env() -> String {
+    std::env::var(env::AGENT)
+        .ok()
+        .map(|v| normalize_agent(&v))
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_AGENT.to_string())
+}
+
+/// Resolve the working directory, defaulting to the current directory.
+pub fn workdir_from_env() -> Result<PathBuf> {
+    match std::env::var(env::WORKDIR) {
+        Ok(v) if !v.trim().is_empty() => Ok(PathBuf::from(v)),
+        _ => std::env::current_dir().context("failed to resolve current directory"),
+    }
+}
+
+/// Normalize an agent value so the `-acp` binary suffix and surrounding
+/// whitespace are accepted (e.g. `codex-acp` → `codex`), matching the provider
+/// ids in `acp-client`.
+pub fn normalize_agent(value: &str) -> String {
+    let v = value.trim();
+    v.strip_suffix("-acp").unwrap_or(v).to_string()
+}
+
+fn require(key: &str) -> Result<String> {
+    let value = std::env::var(key)
+        .with_context(|| format!("missing required environment variable {key}"))?;
+    if value.trim().is_empty() {
+        anyhow::bail!("environment variable {key} is set but empty");
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_acp_suffix() {
+        assert_eq!(normalize_agent("codex-acp"), "codex");
+        assert_eq!(normalize_agent("  claude  "), "claude");
+        assert_eq!(normalize_agent("goose"), "goose");
+    }
+}

--- a/apps/slack-bridge/src/events.rs
+++ b/apps/slack-bridge/src/events.rs
@@ -1,0 +1,207 @@
+//! Slack event parsing.
+//!
+//! Pure functions that turn a raw Slack `app_mention` event payload into an
+//! [`AgentTask`]. No network or side effects, so this is fully unit-testable
+//! against captured JSON fixtures.
+
+use serde::Deserialize;
+
+/// A task derived from a Slack mention, ready to hand to the agent runner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTask {
+    /// Channel the mention arrived in.
+    pub channel: String,
+    /// Thread to reply into. For a root-level mention this is the mention's own
+    /// `ts`, so progress lands in a fresh thread under the mention.
+    pub thread_ts: String,
+    /// The prompt text with the leading bot mention stripped.
+    pub prompt: String,
+    /// The user who mentioned the bot, if present.
+    pub user: Option<String>,
+}
+
+/// Subset of a Slack `app_mention` event we care about.
+///
+/// See https://api.slack.com/events/app_mention
+#[derive(Debug, Deserialize)]
+struct AppMentionEvent {
+    #[serde(rename = "type")]
+    kind: String,
+    channel: Option<String>,
+    user: Option<String>,
+    #[serde(default)]
+    text: String,
+    ts: Option<String>,
+    thread_ts: Option<String>,
+    /// Present when the message was posted by a bot. We ignore those to avoid
+    /// the bridge replying to itself in a loop.
+    bot_id: Option<String>,
+}
+
+/// Parse a raw `app_mention` event payload into an [`AgentTask`].
+///
+/// Returns `None` (the event should be ignored) when:
+/// - the event is not an `app_mention`,
+/// - it originated from a bot (`bot_id` set),
+/// - it is missing the channel or timestamp, or
+/// - the prompt is empty once the mention is stripped.
+pub fn parse_app_mention(payload: &serde_json::Value) -> Option<AgentTask> {
+    let event: AppMentionEvent = serde_json::from_value(payload.clone()).ok()?;
+
+    if event.kind != "app_mention" {
+        return None;
+    }
+    if event.bot_id.is_some() {
+        return None;
+    }
+
+    let channel = event.channel?;
+    let ts = event.ts?;
+
+    let prompt = strip_leading_mention(&event.text).trim().to_string();
+    if prompt.is_empty() {
+        return None;
+    }
+
+    Some(AgentTask {
+        channel,
+        thread_ts: event.thread_ts.unwrap_or(ts),
+        prompt,
+        user: event.user,
+    })
+}
+
+/// Remove a single leading Slack mention token (`<@U…>` or `<@W…|name>`) from
+/// the start of `text`, along with any whitespace that follows it.
+///
+/// Slack always places the bot mention at the start of an `app_mention` event,
+/// so stripping the first token is sufficient and avoids needing the bot's user
+/// id at parse time. Mentions appearing later in the text are left intact.
+pub fn strip_leading_mention(text: &str) -> &str {
+    let trimmed = text.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("<@") {
+        if let Some(end) = rest.find('>') {
+            return rest[end + 1..].trim_start();
+        }
+    }
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn strips_leading_mention_token() {
+        assert_eq!(strip_leading_mention("<@U123> hello world"), "hello world");
+    }
+
+    #[test]
+    fn strips_mention_with_display_name_form() {
+        assert_eq!(strip_leading_mention("<@W999|builderbot> go"), "go");
+    }
+
+    #[test]
+    fn leaves_later_mentions_intact() {
+        assert_eq!(
+            strip_leading_mention("<@U123> ping <@U456> please"),
+            "ping <@U456> please"
+        );
+    }
+
+    #[test]
+    fn passes_through_text_without_mention() {
+        assert_eq!(strip_leading_mention("just text"), "just text");
+    }
+
+    #[test]
+    fn parses_basic_mention_into_task() {
+        let payload = json!({
+            "type": "app_mention",
+            "channel": "C123",
+            "user": "U999",
+            "text": "<@UBOT> run the tests",
+            "ts": "1700000000.000100"
+        });
+        let task = parse_app_mention(&payload).expect("should parse");
+        assert_eq!(
+            task,
+            AgentTask {
+                channel: "C123".into(),
+                thread_ts: "1700000000.000100".into(),
+                prompt: "run the tests".into(),
+                user: Some("U999".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn uses_thread_ts_when_replying_in_existing_thread() {
+        let payload = json!({
+            "type": "app_mention",
+            "channel": "C123",
+            "text": "<@UBOT> continue",
+            "ts": "1700000000.000200",
+            "thread_ts": "1700000000.000001"
+        });
+        let task = parse_app_mention(&payload).expect("should parse");
+        assert_eq!(task.thread_ts, "1700000000.000001");
+    }
+
+    #[test]
+    fn preserves_multiline_prompt() {
+        let payload = json!({
+            "type": "app_mention",
+            "channel": "C1",
+            "text": "<@UBOT> line one\nline two",
+            "ts": "1.1"
+        });
+        let task = parse_app_mention(&payload).expect("should parse");
+        assert_eq!(task.prompt, "line one\nline two");
+    }
+
+    #[test]
+    fn ignores_bot_authored_mentions() {
+        let payload = json!({
+            "type": "app_mention",
+            "channel": "C1",
+            "text": "<@UBOT> hi",
+            "ts": "1.1",
+            "bot_id": "B123"
+        });
+        assert_eq!(parse_app_mention(&payload), None);
+    }
+
+    #[test]
+    fn ignores_non_mention_events() {
+        let payload = json!({
+            "type": "message",
+            "channel": "C1",
+            "text": "<@UBOT> hi",
+            "ts": "1.1"
+        });
+        assert_eq!(parse_app_mention(&payload), None);
+    }
+
+    #[test]
+    fn ignores_mention_with_empty_prompt() {
+        let payload = json!({
+            "type": "app_mention",
+            "channel": "C1",
+            "text": "<@UBOT>   ",
+            "ts": "1.1"
+        });
+        assert_eq!(parse_app_mention(&payload), None);
+    }
+
+    #[test]
+    fn ignores_event_missing_channel() {
+        let payload = json!({
+            "type": "app_mention",
+            "text": "<@UBOT> hi",
+            "ts": "1.1"
+        });
+        assert_eq!(parse_app_mention(&payload), None);
+    }
+}

--- a/apps/slack-bridge/src/lib.rs
+++ b/apps/slack-bridge/src/lib.rs
@@ -1,0 +1,14 @@
+//! Minimal Slack ↔ builderbot bridge.
+//!
+//! Pure, side-effect-free building blocks live here so they can be unit-tested
+//! in isolation:
+//! - [`events`] parses Slack `app_mention` payloads into tasks.
+//! - [`progress`] accumulates streamed agent output into a Slack message body.
+//!
+//! The binary (`main.rs`) wires these into a live Socket Mode connection.
+
+pub mod config;
+pub mod events;
+pub mod progress;
+pub mod runner;
+pub mod slack;

--- a/apps/slack-bridge/src/main.rs
+++ b/apps/slack-bridge/src/main.rs
@@ -1,0 +1,104 @@
+//! slack-bridge entry point.
+//!
+//! Commands:
+//! - `run [--dry-run]` — connect to Slack via Socket Mode and serve mentions.
+//!   With `--dry-run`, mentions are echoed back with a canned progress sequence
+//!   instead of invoking an agent (validates the Slack round-trip).
+//! - `dev <fixture.json>` — fully offline: run a captured event through the
+//!   parser + progress formatter and print the result. No tokens, no network.
+
+use anyhow::{Context, Result};
+
+use slack_bridge::config::Config;
+use slack_bridge::events::parse_app_mention;
+use slack_bridge::progress::ProgressState;
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        Some("run") => {
+            let dry_run = args.any(|a| a == "--dry-run");
+            run(dry_run)
+        }
+        Some("dev") => {
+            let path = args
+                .next()
+                .context("usage: slack-bridge dev <event-fixture.json>")?;
+            run_dev(&path)
+        }
+        Some(other) => {
+            anyhow::bail!(
+                "unknown command '{other}'. Available: run [--dry-run], dev <fixture.json>"
+            )
+        }
+        None => {
+            eprintln!("usage:");
+            eprintln!("  slack-bridge run [--dry-run]   # live Socket Mode bridge");
+            eprintln!("  slack-bridge dev <fixture.json>  # offline parse/format check");
+            Ok(())
+        }
+    }
+}
+
+/// Live Socket Mode bridge.
+fn run(dry_run: bool) -> Result<()> {
+    let config = Config::from_env()?;
+    eprintln!(
+        "slack-bridge: starting (agent={}, workdir={}, dry_run={})",
+        config.agent,
+        config.workdir.display(),
+        dry_run
+    );
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+    rt.block_on(slack_bridge::slack::run(config, dry_run))
+}
+
+/// Offline dry-run: parse a fixture event and print the rendered progress
+/// messages the bridge would post, without contacting Slack or an agent.
+fn run_dev(path: &str) -> Result<()> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture '{path}'"))?;
+    let payload: serde_json::Value =
+        serde_json::from_str(&raw).context("fixture is not valid JSON")?;
+
+    // Accept either a bare event or a Socket Mode envelope payload wrapping one.
+    let event = payload
+        .get("payload")
+        .and_then(|p| p.get("event"))
+        .or_else(|| payload.get("event"))
+        .unwrap_or(&payload);
+
+    let Some(task) = parse_app_mention(event) else {
+        println!("(event ignored — not an actionable @builderbot mention)");
+        return Ok(());
+    };
+
+    println!("Parsed task:");
+    println!("  channel:   {}", task.channel);
+    println!("  thread_ts: {}", task.thread_ts);
+    println!(
+        "  user:      {}",
+        task.user.as_deref().unwrap_or("(unknown)")
+    );
+    println!("  prompt:    {}", task.prompt);
+    println!();
+
+    // Simulate a short progress stream so the formatter output is visible.
+    let mut state = ProgressState::new();
+    println!("--- initial post ---\n{}\n", state.render());
+
+    state.record_tool_call("cargo test --workspace");
+    state.append_text("Running the test suite to reproduce the issue.");
+    println!("--- progress update ---\n{}\n", state.render());
+
+    state.record_tool_result("test result: ok. 42 passed; 0 failed");
+    state.append_text("\n\nAll tests pass. Nothing further to do.");
+    state.mark_done();
+    println!("--- final update ---\n{}", state.render());
+
+    Ok(())
+}

--- a/apps/slack-bridge/src/progress.rs
+++ b/apps/slack-bridge/src/progress.rs
@@ -1,0 +1,254 @@
+//! Progress message formatting.
+//!
+//! [`ProgressState`] accumulates streamed agent output (text chunks and tool
+//! activity) and renders a single Slack-safe message body. Keeping this pure
+//! lets the live bridge simply edit one thread message as state evolves, and
+//! lets us unit-test formatting without touching Slack.
+
+/// Conservative ceiling for a single Slack message. The hard limit is ~4000
+/// characters; we stay under it to leave room for headers and ellipsis.
+pub const SLACK_MAX_MESSAGE_CHARS: usize = 3900;
+
+/// Per-tool-result preview cap, so a single noisy command can't dominate the
+/// message.
+pub const TOOL_RESULT_PREVIEW_CHARS: usize = 300;
+
+const TRUNCATION_SUFFIX: &str = "\n…(truncated)";
+
+/// Accumulated progress for one agent task, rendered into a thread message.
+#[derive(Debug, Clone, Default)]
+pub struct ProgressState {
+    text: String,
+    activity: Vec<String>,
+    done: bool,
+    failed: Option<String>,
+}
+
+impl ProgressState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a streamed text chunk from the agent's message.
+    pub fn append_text(&mut self, chunk: &str) {
+        self.text.push_str(chunk);
+    }
+
+    /// Record that the agent started a tool call.
+    pub fn record_tool_call(&mut self, title: &str) {
+        self.activity.push(format_tool_call(title));
+    }
+
+    /// Record a tool result, stored as a short preview line.
+    pub fn record_tool_result(&mut self, content: &str) {
+        let preview = collapse_whitespace(content);
+        if preview.is_empty() {
+            return;
+        }
+        self.activity.push(format!(
+            "   ↳ {}",
+            truncate(&preview, TOOL_RESULT_PREVIEW_CHARS)
+        ));
+    }
+
+    /// Mark the task as finished successfully.
+    pub fn mark_done(&mut self) {
+        self.done = true;
+    }
+
+    /// Mark the task as failed with an error message.
+    pub fn mark_failed(&mut self, error: &str) {
+        self.failed = Some(error.to_string());
+        self.done = true;
+    }
+
+    /// True when nothing meaningful has been produced yet.
+    pub fn is_empty(&self) -> bool {
+        self.text.trim().is_empty() && self.activity.is_empty()
+    }
+
+    /// Render the current state into a Slack-safe message body.
+    pub fn render(&self) -> String {
+        let mut body = String::new();
+        body.push_str(self.header());
+
+        if !self.activity.is_empty() {
+            body.push_str("\n\n");
+            body.push_str(&self.activity.join("\n"));
+        }
+
+        let text = self.text.trim();
+        if !text.is_empty() {
+            body.push_str("\n\n");
+            body.push_str(text);
+        }
+
+        if let Some(err) = &self.failed {
+            body.push_str("\n\n> ");
+            body.push_str(&collapse_whitespace(err));
+        }
+
+        truncate(&body, SLACK_MAX_MESSAGE_CHARS)
+    }
+
+    fn header(&self) -> &str {
+        if self.failed.is_some() {
+            "❌ builderbot failed"
+        } else if self.done {
+            "✅ builderbot finished"
+        } else {
+            "🤖 builderbot is working…"
+        }
+    }
+
+    /// The raw failure message, if any (used by callers that want detail).
+    pub fn failure(&self) -> Option<&str> {
+        self.failed.as_deref()
+    }
+}
+
+/// Format a tool call title into an activity line.
+pub fn format_tool_call(title: &str) -> String {
+    let title = collapse_whitespace(title);
+    if title.is_empty() {
+        "🔧 (tool call)".to_string()
+    } else {
+        format!("🔧 {title}")
+    }
+}
+
+/// Truncate `s` to at most `max` characters, appending a marker when cut.
+///
+/// Operates on `char` boundaries so multibyte text is never split.
+pub fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let suffix_len = TRUNCATION_SUFFIX.chars().count();
+    // If `max` is too small to hold the marker, hard-cut to `max` chars.
+    if max <= suffix_len {
+        return s.chars().take(max).collect();
+    }
+    let head: String = s.chars().take(max - suffix_len).collect();
+    format!("{head}{TRUNCATION_SUFFIX}")
+}
+
+/// Collapse runs of whitespace (including newlines) into single spaces and trim.
+fn collapse_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_tool_call_with_title() {
+        assert_eq!(format_tool_call("cargo test"), "🔧 cargo test");
+    }
+
+    #[test]
+    fn formats_tool_call_collapsing_whitespace() {
+        assert_eq!(format_tool_call("run\n  the   tests"), "🔧 run the tests");
+    }
+
+    #[test]
+    fn formats_empty_tool_call() {
+        assert_eq!(format_tool_call("   "), "🔧 (tool call)");
+    }
+
+    #[test]
+    fn truncate_leaves_short_strings_untouched() {
+        assert_eq!(truncate("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_cuts_long_strings_and_marks_them() {
+        let out = truncate(&"a".repeat(50), 20);
+        assert!(out.chars().count() <= 20);
+        assert!(out.ends_with("…(truncated)"));
+    }
+
+    #[test]
+    fn truncate_respects_char_boundaries() {
+        // 10 multibyte chars; cap at 5 must not panic or split a char.
+        let out = truncate(&"é".repeat(10), 5);
+        assert!(out.chars().count() <= 5);
+    }
+
+    #[test]
+    fn renders_working_header_for_in_progress_task() {
+        let mut state = ProgressState::new();
+        state.append_text("looking into it");
+        let out = state.render();
+        assert!(out.starts_with("🤖 builderbot is working…"));
+        assert!(out.contains("looking into it"));
+    }
+
+    #[test]
+    fn renders_done_header_after_finish() {
+        let mut state = ProgressState::new();
+        state.append_text("all set");
+        state.mark_done();
+        assert!(state.render().starts_with("✅ builderbot finished"));
+    }
+
+    #[test]
+    fn renders_failed_header_and_exposes_detail() {
+        let mut state = ProgressState::new();
+        state.mark_failed("agent not found");
+        let out = state.render();
+        assert!(out.starts_with("❌ builderbot failed"));
+        assert!(out.contains("agent not found"));
+        assert_eq!(state.failure(), Some("agent not found"));
+    }
+
+    #[test]
+    fn renders_tool_activity_before_text() {
+        let mut state = ProgressState::new();
+        state.record_tool_call("cargo test");
+        state.record_tool_result("ok, 12 passed");
+        state.append_text("done");
+        let out = state.render();
+        let tool_idx = out.find("🔧 cargo test").unwrap();
+        let result_idx = out.find("↳ ok, 12 passed").unwrap();
+        let text_idx = out.find("done").unwrap();
+        assert!(tool_idx < result_idx);
+        assert!(result_idx < text_idx);
+    }
+
+    #[test]
+    fn coalesces_streamed_text_chunks() {
+        let mut state = ProgressState::new();
+        state.append_text("hel");
+        state.append_text("lo ");
+        state.append_text("world");
+        assert!(state.render().contains("hello world"));
+    }
+
+    #[test]
+    fn detects_empty_state() {
+        let mut state = ProgressState::new();
+        assert!(state.is_empty());
+        state.append_text("   ");
+        assert!(state.is_empty());
+        state.append_text("x");
+        assert!(!state.is_empty());
+    }
+
+    #[test]
+    fn render_is_within_slack_limit() {
+        let mut state = ProgressState::new();
+        state.append_text(&"x".repeat(10_000));
+        let out = state.render();
+        assert!(out.chars().count() <= SLACK_MAX_MESSAGE_CHARS);
+    }
+
+    #[test]
+    fn tool_result_preview_is_truncated() {
+        let mut state = ProgressState::new();
+        state.record_tool_result(&"y".repeat(1000));
+        let out = state.render();
+        assert!(out.contains("…(truncated)"));
+    }
+}

--- a/apps/slack-bridge/src/runner.rs
+++ b/apps/slack-bridge/src/runner.rs
@@ -1,0 +1,275 @@
+//! Agent execution.
+//!
+//! Bridges `acp-client`'s streaming [`MessageWriter`] onto a [`ProgressSink`]
+//! (e.g. a Slack thread message). The ACP driver produces text chunks and
+//! tool-call events; we fold them into a [`ProgressState`] and push throttled
+//! snapshots to the sink so the thread updates live without hitting Slack's
+//! rate limits on every token.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use acp_client::{AcpDriver, AgentDriver, MessageWriter, Store};
+
+use crate::progress::ProgressState;
+
+/// Minimum gap between sink updates while streaming.
+const DEFAULT_THROTTLE: Duration = Duration::from_millis(800);
+
+/// Receives rendered progress snapshots. Implemented by the Slack client (to
+/// edit a thread message) and by test/dev sinks.
+///
+/// `Send + Sync` because the ACP [`MessageWriter`] that drives it requires it;
+/// implementors (e.g. a `reqwest`-backed Slack client) are already thread-safe.
+#[async_trait]
+pub trait ProgressSink: Send + Sync {
+    /// Replace the current progress message with `body`.
+    async fn update(&self, body: &str) -> Result<()>;
+}
+
+/// No-op store: the bridge runs one-shot tasks and does not persist sessions.
+struct NoOpStore;
+
+#[async_trait]
+impl Store for NoOpStore {
+    fn set_agent_session_id(
+        &self,
+        _session_id: &str,
+        _agent_session_id: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+struct WriterInner {
+    state: ProgressState,
+    last_flush: Option<Instant>,
+}
+
+/// A [`MessageWriter`] that folds ACP events into a [`ProgressState`] and
+/// forwards throttled renders to a [`ProgressSink`].
+struct StreamingWriter {
+    inner: Arc<Mutex<WriterInner>>,
+    sink: Arc<dyn ProgressSink>,
+    throttle: Duration,
+}
+
+impl StreamingWriter {
+    async fn flush(&self, force: bool) {
+        let body = {
+            let mut guard = self.inner.lock().await;
+            let now = Instant::now();
+            let due = force
+                || guard
+                    .last_flush
+                    .map(|t| now.duration_since(t) >= self.throttle)
+                    .unwrap_or(true);
+            if !due {
+                return;
+            }
+            guard.last_flush = Some(now);
+            guard.state.render()
+        };
+        // Sink errors are non-fatal for streaming updates; the final flush in
+        // `run_task` surfaces the terminal state and any hard failure there.
+        if let Err(e) = self.sink.update(&body).await {
+            log_sink_error(&e);
+        }
+    }
+}
+
+#[async_trait]
+impl MessageWriter for StreamingWriter {
+    async fn append_text(&self, text: &str) {
+        self.inner.lock().await.state.append_text(text);
+        self.flush(false).await;
+    }
+
+    async fn finalize(&self) {
+        self.flush(true).await;
+    }
+
+    async fn record_tool_call(
+        &self,
+        _tool_call_id: &str,
+        title: &str,
+        _raw_input: Option<&serde_json::Value>,
+    ) {
+        self.inner.lock().await.state.record_tool_call(title);
+        self.flush(true).await;
+    }
+
+    async fn update_tool_call_title(
+        &self,
+        _tool_call_id: &str,
+        _title: Option<&str>,
+        _raw_input: Option<&serde_json::Value>,
+    ) {
+        // Title refinements are cosmetic; the original call line is enough.
+    }
+
+    async fn record_tool_result(&self, content: &str) {
+        self.inner.lock().await.state.record_tool_result(content);
+        self.flush(false).await;
+    }
+}
+
+fn log_sink_error(err: &anyhow::Error) {
+    eprintln!("slack-bridge: progress update failed: {err:#}");
+}
+
+/// Run one agent task to completion, streaming progress to `sink`.
+///
+/// `agent_id` is an ACP provider id (e.g. `codex`, `claude`). This future is
+/// `!Send` because the ACP driver uses a `LocalSet`; run it via
+/// [`run_task_blocking`] from a multi-threaded context.
+pub async fn run_task(
+    agent_id: &str,
+    working_dir: &Path,
+    prompt: &str,
+    sink: Arc<dyn ProgressSink>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let inner = Arc::new(Mutex::new(WriterInner {
+        state: ProgressState::new(),
+        last_flush: None,
+    }));
+
+    // Initial placeholder so the thread shows activity immediately.
+    let initial = inner.lock().await.state.render();
+    sink.update(&initial).await?;
+
+    let driver = AcpDriver::new(agent_id).map_err(|e| anyhow!(e))?;
+    let writer: Arc<dyn MessageWriter> = Arc::new(StreamingWriter {
+        inner: Arc::clone(&inner),
+        sink: Arc::clone(&sink),
+        throttle: DEFAULT_THROTTLE,
+    });
+    let store: Arc<dyn Store> = Arc::new(NoOpStore);
+
+    let result = driver
+        .run(
+            "slack-task",
+            prompt,
+            &[],
+            working_dir,
+            &store,
+            &writer,
+            &cancel,
+            None,
+        )
+        .await;
+
+    let body = {
+        let mut guard = inner.lock().await;
+        match &result {
+            Ok(()) => guard.state.mark_done(),
+            Err(e) => guard.state.mark_failed(e),
+        }
+        guard.state.render()
+    };
+    sink.update(&body).await?;
+
+    result.map_err(|e| anyhow!(e))
+}
+
+/// Run [`run_task`] on a dedicated current-thread runtime + `LocalSet`.
+///
+/// The ACP driver's futures are `!Send`, so they need a `LocalSet`. This helper
+/// lets a multi-threaded caller drive a task by handing it an owned working dir,
+/// prompt, and a factory that builds the sink *inside* the worker thread (so any
+/// runtime-bound resources, like an HTTP client, are created on that runtime).
+pub fn run_task_blocking<F>(
+    agent_id: String,
+    working_dir: PathBuf,
+    prompt: String,
+    make_sink: F,
+    cancel: CancellationToken,
+) -> Result<()>
+where
+    F: FnOnce() -> Result<Arc<dyn ProgressSink>> + Send + 'static,
+{
+    std::thread::scope(|scope| {
+        scope
+            .spawn(move || -> Result<()> {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()?;
+                let local = tokio::task::LocalSet::new();
+                local.block_on(&rt, async move {
+                    let sink = make_sink()?;
+                    run_task(&agent_id, &working_dir, &prompt, sink, cancel).await
+                })
+            })
+            .join()
+            .map_err(|_| anyhow!("agent worker thread panicked"))?
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sink that records every update body it receives.
+    #[derive(Default)]
+    struct RecordingSink {
+        updates: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl ProgressSink for RecordingSink {
+        async fn update(&self, body: &str) -> Result<()> {
+            self.updates.lock().await.push(body.to_string());
+            Ok(())
+        }
+    }
+
+    fn writer_with(sink: Arc<RecordingSink>, throttle: Duration) -> StreamingWriter {
+        StreamingWriter {
+            inner: Arc::new(Mutex::new(WriterInner {
+                state: ProgressState::new(),
+                last_flush: None,
+            })),
+            sink,
+            throttle,
+        }
+    }
+
+    #[tokio::test]
+    async fn forwards_tool_calls_immediately() {
+        let sink = Arc::new(RecordingSink::default());
+        let writer = writer_with(Arc::clone(&sink), Duration::from_secs(60));
+
+        writer.record_tool_call("tc1", "cargo test", None).await;
+
+        let updates = sink.updates.lock().await;
+        assert_eq!(updates.len(), 1);
+        assert!(updates[0].contains("🔧 cargo test"));
+    }
+
+    #[tokio::test]
+    async fn throttles_text_chunks_then_forces_on_finalize() {
+        let sink = Arc::new(RecordingSink::default());
+        // Large throttle so streamed chunks coalesce.
+        let writer = writer_with(Arc::clone(&sink), Duration::from_secs(60));
+
+        // First append flushes (no prior flush), later ones are throttled.
+        writer.append_text("one ").await;
+        writer.append_text("two ").await;
+        writer.append_text("three").await;
+
+        let mid = sink.updates.lock().await.len();
+        assert_eq!(mid, 1, "only the first append should flush under throttle");
+
+        writer.finalize().await;
+        let updates = sink.updates.lock().await;
+        assert_eq!(updates.len(), 2, "finalize forces a flush");
+        assert!(updates.last().unwrap().contains("one two three"));
+    }
+}

--- a/apps/slack-bridge/src/runner.rs
+++ b/apps/slack-bridge/src/runner.rs
@@ -145,7 +145,6 @@ pub async fn run_task(
     let initial = inner.lock().await.state.render();
     sink.update(&initial).await?;
 
-    let driver = AcpDriver::new(agent_id).map_err(|e| anyhow!(e))?;
     let writer: Arc<dyn MessageWriter> = Arc::new(StreamingWriter {
         inner: Arc::clone(&inner),
         sink: Arc::clone(&sink),
@@ -153,18 +152,22 @@ pub async fn run_task(
     });
     let store: Arc<dyn Store> = Arc::new(NoOpStore);
 
-    let result = driver
-        .run(
-            "slack-task",
-            prompt,
-            &[],
-            working_dir,
-            &store,
-            &writer,
-            &cancel,
-            None,
-        )
-        .await;
+    let result = match AcpDriver::new(agent_id).map_err(|e| anyhow!(e)) {
+        Ok(driver) => driver
+            .run(
+                "slack-task",
+                prompt,
+                &[],
+                working_dir,
+                &store,
+                &writer,
+                &cancel,
+                None,
+            )
+            .await
+            .map_err(|e| anyhow!(e)),
+        Err(e) => Err(e),
+    };
 
     let body = {
         let mut guard = inner.lock().await;
@@ -176,7 +179,7 @@ pub async fn run_task(
     };
     sink.update(&body).await?;
 
-    result.map_err(|e| anyhow!(e))
+    result
 }
 
 /// Run [`run_task`] on a dedicated current-thread runtime + `LocalSet`.

--- a/apps/slack-bridge/src/slack.rs
+++ b/apps/slack-bridge/src/slack.rs
@@ -1,0 +1,333 @@
+//! Slack integration: Web API client, Socket Mode listener, and the
+//! [`ProgressSink`] that edits a thread message as the agent works.
+//!
+//! Socket Mode is implemented directly over a WebSocket (`tokio-tungstenite`)
+//! plus a few Web API calls (`reqwest`) rather than pulling in a full Slack
+//! framework — the envelope loop is small and we avoid a large dependency tree.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::json;
+use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::config::Config;
+use crate::events::{parse_app_mention, AgentTask};
+use crate::runner::{run_task_blocking, ProgressSink};
+
+const WEB_API_BASE: &str = "https://slack.com/api";
+const RECONNECT_DELAY: Duration = Duration::from_secs(3);
+
+// =============================================================================
+// Web API client
+// =============================================================================
+
+/// Thin Slack Web API client scoped to a bot token.
+#[derive(Clone)]
+pub struct SlackWeb {
+    client: reqwest::Client,
+    bot_token: String,
+}
+
+#[derive(Deserialize)]
+struct ApiResult {
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    ts: Option<String>,
+}
+
+impl SlackWeb {
+    pub fn new(bot_token: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            bot_token,
+        }
+    }
+
+    /// Post a message into a thread, returning the new message's `ts`.
+    pub async fn post_message(&self, channel: &str, thread_ts: &str, text: &str) -> Result<String> {
+        let res: ApiResult = self
+            .call(
+                "chat.postMessage",
+                &json!({ "channel": channel, "thread_ts": thread_ts, "text": text }),
+            )
+            .await?;
+        res.ts
+            .ok_or_else(|| anyhow!("chat.postMessage succeeded but returned no ts"))
+    }
+
+    /// Edit an existing message in place.
+    pub async fn update_message(&self, channel: &str, ts: &str, text: &str) -> Result<()> {
+        let _: ApiResult = self
+            .call(
+                "chat.update",
+                &json!({ "channel": channel, "ts": ts, "text": text }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn call(&self, method: &str, body: &serde_json::Value) -> Result<ApiResult> {
+        let res: ApiResult = self
+            .client
+            .post(format!("{WEB_API_BASE}/{method}"))
+            .bearer_auth(&self.bot_token)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("{method} request failed"))?
+            .json()
+            .await
+            .with_context(|| format!("{method} returned an unparseable response"))?;
+
+        if !res.ok {
+            return Err(anyhow!(
+                "{method} failed: {}",
+                res.error.as_deref().unwrap_or("unknown error")
+            ));
+        }
+        Ok(res)
+    }
+}
+
+// =============================================================================
+// Progress sink
+// =============================================================================
+
+/// A [`ProgressSink`] that lazily posts a thread message on first update, then
+/// edits that same message on every subsequent update.
+pub struct SlackSink {
+    web: SlackWeb,
+    channel: String,
+    thread_ts: String,
+    message_ts: Mutex<Option<String>>,
+}
+
+impl SlackSink {
+    pub fn new(web: SlackWeb, channel: String, thread_ts: String) -> Self {
+        Self {
+            web,
+            channel,
+            thread_ts,
+            message_ts: Mutex::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl ProgressSink for SlackSink {
+    async fn update(&self, body: &str) -> Result<()> {
+        let mut ts_guard = self.message_ts.lock().await;
+        match ts_guard.as_ref() {
+            Some(ts) => self.web.update_message(&self.channel, ts, body).await,
+            None => {
+                let ts = self
+                    .web
+                    .post_message(&self.channel, &self.thread_ts, body)
+                    .await?;
+                *ts_guard = Some(ts);
+                Ok(())
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Socket Mode envelope types
+// =============================================================================
+
+#[derive(Deserialize)]
+struct Envelope {
+    #[serde(rename = "type")]
+    kind: String,
+    envelope_id: Option<String>,
+    payload: Option<serde_json::Value>,
+}
+
+// =============================================================================
+// Socket Mode connection loop
+// =============================================================================
+
+/// Open a Socket Mode connection and dispatch mentions until disconnected,
+/// reconnecting on error. Runs forever.
+pub async fn run(config: Config, dry_run: bool) -> Result<()> {
+    let web = SlackWeb::new(config.bot_token.clone());
+    loop {
+        match connect_and_serve(&config, &web, dry_run).await {
+            Ok(()) => {
+                eprintln!("slack-bridge: server requested reconnect");
+            }
+            Err(e) => {
+                eprintln!("slack-bridge: connection error: {e:#}; retrying in {RECONNECT_DELAY:?}");
+                tokio::time::sleep(RECONNECT_DELAY).await;
+            }
+        }
+    }
+}
+
+/// Ask Slack for a Socket Mode WebSocket URL using the app-level token.
+async fn open_connection_url(app_token: &str) -> Result<String> {
+    #[derive(Deserialize)]
+    struct OpenResult {
+        ok: bool,
+        #[serde(default)]
+        error: Option<String>,
+        #[serde(default)]
+        url: Option<String>,
+    }
+
+    let res: OpenResult = reqwest::Client::new()
+        .post(format!("{WEB_API_BASE}/apps.connections.open"))
+        .bearer_auth(app_token)
+        .send()
+        .await
+        .context("apps.connections.open request failed")?
+        .json()
+        .await
+        .context("apps.connections.open returned an unparseable response")?;
+
+    if !res.ok {
+        return Err(anyhow!(
+            "apps.connections.open failed: {}",
+            res.error.as_deref().unwrap_or("unknown error")
+        ));
+    }
+    res.url
+        .ok_or_else(|| anyhow!("apps.connections.open returned no url"))
+}
+
+async fn connect_and_serve(config: &Config, web: &SlackWeb, dry_run: bool) -> Result<()> {
+    let url = open_connection_url(&config.app_token).await?;
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .context("failed to connect Socket Mode WebSocket")?;
+    eprintln!("slack-bridge: connected (dry_run={dry_run})");
+
+    while let Some(message) = ws.next().await {
+        match message.context("WebSocket read error")? {
+            Message::Text(text) => {
+                if handle_envelope(&text, config, web, dry_run, &mut ws).await? {
+                    return Ok(());
+                }
+            }
+            Message::Ping(payload) => {
+                ws.send(Message::Pong(payload)).await.ok();
+            }
+            Message::Close(_) => return Ok(()),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Process one envelope. Returns `true` when the server asked us to reconnect.
+async fn handle_envelope<S>(
+    text: &str,
+    config: &Config,
+    web: &SlackWeb,
+    dry_run: bool,
+    ws: &mut S,
+) -> Result<bool>
+where
+    S: SinkExt<Message> + Unpin,
+    <S as futures_util::Sink<Message>>::Error: std::error::Error + Send + Sync + 'static,
+{
+    let envelope: Envelope = match serde_json::from_str(text) {
+        Ok(e) => e,
+        Err(_) => return Ok(false), // ignore non-envelope frames (e.g. "hello")
+    };
+
+    // Always acknowledge envelopes with an id, immediately, before any work.
+    if let Some(id) = &envelope.envelope_id {
+        let ack = json!({ "envelope_id": id }).to_string();
+        ws.send(Message::Text(ack.into()))
+            .await
+            .context("failed to send ack")?;
+    }
+
+    match envelope.kind.as_str() {
+        "disconnect" => return Ok(true),
+        "events_api" => {
+            if let Some(task) = envelope
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("event"))
+                .and_then(parse_app_mention)
+            {
+                dispatch_task(task, config, web, dry_run);
+            }
+        }
+        _ => {}
+    }
+    Ok(false)
+}
+
+/// Kick off handling for a parsed task without blocking the WebSocket loop.
+fn dispatch_task(task: AgentTask, config: &Config, web: &SlackWeb, dry_run: bool) {
+    if dry_run {
+        let web = web.clone();
+        tokio::spawn(async move {
+            if let Err(e) = run_dry_run(web, task).await {
+                eprintln!("slack-bridge: dry-run task failed: {e:#}");
+            }
+        });
+        return;
+    }
+
+    let agent = config.agent.clone();
+    let workdir = config.workdir.clone();
+    let bot_token = config.bot_token.clone();
+    let AgentTask {
+        channel,
+        thread_ts,
+        prompt,
+        ..
+    } = task;
+
+    // The ACP driver is `!Send` and needs its own runtime; run it on a blocking
+    // thread. The sink (and its HTTP client) is built inside that thread.
+    tokio::task::spawn_blocking(move || {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let make_sink = {
+            let bot_token = bot_token.clone();
+            let channel = channel.clone();
+            let thread_ts = thread_ts.clone();
+            move || -> Result<Arc<dyn ProgressSink>> {
+                Ok(Arc::new(SlackSink::new(
+                    SlackWeb::new(bot_token),
+                    channel,
+                    thread_ts,
+                )))
+            }
+        };
+        if let Err(e) = run_task_blocking(agent, workdir, prompt, make_sink, cancel) {
+            eprintln!("slack-bridge: agent task failed: {e:#}");
+        }
+    });
+}
+
+/// Live dry-run: echo the parsed prompt and a canned progress sequence into the
+/// thread, exercising the full Slack round-trip without invoking an agent.
+async fn run_dry_run(web: SlackWeb, task: AgentTask) -> Result<()> {
+    use crate::progress::ProgressState;
+
+    let sink = SlackSink::new(web, task.channel.clone(), task.thread_ts.clone());
+
+    let mut state = ProgressState::new();
+    sink.update(&state.render()).await?;
+
+    state.record_tool_call("(dry-run) would start the agent");
+    state.append_text(&format!("Received prompt:\n> {}", task.prompt));
+    sink.update(&state.render()).await?;
+
+    state.mark_done();
+    sink.update(&state.render()).await?;
+    Ok(())
+}

--- a/apps/slack-bridge/src/slack.rs
+++ b/apps/slack-bridge/src/slack.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
+use reqwest::header::RETRY_AFTER;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::Mutex;
@@ -22,6 +24,8 @@ use crate::runner::{run_task_blocking, ProgressSink};
 
 const WEB_API_BASE: &str = "https://slack.com/api";
 const RECONNECT_DELAY: Duration = Duration::from_secs(3);
+const WEB_API_MAX_ATTEMPTS: usize = 3;
+const DEFAULT_RATE_LIMIT_DELAY: Duration = Duration::from_secs(1);
 
 // =============================================================================
 // Web API client
@@ -75,26 +79,61 @@ impl SlackWeb {
     }
 
     async fn call(&self, method: &str, body: &serde_json::Value) -> Result<ApiResult> {
-        let res: ApiResult = self
-            .client
-            .post(format!("{WEB_API_BASE}/{method}"))
-            .bearer_auth(&self.bot_token)
-            .json(body)
-            .send()
-            .await
-            .with_context(|| format!("{method} request failed"))?
-            .json()
-            .await
-            .with_context(|| format!("{method} returned an unparseable response"))?;
+        for attempt in 1..=WEB_API_MAX_ATTEMPTS {
+            let response = self
+                .client
+                .post(format!("{WEB_API_BASE}/{method}"))
+                .bearer_auth(&self.bot_token)
+                .json(body)
+                .send()
+                .await
+                .with_context(|| format!("{method} request failed"))?;
 
-        if !res.ok {
-            return Err(anyhow!(
-                "{method} failed: {}",
-                res.error.as_deref().unwrap_or("unknown error")
-            ));
+            if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                let delay = response
+                    .headers()
+                    .get(RETRY_AFTER)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(parse_retry_after)
+                    .unwrap_or(DEFAULT_RATE_LIMIT_DELAY);
+
+                if attempt < WEB_API_MAX_ATTEMPTS {
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+
+                return Err(anyhow!("{method} rate limited after {attempt} attempts"));
+            }
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                return Err(anyhow!("{method} failed with HTTP {status}: {body}"));
+            }
+
+            let res: ApiResult = response
+                .json()
+                .await
+                .with_context(|| format!("{method} returned an unparseable response"))?;
+
+            if !res.ok {
+                return Err(anyhow!(
+                    "{method} failed: {}",
+                    res.error.as_deref().unwrap_or("unknown error")
+                ));
+            }
+            return Ok(res);
         }
-        Ok(res)
+
+        unreachable!("WEB_API_MAX_ATTEMPTS is non-zero")
     }
+}
+
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    value
+        .parse::<u64>()
+        .ok()
+        .map(Duration::from_secs)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- add a Slack Socket Mode bridge app with config, event handling, runner integration, and progress updates
- document setup and environment configuration for the Slack bridge
- retry Slack rate limits and report driver setup failures back to Slack