### PR TITLE
chore: pin rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## What

Pin the Rust toolchain to an explicit version (`1.95.0`) instead of floating on `stable`.

## Why

- **Deterministic builds.** Floating `stable` means the compiler silently changes whenever a dev or CI runs `rustup update` — which can shift behavior/lints and invalidate build caches. Pinning makes the toolchain reproducible across machines and CI.
- **Consistency.** Our other Rust repos (`goose`, `goose-internal`) already pin explicit versions; `builderbot` was the outlier still on `stable`.

## Notes

- `1.95.0` is the current latest stable.
- One-time toolchain bump: the first build per machine/CI after merge will be a full rebuild, and CI's cached toolchain will update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)