### PR TITLE
fix: let dropdown menus size to content

### DIFF
--- a/apps/staged/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/apps/staged/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -23,7 +23,7 @@
     {sideOffset}
     {align}
     class={cn(
-      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-(--z-index-floating) w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
+      'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-(--z-index-floating) w-auto overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
       className
     )}
     {...restProps}

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -214,8 +214,6 @@
   // More menu state
   let openerApps = $state<OpenerApp[]>([]);
 
-  const dropdownPanelClass = 'w-[180px]';
-
   let unlistenRepoActionsDetection: UnlistenFn | null = null;
 
   function handleActionsChanged(event: CustomEvent) {
@@ -861,7 +859,7 @@
   >
     <MoreVertical size={16} />
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content align="end" sideOffset={4} class={dropdownPanelClass}>
+  <DropdownMenu.Content align="end" sideOffset={4} class="min-w-[160px]">
     {#if !isSettingUp}
       {#if isRemote && branch.workspaceName}
         <DropdownMenu.Item
@@ -877,7 +875,7 @@
           <DropdownMenu.SubTrigger>
             <Play size={14} /> Actions
           </DropdownMenu.SubTrigger>
-          <DropdownMenu.SubContent class={dropdownPanelClass}>
+          <DropdownMenu.SubContent class="min-w-[160px]">
             {#each actionMenuItems as item, i (i)}
               {#if item.type === 'separator'}
                 <DropdownMenu.Separator />
@@ -890,7 +888,7 @@
                     {/if}
                     {item.label}
                   </DropdownMenu.SubTrigger>
-                  <DropdownMenu.SubContent class={dropdownPanelClass}>
+                  <DropdownMenu.SubContent class="min-w-[160px]">
                     {@render renderSubItems(item.children)}
                   </DropdownMenu.SubContent>
                 </DropdownMenu.Sub>
@@ -913,7 +911,7 @@
           <DropdownMenu.SubTrigger>
             <ExternalLink size={14} /> Open In
           </DropdownMenu.SubTrigger>
-          <DropdownMenu.SubContent class={dropdownPanelClass}>
+          <DropdownMenu.SubContent class="min-w-[160px]">
             {@render renderSubItems(openInMenuItems)}
           </DropdownMenu.SubContent>
         </DropdownMenu.Sub>

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -214,6 +214,8 @@
   // More menu state
   let openerApps = $state<OpenerApp[]>([]);
 
+  const dropdownPanelClass = 'w-[180px]';
+
   let unlistenRepoActionsDetection: UnlistenFn | null = null;
 
   function handleActionsChanged(event: CustomEvent) {
@@ -859,7 +861,7 @@
   >
     <MoreVertical size={16} />
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content align="end" sideOffset={4} class="min-w-[160px]">
+  <DropdownMenu.Content align="end" sideOffset={4} class={dropdownPanelClass}>
     {#if !isSettingUp}
       {#if isRemote && branch.workspaceName}
         <DropdownMenu.Item
@@ -875,7 +877,7 @@
           <DropdownMenu.SubTrigger>
             <Play size={14} /> Actions
           </DropdownMenu.SubTrigger>
-          <DropdownMenu.SubContent class="min-w-[160px]">
+          <DropdownMenu.SubContent class={dropdownPanelClass}>
             {#each actionMenuItems as item, i (i)}
               {#if item.type === 'separator'}
                 <DropdownMenu.Separator />
@@ -888,7 +890,7 @@
                     {/if}
                     {item.label}
                   </DropdownMenu.SubTrigger>
-                  <DropdownMenu.SubContent class="min-w-[160px]">
+                  <DropdownMenu.SubContent class={dropdownPanelClass}>
                     {@render renderSubItems(item.children)}
                   </DropdownMenu.SubContent>
                 </DropdownMenu.Sub>
@@ -911,7 +913,7 @@
           <DropdownMenu.SubTrigger>
             <ExternalLink size={14} /> Open In
           </DropdownMenu.SubTrigger>
-          <DropdownMenu.SubContent class="min-w-[160px]">
+          <DropdownMenu.SubContent class={dropdownPanelClass}>
             {@render renderSubItems(openInMenuItems)}
           </DropdownMenu.SubContent>
         </DropdownMenu.Sub>


### PR DESCRIPTION
Summary:
- Let dropdown menu content use auto width instead of forcing anchor width.
- Prevent branch dropdown menus from resizing to the trigger width when menu items need more room.