### PR TITLE
Add AGENTS.md bootstrap option to pm new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -14,3 +14,5 @@ dirs = "6"
 colored = "3"
 dialoguer = "0.11"
 
+[dev-dependencies]
+tempfile = "3"

--- a/crates/pm/README.md
+++ b/crates/pm/README.md
@@ -36,6 +36,16 @@ pm new my-feature
 cd my-feature
 ```
 
+To bootstrap agent instructions into the project root:
+
+```sh
+# Copy ./AGENTS.md into the new project and link CLAUDE.md to it
+pm new my-feature --agents-md
+
+# Or copy a specific AGENTS.md file
+pm new my-feature --agents-md path/to/AGENTS.md
+```
+
 ### Add repos
 
 ```sh

--- a/crates/pm/README.md
+++ b/crates/pm/README.md
@@ -43,7 +43,7 @@ To bootstrap agent instructions into the project root:
 pm new my-feature --agents-md
 
 # Or copy a specific AGENTS.md file
-pm new my-feature --agents-md path/to/AGENTS.md
+pm new my-feature --agents-md=path/to/AGENTS.md
 ```
 
 ### Add repos

--- a/crates/pm/src/cmd.rs
+++ b/crates/pm/src/cmd.rs
@@ -37,8 +37,12 @@ pub fn init(base: &Path) -> Result<()> {
 
 // ── new ─────────────────────────────────────────────────────────────────
 
-pub fn new(base: &Path, name: &str) -> Result<()> {
+pub fn new(base: &Path, name: &str, agents_md: Option<&Path>) -> Result<()> {
     let mut state = State::load_or_err(base)?;
+    let agents_md = match agents_md {
+        Some(path) => Some(resolve_agents_md(path)?),
+        None => None,
+    };
 
     // Handle orphaned state: project in state but dir is gone
     if state.projects.contains_key(name) {
@@ -62,6 +66,10 @@ pub fn new(base: &Path, name: &str) -> Result<()> {
     std::fs::create_dir_all(&project_dir)
         .with_context(|| format!("Failed to create {}", project_dir.display()))?;
 
+    if let Some(agents_md) = agents_md {
+        install_agents_md(&project_dir, &agents_md)?;
+    }
+
     state.projects.insert(
         name.to_string(),
         state::Project {
@@ -80,6 +88,46 @@ pub fn new(base: &Path, name: &str) -> Result<()> {
         "\n  cd into it and run {} to add repos.",
         "pm add <repo>".cyan()
     );
+    Ok(())
+}
+
+fn resolve_agents_md(path: &Path) -> Result<PathBuf> {
+    if !path.exists() {
+        bail!(
+            "AGENTS.md file '{}' was not found. Provide an AGENTS.md file with --agents-md <path>.",
+            path.display(),
+        );
+    }
+    if !path.is_file() {
+        bail!("AGENTS.md path '{}' is not a file.", path.display());
+    }
+    Ok(path.to_path_buf())
+}
+
+fn install_agents_md(project_dir: &Path, source: &Path) -> Result<()> {
+    let agents_md = project_dir.join("AGENTS.md");
+    std::fs::copy(source, &agents_md).with_context(|| {
+        format!(
+            "Failed to copy {} to {}",
+            source.display(),
+            agents_md.display()
+        )
+    })?;
+
+    let claude_md = project_dir.join("CLAUDE.md");
+    if claude_md.is_symlink() || claude_md.exists() {
+        std::fs::remove_file(&claude_md)
+            .with_context(|| format!("Failed to remove {}", claude_md.display()))?;
+    }
+
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("AGENTS.md", &claude_md)
+        .with_context(|| format!("symlink {} → AGENTS.md", claude_md.display()))?;
+
+    #[cfg(not(unix))]
+    std::os::windows::fs::symlink_file("AGENTS.md", &claude_md)
+        .with_context(|| format!("symlink {} → AGENTS.md", claude_md.display()))?;
+
     Ok(())
 }
 

--- a/crates/pm/src/cmd.rs
+++ b/crates/pm/src/cmd.rs
@@ -94,25 +94,33 @@ pub fn new(base: &Path, name: &str, agents_md: Option<&Path>) -> Result<()> {
 fn resolve_agents_md(path: &Path) -> Result<PathBuf> {
     if !path.exists() {
         bail!(
-            "AGENTS.md file '{}' was not found. Provide an AGENTS.md file with --agents-md <path>.",
+            "AGENTS.md file '{}' was not found. Provide an AGENTS.md file with --agents-md=<path>.",
             path.display(),
         );
     }
     if !path.is_file() {
         bail!("AGENTS.md path '{}' is not a file.", path.display());
     }
-    Ok(path.to_path_buf())
+    path.canonicalize()
+        .with_context(|| format!("Failed to resolve {}", path.display()))
 }
 
 fn install_agents_md(project_dir: &Path, source: &Path) -> Result<()> {
     let agents_md = project_dir.join("AGENTS.md");
-    std::fs::copy(source, &agents_md).with_context(|| {
-        format!(
-            "Failed to copy {} to {}",
-            source.display(),
-            agents_md.display()
-        )
-    })?;
+    let already_installed = agents_md
+        .canonicalize()
+        .map(|destination| destination == source)
+        .unwrap_or(false);
+
+    if !already_installed {
+        std::fs::copy(source, &agents_md).with_context(|| {
+            format!(
+                "Failed to copy {} to {}",
+                source.display(),
+                agents_md.display()
+            )
+        })?;
+    }
 
     let claude_md = project_dir.join("CLAUDE.md");
     if claude_md.is_symlink() || claude_md.exists() {

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -30,7 +30,7 @@ enum Commands {
 
         /// Copy AGENTS.md into the project and symlink CLAUDE.md to it.
         /// When passed without a path, uses AGENTS.md from the current directory.
-        #[arg(long, value_name = "PATH", num_args = 0..=1)]
+        #[arg(long, value_name = "PATH", num_args = 0..=1, require_equals = true)]
         agents_md: Option<Option<PathBuf>>,
     },
 

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -27,6 +27,11 @@ enum Commands {
     New {
         /// Project name
         name: String,
+
+        /// Copy AGENTS.md into the project and symlink CLAUDE.md to it.
+        /// When passed without a path, uses AGENTS.md from the current directory.
+        #[arg(long, value_name = "PATH", num_args = 0..=1)]
+        agents_md: Option<Option<PathBuf>>,
     },
 
     /// Add a repo to the current project
@@ -131,7 +136,11 @@ fn main() -> Result<()> {
     }
 
     match cli.command {
-        Commands::New { name } => cmd::new(&base, &name),
+        Commands::New { name, agents_md } => {
+            let agents_md =
+                agents_md.map(|path| path.unwrap_or_else(|| PathBuf::from("AGENTS.md")));
+            cmd::new(&base, &name, agents_md.as_deref())
+        }
         Commands::Add {
             repo,
             branch,

--- a/crates/pm/tests/new_agents.rs
+++ b/crates/pm/tests/new_agents.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn pm() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_pm"))
+}
+
+fn assert_success(output: std::process::Output) {
+    assert!(
+        output.status.success(),
+        "expected command to succeed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn assert_symlink_to_agents(project_dir: &Path) {
+    let claude_md = project_dir.join("CLAUDE.md");
+    let target = fs::read_link(&claude_md).expect("CLAUDE.md should be a symlink");
+    assert_eq!(target, Path::new("AGENTS.md"));
+}
+
+#[test]
+fn new_without_agents_md_option_skips_agent_files() {
+    let workspace = TempDir::new().unwrap();
+
+    let output = pm()
+        .arg("new")
+        .arg("feature")
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert_success(output);
+    let project_dir = workspace.path().join("feature");
+    assert!(!project_dir.join("AGENTS.md").exists());
+    assert!(!project_dir.join("CLAUDE.md").exists());
+}
+
+#[test]
+fn new_with_agents_md_path_copies_agents_and_links_claude() {
+    let workspace = TempDir::new().unwrap();
+    let source_dir = TempDir::new().unwrap();
+    let source = source_dir.path().join("source.AGENTS.md");
+    fs::write(&source, "# Agent instructions\n").unwrap();
+
+    let output = pm()
+        .arg("new")
+        .arg("feature")
+        .arg("--agents-md")
+        .arg(&source)
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert_success(output);
+    let project_dir = workspace.path().join("feature");
+    assert_eq!(
+        fs::read_to_string(project_dir.join("AGENTS.md")).unwrap(),
+        "# Agent instructions\n"
+    );
+    assert_symlink_to_agents(&project_dir);
+}
+
+#[test]
+fn new_with_agents_md_without_path_uses_cwd_agents_md() {
+    let workspace = TempDir::new().unwrap();
+    fs::write(workspace.path().join("AGENTS.md"), "# Local agents\n").unwrap();
+
+    let output = pm()
+        .arg("new")
+        .arg("feature")
+        .arg("--agents-md")
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert_success(output);
+    let project_dir = workspace.path().join("feature");
+    assert_eq!(
+        fs::read_to_string(project_dir.join("AGENTS.md")).unwrap(),
+        "# Local agents\n"
+    );
+    assert_symlink_to_agents(&project_dir);
+}
+
+#[test]
+fn new_with_agents_md_without_path_fails_when_cwd_agents_md_is_missing() {
+    let workspace = TempDir::new().unwrap();
+
+    let output = pm()
+        .arg("new")
+        .arg("feature")
+        .arg("--agents-md")
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("AGENTS.md"),
+        "stderr should mention AGENTS.md, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--agents-md"),
+        "stderr should ask for --agents-md, got:\n{stderr}"
+    );
+}

--- a/crates/pm/tests/new_agents.rs
+++ b/crates/pm/tests/new_agents.rs
@@ -51,8 +51,7 @@ fn new_with_agents_md_path_copies_agents_and_links_claude() {
     let output = pm()
         .arg("new")
         .arg("feature")
-        .arg("--agents-md")
-        .arg(&source)
+        .arg(format!("--agents-md={}", source.display()))
         .current_dir(workspace.path())
         .output()
         .unwrap();
@@ -84,6 +83,51 @@ fn new_with_agents_md_without_path_uses_cwd_agents_md() {
     assert_eq!(
         fs::read_to_string(project_dir.join("AGENTS.md")).unwrap(),
         "# Local agents\n"
+    );
+    assert_symlink_to_agents(&project_dir);
+}
+
+#[test]
+fn new_with_agents_md_before_name_uses_cwd_agents_md() {
+    let workspace = TempDir::new().unwrap();
+    fs::write(workspace.path().join("AGENTS.md"), "# Local agents\n").unwrap();
+
+    let output = pm()
+        .arg("new")
+        .arg("--agents-md")
+        .arg("feature")
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert_success(output);
+    let project_dir = workspace.path().join("feature");
+    assert_eq!(
+        fs::read_to_string(project_dir.join("AGENTS.md")).unwrap(),
+        "# Local agents\n"
+    );
+    assert_symlink_to_agents(&project_dir);
+}
+
+#[test]
+fn new_with_agents_md_source_matching_destination_preserves_agents_md() {
+    let workspace = TempDir::new().unwrap();
+    let project_dir = workspace.path().join("feature");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("AGENTS.md"), "# Existing agents\n").unwrap();
+
+    let output = pm()
+        .arg("new")
+        .arg("feature")
+        .arg("--agents-md=feature/AGENTS.md")
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert_success(output);
+    assert_eq!(
+        fs::read_to_string(project_dir.join("AGENTS.md")).unwrap(),
+        "# Existing agents\n"
     );
     assert_symlink_to_agents(&project_dir);
 }


### PR DESCRIPTION
## Why
Make it easier to bootstrap new `pm` project directories with agent instructions when the caller wants them.

## What
- Add `pm new --agents-md [PATH]` with `./AGENTS.md` as the no-value default
- Copy the selected agent instructions into the project root and symlink `CLAUDE.md` to `AGENTS.md`
- Add integration coverage for omitted, explicit-path, default-path, and missing-file behavior

## Risk Assessment
Low — this only affects `pm new` when the new option is supplied; existing calls without `--agents-md` keep skipping agent files.

## References
- Verified with `cargo test -p pm`
- Verified with `cargo clippy --workspace -- -D warnings`
- Verified with `cargo fmt --all --check`
- Verified with `cargo test --workspace`
- Pre-push passed crates fmt/lint/test plus staged and differ CI

Generated with Codex