### PR TITLE
fix(staged): remove tooltips from timeline row subtitles

### DIFF
--- a/apps/staged/src/lib/features/timeline/TimelineRow.svelte
+++ b/apps/staged/src/lib/features/timeline/TimelineRow.svelte
@@ -352,15 +352,13 @@
         {#if meta || secondaryMeta || tertiaryMeta || (badges && badges.length > 0)}
           <div class="timeline-meta">
             {#if meta}
-              <span class="meta-item" title={meta}>{meta}</span>
+              <span class="meta-item">{meta}</span>
             {/if}
             {#if secondaryMeta}
-              <span class="meta-item meta-sha" class:failed-meta={isFailed} title={secondaryMeta}
-                >{secondaryMeta}</span
-              >
+              <span class="meta-item meta-sha" class:failed-meta={isFailed}>{secondaryMeta}</span>
             {/if}
             {#if tertiaryMeta}
-              <span class="meta-item" title={tertiaryMeta}>{tertiaryMeta}</span>
+              <span class="meta-item">{tertiaryMeta}</span>
             {/if}
             {#if badges}
               {#each badges as badge}


### PR DESCRIPTION
Removes the native `title` hover tooltips from the meta-item subtitle spans in the timeline row (`meta`, `secondaryMeta`/SHA, and `tertiaryMeta`).

These tooltips duplicated text already visible in the row and added hover noise. They were also a contributor to the tooltip-dense, non-virtualized timeline DOM.

## Changes
- `apps/staged/src/lib/features/timeline/TimelineRow.svelte`: drop `title={...}` from the three subtitle `meta-item` spans.