### PR TITLE
feat(staged): validate pikchr diagrams before session completion

### DIFF
--- a/apps/staged/src-tauri/Cargo.lock
+++ b/apps/staged/src-tauri/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "include_dir",
  "libc",
  "log",
+ "pikchr",
  "rand 0.9.4",
  "regex",
  "reqwest",
@@ -3614,6 +3615,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pikchr"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13680336a9060974d823f15053decc0ae5380eebf6f82abf17608523a7d71826"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/apps/staged/src-tauri/Cargo.toml
+++ b/apps/staged/src-tauri/Cargo.toml
@@ -72,6 +72,7 @@ rand = "0.9"
 hex = "0.4"
 subtle = "2.6"
 time = "0.3"
+pikchr = "0.1.4"
 
 # Debug binaries archived — uncomment when needed
 # [[bin]]

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod image_commands;
 pub mod migrations;
 pub mod note_commands;
 pub mod paths;
+pub(crate) mod pikchr_validation;
 pub mod pr_poll_scheduler;
 pub mod project_commands;
 pub mod project_mcp;

--- a/apps/staged/src-tauri/src/pikchr_validation.rs
+++ b/apps/staged/src-tauri/src/pikchr_validation.rs
@@ -1,0 +1,238 @@
+use std::ffi::{CStr, CString};
+
+use libc::{c_int, c_void, free};
+use pikchr::PikchrFlags;
+
+const PIKCHR_SVG_CLASS: &str = "markdown-pikchr-svg";
+const MAX_PIKCHR_SOURCE_LENGTH: usize = 20_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PikchrBlock {
+    pub(crate) source: String,
+    pub(crate) start_line: usize,
+    pub(crate) end_line: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PikchrValidationError {
+    pub(crate) line_number: usize,
+    pub(crate) message: String,
+}
+
+pub(crate) fn extract_pikchr_blocks(markdown: &str) -> Vec<PikchrBlock> {
+    let normalized = markdown.replace("\r\n", "\n").replace('\r', "\n");
+    let lines: Vec<&str> = normalized.split('\n').collect();
+    let mut blocks = Vec::new();
+    let mut line_index = 0;
+
+    while line_index < lines.len() {
+        let Some(opening) = parse_opening_fence(lines[line_index]) else {
+            line_index += 1;
+            continue;
+        };
+
+        let content_start = line_index + 1;
+        let closing_line_index = (content_start..lines.len()).find(|candidate| {
+            is_closing_fence(lines[*candidate], opening.fence_char, opening.fence_length)
+        });
+        let content_end = closing_line_index.unwrap_or(lines.len());
+
+        if is_pikchr_info_string(&opening.info_string) {
+            blocks.push(PikchrBlock {
+                source: lines[content_start..content_end].join("\n"),
+                start_line: line_index + 1,
+                end_line: closing_line_index.map(|closing| closing + 1),
+            });
+        }
+
+        line_index = closing_line_index
+            .map(|closing| closing + 1)
+            .unwrap_or(lines.len());
+    }
+
+    blocks
+}
+
+pub(crate) fn validate_pikchr_blocks(markdown: &str) -> Vec<PikchrValidationError> {
+    extract_pikchr_blocks(markdown)
+        .into_iter()
+        .filter_map(validate_pikchr_block)
+        .collect()
+}
+
+fn validate_pikchr_block(block: PikchrBlock) -> Option<PikchrValidationError> {
+    let message = if block.source.len() > MAX_PIKCHR_SOURCE_LENGTH {
+        "Pikchr source is too large to validate safely.".to_string()
+    } else if let Err(error) = render_pikchr_for_validation(&block.source) {
+        error
+    } else {
+        return None;
+    };
+
+    Some(PikchrValidationError {
+        line_number: block.start_line,
+        message,
+    })
+}
+
+fn render_pikchr_for_validation(source: &str) -> Result<(), String> {
+    let source = CString::new(source).map_err(|e| format!("{e:?}"))?;
+    let class = CString::new(PIKCHR_SVG_CLASS).expect("static SVG class has no nul bytes");
+    let mut width: c_int = 0;
+    let mut height: c_int = 0;
+
+    let rendered = unsafe {
+        pikchr::raw::pikchr(
+            source.as_ptr(),
+            class.as_ptr(),
+            PikchrFlags::default().into(),
+            &mut width,
+            &mut height,
+        )
+    };
+
+    if rendered.is_null() {
+        return Err("Pikchr returned no validation output.".to_string());
+    }
+
+    let output = unsafe { CStr::from_ptr(rendered) }
+        .to_string_lossy()
+        .trim()
+        .to_string();
+    unsafe {
+        free(rendered as *mut c_void);
+    }
+
+    if width < 0 {
+        Err(output)
+    } else {
+        Ok(())
+    }
+}
+
+struct OpeningFence {
+    fence_char: char,
+    fence_length: usize,
+    info_string: String,
+}
+
+fn parse_opening_fence(line: &str) -> Option<OpeningFence> {
+    let rest = strip_allowed_indent(line)?;
+    let fence_char = rest.chars().next()?;
+    if fence_char != '`' && fence_char != '~' {
+        return None;
+    }
+
+    let fence_length = rest.chars().take_while(|c| *c == fence_char).count();
+    if fence_length < 3 {
+        return None;
+    }
+
+    Some(OpeningFence {
+        fence_char,
+        fence_length,
+        info_string: rest[fence_length..].trim().to_string(),
+    })
+}
+
+fn is_closing_fence(line: &str, fence_char: char, fence_length: usize) -> bool {
+    let Some(rest) = strip_allowed_indent(line) else {
+        return false;
+    };
+
+    let closing_length = rest.chars().take_while(|c| *c == fence_char).count();
+    if closing_length < fence_length {
+        return false;
+    }
+
+    rest[closing_length..]
+        .chars()
+        .all(|c| c == ' ' || c == '\t')
+}
+
+fn strip_allowed_indent(line: &str) -> Option<&str> {
+    let mut spaces = 0;
+    for (idx, ch) in line.char_indices() {
+        match ch {
+            ' ' if spaces < 3 => spaces += 1,
+            ' ' => return None,
+            _ => return Some(&line[idx..]),
+        }
+    }
+    Some("")
+}
+
+fn is_pikchr_info_string(info_string: &str) -> bool {
+    info_string
+        .split_whitespace()
+        .next()
+        .is_some_and(|language| language.eq_ignore_ascii_case("pikchr"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_pikchr_blocks, validate_pikchr_blocks};
+
+    #[test]
+    fn extracts_backtick_and_tilde_pikchr_fences_case_insensitively() {
+        let blocks = extract_pikchr_blocks(
+            r#"Before
+```PIKCHR title="flow"
+box "A" fit
+```
+~~~pikchr
+box "B" fit
+~~~
+"#,
+        );
+
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].start_line, 2);
+        assert_eq!(blocks[0].end_line, Some(4));
+        assert_eq!(blocks[0].source, "box \"A\" fit");
+        assert_eq!(blocks[1].start_line, 5);
+        assert_eq!(blocks[1].end_line, Some(7));
+        assert_eq!(blocks[1].source, "box \"B\" fit");
+    }
+
+    #[test]
+    fn ignores_non_pikchr_fences_while_skipping_their_contents() {
+        let blocks = extract_pikchr_blocks(
+            r#"```rust
+let sample = "```pikchr";
+```
+```pikchr
+box "Done" fit
+```"#,
+        );
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].start_line, 4);
+        assert_eq!(blocks[0].source, "box \"Done\" fit");
+    }
+
+    #[test]
+    fn tracks_unclosed_pikchr_fence_through_end_of_markdown() {
+        let blocks = extract_pikchr_blocks("Before\n```pikchr\nbox \"Draft\" fit");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].start_line, 2);
+        assert_eq!(blocks[0].end_line, None);
+        assert_eq!(blocks[0].source, "box \"Draft\" fit");
+    }
+
+    #[test]
+    fn validates_valid_pikchr_blocks() {
+        let errors = validate_pikchr_blocks("```pikchr\nbox \"Start\" fit\n```");
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn returns_line_number_and_parser_message_for_invalid_pikchr() {
+        let errors = validate_pikchr_blocks("Intro\n```pikchr\nbox \"unterminated\n```");
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].line_number, 2);
+        assert!(!errors[0].message.is_empty());
+    }
+}

--- a/apps/staged/src-tauri/src/pikchr_validation.rs
+++ b/apps/staged/src-tauri/src/pikchr_validation.rs
@@ -4,7 +4,6 @@ use libc::{c_int, c_void, free};
 use pikchr::PikchrFlags;
 
 const PIKCHR_SVG_CLASS: &str = "markdown-pikchr-svg";
-const MAX_PIKCHR_SOURCE_LENGTH: usize = 20_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PikchrBlock {
@@ -61,17 +60,11 @@ pub(crate) fn validate_pikchr_blocks(markdown: &str) -> Vec<PikchrValidationErro
 }
 
 fn validate_pikchr_block(block: PikchrBlock) -> Option<PikchrValidationError> {
-    let message = if block.source.len() > MAX_PIKCHR_SOURCE_LENGTH {
-        "Pikchr source is too large to validate safely.".to_string()
-    } else if let Err(error) = render_pikchr_for_validation(&block.source) {
-        error
-    } else {
-        return None;
-    };
+    let error = render_pikchr_for_validation(&block.source).err()?;
 
     Some(PikchrValidationError {
         line_number: block.start_line,
-        message,
+        message: error,
     })
 }
 

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -53,10 +53,12 @@ use crate::git::Span;
 use crate::shell_env::ShellEnvCache;
 use crate::store::{
     Comment, CommentAuthor, CommentType, CompletionReason, FailureStrategy, MessageRole,
-    PipelineExecution, PipelineKind, PipelineStep, SessionStatus, StepStatus, StepType, Store,
+    PipelineExecution, PipelineKind, PipelineStep, SessionMessage, SessionStatus, StepStatus,
+    StepType, Store,
 };
 
 const PIPELINE_STEP_PROMPT_OUTPUT_MAX_CHARS: usize = 30_000;
+const PIKCHR_VALIDATION_MAX_REPAIR_ATTEMPTS: usize = 2;
 
 pub fn git_identity_env_from_global_config() -> Vec<(String, String)> {
     let Some(name) = global_git_config_value("user.name") else {
@@ -463,11 +465,6 @@ pub fn start_session(
                 (driver.with_extra_env(env), None)
             };
 
-            let writer = Arc::new(MessageWriter::new(
-                config.session_id.clone(),
-                Arc::clone(&store),
-            ));
-
             // Read and base64-encode images for the prompt content blocks.
             let mut image_data: Vec<(String, String)> = Vec::new();
             for image_id in &config.image_ids {
@@ -505,30 +502,91 @@ pub fn start_session(
                 }
             }
 
-            // Cast to trait objects for the driver
-            let store_trait: Arc<dyn acp_client::Store> = store;
-            let writer_trait: Arc<dyn acp_client::MessageWriter> = writer;
+            let mut prompt = config.prompt.clone();
+            let mut agent_session_id = config.agent_session_id.clone();
+            let mut repair_attempts = 0;
+            let mut include_images = true;
 
-            driver
-                .run(
-                    &config.session_id,
-                    &config.prompt,
-                    &image_data,
-                    &config.working_dir,
-                    &store_trait,
-                    &writer_trait,
-                    &cancel_token,
-                    config.agent_session_id.as_deref(),
-                )
-                .await
+            loop {
+                let writer = Arc::new(MessageWriter::new(
+                    config.session_id.clone(),
+                    Arc::clone(&store),
+                ));
+                let store_trait: Arc<dyn acp_client::Store> = store.clone();
+                let writer_trait: Arc<dyn acp_client::MessageWriter> = writer;
+                let images = if include_images {
+                    image_data.as_slice()
+                } else {
+                    &[]
+                };
+                include_images = false;
+
+                let turn_result = driver
+                    .run(
+                        &config.session_id,
+                        &prompt,
+                        images,
+                        &config.working_dir,
+                        &store_trait,
+                        &writer_trait,
+                        &cancel_token,
+                        agent_session_id.as_deref(),
+                    )
+                    .await;
+
+                if !should_validate_pikchr_after_turn(&turn_result, cancel_token.is_cancelled()) {
+                    return turn_result;
+                }
+
+                match validate_latest_session_pikchr(&store, &config.session_id)? {
+                    LatestAssistantPikchrValidation::SkippedFinalMessage
+                    | LatestAssistantPikchrValidation::NoPikchr
+                    | LatestAssistantPikchrValidation::Valid => return Ok(()),
+                    LatestAssistantPikchrValidation::Invalid(error) => {
+                        if repair_attempts >= PIKCHR_VALIDATION_MAX_REPAIR_ATTEMPTS {
+                            return Err(format!(
+                                "Pikchr validation failed after {} repair attempts: block starting at line {}: {}",
+                                PIKCHR_VALIDATION_MAX_REPAIR_ATTEMPTS,
+                                error.line_number,
+                                error.message
+                            ));
+                        }
+
+                        repair_attempts += 1;
+                        let prompt_is_for_note =
+                            session_has_note_artifact(&store, &config.session_id);
+                        let corrective_prompt =
+                            build_pikchr_correction_prompt(&error, prompt_is_for_note);
+                        store
+                            .add_session_message(
+                                &config.session_id,
+                                MessageRole::User,
+                                &corrective_prompt,
+                            )
+                            .map_err(|e| {
+                                format!("Failed to persist Pikchr correction prompt: {e}")
+                            })?;
+
+                        if let Some(stored_id) =
+                            stored_agent_session_id(&store, &config.session_id)?
+                        {
+                            agent_session_id = Some(stored_id);
+                        }
+                        if agent_session_id.is_none() {
+                            return Err(
+                                "Pikchr validation failed but no agent session id is available for correction"
+                                    .to_string(),
+                            );
+                        }
+                        prompt = corrective_prompt;
+                    }
+                }
+            }
         });
 
         let cancellation_completion_reason = registry
             .cancellation_completion_reason(&session_id_for_status)
             .unwrap_or(CompletionReason::Interrupted);
-
-        // Always deregister, regardless of outcome.
-        registry.deregister(&session_id_for_status);
 
         // Transition the session to its terminal state, but only if it is
         // still "running". This prevents a late-arriving "completed" from
@@ -556,12 +614,16 @@ pub fn start_session(
             }
         };
 
+        // Always deregister after validation, so a corrective Pikchr follow-up
+        // can keep using the active cancellation token.
+        registry.deregister(&session_id_for_status);
+
         // Run post-completion hooks before transitioning status.
         // These detect artifacts produced by the session (commits, notes).
         // Returns the branch_id when a new commit was detected.
         let committed_branch_id = if new_status == "completed" {
             run_post_completion_hooks(
-                &session_id_for_status,
+                &config.session_id,
                 &config.working_dir,
                 config.pre_head_sha.as_deref(),
                 config.workspace_name.as_deref(),
@@ -673,6 +735,101 @@ pub fn start_session(
     });
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LatestAssistantPikchrValidation {
+    SkippedFinalMessage,
+    NoPikchr,
+    Valid,
+    Invalid(crate::pikchr_validation::PikchrValidationError),
+}
+
+fn should_validate_pikchr_after_turn(result: &Result<(), String>, is_cancelled: bool) -> bool {
+    result.is_ok() && !is_cancelled
+}
+
+fn validate_latest_session_pikchr(
+    store: &Store,
+    session_id: &str,
+) -> Result<LatestAssistantPikchrValidation, String> {
+    let messages = store
+        .get_session_messages(session_id)
+        .map_err(|e| format!("Failed to load session messages for Pikchr validation: {e}"))?;
+    Ok(validate_latest_message_pikchr(&messages))
+}
+
+fn validate_latest_message_pikchr(messages: &[SessionMessage]) -> LatestAssistantPikchrValidation {
+    let Some(message) = messages.last() else {
+        return LatestAssistantPikchrValidation::SkippedFinalMessage;
+    };
+    if message.role != MessageRole::Assistant {
+        return LatestAssistantPikchrValidation::SkippedFinalMessage;
+    }
+
+    let blocks = crate::pikchr_validation::extract_pikchr_blocks(&message.content);
+    if blocks.is_empty() {
+        return LatestAssistantPikchrValidation::NoPikchr;
+    }
+
+    match crate::pikchr_validation::validate_pikchr_blocks(&message.content)
+        .into_iter()
+        .next()
+    {
+        Some(error) => LatestAssistantPikchrValidation::Invalid(error),
+        None => LatestAssistantPikchrValidation::Valid,
+    }
+}
+
+fn stored_agent_session_id(store: &Store, session_id: &str) -> Result<Option<String>, String> {
+    store
+        .get_session(session_id)
+        .map_err(|e| format!("Failed to load session agent id for Pikchr correction: {e}"))
+        .map(|session| session.and_then(|s| s.agent_id))
+}
+
+fn session_has_note_artifact(store: &Store, session_id: &str) -> bool {
+    store
+        .get_note_by_session(session_id)
+        .ok()
+        .flatten()
+        .is_some()
+        || store
+            .get_project_note_by_session(session_id)
+            .ok()
+            .flatten()
+            .is_some()
+}
+
+fn build_pikchr_correction_prompt(
+    error: &crate::pikchr_validation::PikchrValidationError,
+    note_format_required: bool,
+) -> String {
+    let note_format = if note_format_required {
+        "\n\nThis session is producing a Staged note. Preserve the required final response format:\n\
+- Start with a fenced block whose opening line is exactly: ```suggested-next-steps\n\
+- Put only a JSON object in that block, with nullable string fields `suggestedNextCommitStep` and `suggestedNextNoteStep`.\n\
+- After that block, include a `---` separator on its own line.\n\
+- Start the note content immediately after `---` with a markdown H1 (`# <Title>`).\n\
+- Do not wrap the note content in code fences."
+    } else {
+        ""
+    };
+
+    format!(
+        "<action>\n\
+The final assistant response contains an invalid fenced `pikchr` code block.\n\
+\n\
+The Pikchr block starting at line {} failed to parse:\n\
+{}\n\
+\n\
+Return a complete corrected final response. Fix the Pikchr code so every fenced `pikchr` block parses successfully.\n\
+\n\
+Do not edit files, run git operations, create commits, or change repository state.\
+{note_format}\n\
+</action>",
+        error.line_number, error.message
+    )
 }
 
 // =============================================================================
@@ -2564,6 +2721,105 @@ pub fn emit_session_running(
 mod tests {
     use super::*;
     use crate::git::strip_git_env;
+
+    fn session_message(role: MessageRole, content: &str) -> SessionMessage {
+        SessionMessage {
+            id: 0,
+            session_id: "session-1".to_string(),
+            role,
+            content: content.to_string(),
+            created_at: 0,
+            image_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn pikchr_validation_skips_when_latest_message_is_not_assistant() {
+        let messages = vec![session_message(MessageRole::User, "Thanks")];
+
+        assert_eq!(
+            validate_latest_message_pikchr(&messages),
+            LatestAssistantPikchrValidation::SkippedFinalMessage
+        );
+    }
+
+    #[test]
+    fn pikchr_validation_allows_assistant_message_without_pikchr() {
+        let messages = vec![session_message(
+            MessageRole::Assistant,
+            "Done. No diagrams in this response.",
+        )];
+
+        assert_eq!(
+            validate_latest_message_pikchr(&messages),
+            LatestAssistantPikchrValidation::NoPikchr
+        );
+    }
+
+    #[test]
+    fn pikchr_validation_allows_valid_pikchr_in_latest_assistant_message() {
+        let messages = vec![session_message(
+            MessageRole::Assistant,
+            "```pikchr\nbox \"Start\" fit\n```",
+        )];
+
+        assert_eq!(
+            validate_latest_message_pikchr(&messages),
+            LatestAssistantPikchrValidation::Valid
+        );
+    }
+
+    #[test]
+    fn pikchr_validation_reports_invalid_pikchr_for_corrective_prompt() {
+        let messages = vec![session_message(
+            MessageRole::Assistant,
+            "Intro\n```pikchr\nbox \"unterminated\n```",
+        )];
+
+        let outcome = validate_latest_message_pikchr(&messages);
+        match outcome {
+            LatestAssistantPikchrValidation::Invalid(error) => {
+                assert_eq!(error.line_number, 2);
+                assert!(!error.message.is_empty());
+
+                let prompt = build_pikchr_correction_prompt(&error, true);
+                assert!(prompt.contains("line 2"));
+                assert!(prompt.contains(&error.message));
+                assert!(prompt.contains("complete corrected final response"));
+                assert!(prompt.contains("Do not edit files"));
+                assert!(prompt.contains("run git operations"));
+                assert!(prompt.contains("create commits"));
+                assert!(prompt.contains("```suggested-next-steps"));
+                assert!(prompt.contains("`---` separator"));
+                assert!(prompt.contains("# <Title>"));
+            }
+            other => panic!("expected invalid Pikchr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pikchr_validation_skips_failed_cancelled_and_interrupted_turns() {
+        let ok = Ok(());
+        let failed = Err("agent crashed".to_string());
+
+        assert!(should_validate_pikchr_after_turn(&ok, false));
+        assert!(!should_validate_pikchr_after_turn(&failed, false));
+        assert!(!should_validate_pikchr_after_turn(&ok, true));
+        assert!(!should_validate_pikchr_after_turn(&failed, true));
+    }
+
+    #[test]
+    fn pikchr_validation_ignores_older_assistant_when_final_message_is_non_assistant() {
+        let messages = vec![
+            session_message(MessageRole::Assistant, "```pikchr\nbox \"unterminated\n```"),
+            session_message(MessageRole::User, "Please continue"),
+        ];
+
+        assert_eq!(
+            validate_latest_message_pikchr(&messages),
+            LatestAssistantPikchrValidation::SkippedFinalMessage
+        );
+    }
 
     #[cfg(unix)]
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds server-side validation of [Pikchr](https://pikchr.org/) diagrams in an agent's final assistant message before a session is allowed to complete. If a diagram fails to render, the session automatically asks the agent to repair it (up to 2 attempts) before giving up.

## Changes

- **New `pikchr_validation` module** (`pikchr_validation.rs`): extracts fenced `pikchr` code blocks from markdown (handling CRLF normalization, indented/variable-length fences, and unterminated blocks) and validates each by rendering it through the `pikchr` C library, reporting the offending source line and error message on failure.
- **Session runner integration** (`session_runner.rs`): after a successful, non-cancelled turn, validates the Pikchr in the latest assistant message. On failure it persists a corrective follow-up prompt, reuses the active agent session id, and re-runs the driver — looping up to `PIKCHR_VALIDATION_MAX_REPAIR_ATTEMPTS` (2) times. Deregistration is deferred until after validation so the corrective follow-up can keep using the live cancellation token. Images are only sent on the first turn.
- **Dependencies**: adds `pikchr` (and `libc`) to `Cargo.toml`/`Cargo.lock`, and registers the module in `lib.rs`.
- Drops an earlier Pikchr source size cap from validation so large diagrams are validated rather than skipped.

## Test plan

- [x] `crates-fmt`, `crates-lint`, `crates-test`, `staged-ci` green on push