### PR TITLE
fix: share branch session launch state

### DIFF
--- a/apps/staged/src/App.svelte
+++ b/apps/staged/src/App.svelte
@@ -30,6 +30,7 @@
   import {
     navigation,
     initNavigation,
+    closeDiffRouteIfCurrent,
     openSettings,
     popDetailRoute,
     selectPreviousProject,
@@ -519,22 +520,23 @@
         {:else if navigation.activeView === 'settings'}
           <SettingsPage />
         {:else if navigation.currentRoute.kind === 'diff'}
+          {@const diffRoute = navigation.currentRoute}
           <DiffModal
-            branchId={navigation.currentRoute.branchId}
-            projectId={navigation.currentRoute.projectId}
-            commitSha={navigation.currentRoute.commitSha}
-            scope={navigation.currentRoute.scope}
-            reviewId={navigation.currentRoute.reviewId}
-            beforeLabel={navigation.currentRoute.beforeLabel}
-            afterLabel={navigation.currentRoute.afterLabel}
-            readonly={navigation.currentRoute.readonly}
-            commits={navigation.currentRoute.commits}
-            baseBranchLabel={navigation.currentRoute.baseBranchLabel}
-            branchLabel={navigation.currentRoute.branchLabel}
-            projectName={navigation.currentRoute.projectName}
-            githubRepo={navigation.currentRoute.githubRepo}
-            subpath={navigation.currentRoute.subpath}
-            onClose={popDetailRoute}
+            branchId={diffRoute.branchId}
+            projectId={diffRoute.projectId}
+            commitSha={diffRoute.commitSha}
+            scope={diffRoute.scope}
+            reviewId={diffRoute.reviewId}
+            beforeLabel={diffRoute.beforeLabel}
+            afterLabel={diffRoute.afterLabel}
+            readonly={diffRoute.readonly}
+            commits={diffRoute.commits}
+            baseBranchLabel={diffRoute.baseBranchLabel}
+            branchLabel={diffRoute.branchLabel}
+            projectName={diffRoute.projectName}
+            githubRepo={diffRoute.githubRepo}
+            subpath={diffRoute.subpath}
+            onClose={() => closeDiffRouteIfCurrent(diffRoute)}
           />
         {:else if reposUiEnabled && navigation.showReposList}
           <ReposListView />

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -69,6 +69,11 @@
   import BranchCardActionsBar from './BranchCardActionsBar.svelte';
   import BranchCardPrButton from './BranchCardPrButton.svelte';
   import BranchCardSessionManager from './BranchCardSessionManager.svelte';
+  import {
+    addPendingSession,
+    getPendingSessionItems,
+    prunePendingSessionItems,
+  } from './branchSessionLaunch.svelte';
   import RemoteWorkspaceStatusBadge from './RemoteWorkspaceStatusBadge.svelte';
   import RemoteWorkspaceStatusView from './RemoteWorkspaceStatusView.svelte';
   import { branchTimelineReadyKey } from './branchTimelineReady';
@@ -305,10 +310,7 @@
       // Add a pending session item so the session stub appears instantly
       // instead of waiting for the full timeline refresh.
       const title = kind === 'rebase' ? 'Rebasing…' : 'Squashing…';
-      sessionMgr.pendingSessionItems = [
-        ...sessionMgr.pendingSessionItems,
-        { key: pendingKey, type: 'pending-commit', title, sessionId },
-      ];
+      addPendingSession(branch.id, { key: pendingKey, type: 'pending-commit', title, sessionId });
       await loadTimeline();
     } catch (e) {
       notifyError(kind === 'rebase' ? 'Rebase failed' : 'Squash failed', e);
@@ -508,7 +510,7 @@
     timeline = cached;
     loadedTimelineKey = timelineKey;
     loading = false;
-    prunedSessionIds = sessionMgr.prunePendingSessionItems(cached);
+    prunedSessionIds = prunePendingSessionItems(branch.id, cached);
     if (fresh) {
       const version = ++revalidationVersion;
       fresh
@@ -519,7 +521,7 @@
           error = null;
           timeline = next;
           loadedTimelineKey = timelineKey;
-          prunedSessionIds = sessionMgr.prunePendingSessionItems(next);
+          prunedSessionIds = prunePendingSessionItems(branch.id, next);
           void loadTimelineReviewDetails(next.reviews);
         })
         .catch((e) => {
@@ -741,7 +743,7 @@
       if (!isCurrentTimelineLoad(loadVersion, timelineKey)) return;
       timeline = nextTimeline;
       loadedTimelineKey = timelineKey;
-      prunedSessionIds = sessionMgr.prunePendingSessionItems(nextTimeline);
+      prunedSessionIds = prunePendingSessionItems(branch.id, nextTimeline);
       void loadTimelineReviewDetails(nextTimeline.reviews);
     } catch (e) {
       if (!isCurrentTimelineLoad(loadVersion, timelineKey)) return;
@@ -1591,7 +1593,7 @@
               repoDir={branch.worktreePath}
               {hashtagItems}
               pendingDropNotes={isLocal ? pendingDropNotes : undefined}
-              pendingItems={sessionMgr.pendingSessionItems}
+              pendingItems={getPendingSessionItems(branch.id)}
               {prunedSessionIds}
               {error}
               gitActionDisabledReason={branchIdentityWarning}

--- a/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
+++ b/apps/staged/src/lib/features/branches/BranchCardSessionManager.svelte.ts
@@ -1,39 +1,29 @@
 /**
  * BranchCardSessionManager — reactive session creation logic for BranchCard
  *
- * Manages new session modal state, pending session items, auto review
- * adoption/cancellation, and session start orchestration.
+ * Manages new session modal state, auto review adoption/cancellation, and
+ * branch-card session start orchestration.
  *
  * Instantiated with a reactive branch reference. Exposes state as reactive
- * properties and methods. The parent calls prunePendingSessionItems() when
- * the timeline refreshes and reads pendingSessionItems to pass to BranchTimeline.
+ * properties and methods. Shared branch-scoped pending session state lives in
+ * branchSessionLaunch.svelte.ts so diff-launched sessions and branch-card
+ * launches render through the same timeline rows.
  */
 
 import type { Branch, BranchTimeline as BranchTimelineData, BranchSessionType } from '../../types';
 import * as commands from '../../api/commands';
 import { getPreferredAgent } from '../settings/preferences.svelte';
 import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
-import { toast } from 'svelte-sonner';
 import { projectStateStore } from '../../stores/projectState.svelte';
 import { sessionRegistry } from '../../stores/sessionRegistry.svelte';
 import { buildReferringPrompt } from '../../shared/buildReferringPrompt';
 import { shouldQueueBranchSession } from './branchSessionQueue';
-
-type PendingSessionItemType =
-  | 'pending-commit'
-  | 'generating-note'
-  | 'generating-review'
-  | 'queued-commit'
-  | 'queued-note'
-  | 'queued-review';
-
-export type PendingSessionItem = {
-  key: string;
-  type: PendingSessionItemType;
-  title: string;
-  secondaryMeta?: string;
-  sessionId?: string;
-};
+import {
+  getPendingSessionItems,
+  hasPendingQueuedSession,
+  hasPendingSessionStart,
+  startOrQueueBranchSessionWithPending,
+} from './branchSessionLaunch.svelte';
 
 export default class BranchCardSessionManager {
   // Private callback refs — declared first so $derived fields can reference them
@@ -49,16 +39,14 @@ export default class BranchCardSessionManager {
   newSessionMode = $state<BranchSessionType>('commit');
   draftPrompt = $state('');
   draftImageIds = $state<string[]>([]);
-  pendingSessionItems = $state<PendingSessionItem[]>([]);
-  isSessionStartPending = $derived(this.pendingSessionItems.some((item) => !item.sessionId));
-  private hasPendingQueuedSession = $derived(
-    this.pendingSessionItems.some(
-      (item) =>
-        item.type === 'queued-commit' ||
-        item.type === 'queued-note' ||
-        item.type === 'queued-review'
-    )
-  );
+  isSessionStartPending = $derived.by(() => {
+    const branch = this.getBranch?.();
+    return branch ? hasPendingSessionStart(branch.id) : false;
+  });
+  private hasPendingQueuedSession = $derived.by(() => {
+    const branch = this.getBranch?.();
+    return branch ? hasPendingQueuedSession(branch.id) : false;
+  });
 
   // Auto review state — tracks a background review started after each commit
   autoReviewSessionId = $state<string | null>(null);
@@ -78,8 +66,10 @@ export default class BranchCardSessionManager {
 
   /** True when a commit session is pending, queued, or actively running. */
   hasCommitSessionInProgress = $derived.by(() => {
+    const branch = this.getBranch?.();
     if (
-      this.pendingSessionItems.some(
+      branch &&
+      getPendingSessionItems(branch.id).some(
         (item) => item.type === 'pending-commit' || item.type === 'queued-commit'
       )
     ) {
@@ -112,69 +102,6 @@ export default class BranchCardSessionManager {
       hasPendingSessionStart: this.isSessionStartPending,
       hasPendingQueuedSession: this.hasPendingQueuedSession,
     });
-  }
-
-  prunePendingSessionItems(nextTimeline: BranchTimelineData): Set<string> {
-    const persistedSessionIds = new Set<string>();
-    for (const commit of nextTimeline.commits) {
-      if (commit.sessionId) persistedSessionIds.add(commit.sessionId);
-    }
-    for (const note of nextTimeline.notes) {
-      if (note.sessionId) persistedSessionIds.add(note.sessionId);
-    }
-    for (const review of nextTimeline.reviews) {
-      if (review.sessionId) persistedSessionIds.add(review.sessionId);
-    }
-
-    const prunedSessionIds = new Set<string>();
-    this.pendingSessionItems = this.pendingSessionItems.filter((item) => {
-      if (item.sessionId && persistedSessionIds.has(item.sessionId)) {
-        prunedSessionIds.add(item.sessionId);
-        return false;
-      }
-      return true;
-    });
-    return prunedSessionIds;
-  }
-
-  private pendingSessionTypeForMode(mode: BranchSessionType): PendingSessionItemType {
-    switch (mode) {
-      case 'note':
-        return 'generating-note';
-      case 'review':
-        return 'generating-review';
-      default:
-        return 'pending-commit';
-    }
-  }
-
-  private queuedSessionTypeForMode(mode: BranchSessionType): PendingSessionItemType {
-    switch (mode) {
-      case 'note':
-        return 'queued-note';
-      case 'review':
-        return 'queued-review';
-      default:
-        return 'queued-commit';
-    }
-  }
-
-  private pendingSessionTitleForMode(mode: BranchSessionType, prompt: string): string {
-    const trimmed = prompt.trim();
-    if (mode === 'review') return 'Code Review';
-    if (trimmed) return trimmed;
-    return mode === 'note' ? 'Untitled note' : 'Pending commit';
-  }
-
-  private pendingSessionMetaForMode(mode: BranchSessionType): string {
-    switch (mode) {
-      case 'note':
-        return 'Starting note session...';
-      case 'review':
-        return 'Starting review session...';
-      default:
-        return 'Starting commit session...';
-    }
   }
 
   /** Register a session on the frontend and mark it as running. */
@@ -279,65 +206,20 @@ export default class BranchCardSessionManager {
   async startOrQueueSession(mode: BranchSessionType, prompt: string, imageIds: string[] = []) {
     const branch = this.getBranch();
     const isRemote = this.getIsRemote();
-    const willQueue = this.willQueueForMode(mode);
 
     if (this.autoReviewSessionId && mode !== 'note') {
       this.cancelAutoReview();
     }
 
-    const pendingKey = `session-start-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const queueMeta = this.getTimeline()
-      ? 'Queued \u2014 waiting for current session\u2026'
-      : 'Queued \u2014 waiting for workspace\u2026';
-
-    this.pendingSessionItems = [
-      ...this.pendingSessionItems,
-      {
-        key: pendingKey,
-        type: willQueue
-          ? this.queuedSessionTypeForMode(mode)
-          : this.pendingSessionTypeForMode(mode),
-        title: this.pendingSessionTitleForMode(mode, prompt),
-        secondaryMeta: willQueue ? queueMeta : this.pendingSessionMetaForMode(mode),
-      },
-    ];
-
-    try {
-      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
-      const result = await commands.startOrQueueBranchSession(
-        branch.id,
-        prompt,
-        mode,
-        getPreferredAgent(agents) ?? undefined,
-        imageIds.length > 0 ? imageIds : undefined
-      );
-
-      if (!result || !result.sessionId) {
-        throw new Error('Failed to start session: no session ID returned');
-      }
-
-      const queued = result.sessionStatus === 'queued';
-      this.pendingSessionItems = this.pendingSessionItems.map((item) =>
-        item.key === pendingKey
-          ? {
-              ...item,
-              type: queued
-                ? this.queuedSessionTypeForMode(mode)
-                : this.pendingSessionTypeForMode(mode),
-              sessionId: result.sessionId,
-              secondaryMeta: queued ? queueMeta : undefined,
-            }
-          : item
-      );
-
-      this.loadTimeline();
-    } catch (e) {
-      this.pendingSessionItems = this.pendingSessionItems.filter((item) => item.key !== pendingKey);
-      toast.error('Unable to start session', {
-        description: e instanceof Error ? e.message : String(e),
-        duration: Infinity,
-      });
-    }
+    await startOrQueueBranchSessionWithPending({
+      branchId: branch.id,
+      isRemote,
+      mode,
+      prompt,
+      imageIds,
+      getTimeline: () => this.getTimeline(),
+      onTimelineRefresh: () => this.loadTimeline(),
+    });
   }
 
   openNewSession(mode: BranchSessionType, e?: MouseEvent) {

--- a/apps/staged/src/lib/features/branches/branchSessionLaunch.svelte.ts
+++ b/apps/staged/src/lib/features/branches/branchSessionLaunch.svelte.ts
@@ -1,0 +1,270 @@
+import { toast } from 'svelte-sonner';
+import type {
+  BranchSessionLaunchContext,
+  BranchSessionLaunchStatus,
+  BranchSessionResponse,
+  BranchSessionType,
+  BranchTimeline,
+} from '../../types';
+import * as commands from '../../api/commands';
+import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
+import { getPreferredAgent } from '../settings/preferences.svelte';
+import { shouldQueueBranchSession } from './branchSessionQueue';
+
+export type PendingSessionItemType =
+  | 'pending-commit'
+  | 'generating-note'
+  | 'generating-review'
+  | 'queued-commit'
+  | 'queued-note'
+  | 'queued-review';
+
+export type PendingSessionItem = {
+  key: string;
+  type: PendingSessionItemType;
+  title: string;
+  secondaryMeta?: string;
+  sessionId?: string;
+};
+
+const pendingSessionItemsByBranch = $state<Map<string, PendingSessionItem[]>>(new Map());
+let pendingSessionItemsVersion = $state(0);
+
+function readPendingSessionItems(branchId: string): PendingSessionItem[] {
+  return pendingSessionItemsByBranch.get(branchId) ?? [];
+}
+
+function writePendingSessionItems(branchId: string, items: PendingSessionItem[]): void {
+  if (items.length > 0) {
+    pendingSessionItemsByBranch.set(branchId, items);
+  } else {
+    pendingSessionItemsByBranch.delete(branchId);
+  }
+  pendingSessionItemsVersion++;
+}
+
+export function getPendingSessionItems(branchId: string): PendingSessionItem[] {
+  pendingSessionItemsVersion;
+  return readPendingSessionItems(branchId);
+}
+
+export function addPendingSession(branchId: string, item: PendingSessionItem): void {
+  writePendingSessionItems(branchId, [...readPendingSessionItems(branchId), item]);
+}
+
+function sessionModeForPendingType(type: PendingSessionItemType): BranchSessionType {
+  switch (type) {
+    case 'generating-note':
+    case 'queued-note':
+      return 'note';
+    case 'generating-review':
+    case 'queued-review':
+      return 'review';
+    default:
+      return 'commit';
+  }
+}
+
+function pendingSessionTypeForMode(mode: BranchSessionType): PendingSessionItemType {
+  switch (mode) {
+    case 'note':
+      return 'generating-note';
+    case 'review':
+      return 'generating-review';
+    default:
+      return 'pending-commit';
+  }
+}
+
+function queuedSessionTypeForMode(mode: BranchSessionType): PendingSessionItemType {
+  switch (mode) {
+    case 'note':
+      return 'queued-note';
+    case 'review':
+      return 'queued-review';
+    default:
+      return 'queued-commit';
+  }
+}
+
+function pendingSessionTypeForStatus(
+  mode: BranchSessionType,
+  status: BranchSessionLaunchStatus
+): PendingSessionItemType {
+  return status === 'queued' ? queuedSessionTypeForMode(mode) : pendingSessionTypeForMode(mode);
+}
+
+export function updatePendingSession(
+  branchId: string,
+  key: string,
+  sessionId: string,
+  sessionStatus: BranchSessionLaunchStatus,
+  queueMeta?: string
+): void {
+  writePendingSessionItems(
+    branchId,
+    readPendingSessionItems(branchId).map((item) => {
+      if (item.key !== key) return item;
+
+      const mode = sessionModeForPendingType(item.type);
+      return {
+        ...item,
+        type: pendingSessionTypeForStatus(mode, sessionStatus),
+        sessionId,
+        secondaryMeta: sessionStatus === 'queued' ? (queueMeta ?? item.secondaryMeta) : undefined,
+      };
+    })
+  );
+}
+
+export function removePendingSession(branchId: string, key: string): void {
+  writePendingSessionItems(
+    branchId,
+    readPendingSessionItems(branchId).filter((item) => item.key !== key)
+  );
+}
+
+export function prunePendingSessionItems(branchId: string, timeline: BranchTimeline): Set<string> {
+  const persistedSessionIds = new Set<string>();
+  for (const commit of timeline.commits) {
+    if (commit.sessionId) persistedSessionIds.add(commit.sessionId);
+  }
+  for (const note of timeline.notes) {
+    if (note.sessionId) persistedSessionIds.add(note.sessionId);
+  }
+  for (const review of timeline.reviews) {
+    if (review.sessionId) persistedSessionIds.add(review.sessionId);
+  }
+
+  const prunedSessionIds = new Set<string>();
+  const nextItems = readPendingSessionItems(branchId).filter((item) => {
+    if (item.sessionId && persistedSessionIds.has(item.sessionId)) {
+      prunedSessionIds.add(item.sessionId);
+      return false;
+    }
+    return true;
+  });
+  writePendingSessionItems(branchId, nextItems);
+  return prunedSessionIds;
+}
+
+export function hasPendingSessionStart(branchId: string): boolean {
+  return getPendingSessionItems(branchId).some((item) => !item.sessionId);
+}
+
+export function hasPendingQueuedSession(branchId: string): boolean {
+  return getPendingSessionItems(branchId).some(
+    (item) =>
+      item.type === 'queued-commit' || item.type === 'queued-note' || item.type === 'queued-review'
+  );
+}
+
+function pendingSessionTitleForMode(mode: BranchSessionType, prompt: string): string {
+  const trimmed = prompt.trim();
+  if (mode === 'review') return 'Code Review';
+  if (trimmed) return trimmed;
+  return mode === 'note' ? 'Untitled note' : 'Pending commit';
+}
+
+function pendingSessionMetaForMode(mode: BranchSessionType): string {
+  switch (mode) {
+    case 'note':
+      return 'Starting note session...';
+    case 'review':
+      return 'Starting review session...';
+    default:
+      return 'Starting commit session...';
+  }
+}
+
+export function queuedSessionMeta(timeline: BranchTimeline | null | undefined): string {
+  return timeline
+    ? 'Queued \u2014 waiting for current session\u2026'
+    : 'Queued \u2014 waiting for workspace\u2026';
+}
+
+interface StartOrQueueBranchSessionOptions {
+  branchId: string;
+  isRemote: boolean;
+  mode: BranchSessionType;
+  prompt: string;
+  imageIds?: string[];
+  launchContext?: BranchSessionLaunchContext;
+  getTimeline?: () => BranchTimeline | null;
+  onTimelineRefresh?: () => void | Promise<void>;
+  willQueueHint?: boolean;
+  queueMeta?: string;
+  errorTitle?: string;
+}
+
+export async function startOrQueueBranchSessionWithPending({
+  branchId,
+  isRemote,
+  mode,
+  prompt,
+  imageIds = [],
+  launchContext,
+  getTimeline,
+  onTimelineRefresh,
+  willQueueHint,
+  queueMeta,
+  errorTitle = 'Unable to start session',
+}: StartOrQueueBranchSessionOptions): Promise<BranchSessionResponse | null> {
+  const timeline = getTimeline?.() ?? null;
+  const pendingKey = `session-start-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const pendingQueueMeta = queueMeta ?? queuedSessionMeta(timeline);
+  const willQueue =
+    willQueueHint ??
+    shouldQueueBranchSession({
+      mode,
+      timeline,
+      hasPendingSessionStart: hasPendingSessionStart(branchId),
+      hasPendingQueuedSession: hasPendingQueuedSession(branchId),
+    });
+
+  addPendingSession(branchId, {
+    key: pendingKey,
+    type: willQueue ? queuedSessionTypeForMode(mode) : pendingSessionTypeForMode(mode),
+    title: pendingSessionTitleForMode(mode, prompt),
+    secondaryMeta: willQueue ? pendingQueueMeta : pendingSessionMetaForMode(mode),
+  });
+
+  try {
+    const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
+    const result = await commands.startOrQueueBranchSession(
+      branchId,
+      prompt,
+      mode,
+      getPreferredAgent(agents) ?? undefined,
+      imageIds.length > 0 ? imageIds : undefined,
+      launchContext
+    );
+
+    if (!result || !result.sessionId) {
+      throw new Error('Failed to start session: no session ID returned');
+    }
+
+    updatePendingSession(
+      branchId,
+      pendingKey,
+      result.sessionId,
+      result.sessionStatus,
+      pendingQueueMeta
+    );
+
+    try {
+      await onTimelineRefresh?.();
+    } catch (e) {
+      console.warn('Failed to refresh branch timeline after session start:', e);
+    }
+
+    return result;
+  } catch (e) {
+    removePendingSession(branchId, pendingKey);
+    toast.error(errorTitle, {
+      description: e instanceof Error ? e.message : String(e),
+      duration: Infinity,
+    });
+    return null;
+  }
+}

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -9,11 +9,13 @@
   import type { HashtagItem } from '../../types';
   import HashtagInput from '../sessions/HashtagInput.svelte';
   import { buildBranchHashtagItems } from '../sessions/hashtagItems';
-  import { getPreferredAgent } from '../settings/preferences.svelte';
-  import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
   import { viewport } from '../../shared/viewport.svelte';
   import { onBranchSessionStatus } from '../../services/branchEventService';
   import { shouldQueueBranchSession } from '../branches/branchSessionQueue';
+  import {
+    queuedSessionMeta,
+    startOrQueueBranchSessionWithPending,
+  } from '../branches/branchSessionLaunch.svelte';
 
   interface Props {
     branchId: string;
@@ -26,7 +28,7 @@
     subpath?: string | null;
     isRemote: boolean;
     onBeforeStart?: () => boolean | Promise<boolean>;
-    onStarted: () => void | Promise<void>;
+    onRequestClose: () => void | Promise<void>;
   }
 
   let {
@@ -40,7 +42,7 @@
     subpath,
     isRemote,
     onBeforeStart = () => true,
-    onStarted,
+    onRequestClose,
   }: Props = $props();
 
   let draftPrompt = $state('');
@@ -48,6 +50,7 @@
   let starting = $state(false);
   let timelineLoading = $state(true);
   let shouldQueueCommitSession = $state(true);
+  let latestTimeline = $state<Awaited<ReturnType<typeof commands.getBranchTimeline>> | null>(null);
   let textareaElement = $state<HTMLElement | null>(null);
 
   // Hashtag reference items
@@ -85,9 +88,11 @@
   async function refreshQueueState(force = false): Promise<boolean> {
     try {
       const timeline = await commands.getBranchTimeline(branchId, { force });
+      latestTimeline = timeline;
       shouldQueueCommitSession = shouldQueueBranchSession({ mode: 'commit', timeline });
     } catch (e) {
       console.error('[DiffCommitSessionLauncher] Failed to load timeline:', e);
+      latestTimeline = null;
       shouldQueueCommitSession = true;
     } finally {
       timelineLoading = false;
@@ -146,6 +151,7 @@
     if (starting || !draftPrompt.trim()) return;
 
     starting = true;
+    let sessionLaunchSubmitted = false;
     try {
       if (!(await onBeforeStart())) return;
       await tick();
@@ -167,26 +173,30 @@
         reviewId: reviewId ?? null,
       };
 
-      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
-      const provider = getPreferredAgent(agents) ?? undefined;
-
-      await commands.startOrQueueBranchSession(
+      void startOrQueueBranchSessionWithPending({
         branchId,
-        finalPrompt,
-        'commit',
-        provider,
-        undefined,
-        launchContext
-      );
+        isRemote,
+        mode: 'commit',
+        prompt: finalPrompt,
+        launchContext,
+        getTimeline: () => latestTimeline,
+        onTimelineRefresh: () => commands.invalidateBranchTimeline(branchId),
+        willQueueHint: shouldQueueCommitSession,
+        queueMeta: queuedSessionMeta(latestTimeline),
+        errorTitle: 'Unable to start commit session',
+      }).finally(() => {
+        starting = false;
+      });
+      sessionLaunchSubmitted = true;
 
-      await onStarted();
+      await onRequestClose();
     } catch (e) {
       toast.error('Unable to start commit session', {
         description: e instanceof Error ? e.message : String(e),
         duration: Infinity,
       });
     } finally {
-      starting = false;
+      if (!sessionLaunchSubmitted) starting = false;
     }
   }
 </script>

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -33,8 +33,7 @@
   import SessionModal from '../sessions/SessionModal.svelte';
   import NoteModal from '../notes/NoteModal.svelte';
   import { onBranchSessionStatus } from '../../services/branchEventService';
-  import { getPreferredAgent, preferences } from '../settings/preferences.svelte';
-  import { agentState, REMOTE_AGENTS } from '../agents/agent.svelte';
+  import { preferences } from '../settings/preferences.svelte';
   import { createDiffViewerState } from './diffViewerState.svelte';
   import { createReviewState } from './reviewState.svelte';
   import { createSearchState } from '@builderbot/diff-viewer/state';
@@ -58,6 +57,7 @@
   import type { DiffScope } from '../../commands';
   import { findFreshAutoReview, getSession } from '../../commands';
   import * as commands from '../../api/commands';
+  import { startOrQueueBranchSessionWithPending } from '../branches/branchSessionLaunch.svelte';
   import {
     buildFileEntries,
     buildTree,
@@ -502,24 +502,17 @@
       reviewId: activeReviewId ?? null,
     };
 
-    try {
-      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
-      const provider = getPreferredAgent(agents) ?? undefined;
-      const result = await commands.startOrQueueBranchSession(
-        branchId,
-        prompt,
-        mode,
-        provider,
-        undefined,
-        launchContext
-      );
-
+    const result = await startOrQueueBranchSessionWithPending({
+      branchId,
+      isRemote,
+      mode,
+      prompt,
+      launchContext,
+      onTimelineRefresh: () => commands.invalidateBranchTimeline(branchId),
+      errorTitle: `Unable to start ${mode} session`,
+    });
+    if (result) {
       linkCommentToSession(comment, mode, result.sessionId, result.sessionStatus);
-    } catch (e) {
-      toast.error(`Unable to start ${mode} session`, {
-        description: e instanceof Error ? e.message : String(e),
-        duration: Infinity,
-      });
     }
   }
 
@@ -584,26 +577,19 @@
       reviewId: activeReviewId ?? null,
     };
 
-    try {
-      const agents = isRemote ? REMOTE_AGENTS : agentState.providers;
-      const provider = getPreferredAgent(agents) ?? undefined;
-      const result = await commands.startOrQueueBranchSession(
-        branchId,
-        data.prompt,
-        data.mode,
-        provider,
-        data.imageIds,
-        launchContext
-      );
+    const result = await startOrQueueBranchSessionWithPending({
+      branchId,
+      isRemote,
+      mode: data.mode,
+      prompt: data.prompt,
+      imageIds: data.imageIds,
+      launchContext,
+      onTimelineRefresh: () => commands.invalidateBranchTimeline(branchId),
+      errorTitle: `Unable to start ${data.mode} session`,
+    });
 
-      if (originComment) {
-        linkCommentToSession(originComment, data.mode, result.sessionId, result.sessionStatus);
-      }
-    } catch (e) {
-      toast.error(`Unable to start ${data.mode} session`, {
-        description: e instanceof Error ? e.message : String(e),
-        duration: Infinity,
-      });
+    if (originComment && result) {
+      linkCommentToSession(originComment, data.mode, result.sessionId, result.sessionStatus);
     }
   }
 
@@ -1474,7 +1460,7 @@
           {subpath}
           {isRemote}
           onBeforeStart={prepareCommitSessionStart}
-          onStarted={closeDiffModal}
+          onRequestClose={onClose}
         />
       {/if}
     </div>

--- a/apps/staged/src/lib/features/layout/navigation.svelte.ts
+++ b/apps/staged/src/lib/features/layout/navigation.svelte.ts
@@ -276,3 +276,9 @@ export function popDetailRoute(): void {
     persistLastProject(nextRoute.projectId);
   }
 }
+
+/** Pop the diff route only if the provided route is still the current route. */
+export function closeDiffRouteIfCurrent(expectedRoute: DiffDetailRoute): void {
+  if (currentRoute() !== expectedRoute) return;
+  popDetailRoute();
+}


### PR DESCRIPTION
## Summary
- Move branch pending session launch state into a shared helper used by branch cards and diff views.
- Let diff-viewer note and commit launches create shared pending timeline rows and keep queued or running status synced.
- Carry project and repo context through diff routes for launched sessions.

## Testing
- Pre-push hooks passed during git push: crates-fmt, crates-lint, crates-test, staged-ci, differ-ci.