### PR TITLE
fix: improve note deletion and timeline touch row actions

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -400,6 +400,7 @@
               onSessionClick={(sid) => {
                 openSessionId = sid;
               }}
+              deleteDisabledReason={deletingNoteIds.has(note.id) ? 'Deleting...' : undefined}
               onDeleteClick={() => handleDeleteNote(note.id)}
               contextMenuKey={projectNoteContextMenuKey(note)}
             />

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -255,10 +255,13 @@
   let projectNoteContextMenuActions = $derived.by(() => {
     const actions: TimelineContextMenuAction[] = [];
     for (const note of timelineNotes) {
-      const key = projectNoteContextMenuKey(note);
-      if (key) {
-        actions.push({ key, hashtagRef: `#project-note:${note.id}` });
-      }
+      const deleting = deletingNoteIds.has(note.id);
+      actions.push({
+        key: projectNoteContextMenuKey(note),
+        hashtagRef: isCompletedProjectNote(note) ? `#project-note:${note.id}` : undefined,
+        deleteDisabledReason: deleting ? 'Deleting...' : undefined,
+        onDelete: deleting ? undefined : () => handleDeleteNote(note.id),
+      });
     }
     return actions;
   });
@@ -277,8 +280,8 @@
     return !isRunning && !isFailed;
   }
 
-  function projectNoteContextMenuKey(note: ProjectNote): string | undefined {
-    return isCompletedProjectNote(note) ? `project-note-${note.id}` : undefined;
+  function projectNoteContextMenuKey(note: ProjectNote): string {
+    return `project-note-${note.id}`;
   }
 
   function handleProjectNoteNewSessionReferring(ref: string) {

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -259,7 +259,6 @@
       actions.push({
         key: projectNoteContextMenuKey(note),
         hashtagRef: isCompletedProjectNote(note) ? `#project-note:${note.id}` : undefined,
-        deleteDisabledReason: deleting ? 'Deleting...' : undefined,
         onDelete: deleting ? undefined : () => handleDeleteNote(note.id),
       });
     }

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -816,7 +816,6 @@
       key: item.key,
       commitSha: item.commitSha,
       hashtagRef: item.hashtagRef,
-      deleteDisabledReason,
       onDelete:
         isDeletable(item) && !deleteDisabledReason
           ? (opts) => handleDeleteClick(item, opts)

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -805,15 +805,22 @@
   }
 
   function hasContextMenuAction(item: DisplayItem): boolean {
-    return !!item.commitSha || (!!item.hashtagRef && !!onNewSessionReferring);
+    return !!item.commitSha || (!!item.hashtagRef && !!onNewSessionReferring) || isDeletable(item);
   }
 
   function contextMenuActionForItem(item: DisplayItem): TimelineContextMenuAction | null {
     if (!hasContextMenuAction(item)) return null;
+    const deleteDisabledReason = isDeletable(item) ? item.deleteDisabledReason : undefined;
+
     return {
       key: item.key,
       commitSha: item.commitSha,
       hashtagRef: item.hashtagRef,
+      deleteDisabledReason,
+      onDelete:
+        isDeletable(item) && !deleteDisabledReason
+          ? (opts) => handleDeleteClick(item, opts)
+          : undefined,
     };
   }
 

--- a/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
@@ -2,12 +2,15 @@
   import type { Snippet } from 'svelte';
   import Copy from '@lucide/svelte/icons/copy';
   import MessageSquarePlus from '@lucide/svelte/icons/message-square-plus';
+  import Trash2 from '@lucide/svelte/icons/trash-2';
   import * as ContextMenu from '$lib/components/ui/context-menu';
 
   export type TimelineContextMenuAction = {
     key: string;
     commitSha?: string;
     hashtagRef?: string;
+    deleteDisabledReason?: string;
+    onDelete?: (opts?: { altKey: boolean }) => void;
   };
 
   interface Props {
@@ -22,7 +25,12 @@
   let activeActionKey = $state<string | null>(null);
 
   function hasVisibleAction(action: TimelineContextMenuAction): boolean {
-    return !!action.commitSha || (!!action.hashtagRef && !!onNewSessionReferring);
+    return (
+      !!action.commitSha ||
+      (!!action.hashtagRef && !!onNewSessionReferring) ||
+      !!action.onDelete ||
+      !!action.deleteDisabledReason
+    );
   }
 
   let actionByKey = $derived.by(() => {
@@ -96,6 +104,10 @@
     }
   }
 
+  function handleDelete() {
+    activeAction?.onDelete?.({ altKey: false });
+  }
+
   $effect(() => {
     if (activeActionKey && !actionByKey.has(activeActionKey)) {
       activeActionKey = null;
@@ -123,6 +135,16 @@
         {#if activeAction.hashtagRef && onNewSessionReferring}
           <ContextMenu.Item onSelect={handleNewSessionReferring}>
             <MessageSquarePlus size={14} /> New session referring to this
+          </ContextMenu.Item>
+        {/if}
+        {#if activeAction.onDelete || activeAction.deleteDisabledReason}
+          <ContextMenu.Item
+            variant="destructive"
+            disabled={!!activeAction.deleteDisabledReason}
+            title={activeAction.deleteDisabledReason ?? 'Delete'}
+            onSelect={handleDelete}
+          >
+            <Trash2 size={14} /> Delete
           </ContextMenu.Item>
         {/if}
       {/if}

--- a/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineContextMenu.svelte
@@ -9,7 +9,6 @@
     key: string;
     commitSha?: string;
     hashtagRef?: string;
-    deleteDisabledReason?: string;
     onDelete?: (opts?: { altKey: boolean }) => void;
   };
 
@@ -26,10 +25,7 @@
 
   function hasVisibleAction(action: TimelineContextMenuAction): boolean {
     return (
-      !!action.commitSha ||
-      (!!action.hashtagRef && !!onNewSessionReferring) ||
-      !!action.onDelete ||
-      !!action.deleteDisabledReason
+      !!action.commitSha || (!!action.hashtagRef && !!onNewSessionReferring) || !!action.onDelete
     );
   }
 
@@ -137,13 +133,8 @@
             <MessageSquarePlus size={14} /> New session referring to this
           </ContextMenu.Item>
         {/if}
-        {#if activeAction.onDelete || activeAction.deleteDisabledReason}
-          <ContextMenu.Item
-            variant="destructive"
-            disabled={!!activeAction.deleteDisabledReason}
-            title={activeAction.deleteDisabledReason ?? 'Delete'}
-            onSelect={handleDelete}
-          >
+        {#if activeAction.onDelete}
+          <ContextMenu.Item variant="destructive" onSelect={handleDelete}>
             <Trash2 size={14} /> Delete
           </ContextMenu.Item>
         {/if}

--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -568,13 +568,17 @@
             onclick={handleSessionClick}
             title="View session"
             aria-label="View session"
-            class="size-[22px] text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-[var(--ui-accent)] [&_svg]:!size-3"
+            class="session-action size-[22px] text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-[var(--ui-accent)] [&_svg]:!size-3"
           >
             <MessageSquare size={12} />
           </Button>
         {/if}
         {#if onDeleteClick || deleteDisabledReason}
-          <span class="inline-flex" title={deleteTitle}>
+          <span
+            class="inline-flex delete-action"
+            class:context-menu-only={!!contextMenuKey}
+            title={deleteTitle}
+          >
             <Button
               variant="ghost"
               size="icon-xs"
@@ -868,6 +872,15 @@
   @media (hover: none), (pointer: coarse) {
     .timeline-actions {
       opacity: 1;
+    }
+
+    .timeline-actions :global(.session-action) {
+      width: 44px;
+      min-width: 44px;
+    }
+
+    .delete-action.context-menu-only {
+      display: none;
     }
   }
 


### PR DESCRIPTION
## Summary

Improves note deletion affordances and timeline row actions on touch devices.

- Add a **Delete** action to the timeline context menu, surfacing deletion for deletable items (including project notes) alongside the existing copy / new-session actions.
- On touch devices, hide the inline delete button when a context-menu action is available and widen the session action button for an easier tap target, relying on the context menu for deletion instead.
- While a note delete is in flight, disable the inline delete button (with a "Deleting..." reason) and hide the context-menu delete entry rather than leaving it actionable.

## Changes

- `ProjectSection.svelte` — always provide a context-menu key for project notes, gate the delete handler/hashtag ref on note state, and pass a `deleteDisabledReason` while deleting.
- `BranchTimeline.svelte` — wire `onDelete` into context-menu actions for deletable items, respecting `deleteDisabledReason`.
- `TimelineContextMenu.svelte` — add the destructive **Delete** menu item and `onDelete` action support.
- `TimelineRow.svelte` — hide the inline delete on touch when a context-menu key exists and widen the session action on touch.