### PR TITLE
fix: contain branch card footer buttons within their layout

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1696,10 +1696,10 @@
                             afterLabel: branch.branchName,
                           });
                         }}
-                        class="text-xs"
+                        class="min-w-0 max-w-full !shrink text-xs"
                       >
                         <FileDiff size={13} />
-                        <span>Diff</span>
+                        <span class="truncate">Diff</span>
                       </Button>
                     {/if}
                   </div>
@@ -1891,6 +1891,8 @@
   .branch-card {
     display: flex;
     flex-direction: column;
+    min-width: 0;
+    max-width: 100%;
     background-color: var(--bg-primary);
     border-radius: 8px;
     border: 1px solid var(--border-subtle);
@@ -1984,7 +1986,13 @@
     --timeline-row-bleed: 16px;
 
     padding: 16px;
+    min-width: 0;
     min-height: 80px;
+  }
+
+  .timeline-interior,
+  .timeline-placeholder {
+    min-width: 0;
   }
 
   .loading {
@@ -2030,6 +2038,23 @@
   .footer-right-actions {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
     gap: 4px;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .footer-right-actions :global(.inline-flex) {
+    min-width: 0;
+    max-width: 100%;
+    flex: 0 1 auto;
+  }
+
+  .footer-right-actions :global([data-slot='button']) {
+    min-width: 0;
+    max-width: 100%;
+    flex-shrink: 1;
   }
 </style>

--- a/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardPrButton.svelte
@@ -666,12 +666,12 @@
 </script>
 
 {#snippet prButton(props: Record<string, unknown>)}
-  <span {...props} class="inline-flex">
+  <span {...props} class="inline-flex min-w-0 max-w-full">
     <Button
       variant="outline"
       size="sm"
       class={[
-        'gap-1.5 whitespace-nowrap text-xs font-medium [&_svg]:!size-3.5',
+        'min-w-0 max-w-full !shrink gap-1.5 whitespace-nowrap text-xs font-medium [&_svg]:!size-3.5',
         prState === 'creating' && 'border-[var(--border-muted)]',
         (prState === 'error' || pushState === 'error') &&
           'border-destructive text-destructive hover:bg-[var(--ui-danger-bg)] hover:text-destructive',
@@ -698,7 +698,7 @@
       {:else}
         <GitPullRequestCreateArrow size={13} />
       {/if}
-      <span>
+      <span class="min-w-0 truncate">
         {#if pushState === 'pushing'}
           Pushing…
         {:else if pushState === 'error'}

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -1154,7 +1154,7 @@
                       'hidden',
                       !actionButtonsEnlarged &&
                         '@max-3xl/timeline:inline @max-[480px]/timeline:hidden',
-                    ]}>Code review</span
+                    ]}>Review</span
                   >
                 </Button>
               </span>

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -1194,9 +1194,11 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
     gap: 6px;
     padding: 6px var(--timeline-row-padding-inline, 12px);
     margin: 0 calc(-1 * var(--timeline-row-bleed, 16px));
+    min-width: 0;
     position: relative;
     z-index: 1;
     transition:
@@ -1214,8 +1216,22 @@
   .footer-left-actions {
     display: flex;
     align-items: center;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
     gap: 6px;
+    min-width: 0;
     transition: gap 0.3s ease;
+  }
+
+  .footer-left-actions > span {
+    min-width: 0;
+    flex-shrink: 1;
+  }
+
+  .footer-left-actions :global([data-slot='button']) {
+    min-width: 0;
+    max-width: 100%;
+    flex-shrink: 1;
   }
 
   .footer-left-actions-enlarged {


### PR DESCRIPTION
## Summary

Prevents the branch card and timeline footer action buttons from overflowing their containers when horizontal space is tight.

- **BranchCard**: add `min-width: 0` / `max-width: 100%` constraints to the card, timeline content, and right-action footer so buttons can shrink rather than push the card wider. The footer now wraps, right-aligns, and lets its buttons (including the "Diff" label) shrink and truncate.
- **BranchCardPrButton**: allow the PR button and its label to shrink and truncate instead of forcing `whitespace-nowrap` width.
- **BranchTimeline**: shorten the "Code review" label to "Review", let the footer rows wrap, and allow the left-action buttons to shrink within the available width.

These are CSS/layout-only changes with no behavioral impact.