### PR TITLE
fix: align note and chat modal backgrounds

### DIFF
--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -359,7 +359,7 @@
     overflow-y: auto;
     padding: 24px;
     min-height: 0;
-    background: color-mix(in srgb, var(--bg-elevated) 50%, var(--bg-primary) 50%);
+    background: var(--bg-primary);
   }
 
   .modal-content::-webkit-scrollbar {

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -527,6 +527,7 @@
     gap: 8px;
     padding: 12px 16px;
     border-top: 1px solid var(--border-subtle);
+    background: var(--bg-chrome);
     flex-shrink: 0;
   }
 

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -1575,9 +1575,7 @@
     overflow-y: auto;
     padding: 16px;
     min-height: 0;
-    /* Blend the messages-area surface halfway toward the composer's
-       --bg-chrome so it reads as distinct from the input field below. */
-    background: color-mix(in srgb, var(--bg-primary) 50%, var(--bg-chrome) 50%);
+    background: var(--bg-primary);
   }
 
   /* Custom scrollbar */


### PR DESCRIPTION
## Summary
- Use the primary background for note and chat modal content areas.
- Match the note footer background with the chat composer surface.