### PR TITLE
fix: make timeline rows full bleed

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1970,6 +1970,8 @@
 
   /* Content */
   .card-content {
+    --timeline-row-bleed: 16px;
+
     padding: 16px;
     min-height: 80px;
   }

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -514,10 +514,12 @@
   }
 
   .project-overview-card {
+    --project-card-padding-inline: 16px;
+
     display: flex;
     flex-direction: column;
     gap: 14px;
-    padding: 18px 16px 14px;
+    padding: 18px var(--project-card-padding-inline) 14px;
     border: 1px solid var(--border-subtle);
     border-radius: 8px;
     background-color: var(--bg-primary);
@@ -534,9 +536,10 @@
   }
 
   .notes-timeline {
+    --timeline-row-bleed: var(--project-card-padding-inline);
+
     display: flex;
     flex-direction: column;
-    padding: 0 8px;
   }
 
   .project-session-footer {
@@ -571,7 +574,9 @@
     }
 
     .project-overview-card {
-      padding: 16px 14px 12px;
+      --project-card-padding-inline: 14px;
+
+      padding: 16px var(--project-card-padding-inline) 12px;
     }
 
     .project-title {

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -1195,8 +1195,8 @@
     align-items: center;
     justify-content: space-between;
     gap: 6px;
-    padding: 6px 8px;
-    margin: 0 -8px;
+    padding: 6px var(--timeline-row-padding-inline, 12px);
+    margin: 0 calc(-1 * var(--timeline-row-bleed, 16px));
     position: relative;
     z-index: 1;
     transition:

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -600,9 +600,9 @@
     display: flex;
     align-items: flex-start;
     gap: 10px;
-    padding: 8px;
-    margin: 0 -8px;
-    border-radius: 6px;
+    padding: 8px var(--timeline-row-padding-inline, 12px);
+    margin: 0 calc(-1 * var(--timeline-row-bleed, 16px));
+    border-radius: 0;
     position: relative;
     transition: background-color 0.15s ease;
   }
@@ -620,7 +620,7 @@
   }
 
   .timeline-row.compact {
-    padding: 6px 8px;
+    padding: 6px var(--timeline-row-padding-inline, 12px);
   }
 
   .timeline-row.failed {


### PR DESCRIPTION
## Summary
- Make timeline row backgrounds span the full card width with configurable bleed and padding variables.
- Align project overview and branch card timeline spacing with their card padding.