### PR TITLE
feat: connect review comments with sessions

### DIFF
--- a/apps/differ/src/App.svelte
+++ b/apps/differ/src/App.svelte
@@ -439,6 +439,8 @@
       githubCommentId: null,
       githubCommentType: null,
       githubCommentStale: false,
+      noteSessionId: null,
+      commitSessionId: null,
     };
     localComments = [...localComments, comment];
   }

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -2216,6 +2216,7 @@ pub fn run() {
             note_commands::create_project_note,
             note_commands::list_project_notes,
             note_commands::get_project_note_by_session,
+            note_commands::get_branch_note_by_session,
             note_commands::delete_project_note,
             // Images
             image_commands::create_image,
@@ -2307,6 +2308,8 @@ pub fn run() {
             review_commands::unmark_reviewed,
             review_commands::add_comment,
             review_commands::update_comment,
+            review_commands::link_comment_session,
+            review_commands::get_branch_commit_by_session,
             review_commands::delete_comment,
             review_commands::delete_all_comments,
             review_commands::restore_comment,

--- a/apps/staged/src-tauri/src/note_commands.rs
+++ b/apps/staged/src-tauri/src/note_commands.rs
@@ -56,6 +56,21 @@ pub fn delete_note(
     Ok(())
 }
 
+/// Get a single branch note by its linked session ID.
+///
+/// Parallels [`get_project_note_by_session`]; lets the frontend resolve the
+/// note a review comment produced (for `NoteModal`) without refetching the
+/// whole branch timeline.
+#[tauri::command(rename_all = "camelCase")]
+pub fn get_branch_note_by_session(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    session_id: String,
+) -> Result<Option<crate::store::Note>, String> {
+    crate::get_store(&store)?
+        .get_note_by_session(&session_id)
+        .map_err(|e| e.to_string())
+}
+
 // =============================================================================
 // Project note commands
 // =============================================================================

--- a/apps/staged/src-tauri/src/review_commands.rs
+++ b/apps/staged/src-tauri/src/review_commands.rs
@@ -107,6 +107,40 @@ pub async fn update_comment(
         .map_err(|e| e.to_string())
 }
 
+/// Link a comment to the note/commit session started from its button.
+///
+/// `session_type` is `"note"` or `"commit"`; the two links are independent so
+/// a single comment can have both. Called after a session successfully starts
+/// from a review comment so the button can reflect that session's state.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn link_comment_session(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    comment_id: String,
+    session_id: String,
+    session_type: String,
+) -> Result<(), String> {
+    crate::get_store(&store)?
+        .set_comment_session(&comment_id, &session_type, &session_id)
+        .map_err(|e| e.to_string())
+}
+
+/// Resolve the commit SHA produced by a session.
+///
+/// Returns `None` when no commit is linked to the session or when its SHA has
+/// not landed yet (pending commit). Lets the frontend show a comment's
+/// completed commit in the open diff viewer without refetching the whole
+/// branch timeline.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_branch_commit_by_session(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    session_id: String,
+) -> Result<Option<String>, String> {
+    let commit = crate::get_store(&store)?
+        .get_commit_by_session(&session_id)
+        .map_err(|e| e.to_string())?;
+    Ok(commit.and_then(|c| c.sha))
+}
+
 /// Delete a comment.
 #[tauri::command(rename_all = "camelCase")]
 pub async fn delete_comment(

--- a/apps/staged/src-tauri/src/store/migration_tests.rs
+++ b/apps/staged/src-tauri/src/store/migration_tests.rs
@@ -145,11 +145,13 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         )
         .unwrap();
 
-    assert_eq!(version, 15);
+    assert_eq!(version, 16);
     assert_eq!(app_version, super::APP_VERSION);
     assert!(table_exists(&conn, "projects"));
     assert!(table_exists(&conn, "project_notes"));
     assert!(table_exists(&conn, "images"));
+    assert!(column_exists(&conn, "comments", "note_session_id"));
+    assert!(column_exists(&conn, "comments", "commit_session_id"));
 
     let trigger_count: i64 = conn
         .query_row(
@@ -205,7 +207,7 @@ fn test_store_repairs_github_comment_tracking_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 15);
+    assert_eq!(version, 16);
     assert!(column_exists(&conn, "sessions", "pipeline"));
 
     cleanup_db(&path);
@@ -248,7 +250,7 @@ fn test_store_repairs_pipeline_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 15);
+    assert_eq!(version, 16);
     assert!(column_exists(&conn, "comments", "github_comment_id"));
     assert!(column_exists(&conn, "comments", "github_comment_type"));
     assert!(column_exists(&conn, "comments", "github_comment_stale"));

--- a/apps/staged/src-tauri/src/store/migrations/0016-comment-session-links/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0016-comment-session-links/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comments ADD COLUMN note_session_id TEXT;
+ALTER TABLE comments ADD COLUMN commit_session_id TEXT;

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -1152,6 +1152,10 @@ pub struct Comment {
     pub github_comment_type: Option<String>,
     /// Whether the local content has been edited since the last GitHub sync.
     pub github_comment_stale: bool,
+    /// The note session started from this comment's "Note" button, if any.
+    pub note_session_id: Option<String>,
+    /// The commit session started from this comment's "Commit" button, if any.
+    pub commit_session_id: Option<String>,
 }
 
 impl Comment {
@@ -1168,6 +1172,8 @@ impl Comment {
             github_comment_id: None,
             github_comment_type: None,
             github_comment_stale: false,
+            note_session_id: None,
+            commit_session_id: None,
         }
     }
 

--- a/apps/staged/src-tauri/src/store/reviews.rs
+++ b/apps/staged/src-tauri/src/store/reviews.rs
@@ -227,6 +227,32 @@ impl Store {
         Ok(())
     }
 
+    /// Link a comment to the note/commit session started from its button.
+    ///
+    /// `session_type` selects which link to set: `"note"` populates
+    /// `note_session_id`, `"commit"` populates `commit_session_id`. The two
+    /// links are independent so a single comment can spawn both.
+    pub fn set_comment_session(
+        &self,
+        comment_id: &str,
+        session_type: &str,
+        session_id: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        match session_type {
+            "note" => conn.execute(
+                "UPDATE comments SET note_session_id = ?1 WHERE id = ?2",
+                params![session_id, comment_id],
+            )?,
+            "commit" => conn.execute(
+                "UPDATE comments SET commit_session_id = ?1 WHERE id = ?2",
+                params![session_id, comment_id],
+            )?,
+            other => return Err(StoreError(format!("Invalid comment session type: {other}"))),
+        };
+        Ok(())
+    }
+
     /// Soft-delete a comment by setting `deleted_at` to the current timestamp.
     pub fn delete_comment(&self, comment_id: &str) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
@@ -266,7 +292,7 @@ impl Store {
     pub fn get_deleted_comments(&self, review_id: &str) -> Result<Vec<Comment>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, path, span_start, span_end, content, author, comment_type, created_at, deleted_at, github_comment_id, github_comment_type, github_comment_stale
+            "SELECT id, path, span_start, span_end, content, author, comment_type, created_at, deleted_at, github_comment_id, github_comment_type, github_comment_stale, note_session_id, commit_session_id
              FROM comments WHERE review_id = ?1 AND deleted_at IS NOT NULL ORDER BY deleted_at DESC",
         )?;
         let comments = stmt
@@ -286,6 +312,8 @@ impl Store {
                     github_comment_id: row.get(9)?,
                     github_comment_type: row.get(10)?,
                     github_comment_stale: row.get(11)?,
+                    note_session_id: row.get(12)?,
+                    commit_session_id: row.get(13)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -520,7 +548,7 @@ impl Store {
 
         // Load comments (only active — soft-deleted comments are excluded)
         let mut stmt = conn.prepare(
-            "SELECT id, path, span_start, span_end, content, author, comment_type, created_at, github_comment_id, github_comment_type, github_comment_stale
+            "SELECT id, path, span_start, span_end, content, author, comment_type, created_at, github_comment_id, github_comment_type, github_comment_stale, note_session_id, commit_session_id
              FROM comments WHERE review_id = ?1 AND deleted_at IS NULL ORDER BY created_at ASC",
         )?;
         review.comments = stmt
@@ -540,6 +568,8 @@ impl Store {
                     github_comment_id: row.get(8)?,
                     github_comment_type: row.get(9)?,
                     github_comment_stale: row.get(10)?,
+                    note_session_id: row.get(11)?,
+                    commit_session_id: row.get(12)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -1585,6 +1585,72 @@ fn test_review_with_comments_and_files() {
 }
 
 #[test]
+fn test_set_comment_session_round_trips() {
+    use crate::git::Span;
+
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let branch = Branch::new(&project.id, "feature", "main");
+    store.create_branch(&branch).unwrap();
+
+    let review = Review::new(&branch.id, "abc123", ReviewScope::Branch);
+    store.create_review(&review).unwrap();
+
+    let comment = Comment::new("src/main.rs", Span::new(10, 15), "Needs a follow-up");
+    store.add_comment(&review.id, &comment).unwrap();
+
+    // Freshly added comments load with no linked sessions.
+    let loaded = store.get_review(&review.id).unwrap().unwrap();
+    let loaded_comment = loaded.comments.iter().find(|c| c.id == comment.id).unwrap();
+    assert_eq!(loaded_comment.note_session_id, None);
+    assert_eq!(loaded_comment.commit_session_id, None);
+
+    // The note and commit links are independent and coexist on one comment.
+    store
+        .set_comment_session(&comment.id, "note", "note-session-1")
+        .unwrap();
+    store
+        .set_comment_session(&comment.id, "commit", "commit-session-1")
+        .unwrap();
+
+    let linked = store.get_review(&review.id).unwrap().unwrap();
+    let linked_comment = linked.comments.iter().find(|c| c.id == comment.id).unwrap();
+    assert_eq!(
+        linked_comment.note_session_id.as_deref(),
+        Some("note-session-1")
+    );
+    assert_eq!(
+        linked_comment.commit_session_id.as_deref(),
+        Some("commit-session-1")
+    );
+
+    // Re-linking the same type is last-write-wins.
+    store
+        .set_comment_session(&comment.id, "note", "note-session-2")
+        .unwrap();
+    let relinked = store.get_review(&review.id).unwrap().unwrap();
+    let relinked_comment = relinked
+        .comments
+        .iter()
+        .find(|c| c.id == comment.id)
+        .unwrap();
+    assert_eq!(
+        relinked_comment.note_session_id.as_deref(),
+        Some("note-session-2")
+    );
+    assert_eq!(
+        relinked_comment.commit_session_id.as_deref(),
+        Some("commit-session-1")
+    );
+
+    // An unknown session type is rejected.
+    assert!(store
+        .set_comment_session(&comment.id, "bogus", "x")
+        .is_err());
+}
+
+#[test]
 fn test_set_review_auto_restamps_completed_at_when_made_visible() {
     let store = Store::in_memory().unwrap();
     let project = Project::new("test-owner/test-repo");

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2295,6 +2295,14 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                 .map_err(|e| e.to_string())?;
             Ok(serde_json::to_value(note).unwrap())
         }
+        "get_branch_note_by_session" => {
+            let store = get_store(store_mutex)?;
+            let session_id: String = arg(&args, "sessionId")?;
+            let note = store
+                .get_note_by_session(&session_id)
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::to_value(note).unwrap())
+        }
         "delete_project_note" => {
             let store = get_store(store_mutex)?;
             let note_id: String = arg(&args, "noteId")?;
@@ -2547,6 +2555,24 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                 .update_comment(&comment_id, &content)
                 .map_err(|e| e.to_string())?;
             Ok(Value::Null)
+        }
+        "link_comment_session" => {
+            let store = get_store(store_mutex)?;
+            let comment_id: String = arg(&args, "commentId")?;
+            let session_id: String = arg(&args, "sessionId")?;
+            let session_type: String = arg(&args, "sessionType")?;
+            store
+                .set_comment_session(&comment_id, &session_type, &session_id)
+                .map_err(|e| e.to_string())?;
+            Ok(Value::Null)
+        }
+        "get_branch_commit_by_session" => {
+            let store = get_store(store_mutex)?;
+            let session_id: String = arg(&args, "sessionId")?;
+            let commit = store
+                .get_commit_by_session(&session_id)
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::to_value(commit.and_then(|c| c.sha)).unwrap())
         }
         "delete_comment" => {
             let store = get_store(store_mutex)?;

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -24,6 +24,7 @@ import type {
   File,
   Review,
   Comment,
+  BranchNote,
   WorkspaceInfo,
   PullRequest,
   Issue,
@@ -853,6 +854,28 @@ export function addComment(
 /** Update a comment's content. */
 export function updateComment(commentId: string, content: string): Promise<void> {
   return invokeCommand('update_comment', { commentId, content });
+}
+
+/** Link a review comment to the note/commit session started from its button.
+ *  The two links are independent, so a single comment can have both. */
+export function linkCommentSession(
+  commentId: string,
+  sessionId: string,
+  sessionType: 'note' | 'commit'
+): Promise<void> {
+  return invokeCommand('link_comment_session', { commentId, sessionId, sessionType });
+}
+
+/** Resolve the branch note produced by a session (for NoteModal).
+ *  Returns null if no note is linked to the session. */
+export function getBranchNoteBySession(sessionId: string): Promise<BranchNote | null> {
+  return invokeCommand('get_branch_note_by_session', { sessionId });
+}
+
+/** Resolve the commit SHA produced by a session.
+ *  Returns null if no commit is linked, or its SHA is still pending. */
+export function getBranchCommitBySession(sessionId: string): Promise<string | null> {
+  return invokeCommand('get_branch_commit_by_session', { sessionId });
 }
 
 /** Delete a comment (soft delete). */

--- a/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
@@ -4,11 +4,14 @@
   import Check from '@lucide/svelte/icons/check';
   import ChevronRight from '@lucide/svelte/icons/chevron-right';
   import Copy from '@lucide/svelte/icons/copy';
+  import FileText from '@lucide/svelte/icons/file-text';
+  import GitCommitVertical from '@lucide/svelte/icons/git-commit-vertical';
   import MessageSquare from '@lucide/svelte/icons/message-square';
   import Trash2 from '@lucide/svelte/icons/trash-2';
   import Undo2 from '@lucide/svelte/icons/undo-2';
   import { Button } from '$lib/components/ui/button';
-  import type { Comment } from '../../types';
+  import type { Comment, CommentSessionState } from '../../types';
+  import Spinner from '../../shared/Spinner.svelte';
   import { formatLineRange, truncateText } from './diffModalHelpers';
 
   interface Props {
@@ -21,6 +24,10 @@
     onDeleteAll: () => void;
     onDeleteComment: (commentId: string) => void;
     onRestoreComment: (commentId: string) => void;
+    /** Note-session state for a comment; omit to fall back to the type icons. */
+    commentNoteState?: (comment: Comment) => CommentSessionState;
+    /** Commit-session state for a comment; omit to fall back to the type icons. */
+    commentCommitState?: (comment: Comment) => CommentSessionState;
   }
 
   let {
@@ -33,6 +40,8 @@
     onDeleteAll,
     onDeleteComment,
     onRestoreComment,
+    commentNoteState,
+    commentCommitState,
   }: Props = $props();
 
   let deletedExpanded = $state(false);
@@ -42,21 +51,56 @@
   }
 </script>
 
-{#snippet commentItemContent(comment: Comment)}
-  <span class="comment-icons">
-    {#if comment.author === 'agent'}
-      <span class="comment-icon agent-icon">
-        <Bot size={12} />
-      </span>
-    {/if}
-    <span class="comment-icon" class:comment-icon-warning={comment.commentType === 'warning'}>
-      {#if comment.commentType === 'warning'}
-        <AlertTriangle size={12} />
-      {:else}
-        <MessageSquare size={12} />
+{#snippet commentItemContent(
+  comment: Comment,
+  noteState: CommentSessionState,
+  commitState: CommentSessionState
+)}
+  {#if noteState !== 'idle' || commitState !== 'idle'}
+    <!-- A launched note/commit session takes precedence over the agent and
+         warning/message icons, mirroring the stateful inline-diff buttons. -->
+    <span class="comment-session-badges">
+      {#if noteState !== 'idle'}
+        <span
+          class="comment-session-badge note"
+          title={noteState === 'running' ? 'Note session in progress' : 'Note ready'}
+        >
+          {#if noteState === 'running'}
+            <Spinner size={12} />
+          {:else}
+            <FileText size={12} />
+          {/if}
+        </span>
+      {/if}
+      {#if commitState !== 'idle'}
+        <span
+          class="comment-session-badge commit"
+          title={commitState === 'running' ? 'Commit session in progress' : 'Commit ready'}
+        >
+          {#if commitState === 'running'}
+            <Spinner size={12} />
+          {:else}
+            <GitCommitVertical size={12} />
+          {/if}
+        </span>
       {/if}
     </span>
-  </span>
+  {:else}
+    <span class="comment-icons">
+      {#if comment.author === 'agent'}
+        <span class="comment-icon agent-icon">
+          <Bot size={12} />
+        </span>
+      {/if}
+      <span class="comment-icon" class:comment-icon-warning={comment.commentType === 'warning'}>
+        {#if comment.commentType === 'warning'}
+          <AlertTriangle size={12} />
+        {:else}
+          <MessageSquare size={12} />
+        {/if}
+      </span>
+    </span>
+  {/if}
   <span class="comment-details">
     <span class="comment-location">
       <span class="comment-file">{getFileName(comment.path)}</span>
@@ -112,6 +156,8 @@
 {#if comments.length > 0}
   <ul class="tree-section comments-section">
     {#each comments as comment (comment.id)}
+      {@const noteState = commentNoteState?.(comment) ?? 'idle'}
+      {@const commitState = commentCommitState?.(comment) ?? 'idle'}
       <li class="tree-item-wrapper">
         <div class="comment-item-container group/comment">
           <button
@@ -120,7 +166,7 @@
             style="padding-left: 8px"
             onclick={() => onSelectComment(comment)}
           >
-            {@render commentItemContent(comment)}
+            {@render commentItemContent(comment, noteState, commitState)}
           </button>
           <Button
             variant="ghost"
@@ -160,7 +206,9 @@
         <li class="tree-item-wrapper">
           <div class="comment-item-container deleted-comment group/comment">
             <div class="tree-item comment-item" style="padding-left: 8px">
-              {@render commentItemContent(comment)}
+              <!-- Deleted comments come from a separate source and aren't
+                   session-seeded, so they always show the type icons. -->
+              {@render commentItemContent(comment, 'idle', 'idle')}
             </div>
             <Button
               variant="ghost"
@@ -328,6 +376,39 @@
 
   .comment-icon.comment-icon-warning {
     color: var(--status-modified);
+  }
+
+  /* Session badges replace the icon gutter when a comment launched a note or
+     commit session. Reuses the --note/--commit colours from the timeline icons
+     (TimelineRow.svelte) and the shared Spinner. Offset left enough that two
+     16px chips still clear the comment text when a comment spawned both. */
+  .comment-session-badges {
+    position: absolute;
+    left: 4px;
+    top: 6px;
+    display: flex;
+    align-items: center;
+    gap: 3px;
+  }
+
+  .comment-session-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  .comment-session-badge.note {
+    color: var(--note-color);
+    background-color: var(--note-bg);
+  }
+
+  .comment-session-badge.commit {
+    color: var(--commit-color);
+    background-color: var(--commit-bg);
   }
 
   .comment-details {

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -28,6 +28,7 @@
   import DiffFileTreeSection from './DiffFileTreeSection.svelte';
   import DiffCommitSessionLauncher from './DiffCommitSessionLauncher.svelte';
   import DiffReferenceSection from './DiffReferenceSection.svelte';
+  import ReviewCommentActions from './ReviewCommentActions.svelte';
   import NewSessionModal from '../sessions/NewSessionModal.svelte';
   import SessionModal from '../sessions/SessionModal.svelte';
   import NoteModal from '../notes/NoteModal.svelte';
@@ -48,6 +49,7 @@
     BranchSessionType,
     BranchSessionLaunchStatus,
     Comment,
+    CommentActionContext,
     CommitTimelineItem,
     SessionStatus,
     SmartDiffAnnotation,
@@ -1531,6 +1533,19 @@
   {/if}
 {/snippet}
 
+{#snippet reviewCommentActions(context: CommentActionContext)}
+  <ReviewCommentActions
+    comment={context.comment}
+    noteState={getCommentNoteState(context.comment)}
+    commitState={getCommentCommitState(context.comment)}
+    githubState={getCommentGithubState(context.comment)}
+    {hasPr}
+    onNote={handleNewNote}
+    onCommit={handleNewCommit}
+    onGithub={handleSendToGithub}
+  />
+{/snippet}
+
 <div class="diff-detail" bind:this={diffDetailEl}>
   <div class="modal-body">
     <!-- Diff viewer -->
@@ -1562,12 +1577,7 @@
         onAddComment={readonly ? undefined : handleAddComment}
         onUpdateComment={readonly ? undefined : handleUpdateComment}
         onDeleteComment={readonly ? undefined : handleDeleteCommentFromViewer}
-        onCommentNote={readonly ? undefined : handleNewNote}
-        onCommentCommit={readonly ? undefined : handleNewCommit}
-        onCommentGithub={readonly || !hasPr ? undefined : handleSendToGithub}
-        commentGithubState={readonly || !hasPr ? undefined : getCommentGithubState}
-        commentNoteState={readonly ? undefined : getCommentNoteState}
-        commentCommitState={readonly ? undefined : getCommentCommitState}
+        commentActions={readonly ? undefined : reviewCommentActions}
         clickDismissBoundary={diffDetailEl}
         bind:scrollApi={diffViewerScrollApi}
       />

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -804,6 +804,9 @@
           .then((session) => {
             // Dangling link (session deleted) → leave unset so it reads as idle.
             if (!session) return;
+            // A live `session-status-changed` update may have landed while this
+            // fetch was in flight; that value is fresher, so don't clobber it.
+            if (sessionStatusById.has(id)) return;
             sessionStatusById = new Map(sessionStatusById).set(id, session.status);
           })
           .catch((e) => console.warn('Failed to load comment session status:', e));

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -490,9 +490,6 @@
       );
 
       linkCommentToSession(comment, mode, result.sessionId, result.sessionStatus);
-
-      const label = mode === 'note' ? 'Note' : 'Commit';
-      toast.success(`${label} session ${result.sessionStatus === 'queued' ? 'queued' : 'started'}`);
     } catch (e) {
       toast.error(`Unable to start ${mode} session`, {
         description: e instanceof Error ? e.message : String(e),
@@ -577,9 +574,6 @@
       if (originComment) {
         linkCommentToSession(originComment, data.mode, result.sessionId, result.sessionStatus);
       }
-
-      const label = data.mode === 'note' ? 'Note' : data.mode === 'commit' ? 'Commit' : 'Review';
-      toast.success(`${label} session ${result.sessionStatus === 'queued' ? 'queued' : 'started'}`);
     } catch (e) {
       toast.error(`Unable to start ${data.mode} session`, {
         description: e instanceof Error ? e.message : String(e),

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -319,6 +319,7 @@
   let lineJumpToken = 0;
   let isSmallDiffViewport = $state(false);
   let showMobileSidebar = $state(false);
+  let diffDetailEl: HTMLDivElement | null = $state(null);
   let diffViewerContainerEl: HTMLDivElement | null = $state(null);
   let mobileDiffDragX = $state(0);
   let mobileDiffPointerId: number | null = null;
@@ -1523,7 +1524,7 @@
   {/if}
 {/snippet}
 
-<div class="diff-detail">
+<div class="diff-detail" bind:this={diffDetailEl}>
   <div class="modal-body">
     <!-- Diff viewer -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -1560,6 +1561,7 @@
         commentGithubState={readonly || !hasPr ? undefined : getCommentGithubState}
         commentNoteState={readonly ? undefined : getCommentNoteState}
         commentCommitState={readonly ? undefined : getCommentCommitState}
+        clickDismissBoundary={diffDetailEl}
         bind:scrollApi={diffViewerScrollApi}
       />
     </div>

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -1410,6 +1410,8 @@
             onDeleteAll={handleDeleteAllComments}
             onDeleteComment={handleDeleteComment}
             onRestoreComment={handleRestoreComment}
+            commentNoteState={getCommentNoteState}
+            commentCommitState={getCommentCommitState}
           />
         {/if}
       </div>

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -31,7 +31,7 @@
   import NewSessionModal from '../sessions/NewSessionModal.svelte';
   import SessionModal from '../sessions/SessionModal.svelte';
   import NoteModal from '../notes/NoteModal.svelte';
-  import { onSessionStatusChanged } from '../../services/branchEventService';
+  import { onBranchSessionStatus } from '../../services/branchEventService';
   import { getPreferredAgent, preferences } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { createDiffViewerState } from './diffViewerState.svelte';
@@ -818,7 +818,14 @@
   // Keep linked-session statuses live while the modal is open. Mirrors the
   // auto-review polling precedent, but event-driven via the shared listener.
   $effect(() => {
-    const unlisten = onSessionStatusChanged((payload) => {
+    const linkedSessionIds = new Set<string>();
+    for (const comment of allComments) {
+      if (comment.noteSessionId) linkedSessionIds.add(comment.noteSessionId);
+      if (comment.commitSessionId) linkedSessionIds.add(comment.commitSessionId);
+    }
+
+    const unlisten = onBranchSessionStatus(branchId, (payload) => {
+      if (!linkedSessionIds.has(payload.sessionId)) return;
       if (sessionStatusById.get(payload.sessionId) === payload.status) return;
       sessionStatusById = new Map(sessionStatusById).set(payload.sessionId, payload.status);
     });

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -29,6 +29,9 @@
   import DiffCommitSessionLauncher from './DiffCommitSessionLauncher.svelte';
   import DiffReferenceSection from './DiffReferenceSection.svelte';
   import NewSessionModal from '../sessions/NewSessionModal.svelte';
+  import SessionModal from '../sessions/SessionModal.svelte';
+  import NoteModal from '../notes/NoteModal.svelte';
+  import { onSessionStatusChanged } from '../../services/branchEventService';
   import { getPreferredAgent, preferences } from '../settings/preferences.svelte';
   import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { createDiffViewerState } from './diffViewerState.svelte';
@@ -43,8 +46,10 @@
   import type {
     Branch,
     BranchSessionType,
+    BranchSessionLaunchStatus,
     Comment,
     CommitTimelineItem,
+    SessionStatus,
     SmartDiffAnnotation,
     Span,
   } from '../../types';
@@ -432,6 +437,26 @@
   let showNewSessionModal = $state(false);
   let newSessionMode = $state<BranchSessionType>('note');
   let newSessionPrefill = $state('');
+  /** The comment that opened the New Session dialog, so submit knows the origin. */
+  let newSessionComment = $state<Comment | null>(null);
+
+  // ==========================================================================
+  // Comment ↔ session links (stateful Note/Commit buttons)
+  // ==========================================================================
+
+  /** Linked session dialogs opened from a comment's Note/Commit button. */
+  let openSessionId = $state<string | null>(null);
+  let openNote = $state<{
+    title: string;
+    content: string;
+    sessionId?: string;
+    noteUpdatedAt?: number;
+  } | null>(null);
+
+  /** Live status for every comment-linked session id (note + commit). */
+  let sessionStatusById = $state(new Map<string, SessionStatus>());
+  /** Linked session ids already fetched, to dedupe getSession calls. */
+  const requestedSessionIds = new Set<string>();
 
   function buildCommentPrompt(comment: Comment, mode: 'note' | 'commit'): string {
     const reviewId = reviewHandle?.state.review?.id ?? activeReviewId;
@@ -461,6 +486,8 @@
         launchContext
       );
 
+      linkCommentToSession(comment, mode, result.sessionId, result.sessionStatus);
+
       const label = mode === 'note' ? 'Note' : 'Commit';
       toast.success(`${label} session ${result.sessionStatus === 'queued' ? 'queued' : 'started'}`);
     } catch (e) {
@@ -472,20 +499,44 @@
   }
 
   function handleNewNote(comment: Comment, event: MouseEvent) {
+    // Route by the linked note session's state (idle → start, running → open
+    // session, completed → open note).
+    const state = getCommentNoteState(comment);
+    if (state === 'running' && comment.noteSessionId) {
+      openSessionId = comment.noteSessionId;
+      return;
+    }
+    if (state === 'completed' && comment.noteSessionId) {
+      void openCompletedNote(comment.noteSessionId);
+      return;
+    }
     if (event.altKey) {
       launchSessionDirectly(comment, 'note');
       return;
     }
+    newSessionComment = comment;
     newSessionMode = 'note';
     newSessionPrefill = buildCommentPrompt(comment, 'note');
     showNewSessionModal = true;
   }
 
   function handleNewCommit(comment: Comment, event: MouseEvent) {
+    // Route by the linked commit session's state (idle → start, running → open
+    // session, completed → show the commit in the open diff viewer).
+    const state = getCommentCommitState(comment);
+    if (state === 'running' && comment.commitSessionId) {
+      openSessionId = comment.commitSessionId;
+      return;
+    }
+    if (state === 'completed' && comment.commitSessionId) {
+      void openCompletedCommit(comment.commitSessionId);
+      return;
+    }
     if (event.altKey) {
       launchSessionDirectly(comment, 'commit');
       return;
     }
+    newSessionComment = comment;
     newSessionMode = 'commit';
     newSessionPrefill = buildCommentPrompt(comment, 'commit');
     showNewSessionModal = true;
@@ -497,6 +548,10 @@
     imageIds: string[];
   }) {
     showNewSessionModal = false;
+    // Capture (and clear) the origin comment before awaiting so a follow-up
+    // dialog can't reuse a stale reference.
+    const originComment = newSessionComment;
+    newSessionComment = null;
     const launchContext = {
       source: 'diff_viewer' as const,
       scope: reviewableScope(),
@@ -515,6 +570,10 @@
         data.imageIds,
         launchContext
       );
+
+      if (originComment) {
+        linkCommentToSession(originComment, data.mode, result.sessionId, result.sessionStatus);
+      }
 
       const label = data.mode === 'note' ? 'Note' : data.mode === 'commit' ? 'Commit' : 'Review';
       toast.success(`${label} session ${result.sessionStatus === 'queued' ? 'queued' : 'started'}`);
@@ -599,6 +658,101 @@
     return 'idle';
   }
 
+  /**
+   * Persist + optimistically reflect a comment→session link after a successful
+   * start. Mirrors the GitHub optimistic-update flow. No-op for non note/commit
+   * modes (e.g. review).
+   */
+  function linkCommentToSession(
+    comment: Comment,
+    mode: BranchSessionType,
+    sessionId: string,
+    initialStatus: BranchSessionLaunchStatus
+  ) {
+    if (mode !== 'note' && mode !== 'commit') return;
+
+    // Reflect the link + initial status immediately so the button updates.
+    requestedSessionIds.add(sessionId);
+    sessionStatusById = new Map(sessionStatusById).set(sessionId, initialStatus);
+    if (reviewHandle) {
+      reviewHandle.state.comments = reviewHandle.state.comments.map((c) =>
+        c.id === comment.id
+          ? mode === 'note'
+            ? { ...c, noteSessionId: sessionId }
+            : { ...c, commitSessionId: sessionId }
+          : c
+      );
+    }
+
+    // Persist in the background — the optimistic update already updated the UI.
+    commands
+      .linkCommentSession(comment.id, sessionId, mode)
+      .catch((e) => console.warn('Failed to persist comment session link:', e));
+  }
+
+  /** Map a linked session id's status to the Note/Commit button state. */
+  function sessionStateFor(sessionId: string | null): 'idle' | 'running' | 'completed' {
+    if (!sessionId) return 'idle';
+    switch (sessionStatusById.get(sessionId)) {
+      case 'queued':
+      case 'running':
+        return 'running';
+      case 'completed':
+        return 'completed';
+      // error/cancelled → idle so the user can retry; a dangling link (missing
+      // session, status still unknown) also falls back to idle.
+      default:
+        return 'idle';
+    }
+  }
+
+  function getCommentNoteState(comment: Comment): 'idle' | 'running' | 'completed' {
+    return sessionStateFor(comment.noteSessionId);
+  }
+
+  function getCommentCommitState(comment: Comment): 'idle' | 'running' | 'completed' {
+    return sessionStateFor(comment.commitSessionId);
+  }
+
+  /** Resolve a completed note session's note and open the NoteModal. */
+  async function openCompletedNote(sessionId: string) {
+    try {
+      const note = await commands.getBranchNoteBySession(sessionId);
+      if (!note) {
+        // Link points at a session with no note — fall back to the session view.
+        openSessionId = sessionId;
+        return;
+      }
+      openNote = {
+        title: note.title,
+        content: note.content,
+        sessionId,
+        noteUpdatedAt: note.updatedAt,
+      };
+    } catch (e) {
+      toast.error('Unable to open note', {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  /** Resolve a completed commit session's sha and show it in the open viewer. */
+  async function openCompletedCommit(sessionId: string) {
+    try {
+      const sha = await commands.getBranchCommitBySession(sessionId);
+      if (!sha) {
+        // Commit hasn't landed yet (pending sha) — show the session instead.
+        openSessionId = sessionId;
+        return;
+      }
+      await switchDiffContext('commit', sha);
+    } catch (e) {
+      toast.error('Unable to show commit', {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
   // Create tracker for search initialization
   const checkSearchInitialization = createSearchInitializationTracker({
     searchState,
@@ -636,6 +790,35 @@
     if (jumpToComment && !currentComments.some((c) => c.id === jumpToComment?.id)) {
       jumpToComment = null;
     }
+  });
+
+  // Seed the status map for every comment-linked session id when comments load.
+  // `requestedSessionIds` dedupes fetches; the map is then kept live by the
+  // `session-status-changed` subscription below.
+  $effect(() => {
+    for (const c of allComments) {
+      for (const id of [c.noteSessionId, c.commitSessionId]) {
+        if (!id || requestedSessionIds.has(id)) continue;
+        requestedSessionIds.add(id);
+        getSession(id)
+          .then((session) => {
+            // Dangling link (session deleted) → leave unset so it reads as idle.
+            if (!session) return;
+            sessionStatusById = new Map(sessionStatusById).set(id, session.status);
+          })
+          .catch((e) => console.warn('Failed to load comment session status:', e));
+      }
+    }
+  });
+
+  // Keep linked-session statuses live while the modal is open. Mirrors the
+  // auto-review polling precedent, but event-driven via the shared listener.
+  $effect(() => {
+    const unlisten = onSessionStatusChanged((payload) => {
+      if (sessionStatusById.get(payload.sessionId) === payload.status) return;
+      sessionStatusById = new Map(sessionStatusById).set(payload.sessionId, payload.status);
+    });
+    return () => unlisten();
   });
 
   /** Convert "information" comments to SmartDiffAnnotation for the overlay system.
@@ -1370,6 +1553,8 @@
         onCommentCommit={readonly ? undefined : handleNewCommit}
         onCommentGithub={readonly || !hasPr ? undefined : handleSendToGithub}
         commentGithubState={readonly || !hasPr ? undefined : getCommentGithubState}
+        commentNoteState={readonly ? undefined : getCommentNoteState}
+        commentCommitState={readonly ? undefined : getCommentCommitState}
         bind:scrollApi={diffViewerScrollApi}
       />
     </div>
@@ -1415,10 +1600,38 @@
       prefillSelection="last-line"
       onClose={() => {
         showNewSessionModal = false;
+        newSessionComment = null;
       }}
       onSubmit={handleSessionModalSubmit}
     />
   {/if}
+
+  <SessionModal
+    open={openSessionId !== null}
+    sessionId={openSessionId ?? ''}
+    repoDir={branch?.worktreePath}
+    {branchId}
+    {projectId}
+    repoLabel={githubRepo ? { githubRepo, subpath: subpath ?? null, headRepo: null } : null}
+    onClose={() => {
+      openSessionId = null;
+    }}
+  />
+
+  <NoteModal
+    open={openNote !== null}
+    title={openNote?.title ?? ''}
+    content={openNote?.content ?? ''}
+    sessionId={openNote?.sessionId}
+    noteUpdatedAt={openNote?.noteUpdatedAt}
+    onClose={() => {
+      openNote = null;
+    }}
+    onOpenSession={(sid) => {
+      openNote = null;
+      openSessionId = sid;
+    }}
+  />
 </div>
 
 <style>

--- a/apps/staged/src/lib/features/diff/ReviewCommentActions.svelte
+++ b/apps/staged/src/lib/features/diff/ReviewCommentActions.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import Check from '@lucide/svelte/icons/check';
+  import FileText from '@lucide/svelte/icons/file-text';
+  import GitCommitVertical from '@lucide/svelte/icons/git-commit-vertical';
+  import GitPullRequest from '@lucide/svelte/icons/git-pull-request';
+  import Spinner from '../../shared/Spinner.svelte';
+  import type { Comment, CommentSessionState, GithubButtonState } from '../../types';
+
+  interface Props {
+    comment: Comment;
+    noteState: CommentSessionState;
+    commitState: CommentSessionState;
+    githubState: GithubButtonState;
+    hasPr: boolean;
+    onNote: (comment: Comment, event: MouseEvent) => void;
+    onCommit: (comment: Comment, event: MouseEvent) => void;
+    onGithub: (comment: Comment) => void;
+  }
+
+  let { comment, noteState, commitState, githubState, hasPr, onNote, onCommit, onGithub }: Props =
+    $props();
+</script>
+
+<button
+  class="comment-action-btn note-btn"
+  class:session-active={noteState !== 'idle'}
+  onclick={(event) => onNote(comment, event)}
+  title={noteState === 'running'
+    ? 'Note session in progress'
+    : noteState === 'completed'
+      ? 'Open note'
+      : 'New note (Option+click to skip dialog)'}
+>
+  {#if noteState === 'running'}
+    <Spinner size={12} />
+  {:else}
+    <FileText size={12} />
+  {/if}
+  <span>Note</span>
+</button>
+
+<button
+  class="comment-action-btn commit-btn"
+  class:session-active={commitState !== 'idle'}
+  onclick={(event) => onCommit(comment, event)}
+  title={commitState === 'running'
+    ? 'Commit session in progress'
+    : commitState === 'completed'
+      ? 'Show commit'
+      : 'New commit (Option+click to skip dialog)'}
+>
+  {#if commitState === 'running'}
+    <Spinner size={12} />
+  {:else}
+    <GitCommitVertical size={12} />
+  {/if}
+  <span>Commit</span>
+</button>
+
+{#if hasPr}
+  <button
+    class="comment-action-btn github-btn"
+    class:github-btn-sent={githubState === 'sent'}
+    onclick={() => onGithub(comment)}
+    title={githubState === 'sent'
+      ? 'Open GitHub comment'
+      : githubState === 'stale'
+        ? 'Update on GitHub'
+        : 'Send to GitHub'}
+    disabled={githubState === 'sending'}
+  >
+    {#if githubState === 'sending'}
+      <Spinner size={12} />
+    {:else if githubState === 'sent'}
+      <Check size={12} class="github-sent-check" />
+      <GitPullRequest size={12} />
+    {:else}
+      <GitPullRequest size={12} />
+    {/if}
+    {#if githubState === 'stale'}
+      <span>Update on GitHub</span>
+    {:else}
+      <span>GitHub</span>
+    {/if}
+  </button>
+{/if}
+
+<style>
+  .comment-action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    border: 1px dashed var(--border-subtle);
+    background: transparent;
+    color: var(--text-muted);
+    font-size: calc(var(--size-xs) - 1px);
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      color 0.15s,
+      border-color 0.15s,
+      background-color 0.15s;
+  }
+
+  .comment-action-btn.note-btn :global(svg) {
+    color: var(--note-color);
+  }
+
+  .comment-action-btn.commit-btn :global(svg) {
+    color: var(--commit-color);
+  }
+
+  .comment-action-btn.github-btn :global(svg) {
+    color: var(--text-primary);
+  }
+
+  .comment-action-btn.note-btn:hover {
+    color: var(--note-color);
+    border-color: var(--note-color);
+    background-color: var(--note-bg);
+  }
+
+  .comment-action-btn.commit-btn:hover {
+    color: var(--commit-color);
+    border-color: var(--commit-color);
+    background-color: var(--commit-bg);
+  }
+
+  /* Mirrors the styled running/completed note and commit actions in the timeline. */
+  .comment-action-btn.note-btn.session-active {
+    color: var(--note-color);
+    border-color: transparent;
+    background-color: var(--note-bg);
+  }
+
+  .comment-action-btn.commit-btn.session-active {
+    color: var(--commit-color);
+    border-color: transparent;
+    background-color: var(--commit-bg);
+  }
+
+  .comment-action-btn.github-btn:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+    background-color: var(--bg-hover);
+  }
+
+  .comment-action-btn.github-btn:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+
+  .comment-action-btn.github-btn-sent {
+    border-style: solid;
+    color: var(--text-primary);
+    border-color: var(--status-added);
+  }
+
+  .comment-action-btn.github-btn-sent :global(.github-sent-check) {
+    color: var(--status-added) !important;
+  }
+</style>

--- a/apps/staged/src/lib/features/diff/diffViewerCommentState.test.ts
+++ b/apps/staged/src/lib/features/diff/diffViewerCommentState.test.ts
@@ -15,6 +15,8 @@ function createComment(overrides: Partial<Comment> = {}): Comment {
     githubCommentId: null,
     githubCommentType: null,
     githubCommentStale: false,
+    noteSessionId: null,
+    commitSessionId: null,
     ...overrides,
   };
 }

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -151,6 +151,20 @@ export interface NoteTimelineItem {
   suggestedNextNoteStep: string | null;
 }
 
+/** A full branch note record, as returned by `get_branch_note_by_session`. */
+export interface BranchNote {
+  id: string;
+  branchId: string;
+  sessionId: string | null;
+  title: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+  suggestedNextCommitStep: string | null;
+  suggestedNextNoteStep: string | null;
+}
+
 export interface ReviewTimelineItem {
   id: string;
   commitSha: string;

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -487,6 +487,10 @@ export type {
   ReviewCommands,
 } from '@builderbot/diff-viewer/types';
 
+// CommentSessionState lives with the CommentEditor component, re-exported from
+// the package's components barrel rather than its /types entry.
+export type { CommentSessionState } from '@builderbot/diff-viewer/components';
+
 // =============================================================================
 // Hashtag references
 // =============================================================================

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -479,6 +479,7 @@ export type {
   CommentAuthor,
   CommentType,
   Comment,
+  CommentActionContext,
   Review,
   LineSpan,
   AnnotationCategory,
@@ -487,9 +488,14 @@ export type {
   ReviewCommands,
 } from '@builderbot/diff-viewer/types';
 
-// CommentSessionState lives with the CommentEditor component, re-exported from
-// the package's components barrel rather than its /types entry.
-export type { CommentSessionState } from '@builderbot/diff-viewer/components';
+export type GithubButtonState = 'idle' | 'sending' | 'sent' | 'stale';
+
+/**
+ * State of a review comment's "Note"/"Commit" action, derived from the linked
+ * session's status. `queued` is treated as `running`, and `error`/`cancelled`
+ * collapse back to `idle` so the user can retry.
+ */
+export type CommentSessionState = 'idle' | 'running' | 'completed';
 
 // =============================================================================
 // Hashtag references

--- a/packages/diff-viewer/src/lib/components/CommentEditor.svelte
+++ b/packages/diff-viewer/src/lib/components/CommentEditor.svelte
@@ -10,6 +10,13 @@
 
   export type GithubButtonState = 'idle' | 'sending' | 'sent' | 'stale';
 
+  /**
+   * State of a comment's "Note"/"Commit" button, derived from the linked
+   * session's status by the parent. `queued` is treated as `running`, and
+   * `error`/`cancelled` collapse back to `idle` so the user can retry.
+   */
+  export type CommentSessionState = 'idle' | 'running' | 'completed';
+
   interface Props {
     /** Position relative to the viewer container */
     top: number;
@@ -37,6 +44,10 @@
     onGithub?: () => void;
     /** Current state of the GitHub send/update button. */
     githubState?: GithubButtonState;
+    /** Current state of the "Note" button, reflecting its linked session. */
+    noteState?: CommentSessionState;
+    /** Current state of the "Commit" button, reflecting its linked session. */
+    commitState?: CommentSessionState;
   }
 
   let {
@@ -54,6 +65,8 @@
     onCommit,
     onGithub,
     githubState = 'idle',
+    noteState = 'idle',
+    commitState = 'idle',
   }: Props = $props();
 
   // Track current input value - initialized by effect when existingComment changes
@@ -130,20 +143,38 @@
         {#if onNote}
           <button
             class="comment-action-btn note-btn"
+            class:session-active={noteState !== 'idle'}
             onclick={(e) => onNote?.(e)}
-            title="New note (Option+click to skip dialog)"
+            title={noteState === 'running'
+              ? 'Note session in progress'
+              : noteState === 'completed'
+                ? 'Open note'
+                : 'New note (Option+click to skip dialog)'}
           >
-            <FileText size={12} />
+            {#if noteState === 'running'}
+              <Loader2 size={12} class="spinner" />
+            {:else}
+              <FileText size={12} />
+            {/if}
             <span>Note</span>
           </button>
         {/if}
         {#if onCommit}
           <button
             class="comment-action-btn commit-btn"
+            class:session-active={commitState !== 'idle'}
             onclick={(e) => onCommit?.(e)}
-            title="New commit (Option+click to skip dialog)"
+            title={commitState === 'running'
+              ? 'Commit session in progress'
+              : commitState === 'completed'
+                ? 'Show commit'
+                : 'New commit (Option+click to skip dialog)'}
           >
-            <GitCommitVertical size={12} />
+            {#if commitState === 'running'}
+              <Loader2 size={12} class="spinner" />
+            {:else}
+              <GitCommitVertical size={12} />
+            {/if}
             <span>Commit</span>
           </button>
         {/if}
@@ -286,6 +317,20 @@
   .comment-action-btn.commit-btn:hover {
     color: var(--commit-color);
     border-color: var(--commit-color);
+    background-color: var(--commit-bg);
+  }
+
+  /* Running/completed state — mirrors the styled spinner-with-background and
+     completed icon used on Branch Card timeline rows (TimelineRow.svelte). */
+  .comment-action-btn.note-btn.session-active {
+    color: var(--note-color);
+    border-color: transparent;
+    background-color: var(--note-bg);
+  }
+
+  .comment-action-btn.commit-btn.session-active {
+    color: var(--commit-color);
+    border-color: transparent;
     background-color: var(--commit-bg);
   }
 

--- a/packages/diff-viewer/src/lib/components/CommentEditor.svelte
+++ b/packages/diff-viewer/src/lib/components/CommentEditor.svelte
@@ -355,7 +355,16 @@
     color: var(--status-added, #3fb950) !important;
   }
 
+  /* Spin in place like the app's shared Spinner. Without an explicit
+     transform-box/origin, WebKit rotates the SVG about an off-center point,
+     making the icon visibly wobble; pin the origin to the exact viewBox
+     center (and promote to a layer) so it spins cleanly. */
   .comment-action-btn :global(.spinner) {
+    display: block;
+    overflow: visible;
+    transform-box: view-box;
+    transform-origin: 50% 50%;
+    backface-visibility: hidden;
     animation: spin 1s linear infinite;
   }
 

--- a/packages/diff-viewer/src/lib/components/CommentEditor.svelte
+++ b/packages/diff-viewer/src/lib/components/CommentEditor.svelte
@@ -5,17 +5,9 @@
   Handles its own visibility based on scroll position.
 -->
 <script lang="ts">
-  import { Check, FileText, GitCommitVertical, Github, Loader2, Trash2 } from 'lucide-svelte';
-  import type { Comment } from '../types';
-
-  export type GithubButtonState = 'idle' | 'sending' | 'sent' | 'stale';
-
-  /**
-   * State of a comment's "Note"/"Commit" button, derived from the linked
-   * session's status by the parent. `queued` is treated as `running`, and
-   * `error`/`cancelled` collapse back to `idle` so the user can retry.
-   */
-  export type CommentSessionState = 'idle' | 'running' | 'completed';
+  import { Trash2 } from 'lucide-svelte';
+  import type { Snippet } from 'svelte';
+  import type { Comment, CommentActionContext } from '../types';
 
   interface Props {
     /** Position relative to the viewer container */
@@ -36,18 +28,8 @@
     onCancel: () => void;
     /** Called when comment is deleted (only shown if existingComment is set) */
     onDelete?: () => void;
-    /** Called when "Note" action is clicked (only shown if existingComment is set). */
-    onNote?: (event: MouseEvent) => void;
-    /** Called when "Commit" action is clicked (only shown if existingComment is set). */
-    onCommit?: (event: MouseEvent) => void;
-    /** Called when "GitHub" action is clicked (only shown if existingComment is set). */
-    onGithub?: () => void;
-    /** Current state of the GitHub send/update button. */
-    githubState?: GithubButtonState;
-    /** Current state of the "Note" button, reflecting its linked session. */
-    noteState?: CommentSessionState;
-    /** Current state of the "Commit" button, reflecting its linked session. */
-    commitState?: CommentSessionState;
+    /** Host-rendered actions for existing comments. */
+    commentActions?: Snippet<[CommentActionContext]>;
   }
 
   let {
@@ -61,12 +43,7 @@
     onSubmit,
     onCancel,
     onDelete,
-    onNote,
-    onCommit,
-    onGithub,
-    githubState = 'idle',
-    noteState = 'idle',
-    commitState = 'idle',
+    commentActions,
   }: Props = $props();
 
   // Track current input value - initialized by effect when existingComment changes
@@ -138,73 +115,9 @@
     <span class="comment-editor-help">
       {readOnly ? 'Read-only · Esc to close' : 'Enter to save · Esc to cancel'}
     </span>
-    {#if existingComment && (onNote || onCommit || onGithub)}
+    {#if existingComment && commentActions}
       <div class="comment-action-buttons">
-        {#if onNote}
-          <button
-            class="comment-action-btn note-btn"
-            class:session-active={noteState !== 'idle'}
-            onclick={(e) => onNote?.(e)}
-            title={noteState === 'running'
-              ? 'Note session in progress'
-              : noteState === 'completed'
-                ? 'Open note'
-                : 'New note (Option+click to skip dialog)'}
-          >
-            {#if noteState === 'running'}
-              <Loader2 size={12} class="spinner" />
-            {:else}
-              <FileText size={12} />
-            {/if}
-            <span>Note</span>
-          </button>
-        {/if}
-        {#if onCommit}
-          <button
-            class="comment-action-btn commit-btn"
-            class:session-active={commitState !== 'idle'}
-            onclick={(e) => onCommit?.(e)}
-            title={commitState === 'running'
-              ? 'Commit session in progress'
-              : commitState === 'completed'
-                ? 'Show commit'
-                : 'New commit (Option+click to skip dialog)'}
-          >
-            {#if commitState === 'running'}
-              <Loader2 size={12} class="spinner" />
-            {:else}
-              <GitCommitVertical size={12} />
-            {/if}
-            <span>Commit</span>
-          </button>
-        {/if}
-        {#if onGithub}
-          <button
-            class="comment-action-btn github-btn"
-            class:github-btn-sent={githubState === 'sent'}
-            onclick={() => onGithub?.()}
-            title={githubState === 'sent'
-              ? 'Open GitHub comment'
-              : githubState === 'stale'
-                ? 'Update on GitHub'
-                : 'Send to GitHub'}
-            disabled={githubState === 'sending'}
-          >
-            {#if githubState === 'sending'}
-              <Loader2 size={12} class="spinner" />
-            {:else if githubState === 'sent'}
-              <Check size={12} class="github-sent-check" />
-              <Github size={12} />
-            {:else}
-              <Github size={12} />
-            {/if}
-            {#if githubState === 'stale'}
-              <span>Update on GitHub</span>
-            {:else}
-              <span>GitHub</span>
-            {/if}
-          </button>
-        {/if}
+        {@render commentActions({ comment: existingComment })}
       </div>
     {/if}
     {#if existingComment && onDelete}
@@ -276,105 +189,6 @@
     display: flex;
     align-items: center;
     gap: 4px;
-  }
-
-  .comment-action-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 6px;
-    border-radius: 4px;
-    border: 1px dashed var(--border-subtle);
-    background: transparent;
-    color: var(--text-muted);
-    font-size: calc(var(--size-xs) - 1px);
-    font-weight: 500;
-    cursor: pointer;
-    transition:
-      color 0.15s,
-      border-color 0.15s,
-      background-color 0.15s;
-  }
-
-  .comment-action-btn.note-btn :global(svg) {
-    color: var(--note-color);
-  }
-
-  .comment-action-btn.commit-btn :global(svg) {
-    color: var(--commit-color);
-  }
-
-  .comment-action-btn.github-btn :global(svg) {
-    color: var(--text-primary);
-  }
-
-  .comment-action-btn.note-btn:hover {
-    color: var(--note-color);
-    border-color: var(--note-color);
-    background-color: var(--note-bg);
-  }
-
-  .comment-action-btn.commit-btn:hover {
-    color: var(--commit-color);
-    border-color: var(--commit-color);
-    background-color: var(--commit-bg);
-  }
-
-  /* Running/completed state — mirrors the styled spinner-with-background and
-     completed icon used on Branch Card timeline rows (TimelineRow.svelte). */
-  .comment-action-btn.note-btn.session-active {
-    color: var(--note-color);
-    border-color: transparent;
-    background-color: var(--note-bg);
-  }
-
-  .comment-action-btn.commit-btn.session-active {
-    color: var(--commit-color);
-    border-color: transparent;
-    background-color: var(--commit-bg);
-  }
-
-  .comment-action-btn.github-btn:hover:not(:disabled) {
-    color: var(--text-primary);
-    border-color: var(--text-muted);
-    background-color: var(--bg-hover);
-  }
-
-  .comment-action-btn.github-btn:disabled {
-    cursor: default;
-    opacity: 0.7;
-  }
-
-  .comment-action-btn.github-btn-sent {
-    border-style: solid;
-    color: var(--text-primary);
-    border-color: var(--status-added, #3fb950);
-  }
-
-  .comment-action-btn.github-btn-sent :global(.github-sent-check) {
-    color: var(--status-added, #3fb950) !important;
-  }
-
-  /* Spin in place like the app's shared Spinner. Without an explicit
-     transform-box/origin, WebKit rotates the SVG about an off-center point,
-     making the icon visibly wobble; pin the origin to the exact viewBox
-     center (and promote to a layer) so it spins cleanly. */
-  .comment-action-btn :global(.spinner) {
-    display: block;
-    overflow: visible;
-    transform-box: view-box;
-    transform-origin: 50% 50%;
-    backface-visibility: hidden;
-    animation: spin 1s linear infinite;
-  }
-
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
   }
 
   .delete-comment-btn {

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -123,6 +123,8 @@
     annotationsRevealed?: boolean;
     /** Search state for highlighting matches in the diff content. */
     searchState?: SearchState;
+    /** Host-owned area where clicks may dismiss this viewer's active line selection. */
+    clickDismissBoundary?: HTMLElement | null;
 
     // -- Comment callbacks (all optional; without them commenting is disabled) --
     onAddComment?: (path: string, span: Span, content: string) => Promise<void>;
@@ -158,6 +160,7 @@
     annotations = [],
     annotationsRevealed = false,
     searchState,
+    clickDismissBoundary = null,
     onAddComment,
     onUpdateComment,
     onDeleteComment,
@@ -1884,12 +1887,13 @@
     focusedHunkIndex = null;
 
     const target = event.target as HTMLElement;
-    // The comment editor and line selection belong to this viewer, so only a
-    // click inside the viewer should dismiss them. Anything outside — most
-    // visibly a Note/Commit/Session dialog, which renders into a body portal in
-    // the host app and so carries no markup we can recognize here — must leave
-    // the editor open.
-    if (diffViewerEl && !diffViewerEl.contains(target)) {
+    // The comment editor and line selection belong to this viewer. Host apps
+    // can extend the dismissal area to adjacent chrome (for example, a sidebar)
+    // while body-level dialog portals remain outside that boundary.
+    const isInsideDismissArea =
+      (diffViewerEl?.contains(target) ?? false) ||
+      (clickDismissBoundary?.contains(target) ?? false);
+    if (!isInsideDismissArea) {
       return;
     }
     if (

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -16,10 +16,18 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
+  import type { Snippet } from 'svelte';
   import { MessageSquarePlus, MessageSquare, X, FileText, Code } from 'lucide-svelte';
   import { marked } from 'marked';
   import { sanitize } from '../utils/sanitize';
-  import type { FileDiff, Alignment, Comment, Span, SmartDiffAnnotation } from '../types';
+  import type {
+    FileDiff,
+    Alignment,
+    Comment,
+    Span,
+    SmartDiffAnnotation,
+    CommentActionContext,
+  } from '../types';
   import {
     initHighlighter,
     highlightLines,
@@ -75,10 +83,7 @@
     getHeaderAwareActiveStructuralStack,
     getStructuralDeclarations,
   } from '../utils/structuralHeaders';
-  import CommentEditor, {
-    type GithubButtonState,
-    type CommentSessionState,
-  } from './CommentEditor.svelte';
+  import CommentEditor from './CommentEditor.svelte';
   import AnnotationOverlay from './AnnotationOverlay.svelte';
   import BeforeAnnotationOverlay from './BeforeAnnotationOverlay.svelte';
   import Scrollbar from './Scrollbar.svelte';
@@ -131,16 +136,8 @@
     onUpdateComment?: (commentId: string, content: string) => Promise<void>;
     onDeleteComment?: (commentId: string) => Promise<void>;
 
-    // -- Comment action callbacks (optional; shown in editor bottom bar) --
-    onCommentNote?: (comment: Comment, event: MouseEvent) => void;
-    onCommentCommit?: (comment: Comment, event: MouseEvent) => void;
-    onCommentGithub?: (comment: Comment) => void;
-    /** Returns the GitHub button state for a given comment. */
-    commentGithubState?: (comment: Comment) => GithubButtonState;
-    /** Returns the "Note" button state (linked note session) for a given comment. */
-    commentNoteState?: (comment: Comment) => CommentSessionState;
-    /** Returns the "Commit" button state (linked commit session) for a given comment. */
-    commentCommitState?: (comment: Comment) => CommentSessionState;
+    /** Host-rendered actions for an existing comment's editor footer. */
+    commentActions?: Snippet<[CommentActionContext]>;
 
     /** Bindable API object exposing scroll control for external callers (e.g. mobile touch scroll). */
     scrollApi?: DiffViewerScrollApi | null;
@@ -164,12 +161,7 @@
     onAddComment,
     onUpdateComment,
     onDeleteComment,
-    onCommentNote,
-    onCommentCommit,
-    onCommentGithub,
-    commentGithubState,
-    commentNoteState,
-    commentCommitState,
+    commentActions,
     scrollApi = $bindable(null),
   }: Props = $props();
 
@@ -2569,24 +2561,7 @@
               handleCommentCancel();
             }
           : undefined}
-        onNote={existingComment && onCommentNote
-          ? (e) => onCommentNote(existingComment, e)
-          : undefined}
-        onCommit={existingComment && onCommentCommit
-          ? (e) => onCommentCommit(existingComment, e)
-          : undefined}
-        onGithub={existingComment && onCommentGithub
-          ? () => onCommentGithub(existingComment)
-          : undefined}
-        githubState={existingComment && commentGithubState
-          ? commentGithubState(existingComment)
-          : 'idle'}
-        noteState={existingComment && commentNoteState
-          ? commentNoteState(existingComment)
-          : 'idle'}
-        commitState={existingComment && commentCommitState
-          ? commentCommitState(existingComment)
-          : 'idle'}
+        {commentActions}
       />
     {/if}
 
@@ -2643,24 +2618,7 @@
               clearLineSelection();
             }
           : undefined}
-        onNote={existingComment && onCommentNote
-          ? (e) => onCommentNote(existingComment, e)
-          : undefined}
-        onCommit={existingComment && onCommentCommit
-          ? (e) => onCommentCommit(existingComment, e)
-          : undefined}
-        onGithub={existingComment && onCommentGithub
-          ? () => onCommentGithub(existingComment)
-          : undefined}
-        githubState={existingComment && commentGithubState
-          ? commentGithubState(existingComment)
-          : 'idle'}
-        noteState={existingComment && commentNoteState
-          ? commentNoteState(existingComment)
-          : 'idle'}
-        commitState={existingComment && commentCommitState
-          ? commentCommitState(existingComment)
-          : 'idle'}
+        {commentActions}
       />
     {/if}
   {/if}

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -75,7 +75,10 @@
     getHeaderAwareActiveStructuralStack,
     getStructuralDeclarations,
   } from '../utils/structuralHeaders';
-  import CommentEditor, { type GithubButtonState } from './CommentEditor.svelte';
+  import CommentEditor, {
+    type GithubButtonState,
+    type CommentSessionState,
+  } from './CommentEditor.svelte';
   import AnnotationOverlay from './AnnotationOverlay.svelte';
   import BeforeAnnotationOverlay from './BeforeAnnotationOverlay.svelte';
   import Scrollbar from './Scrollbar.svelte';
@@ -132,6 +135,10 @@
     onCommentGithub?: (comment: Comment) => void;
     /** Returns the GitHub button state for a given comment. */
     commentGithubState?: (comment: Comment) => GithubButtonState;
+    /** Returns the "Note" button state (linked note session) for a given comment. */
+    commentNoteState?: (comment: Comment) => CommentSessionState;
+    /** Returns the "Commit" button state (linked commit session) for a given comment. */
+    commentCommitState?: (comment: Comment) => CommentSessionState;
 
     /** Bindable API object exposing scroll control for external callers (e.g. mobile touch scroll). */
     scrollApi?: DiffViewerScrollApi | null;
@@ -158,6 +165,8 @@
     onCommentCommit,
     onCommentGithub,
     commentGithubState,
+    commentNoteState,
+    commentCommitState,
     scrollApi = $bindable(null),
   }: Props = $props();
 
@@ -2560,6 +2569,12 @@
         githubState={existingComment && commentGithubState
           ? commentGithubState(existingComment)
           : 'idle'}
+        noteState={existingComment && commentNoteState
+          ? commentNoteState(existingComment)
+          : 'idle'}
+        commitState={existingComment && commentCommitState
+          ? commentCommitState(existingComment)
+          : 'idle'}
       />
     {/if}
 
@@ -2627,6 +2642,12 @@
           : undefined}
         githubState={existingComment && commentGithubState
           ? commentGithubState(existingComment)
+          : 'idle'}
+        noteState={existingComment && commentNoteState
+          ? commentNoteState(existingComment)
+          : 'idle'}
+        commitState={existingComment && commentCommitState
+          ? commentCommitState(existingComment)
           : 'idle'}
       />
     {/if}

--- a/packages/diff-viewer/src/lib/components/DiffViewer.svelte
+++ b/packages/diff-viewer/src/lib/components/DiffViewer.svelte
@@ -1884,6 +1884,14 @@
     focusedHunkIndex = null;
 
     const target = event.target as HTMLElement;
+    // The comment editor and line selection belong to this viewer, so only a
+    // click inside the viewer should dismiss them. Anything outside — most
+    // visibly a Note/Commit/Session dialog, which renders into a body portal in
+    // the host app and so carries no markup we can recognize here — must leave
+    // the editor open.
+    if (diffViewerEl && !diffViewerEl.contains(target)) {
+      return;
+    }
     if (
       target.closest('.line-selection-toolbar') ||
       target.closest('.line-comment-editor') ||

--- a/packages/diff-viewer/src/lib/components/index.ts
+++ b/packages/diff-viewer/src/lib/components/index.ts
@@ -1,7 +1,7 @@
 export { default as DiffViewer } from './DiffViewer.svelte';
 export { default as ImageDiffViewer } from './ImageDiffViewer.svelte';
 export { default as CommentEditor } from './CommentEditor.svelte';
-export type { CommentSessionState } from './CommentEditor.svelte';
+export type { CommentActionContext } from '../types';
 export { default as AnnotationOverlay } from './AnnotationOverlay.svelte';
 export { default as BeforeAnnotationOverlay } from './BeforeAnnotationOverlay.svelte';
 export { default as Scrollbar } from './Scrollbar.svelte';

--- a/packages/diff-viewer/src/lib/components/index.ts
+++ b/packages/diff-viewer/src/lib/components/index.ts
@@ -1,6 +1,7 @@
 export { default as DiffViewer } from './DiffViewer.svelte';
 export { default as ImageDiffViewer } from './ImageDiffViewer.svelte';
 export { default as CommentEditor } from './CommentEditor.svelte';
+export type { CommentSessionState } from './CommentEditor.svelte';
 export { default as AnnotationOverlay } from './AnnotationOverlay.svelte';
 export { default as BeforeAnnotationOverlay } from './BeforeAnnotationOverlay.svelte';
 export { default as Scrollbar } from './Scrollbar.svelte';

--- a/packages/diff-viewer/src/lib/types.ts
+++ b/packages/diff-viewer/src/lib/types.ts
@@ -95,6 +95,11 @@ export interface Comment {
   commitSessionId: string | null;
 }
 
+/** Context passed to host-rendered comment action snippets. */
+export interface CommentActionContext {
+  comment: Comment;
+}
+
 /** A review anchored to a branch + commit + scope. */
 export interface Review {
   id: string;

--- a/packages/diff-viewer/src/lib/types.ts
+++ b/packages/diff-viewer/src/lib/types.ts
@@ -89,6 +89,10 @@ export interface Comment {
   githubCommentType: string | null;
   /** Whether the local content has been edited since the last GitHub sync. */
   githubCommentStale: boolean;
+  /** The note session started from this comment's "Note" button, if any. */
+  noteSessionId: string | null;
+  /** The commit session started from this comment's "Commit" button, if any. */
+  commitSessionId: string | null;
 }
 
 /** A review anchored to a branch + commit + scope. */


### PR DESCRIPTION
Persist review comment links to note and commit sessions. Show session state and actions in the diff comment UI. Keep differ demo comments compatible with the shared comment type.