### PR TITLE
fix: make diff commit chooser opaque

### DIFF
--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -340,12 +340,15 @@ mark.search-match-current {
  *    utilities `z-(--z-index-overlay)` / `z-(--z-index-floating)` and raw
  *    `var(--z-index-*)` references (e.g. HashtagInput's fixed-positioned
  *    dropdown) resolve to the same source.
+ *    `top-bar` sits above page content and in-content diff controls, while
+ *    staying below full-screen overlays and portaled primitives.
  *    `overlay` sits above the legacy full-screen overlay max (9999, e.g.
  *    .diff-modal-backdrop) so design-system dialogs own the top layer;
  *    `floating` sits one above `overlay` so portaled primitives (dropdown,
  *    select, popover, tooltip, context-menu, hashtag dropdown) paint above
  *    dialog content even when opened from inside a dialog. ── */
 @theme {
+  --z-index-top-bar: 200;
   --z-index-overlay: 10000;
   --z-index-floating: 10001;
 }

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -27,6 +27,7 @@
   --bg-chrome: #18151d;
   --bg-deepest: #020203;
   --bg-elevated: #38333f;
+  --bg-menu: #38333f;
   --bg-hover: #342e3b;
 
   --border-subtle: #38333f;

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -1684,10 +1684,10 @@
     top: 100%;
     right: 0;
     margin-top: 4px;
-    background: var(--bg-primary);
+    background: var(--bg-menu);
     border: 1px solid var(--border-muted);
     border-radius: 6px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-elevated);
     overflow: hidden;
     z-index: var(--z-index-floating);
     min-width: 220px;

--- a/apps/staged/src/lib/features/layout/TopBar.svelte
+++ b/apps/staged/src/lib/features/layout/TopBar.svelte
@@ -100,6 +100,7 @@
   .top-bar {
     position: relative;
     isolation: isolate;
+    z-index: var(--z-index-top-bar);
     display: flex;
     align-items: center;
     gap: 8px;


### PR DESCRIPTION
## Summary
- Add a dedicated menu background color token.
- Use the menu token and elevated shadow for the diff modal commit chooser.