### PR TITLE
perf: lazy mount closed modals

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1040,6 +1040,44 @@
     }
   }
 
+  async function handleSessionModalClose() {
+    const closedSessionId = sessionMgr.openSessionId;
+    sessionMgr.openSessionId = null;
+    void loadTimeline();
+    // If the closed modal was the PR session, check if it finished while open
+    if (
+      prButton &&
+      closedSessionId &&
+      closedSessionId === prButton.getPrSessionId() &&
+      prButton.getPrCreatingState() === 'creating'
+    ) {
+      try {
+        const session = await commands.getSession(closedSessionId);
+        if (session && session.status !== 'running') {
+          prButton.handlePrSessionComplete(session.status);
+        }
+      } catch {
+        // Ignore — the polling fallback will catch it
+      }
+    }
+    // If the closed modal was the push session, check if it finished while open
+    if (
+      prButton &&
+      closedSessionId &&
+      closedSessionId === prButton.getPushSessionId() &&
+      prButton.getPushingState() === 'pushing'
+    ) {
+      try {
+        const session = await commands.getSession(closedSessionId);
+        if (session && session.status !== 'running') {
+          prButton.handlePushSessionComplete(session.status, session);
+        }
+      } catch {
+        // Ignore — the polling fallback will catch it
+      }
+    }
+  }
+
   function formatDiscardPreview(preview: WorktreeChangesPreview): string {
     const sections: string[] = [];
     if (preview.revertPaths.length > 0) {
@@ -1671,38 +1709,42 @@
   {/if}
 </div>
 
-<NoteModal
-  open={openNote !== null}
-  title={openNote?.title ?? ''}
-  content={openNote?.content ?? ''}
-  sessionId={openNote?.sessionId}
-  noteUpdatedAt={openNote?.noteUpdatedAt}
-  nextSteps={openNote?.nextSteps}
-  onClose={() => (openNote = null)}
-  onOpenSession={(sid) => {
-    openNote = null;
-    sessionMgr.openSessionId = sid;
-  }}
-  onStartSession={(mode, prefill) => {
-    const noteRef = openNote?.noteId ? `Re: #note:${openNote.noteId}` : '';
-    openNote = null;
-    void sessionMgr.startOrQueueSession(mode, noteRef ? `${noteRef}\n${prefill}` : prefill);
-  }}
-/>
+{#if openNote}
+  <NoteModal
+    open={true}
+    title={openNote.title}
+    content={openNote.content}
+    sessionId={openNote.sessionId}
+    noteUpdatedAt={openNote.noteUpdatedAt}
+    nextSteps={openNote.nextSteps}
+    onClose={() => (openNote = null)}
+    onOpenSession={(sid) => {
+      openNote = null;
+      sessionMgr.openSessionId = sid;
+    }}
+    onStartSession={(mode, prefill) => {
+      const noteRef = openNote?.noteId ? `Re: #note:${openNote.noteId}` : '';
+      openNote = null;
+      void sessionMgr.startOrQueueSession(mode, noteRef ? `${noteRef}\n${prefill}` : prefill);
+    }}
+  />
+{/if}
 
-<ImageViewerModal
-  open={viewImageId !== null}
-  imageId={viewImageId ?? ''}
-  filename={viewImageFilename}
-  onClose={() => {
-    viewImageId = null;
-  }}
-  onDelete={() => {
-    if (viewImageId) {
-      handleDeleteImage(viewImageId);
-    }
-  }}
-/>
+{#if viewImageId}
+  <ImageViewerModal
+    open={true}
+    imageId={viewImageId}
+    filename={viewImageFilename}
+    onClose={() => {
+      viewImageId = null;
+    }}
+    onDelete={() => {
+      if (viewImageId) {
+        handleDeleteImage(viewImageId);
+      }
+    }}
+  />
+{/if}
 
 {#if sessionMgr.showNewSession}
   {@const commitPrefillBase = suggestedPrefill.commit}
@@ -1753,101 +1795,71 @@
   />
 {/if}
 
-<SessionModal
-  open={sessionMgr.openSessionId !== null}
-  sessionId={sessionMgr.openSessionId ?? ''}
-  repoDir={branch.worktreePath}
-  branchId={branch.id}
-  projectId={branch.projectId}
-  {repoLabel}
-  noteInfo={sessionMgr.openSessionId ? findNoteForSession(sessionMgr.openSessionId) : null}
-  onOpenNote={(note) => {
-    const sid = sessionMgr.openSessionId;
-    sessionMgr.openSessionId = null;
-    openNote = {
-      noteId: note.id,
-      title: note.title,
-      content: note.content,
-      sessionId: sid ?? undefined,
-      noteUpdatedAt: note.updatedAt,
-      nextSteps: computeNoteNextSteps(note.id),
-    };
-  }}
-  onClose={async () => {
-    const closedSessionId = sessionMgr.openSessionId;
-    sessionMgr.openSessionId = null;
-    loadTimeline();
-    // If the closed modal was the PR session, check if it finished while open
-    if (
-      prButton &&
-      closedSessionId &&
-      closedSessionId === prButton.getPrSessionId() &&
-      prButton.getPrCreatingState() === 'creating'
-    ) {
-      try {
-        const session = await commands.getSession(closedSessionId);
-        if (session && session.status !== 'running') {
-          prButton.handlePrSessionComplete(session.status);
-        }
-      } catch {
-        // Ignore — the polling fallback will catch it
-      }
-    }
-    // If the closed modal was the push session, check if it finished while open
-    if (
-      prButton &&
-      closedSessionId &&
-      closedSessionId === prButton.getPushSessionId() &&
-      prButton.getPushingState() === 'pushing'
-    ) {
-      try {
-        const session = await commands.getSession(closedSessionId);
-        if (session && session.status !== 'running') {
-          prButton.handlePushSessionComplete(session.status, session);
-        }
-      } catch {
-        // Ignore — the polling fallback will catch it
-      }
-    }
-  }}
-/>
+{#if sessionMgr.openSessionId}
+  <SessionModal
+    open={true}
+    sessionId={sessionMgr.openSessionId}
+    repoDir={branch.worktreePath}
+    branchId={branch.id}
+    projectId={branch.projectId}
+    {repoLabel}
+    noteInfo={findNoteForSession(sessionMgr.openSessionId)}
+    onOpenNote={(note) => {
+      const sid = sessionMgr.openSessionId;
+      sessionMgr.openSessionId = null;
+      openNote = {
+        noteId: note.id,
+        title: note.title,
+        content: note.content,
+        sessionId: sid ?? undefined,
+        noteUpdatedAt: note.updatedAt,
+        nextSteps: computeNoteNextSteps(note.id),
+      };
+    }}
+    onClose={handleSessionModalClose}
+  />
+{/if}
 
-<AlertDialog.Root bind:open={showForcePushDialog}>
-  <AlertDialog.Content>
-    <AlertDialog.Header>
-      <AlertDialog.Title>Force Push</AlertDialog.Title>
-      <AlertDialog.Description>
-        The remote branch has commits that would be lost. Do you want to force push? This will
-        overwrite the remote branch with your local version.
-      </AlertDialog.Description>
-    </AlertDialog.Header>
-    <AlertDialog.Footer>
-      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-      <AlertDialog.Action variant="destructive" onclick={confirmForcePush}>
-        Force Push
-      </AlertDialog.Action>
-    </AlertDialog.Footer>
-  </AlertDialog.Content>
-</AlertDialog.Root>
+{#if showForcePushDialog}
+  <AlertDialog.Root bind:open={showForcePushDialog}>
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Force Push</AlertDialog.Title>
+        <AlertDialog.Description>
+          The remote branch has commits that would be lost. Do you want to force push? This will
+          overwrite the remote branch with your local version.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+        <AlertDialog.Action variant="destructive" onclick={confirmForcePush}>
+          Force Push
+        </AlertDialog.Action>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+{/if}
 
-<AlertDialog.Root bind:open={showResetToOriginDialog}>
-  <AlertDialog.Content>
-    <AlertDialog.Header>
-      <AlertDialog.Title>Reset to Origin</AlertDialog.Title>
-      <AlertDialog.Description>{resetToOriginDescription}</AlertDialog.Description>
-    </AlertDialog.Header>
-    <AlertDialog.Footer>
-      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-      <AlertDialog.Action variant="destructive" onclick={confirmResetToOrigin}>
-        Reset to Origin
-      </AlertDialog.Action>
-    </AlertDialog.Footer>
-  </AlertDialog.Content>
-</AlertDialog.Root>
+{#if showResetToOriginDialog}
+  <AlertDialog.Root bind:open={showResetToOriginDialog}>
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Reset to Origin</AlertDialog.Title>
+        <AlertDialog.Description>{resetToOriginDescription}</AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+        <AlertDialog.Action variant="destructive" onclick={confirmResetToOrigin}>
+          Reset to Origin
+        </AlertDialog.Action>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+{/if}
 
-<AlertDialog.Root open={confirmDelete !== null} onOpenChange={(v) => !v && (confirmDelete = null)}>
-  <AlertDialog.Content>
-    {#if confirmDelete}
+{#if confirmDelete}
+  <AlertDialog.Root open={true} onOpenChange={(v) => !v && (confirmDelete = null)}>
+    <AlertDialog.Content>
       <AlertDialog.Header>
         <AlertDialog.Title>{confirmDelete.title}</AlertDialog.Title>
         <AlertDialog.Description>{confirmDelete.message}</AlertDialog.Description>
@@ -1858,9 +1870,9 @@
           {confirmDelete.confirmLabel ?? 'Delete'}
         </AlertDialog.Action>
       </AlertDialog.Footer>
-    {/if}
-  </AlertDialog.Content>
-</AlertDialog.Root>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+{/if}
 
 <style>
   .branch-card {

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -742,55 +742,63 @@
   {@render renderButton()}
 {/if}
 
-<AlertDialog.Root bind:open={showPrErrorDialog}>
-  <AlertDialog.Content>
-    <AlertDialog.Header>
-      <AlertDialog.Title>PR Creation Failed</AlertDialog.Title>
-      <AlertDialog.Description class="max-h-[42vh] overflow-auto whitespace-pre-line">
-        {prError ?? 'An unknown error occurred while creating the PR.'}
-      </AlertDialog.Description>
-    </AlertDialog.Header>
-    <AlertDialog.Footer>
-      <AlertDialog.Cancel onclick={handlePrErrorClose}>Cancel</AlertDialog.Cancel>
-      <AlertDialog.Action variant="outline" onclick={handlePrErrorRetry}>Retry</AlertDialog.Action>
-    </AlertDialog.Footer>
-  </AlertDialog.Content>
-</AlertDialog.Root>
+{#if showPrErrorDialog}
+  <AlertDialog.Root bind:open={showPrErrorDialog}>
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>PR Creation Failed</AlertDialog.Title>
+        <AlertDialog.Description class="max-h-[42vh] overflow-auto whitespace-pre-line">
+          {prError ?? 'An unknown error occurred while creating the PR.'}
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel onclick={handlePrErrorClose}>Cancel</AlertDialog.Cancel>
+        <AlertDialog.Action variant="outline" onclick={handlePrErrorRetry}>
+          Retry
+        </AlertDialog.Action>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+{/if}
 
-<AlertDialog.Root bind:open={showPushErrorDialog}>
-  <AlertDialog.Content>
-    <AlertDialog.Header>
-      <AlertDialog.Title>Push Failed</AlertDialog.Title>
-      <AlertDialog.Description class="max-h-[42vh] overflow-auto whitespace-pre-line">
-        {pushError ?? 'An unknown error occurred while pushing.'}
-      </AlertDialog.Description>
-    </AlertDialog.Header>
-    <AlertDialog.Footer>
-      <AlertDialog.Cancel onclick={handlePushErrorClose}>Cancel</AlertDialog.Cancel>
-      <AlertDialog.Action variant="outline" onclick={handlePushErrorRetry}>
-        Retry
-      </AlertDialog.Action>
-    </AlertDialog.Footer>
-  </AlertDialog.Content>
-</AlertDialog.Root>
+{#if showPushErrorDialog}
+  <AlertDialog.Root bind:open={showPushErrorDialog}>
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Push Failed</AlertDialog.Title>
+        <AlertDialog.Description class="max-h-[42vh] overflow-auto whitespace-pre-line">
+          {pushError ?? 'An unknown error occurred while pushing.'}
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel onclick={handlePushErrorClose}>Cancel</AlertDialog.Cancel>
+        <AlertDialog.Action variant="outline" onclick={handlePushErrorRetry}>
+          Retry
+        </AlertDialog.Action>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+{/if}
 
-<AlertDialog.Root bind:open={showForcePushDialog}>
-  <AlertDialog.Content>
-    <AlertDialog.Header>
-      <AlertDialog.Title>Push Rejected</AlertDialog.Title>
-      <AlertDialog.Description>
-        The remote branch has commits that would be lost. Do you want to force push? This will
-        overwrite the remote branch with your local version.
-      </AlertDialog.Description>
-    </AlertDialog.Header>
-    <AlertDialog.Footer>
-      <AlertDialog.Cancel onclick={handleForcePushCancel}>Cancel</AlertDialog.Cancel>
-      <AlertDialog.Action variant="destructive" onclick={handleForcePushConfirm}>
-        Force Push
-      </AlertDialog.Action>
-    </AlertDialog.Footer>
-  </AlertDialog.Content>
-</AlertDialog.Root>
+{#if showForcePushDialog}
+  <AlertDialog.Root bind:open={showForcePushDialog}>
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Push Rejected</AlertDialog.Title>
+        <AlertDialog.Description>
+          The remote branch has commits that would be lost. Do you want to force push? This will
+          overwrite the remote branch with your local version.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel onclick={handleForcePushCancel}>Cancel</AlertDialog.Cancel>
+        <AlertDialog.Action variant="destructive" onclick={handleForcePushConfirm}>
+          Force Push
+        </AlertDialog.Action>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+{/if}
 
 <style>
   /* PR status indicator circle */

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -5,7 +5,7 @@
   Read-only view.
 -->
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
   import X from '@lucide/svelte/icons/x';
   import Copy from '@lucide/svelte/icons/copy';
   import Check from '@lucide/svelte/icons/check';
@@ -68,12 +68,21 @@
   let contentEl: HTMLDivElement;
   let unregisterSearchTarget: (() => void) | null = null;
 
-  onMount(() => {
-    unregisterSearchTarget = registerSearchShortcutTarget({
+  // Register the global search-shortcut target only while the modal is open.
+  // Branch and project views lazy-mount this component, but this guard keeps
+  // persistent callers from letting a closed note modal capture Cmd/Ctrl+F.
+  $effect(() => {
+    if (!open) return;
+    const unregister = registerSearchShortcutTarget({
       find: openSearch,
       next: nextMatch,
       previous: previousMatch,
     });
+    unregisterSearchTarget = unregister;
+    return () => {
+      unregister();
+      unregisterSearchTarget = null;
+    };
   });
 
   onDestroy(() => {

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -467,42 +467,44 @@
   />
 {/if}
 
-<NoteModal
-  open={openNote !== null}
-  title={openNote?.title ?? ''}
-  content={openNote?.content ?? ''}
-  sessionId={openNote?.sessionId}
-  noteUpdatedAt={openNote?.noteUpdatedAt}
-  onClose={() => (openNote = null)}
-  onOpenSession={(sid) => {
-    openNote = null;
-    openSessionId = sid;
-  }}
-/>
+{#if openNote}
+  <NoteModal
+    open={true}
+    title={openNote.title}
+    content={openNote.content}
+    sessionId={openNote.sessionId}
+    noteUpdatedAt={openNote.noteUpdatedAt}
+    onClose={() => (openNote = null)}
+    onOpenSession={(sid) => {
+      openNote = null;
+      openSessionId = sid;
+    }}
+  />
+{/if}
 
-<SessionModal
-  open={openSessionId !== null}
-  sessionId={openSessionId ?? ''}
-  repoDir={projectDisplayRootCandidates}
-  projectId={project.id}
-  noteInfo={openSessionId
-    ? linkedNoteContext(projectNotes.find((n) => n.sessionId === openSessionId))
-    : null}
-  onOpenNote={(note) => {
-    const sid = openSessionId;
-    openSessionId = null;
-    openNote = {
-      title: note.title,
-      content: note.content,
-      sessionId: sid ?? undefined,
-      noteUpdatedAt: note.updatedAt,
-    };
-  }}
-  onClose={() => {
-    openSessionId = null;
-    loadProjectNotes();
-  }}
-/>
+{#if openSessionId}
+  <SessionModal
+    open={true}
+    sessionId={openSessionId}
+    repoDir={projectDisplayRootCandidates}
+    projectId={project.id}
+    noteInfo={linkedNoteContext(projectNotes.find((n) => n.sessionId === openSessionId))}
+    onOpenNote={(note) => {
+      const sid = openSessionId;
+      openSessionId = null;
+      openNote = {
+        title: note.title,
+        content: note.content,
+        sessionId: sid ?? undefined,
+        noteUpdatedAt: note.updatedAt,
+      };
+    }}
+    onClose={() => {
+      openSessionId = null;
+      loadProjectNotes();
+    }}
+  />
+{/if}
 
 <style>
   .project-section {


### PR DESCRIPTION
Summary:
- Lazy-mount branch and project note/session modals only while open.
- Lazy-mount branch PR/push/force-push dialogs only while visible.
- Keep session close completion checks and NoteModal search shortcut registration scoped to active modal state.