### PR TITLE
fix: replace branch rename prompt with dialog

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -95,7 +95,7 @@
     worktreeError?: string;
     workspaceError?: string;
     onDelete?: () => void;
-    onRename?: (branchName: string) => void;
+    onRename?: (branchName: string) => void | Promise<void>;
     onRetryWorktree?: () => void;
   }
 

--- a/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardActionsBar.svelte
@@ -56,6 +56,7 @@
   import { onBranchActionStatus, onBranchRunPhaseChanged } from '../../services/branchEventService';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
   import { Button } from '$lib/components/ui/button';
+  import RenameBranchDialog from './RenameBranchDialog.svelte';
 
   type MenuIconComponent = typeof MoreVertical;
   type ActionMenuItem = {
@@ -85,7 +86,7 @@
     isSettingUp: boolean;
     remoteWorkspaceStatus: string | null;
     onDelete?: () => void;
-    onRename?: (branchName: string) => void;
+    onRename?: (branchName: string) => void | Promise<void>;
     onNoteCreated?: () => void;
     onRebaseBranch?: () => void;
     onSquashCommits?: () => void;
@@ -202,6 +203,7 @@
     actionName: string;
     isStopping: boolean;
   } | null>(null);
+  let renameDialogOpen = $state(false);
   let stoppingExecutions = $state<Set<string>>(new Set());
 
   // Run phase tracking for run actions (building, running, endpoint detection)
@@ -477,11 +479,7 @@
   }
 
   function handleRenameFromMenu() {
-    const next = window.prompt('Rename branch', branch.branchName);
-    if (!next) return;
-    const trimmed = next.trim();
-    if (!trimmed || trimmed === branch.branchName) return;
-    onRename?.(trimmed);
+    renameDialogOpen = true;
   }
 
   function getActionIcon(actionType: string) {
@@ -940,6 +938,8 @@
     </DropdownMenu.Item>
   </DropdownMenu.Content>
 </DropdownMenu.Root>
+
+<RenameBranchDialog bind:open={renameDialogOpen} branchName={branch.branchName} {onRename} />
 
 <ActionOutputModal
   open={actionOutputModal !== null}

--- a/apps/staged/src/lib/features/branches/RenameBranchDialog.svelte
+++ b/apps/staged/src/lib/features/branches/RenameBranchDialog.svelte
@@ -1,0 +1,145 @@
+<script lang="ts" module>
+  let inputCounter = 0;
+</script>
+
+<script lang="ts">
+  import { tick } from 'svelte';
+  import * as Dialog from '$lib/components/ui/dialog';
+  import { Button } from '$lib/components/ui/button';
+  import { Input } from '$lib/components/ui/input';
+  import { Label } from '$lib/components/ui/label';
+  import Spinner from '../../shared/Spinner.svelte';
+
+  interface Props {
+    open: boolean;
+    branchName: string;
+    onRename?: (branchName: string) => void | Promise<void>;
+  }
+
+  let { open = $bindable(false), branchName, onRename }: Props = $props();
+
+  const inputId = `rename-branch-${++inputCounter}`;
+  let draft = $state('');
+  let error = $state<string | null>(null);
+  let renaming = $state(false);
+  let inputElement = $state<HTMLInputElement | null>(null);
+  let wasOpen = false;
+
+  $effect(() => {
+    if (open && !wasOpen) {
+      draft = branchName;
+      error = null;
+      renaming = false;
+      void tick().then(() => {
+        inputElement?.focus();
+        inputElement?.select();
+      });
+    }
+    wasOpen = open;
+  });
+
+  function errorMessage(e: unknown): string {
+    if (e instanceof Error) return e.message;
+    return String(e);
+  }
+
+  function requestClose() {
+    if (renaming) return;
+    open = false;
+  }
+
+  async function handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    if (renaming) return;
+
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      error = 'Enter a branch name.';
+      return;
+    }
+    if (trimmed === branchName) {
+      error = 'Use a different branch name.';
+      return;
+    }
+
+    renaming = true;
+    error = null;
+    try {
+      await onRename?.(trimmed);
+      open = false;
+    } catch (e) {
+      error = errorMessage(e);
+    } finally {
+      renaming = false;
+    }
+  }
+</script>
+
+<Dialog.Root
+  {open}
+  onOpenChange={(nextOpen) => {
+    if (nextOpen) {
+      open = true;
+    } else {
+      requestClose();
+    }
+  }}
+>
+  <Dialog.Content class="sm:max-w-[420px] gap-4">
+    <Dialog.Header>
+      <Dialog.Title>Rename Branch</Dialog.Title>
+    </Dialog.Header>
+
+    <form class="rename-form" onsubmit={handleSubmit}>
+      <div class="rename-field">
+        <Label for={inputId}>Branch name</Label>
+        <Input
+          id={inputId}
+          bind:ref={inputElement}
+          bind:value={draft}
+          disabled={renaming}
+          aria-invalid={error ? 'true' : undefined}
+          oninput={() => (error = null)}
+        />
+      </div>
+
+      {#if error}
+        <p class="rename-error" role="alert">{error}</p>
+      {/if}
+
+      <Dialog.Footer>
+        <Button type="button" variant="outline" onclick={requestClose} disabled={renaming}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={renaming}>
+          {#if renaming}
+            <Spinner size={14} />
+            <span>Renaming...</span>
+          {:else}
+            Rename
+          {/if}
+        </Button>
+      </Dialog.Footer>
+    </form>
+  </Dialog.Content>
+</Dialog.Root>
+
+<style>
+  .rename-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .rename-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .rename-error {
+    margin: 0;
+    color: var(--ui-danger);
+    font-size: var(--size-xs);
+  }
+</style>

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -1026,6 +1026,7 @@
       );
     } catch (e) {
       console.error('Failed to rename branch:', e);
+      throw e;
     }
   }
 </script>

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -44,7 +44,7 @@
     worktreeErrors?: Map<string, string>;
     workspaceErrors?: Map<string, string>;
     onDeleteBranch?: (branchId: string) => void;
-    onRenameBranch?: (branchId: string, branchName: string) => void;
+    onRenameBranch?: (branchId: string, branchName: string) => void | Promise<void>;
     onProjectTitleElement?: (element: HTMLHeadingElement | null) => void;
     onRepoSelected?: (selection: RepoPickerSelection) => void | Promise<void>;
     onRetryWorktree?: (branchId: string) => void;


### PR DESCRIPTION
## Summary
- replace the browser prompt rename flow with a dedicated branch rename dialog
- validate unchanged/empty names and keep the dialog open while rename is running
- surface rename failures in the dialog by propagating errors from the rename handler

## Testing
- git push hooks: crates-fmt, crates-lint, crates-test, differ-ci, staged-ci