### PR TITLE
fix: stabilize compact hover surfaces

### DIFF
--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -101,11 +101,11 @@
 
   /* ── Sizing (not theme-dependent) ── */
   --size-base: 13px;
-  --size-xs: calc(var(--size-base) * 0.846);
-  --size-sm: calc(var(--size-base) * 0.923);
+  --size-xs: calc(var(--size-base) - 2px);
+  --size-sm: calc(var(--size-base) - 1px);
   --size-md: var(--size-base);
-  --size-lg: calc(var(--size-base) * 1.077);
-  --size-xl: calc(var(--size-base) * 1.231);
+  --size-lg: calc(var(--size-base) + 1px);
+  --size-xl: calc(var(--size-base) + 3px);
 
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
   font-size: var(--size-md);
@@ -202,6 +202,12 @@ body {
   background: var(--scrollbar-thumb-hover);
 }
 
+/* Keep compositor hints limited to tiny glyph and badge surfaces. */
+.stable-raster,
+.stable-raster-glyphs svg {
+  transform: translateZ(0);
+}
+
 /* ── In-content search highlights ── */
 mark.search-match {
   background-color: rgba(255, 235, 59, 0.4);
@@ -281,7 +287,7 @@ mark.search-match-current {
    *    the Staged px scale. The app sets the root font-size to 13px (--size-md),
    *    so Tailwind's unitless defaults (text-sm = 0.875rem ≈ 11.4px,
    *    text-xs = 0.75rem ≈ 9.75px) render smaller than the pre-shadcn UI, which
-   *    sized text off --size-* tokens (e.g. FormButton's var(--size-sm) ≈ 12px).
+   *    sized text off --size-* tokens (e.g. FormButton's var(--size-sm) = 12px).
    *    Map each `text-*` utility to its --size-* analogue so every migrated
    *    `text-*` tracks the old scale in one place. Line-heights keep Tailwind's
    *    paired defaults. ── */

--- a/apps/staged/src/lib/components/ui/badge/badge.svelte
+++ b/apps/staged/src/lib/components/ui/badge/badge.svelte
@@ -2,7 +2,7 @@
   import { type VariantProps, tv } from 'tailwind-variants';
 
   export const badgeVariants = tv({
-    base: 'h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap transition-colors focus-visible:ring-[3px] [&>svg]:pointer-events-none',
+    base: 'h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-[color,background-color,border-color,box-shadow,opacity] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive group/badge stable-raster stable-raster-glyphs inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap focus-visible:ring-[3px] [&>svg]:pointer-events-none',
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',

--- a/apps/staged/src/lib/components/ui/button/button.svelte
+++ b/apps/staged/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
   import { type VariantProps, tv } from 'tailwind-variants';
 
   export const buttonVariants = tv({
-    base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button stable-raster-glyphs inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-[color,background-color,border-color,box-shadow,opacity] outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/80',

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -412,8 +412,8 @@
           onclick={openProjectSessionModal}
           aria-label="New project note"
           class={[
-            'inline-flex items-center font-medium transition-all duration-300',
-            '[&_svg]:transition-all [&_svg]:duration-300',
+            'inline-flex items-center font-medium transition-[color,background-color,border-color,box-shadow,opacity] duration-300',
+            '[&_svg]:transition-colors [&_svg]:duration-300',
             projectNotes.length === 0
               ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:bg-[var(--note-bg)] hover:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
               : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:border-[var(--note-color)] hover:bg-[var(--note-bg)] hover:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)]',

--- a/apps/staged/src/lib/features/projects/SplashScreen.svelte
+++ b/apps/staged/src/lib/features/projects/SplashScreen.svelte
@@ -114,7 +114,7 @@
     <div class="splash-actions">
       <Button
         variant="outline"
-        class="h-auto rounded-full border-transparent bg-[var(--bg-elevated)] px-9 py-3 text-sm font-medium text-foreground shadow-none transition-all hover:-translate-y-px hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
+        class="h-auto rounded-full border-transparent bg-[var(--bg-elevated)] px-9 py-3 text-sm font-medium text-foreground shadow-none transition-[color,background-color,border-color,box-shadow,opacity,transform] hover:-translate-y-px hover:border-[var(--border-muted)] hover:bg-[var(--bg-hover)] hover:text-foreground"
         onclick={openForm}
       >
         Create your first project

--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -245,7 +245,7 @@
 
   function createBadgeElement(item: HashtagItem): HTMLSpanElement {
     const badge = document.createElement('span');
-    badge.className = 'hashtag-badge';
+    badge.className = 'hashtag-badge stable-raster stable-raster-glyphs';
     badge.contentEditable = 'false';
     badge.dataset.token = `#${item.type}:${item.id}`;
     const iconSvg = hashtagTypeIconSvg[item.type] ?? '';

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -314,7 +314,7 @@ export function renderHashtagTokens(text: string, items: HashtagItem[]): string 
         ? id.slice(0, 8) + '…'
         : id;
     parts.push(
-      `<span class="hashtag-badge" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
+      `<span class="hashtag-badge stable-raster stable-raster-glyphs" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
     );
 
     lastIndex = match.index + match[0].length;

--- a/apps/staged/src/lib/features/settings/preferences.svelte.ts
+++ b/apps/staged/src/lib/features/settings/preferences.svelte.ts
@@ -53,6 +53,10 @@ const DEFAULT_APP_MODE: AppMode = 'system';
 
 export type AutoReviewMode = 'never' | 'after-changes';
 
+function normalizeSize(size: number): number {
+  return Math.min(SIZE_MAX, Math.max(SIZE_MIN, Math.round(size)));
+}
+
 // =============================================================================
 // Fixed chrome base colors
 // =============================================================================
@@ -132,6 +136,7 @@ export const preferences = $state({
 // =============================================================================
 
 function applySize() {
+  preferences.sizeBase = normalizeSize(preferences.sizeBase);
   document.documentElement.style.setProperty('--size-base', `${preferences.sizeBase}px`);
 }
 
@@ -212,8 +217,13 @@ export async function initPreferences(): Promise<void> {
 
   // Load size
   const savedSize = await getStoreValue<number>(SIZE_STORE_KEY);
-  if (savedSize !== undefined && savedSize >= SIZE_MIN && savedSize <= SIZE_MAX) {
-    preferences.sizeBase = savedSize;
+  if (
+    typeof savedSize === 'number' &&
+    Number.isFinite(savedSize) &&
+    savedSize >= SIZE_MIN &&
+    savedSize <= SIZE_MAX
+  ) {
+    preferences.sizeBase = normalizeSize(savedSize);
   }
   applySize();
 
@@ -313,7 +323,7 @@ export function setAutoReviewMode(mode: AutoReviewMode): void {
  */
 export function increaseSize(): void {
   if (preferences.sizeBase < SIZE_MAX) {
-    preferences.sizeBase += SIZE_STEP;
+    preferences.sizeBase = normalizeSize(preferences.sizeBase + SIZE_STEP);
     applySize();
     setStoreValue(SIZE_STORE_KEY, preferences.sizeBase);
   }
@@ -324,7 +334,7 @@ export function increaseSize(): void {
  */
 export function decreaseSize(): void {
   if (preferences.sizeBase > SIZE_MIN) {
-    preferences.sizeBase -= SIZE_STEP;
+    preferences.sizeBase = normalizeSize(preferences.sizeBase - SIZE_STEP);
     applySize();
     setStoreValue(SIZE_STORE_KEY, preferences.sizeBase);
   }

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -1047,8 +1047,8 @@
                   disabled={newSessionDisabled}
                   aria-label="New note"
                   class={[
-                    'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                    '[&_svg]:transition-all [&_svg]:duration-300',
+                    'inline-flex items-center font-medium transition-[color,background-color,border-color,box-shadow,opacity] duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                    '[&_svg]:transition-colors [&_svg]:duration-300',
                     actionButtonsEnlarged
                       ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--note-color)]'
                       : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--note-color)] hover:not-disabled:bg-[var(--note-bg)] hover:not-disabled:text-[var(--note-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--note-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
@@ -1087,8 +1087,8 @@
                   disabled={newSessionDisabled}
                   aria-label="New commit"
                   class={[
-                    'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                    '[&_svg]:transition-all [&_svg]:duration-300',
+                    'inline-flex items-center font-medium transition-[color,background-color,border-color,box-shadow,opacity] duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                    '[&_svg]:transition-colors [&_svg]:duration-300',
                     actionButtonsEnlarged
                       ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--commit-color)]'
                       : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--commit-color)] hover:not-disabled:bg-[var(--commit-bg)] hover:not-disabled:text-[var(--commit-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--commit-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
@@ -1127,8 +1127,8 @@
                   disabled={newSessionDisabled}
                   aria-label="New code review"
                   class={[
-                    'inline-flex items-center font-medium transition-all duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
-                    '[&_svg]:transition-all [&_svg]:duration-300',
+                    'inline-flex items-center font-medium transition-[color,background-color,border-color,box-shadow,opacity] duration-300 disabled:opacity-30 disabled:cursor-not-allowed',
+                    '[&_svg]:transition-colors [&_svg]:duration-300',
                     actionButtonsEnlarged
                       ? 'flex-1 justify-center gap-2 px-1.5 py-2.5 h-auto rounded-lg border border-solid border-transparent bg-[var(--bg-elevated)] text-sm hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[18px] [&_svg]:text-[var(--review-color)]'
                       : 'gap-[5px] px-2.5 h-8 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent text-xs hover:not-disabled:border-[var(--review-color)] hover:not-disabled:bg-[var(--review-bg)] hover:not-disabled:text-[var(--review-color)] [&_svg]:!size-[13px] [&_svg]:text-[var(--review-color)] @max-[480px]/timeline:gap-0.5 @max-[480px]/timeline:px-1.5',
@@ -1199,9 +1199,6 @@
     margin: 0 -8px;
     position: relative;
     z-index: 1;
-    /* Keep footer controls on a tiny stable layer while row hover backgrounds
-       repaint above, without restoring a compositor layer on every row. */
-    transform: translateZ(0);
     transition:
       gap 0.3s ease,
       padding 0.3s ease,

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -289,7 +289,7 @@
   >
     <div class="timeline-marker">
       <div
-        class="timeline-icon"
+        class="timeline-icon stable-raster"
         class:commit-icon={type === 'commit' ||
           type === 'pending-commit' ||
           type === 'queued-commit'}
@@ -364,7 +364,7 @@
             {/if}
             {#if badges}
               {#each badges as badge}
-                <span class="meta-badge">
+                <span class="meta-badge stable-raster stable-raster-glyphs">
                   {#if badge.icon === 'warning'}
                     <AlertTriangle size={10} />
                   {:else}
@@ -668,11 +668,6 @@
     flex-shrink: 0;
     background-color: var(--bg-elevated);
     border: 1px solid var(--border-subtle);
-    /* Pin the icon onto its own compositing layer so it rasterizes at integer
-       pixels and stays put during the row's hover background-color transition.
-       Restores the layer hint #775 dropped from .timeline-row, but on the tiny
-       icon rather than the full-width row to keep that commit's memory win. */
-    transform: translateZ(0);
   }
 
   .timeline-icon.commit-icon {
@@ -796,11 +791,6 @@
     align-items: center;
     line-height: 1;
     vertical-align: -2px;
-    transform: translateZ(0);
-  }
-
-  .timeline-title :global(.hashtag-badge svg) {
-    transform: translateZ(0);
   }
 
   .timeline-row.git-state .timeline-title :global(.git-ref-badge) {
@@ -857,10 +847,6 @@
     font-size: calc(var(--size-xs) - 1px);
     font-weight: 600;
     line-height: 1;
-    /* Pin the review badge onto its own compositing layer (same rationale as
-       .timeline-icon) so its icon stays put during the row's hover
-       background-color transition instead of re-snapping to fractional pixels. */
-    transform: translateZ(0);
   }
 
   /* Actions container — visible on row hover */
@@ -871,12 +857,6 @@
     flex-shrink: 0;
     opacity: 0;
     transition: opacity 0.1s;
-  }
-
-  /* Pin each action-button icon onto its own layer so it doesn't jiggle during
-     the container's opacity fade or the Button's transition-all on hover. */
-  .timeline-actions :global(svg) {
-    transform: translateZ(0);
   }
 
   .timeline-row:hover .timeline-actions,

--- a/apps/staged/src/lib/shared/RepoBadge.svelte
+++ b/apps/staged/src/lib/shared/RepoBadge.svelte
@@ -21,7 +21,7 @@
   let fg = $derived(badgeFg(hue, darkMode.value));
 </script>
 
-<span class="repo-badge" class:small style="background: {bg}; color: {fg};">
+<span class="repo-badge stable-raster" class:small style="background: {bg}; color: {fg};">
   {shortName}
 </span>
 


### PR DESCRIPTION
## Summary
- narrow compact control hover transitions to color, background, border, opacity, shadow, and intentional transform changes
- add stable raster layer classes to small badge, glyph, repo, and timeline icon surfaces
- normalize saved and adjusted UI size values before applying root sizing tokens