### PR TITLE
fix(staged): equalize project detail horizontal and vertical spacing

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -1589,7 +1589,7 @@
     width: 100%;
     max-width: 900px;
     margin: 0 auto;
-    padding: 16px 24px 24px;
+    padding: 16px;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
@@ -1620,7 +1620,7 @@
     }
 
     .projects-list {
-      padding: 12px 16px 16px;
+      padding: 12px;
       gap: 20px;
     }
   }


### PR DESCRIPTION
Equalizes the padding around the projects list in the project detail view so the horizontal and vertical gaps match.

- `.projects-list` padding goes from `16px 24px 24px` to a uniform `16px`.
- The responsive (narrow-width) override goes from `12px 16px 16px` to a uniform `12px`.

Previously the horizontal padding (24px / 16px) was larger than the top padding (16px / 12px), giving uneven spacing around the content.