### PR TITLE
fix: show hover actions on touch devices

### DIFF
--- a/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommentsSection.svelte
@@ -171,7 +171,7 @@
           <Button
             variant="ghost"
             size="icon"
-            class="absolute top-1/2 right-3 z-10 size-auto -translate-y-1/2 rounded p-1 text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-primary)] hover:text-[var(--status-deleted)] group-hover/comment:opacity-100 [&_svg]:!size-3"
+            class="comment-row-action absolute top-1/2 right-3 z-10 size-auto -translate-y-1/2 rounded p-1 text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-primary)] hover:text-[var(--status-deleted)] group-hover/comment:opacity-100 [&_svg]:!size-3"
             title="Delete comment"
             aria-label="Delete comment"
             onclick={(e: MouseEvent) => {
@@ -213,7 +213,7 @@
             <Button
               variant="ghost"
               size="icon"
-              class="absolute top-1/2 right-3 z-10 size-auto -translate-y-1/2 rounded p-1 text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-primary)] hover:text-[var(--status-added)] group-hover/comment:opacity-100 [&_svg]:!size-3"
+              class="comment-row-action absolute top-1/2 right-3 z-10 size-auto -translate-y-1/2 rounded p-1 text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-primary)] hover:text-[var(--status-added)] group-hover/comment:opacity-100 [&_svg]:!size-3"
               title="Restore comment"
               aria-label="Restore comment"
               onclick={(e: MouseEvent) => {
@@ -342,6 +342,17 @@
   .comment-item-container {
     position: relative;
     width: 100%;
+  }
+
+  .comment-item-container:focus-within :global(.comment-row-action),
+  :global(.comment-row-action:focus-visible) {
+    opacity: 1;
+  }
+
+  @media (hover: none), (pointer: coarse) {
+    :global(.comment-row-action) {
+      opacity: 1;
+    }
   }
 
   .comment-item {

--- a/apps/staged/src/lib/features/diff/DiffReferenceSection.svelte
+++ b/apps/staged/src/lib/features/diff/DiffReferenceSection.svelte
@@ -47,7 +47,7 @@
           <Button
             variant="ghost"
             size="icon"
-            class="ml-auto size-auto shrink-0 rounded-[3px] p-0.5 text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-hover)] hover:text-foreground group-hover/ref-item:opacity-100 [&_svg]:!size-3"
+            class="reference-remove-action ml-auto size-auto shrink-0 rounded-[3px] p-0.5 text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-hover)] hover:text-foreground group-hover/ref-item:opacity-100 [&_svg]:!size-3"
             title="Remove reference file"
             aria-label="Remove reference file"
             onclick={(e: MouseEvent) => {
@@ -189,6 +189,17 @@
 
   .reference-item {
     position: relative;
+  }
+
+  .reference-item:focus-within :global(.reference-remove-action),
+  :global(.reference-remove-action:focus-visible) {
+    opacity: 1;
+  }
+
+  @media (hover: none), (pointer: coarse) {
+    :global(.reference-remove-action) {
+      opacity: 1;
+    }
   }
 
   .reference-icon {

--- a/apps/staged/src/lib/features/sessions/ImageAttachment.svelte
+++ b/apps/staged/src/lib/features/sessions/ImageAttachment.svelte
@@ -144,7 +144,7 @@
           <Button
             variant="ghost"
             size="icon"
-            class="absolute top-0.5 right-0.5 size-4 rounded-full bg-[var(--bg-deepest)] text-muted-foreground opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-chrome)] hover:text-foreground group-hover/thumb:opacity-100 [&_svg]:!size-2.5"
+            class="image-remove-action absolute top-0.5 right-0.5 size-4 rounded-full bg-[var(--bg-deepest)] text-muted-foreground opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-chrome)] hover:text-foreground group-hover/thumb:opacity-100 [&_svg]:!size-2.5"
             title="Remove image"
             aria-label="Remove image"
             onclick={() => removeImage(imageId)}
@@ -206,6 +206,17 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  .image-thumb:focus-within :global(.image-remove-action),
+  :global(.image-remove-action:focus-visible) {
+    opacity: 1;
+  }
+
+  @media (hover: none), (pointer: coarse) {
+    :global(.image-remove-action) {
+      opacity: 1;
+    }
   }
 
   .image-placeholder {

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -1175,7 +1175,7 @@
                       <Button
                         variant="ghost"
                         size="icon"
-                        class="absolute top-1.5 right-1.5 size-auto rounded p-[3px] text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-hover)] hover:text-foreground group-hover/bubble:opacity-100 [&_svg]:!size-3"
+                        class="message-copy-action absolute top-1.5 right-1.5 size-auto rounded p-[3px] text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-hover)] hover:text-foreground group-hover/bubble:opacity-100 [&_svg]:!size-3"
                         title={copiedId === group.message.id ? 'Copied!' : 'Copy message'}
                         aria-label={copiedId === group.message.id ? 'Copied!' : 'Copy message'}
                         onclick={() => copyContent(group.message.content, group.message.id)}
@@ -1198,7 +1198,7 @@
                     <Button
                       variant="ghost"
                       size="icon"
-                      class="absolute top-0 right-0 size-auto rounded p-[3px] text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-hover)] hover:text-foreground group-hover/assistant:opacity-100 [&_svg]:!size-3"
+                      class="message-copy-action absolute top-0 right-0 size-auto rounded p-[3px] text-[var(--text-faint)] opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-hover)] hover:text-foreground group-hover/assistant:opacity-100 [&_svg]:!size-3"
                       title={copiedId === group.message.id ? 'Copied!' : 'Copy message'}
                       aria-label={copiedId === group.message.id ? 'Copied!' : 'Copy message'}
                       onclick={() => copyContent(group.message.content, group.message.id)}
@@ -1435,7 +1435,7 @@
                   <Button
                     variant="ghost"
                     size="icon"
-                    class="absolute top-0.5 right-0.5 size-4 rounded-full bg-[var(--bg-deepest)] text-muted-foreground opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-chrome)] hover:text-foreground group-hover/thumb:opacity-100 [&_svg]:!size-2.5"
+                    class="reply-image-remove-action absolute top-0.5 right-0.5 size-4 rounded-full bg-[var(--bg-deepest)] text-muted-foreground opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-chrome)] hover:text-foreground group-hover/thumb:opacity-100 [&_svg]:!size-2.5"
                     title="Remove image"
                     aria-label="Remove image"
                     onclick={() => removeReplyImage(imageId)}
@@ -1778,6 +1778,21 @@
     flex: 1;
     min-width: 0;
     padding-right: 28px;
+  }
+
+  .human-bubble:focus-within :global(.message-copy-action),
+  .assistant-content:focus-within :global(.message-copy-action),
+  .reply-image-thumb:focus-within :global(.reply-image-remove-action),
+  :global(.message-copy-action:focus-visible),
+  :global(.reply-image-remove-action:focus-visible) {
+    opacity: 1;
+  }
+
+  @media (hover: none), (pointer: coarse) {
+    :global(.message-copy-action),
+    :global(.reply-image-remove-action) {
+      opacity: 1;
+    }
   }
 
   /* ----- Tool calls ------------------------------------------------------ */

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -863,7 +863,7 @@
     transform: translateZ(0);
   }
 
-  /* Actions container — visible on row hover */
+  /* Actions container - visible on row hover/focus, always available on touch */
   .timeline-actions {
     display: flex;
     align-items: center;
@@ -880,8 +880,15 @@
   }
 
   .timeline-row:hover .timeline-actions,
+  .timeline-row:focus-within .timeline-actions,
   .timeline-actions.always-visible {
     opacity: 1;
+  }
+
+  @media (hover: none), (pointer: coarse) {
+    .timeline-actions {
+      opacity: 1;
+    }
   }
 
   @keyframes pulse {


### PR DESCRIPTION
Summary:
- Make comment, reference, image, message, and timeline hover actions available on touch/coarse-pointer devices.
- Preserve keyboard accessibility by revealing hidden actions on focus.

Tests:
- Push hooks ran crates-fmt, crates-lint, crates-test, staged-ci, and differ-ci.