### PR TITLE
feat(staged): add preview_pikchr MCP tool for note-writing sessions

### DIFF
--- a/apps/staged/src-tauri/Cargo.lock
+++ b/apps/staged/src-tauri/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "reqwest",
+ "resvg",
  "rmcp",
  "rusqlite",
  "rusqlite_migration",
@@ -47,10 +48,12 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "time",
+ "tiny-skia",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tower-http",
+ "usvg",
  "uuid",
 ]
 
@@ -203,6 +206,12 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -869,6 +878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +982,15 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1125,6 +1149,12 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deranged"
@@ -1442,6 +1472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1601,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1623,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1916,6 +1984,16 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2496,6 +2574,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +2816,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,6 +2886,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2925,6 +3037,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -3618,6 +3739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pikchr"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +3834,15 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -4215,6 +4351,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,6 +4389,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -4323,6 +4485,21 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4487,6 +4664,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -4911,6 +5106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4927,6 +5131,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -5024,6 +5237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5113,6 +5335,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher 1.0.2",
+]
 
 [[package]]
 name = "swift-rs"
@@ -5801,6 +6033,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.18.1",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6132,6 +6390,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6218,16 +6485,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-xid"
@@ -6264,6 +6567,34 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher 1.0.2",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -7400,6 +7731,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yoke"

--- a/apps/staged/src-tauri/Cargo.toml
+++ b/apps/staged/src-tauri/Cargo.toml
@@ -74,6 +74,12 @@ subtle = "2.6"
 time = "0.3"
 pikchr = "0.1.4"
 
+# Pikchr preview MCP tool: render Pikchr source to SVG (same C engine as the
+# frontend's pikchr-js) and rasterize to PNG for the note-writing agent.
+resvg = "0.47"
+usvg = "0.47"
+tiny-skia = "0.12"
+
 # Debug binaries archived — uncomment when needed
 # [[bin]]
 # name = "debug_diff"

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod image_commands;
 pub mod migrations;
 pub mod note_commands;
 pub mod paths;
+pub mod pikchr_mcp;
 pub(crate) mod pikchr_validation;
 pub mod pr_poll_scheduler;
 pub mod project_commands;

--- a/apps/staged/src-tauri/src/pikchr_mcp.rs
+++ b/apps/staged/src-tauri/src/pikchr_mcp.rs
@@ -495,9 +495,13 @@ fn rasterize_svg_to_png(svg: &str, scale: f32) -> Option<Vec<u8>> {
     let (w, h) = (size.width().max(1.0), size.height().max(1.0));
 
     let mut s = scale.clamp(MIN_SCALE, MAX_SCALE);
+    // Scale down to fit within MAX_RENDER_DIMENSION. We let `fit` go below
+    // MIN_SCALE here (rather than flooring it) so an oversized diagram is shown
+    // whole — shrunk but uncropped — which keeps the overlap layout visible
+    // instead of clipping it to the top-left corner.
     let fit = (MAX_RENDER_DIMENSION as f32 / w).min(MAX_RENDER_DIMENSION as f32 / h);
     if s > fit {
-        s = fit.max(MIN_SCALE / 2.0);
+        s = fit;
     }
 
     let px_w = ((w * s).ceil() as u32).clamp(1, MAX_RENDER_DIMENSION);

--- a/apps/staged/src-tauri/src/pikchr_mcp.rs
+++ b/apps/staged/src-tauri/src/pikchr_mcp.rs
@@ -29,9 +29,6 @@ use rmcp::transport::streamable_http_server::{
 };
 use rmcp::{schemars, tool, tool_handler, tool_router, ErrorData, ServerHandler};
 
-/// Frontend parity: reject oversized source like `pikchrRendering.ts`
-/// (`MAX_PIKCHR_SOURCE_LENGTH`).
-const MAX_PIKCHR_SOURCE_LENGTH: usize = 20_000;
 /// Cap the rasterized PNG so a runaway diagram can't allocate a huge pixmap.
 const MAX_RENDER_DIMENSION: u32 = 4096;
 /// Default rasterization scale — 2× keeps labels legible.
@@ -548,18 +545,6 @@ fn run_preview(source: &str, scale: f32) -> PreviewOutcome {
             is_error: true,
         };
     }
-    if source.len() > MAX_PIKCHR_SOURCE_LENGTH {
-        return PreviewOutcome {
-            png: None,
-            summary: format!(
-                "Pikchr source is too large to render safely ({} chars; limit {}).",
-                source.len(),
-                MAX_PIKCHR_SOURCE_LENGTH
-            ),
-            is_error: true,
-        };
-    }
-
     let rendered = match render_pikchr_svg(source) {
         Ok(rendered) => rendered,
         Err(err) => {
@@ -768,14 +753,6 @@ arrow from COLL.e to SNOW.w"#;
         let outcome = run_preview("   \n  ", DEFAULT_SCALE);
         assert!(outcome.is_error);
         assert!(outcome.png.is_none());
-    }
-
-    #[test]
-    fn oversized_source_is_rejected() {
-        let big = "box\n".repeat(MAX_PIKCHR_SOURCE_LENGTH);
-        let outcome = run_preview(&big, DEFAULT_SCALE);
-        assert!(outcome.is_error);
-        assert!(outcome.summary.contains("too large"));
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/pikchr_mcp.rs
+++ b/apps/staged/src-tauri/src/pikchr_mcp.rs
@@ -1,0 +1,785 @@
+//! Stateless MCP server exposing a single `preview_pikchr` tool.
+//!
+//! Note-writing sessions (project notes and local branch notes) use this to
+//! *see* their Pikchr diagrams before shipping them: the tool renders the
+//! supplied source to a PNG and reports any box overlaps it detects, so the
+//! agent can catch bad layouts (overlapping boxes, colliding labels) and
+//! iterate instead of silently shipping a broken diagram.
+//!
+//! Fidelity: rendering goes through the `pikchr` crate, which bundles the same
+//! official `pikchr.c` that the frontend's `pikchr-js` compiles to WASM. The
+//! geometry — the part that matters for overlap detection — is therefore
+//! identical to what the user eventually sees. Native rasterization via
+//! `resvg` won't reproduce the frontend's side-label gap transform or browser
+//! font metrics exactly, so label spacing may differ by a hair; that is
+//! acceptable for a preview.
+//!
+//! Unlike `project_mcp`, this handler holds no state: it never touches the
+//! store, registry, or project, so it is safe to attach to any local session.
+
+use std::sync::{Arc, OnceLock};
+use tokio::task::JoinHandle;
+
+use axum::Router;
+use base64::Engine;
+use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
+use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+};
+use rmcp::{schemars, tool, tool_handler, tool_router, ErrorData, ServerHandler};
+
+/// Frontend parity: reject oversized source like `pikchrRendering.ts`
+/// (`MAX_PIKCHR_SOURCE_LENGTH`).
+const MAX_PIKCHR_SOURCE_LENGTH: usize = 20_000;
+/// Cap the rasterized PNG so a runaway diagram can't allocate a huge pixmap.
+const MAX_RENDER_DIMENSION: u32 = 4096;
+/// Default rasterization scale — 2× keeps labels legible.
+const DEFAULT_SCALE: f32 = 2.0;
+const MIN_SCALE: f32 = 0.5;
+const MAX_SCALE: f32 = 4.0;
+/// Ignore overlaps thinner than this (px in Pikchr's coordinate space) so that
+/// shapes which merely share an edge or corner aren't flagged.
+const MIN_OVERLAP_PX: f64 = 1.0;
+/// Truncate derived shape labels in the overlap summary.
+const MAX_LABEL_CHARS: usize = 48;
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct PreviewPikchrParams {
+    /// The Pikchr source to render — the contents of a ```pikchr fenced code
+    /// block, without the fences.
+    pub source: String,
+    /// Rasterization scale for the returned PNG. Higher values produce a
+    /// larger image with more legible labels. Defaults to 2.0; clamped to
+    /// the range [0.5, 4.0].
+    pub scale: Option<f32>,
+}
+
+/// Axis-aligned bounding box in Pikchr's (unscaled) SVG coordinate space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct BBox {
+    min_x: f64,
+    min_y: f64,
+    max_x: f64,
+    max_y: f64,
+}
+
+impl BBox {
+    fn width(&self) -> f64 {
+        self.max_x - self.min_x
+    }
+
+    fn height(&self) -> f64 {
+        self.max_y - self.min_y
+    }
+
+    fn center(&self) -> (f64, f64) {
+        (
+            (self.min_x + self.max_x) / 2.0,
+            (self.min_y + self.max_y) / 2.0,
+        )
+    }
+
+    fn contains(&self, x: f64, y: f64) -> bool {
+        x >= self.min_x && x <= self.max_x && y >= self.min_y && y <= self.max_y
+    }
+
+    /// Width and height of the rectangle where `self` and `other` overlap.
+    /// Both are zero (or negative) when the boxes don't intersect.
+    fn overlap_extent(&self, other: &BBox) -> (f64, f64) {
+        let w = self.max_x.min(other.max_x) - self.min_x.max(other.min_x);
+        let h = self.max_y.min(other.max_y) - self.min_y.max(other.min_y);
+        (w, h)
+    }
+}
+
+/// A box-like shape and the label text rendered inside it (if any).
+#[derive(Clone, Debug)]
+struct LabeledShape {
+    bounds: BBox,
+    label: Option<String>,
+}
+
+/// One detected overlap between two box-like shapes.
+#[derive(Clone, Debug)]
+struct Overlap {
+    a: usize,
+    b: usize,
+    overlap_w: f64,
+    overlap_h: f64,
+}
+
+/// A `<text>` element with its anchor point and rendered content.
+#[derive(Clone, Debug)]
+struct SvgLabel {
+    x: f64,
+    y: f64,
+    text: String,
+}
+
+// =============================================================================
+// Pikchr rendering (SVG)
+// =============================================================================
+
+/// Outcome of rendering Pikchr source to SVG.
+struct RenderedSvg {
+    svg: String,
+    width: i64,
+    height: i64,
+}
+
+/// Render Pikchr source to SVG using the bundled `pikchr.c` engine.
+///
+/// Returns the Pikchr error message (plain text) on parse/layout failure so the
+/// caller can hand it straight back to the agent.
+fn render_pikchr_svg(source: &str) -> Result<RenderedSvg, String> {
+    use pikchr::{Pikchr, PikchrFlags};
+
+    let pic = Pikchr::render(source, None, PikchrFlags::default())?;
+    Ok(RenderedSvg {
+        svg: pic.rendered().to_string(),
+        width: pic.width() as i64,
+        height: pic.height() as i64,
+    })
+}
+
+// =============================================================================
+// Overlap detection
+// =============================================================================
+
+/// Split an SVG path `d` attribute into command letters and numbers.
+enum PathToken {
+    Cmd(char),
+    Num(f64),
+}
+
+fn tokenize_path(d: &str) -> Vec<PathToken> {
+    let bytes = d.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c.is_ascii_alphabetic() {
+            tokens.push(PathToken::Cmd(c));
+            i += 1;
+        } else if c.is_ascii_digit() || c == '+' || c == '-' || c == '.' {
+            let start = i;
+            i += 1;
+            while i < bytes.len() {
+                let n = bytes[i] as char;
+                if n.is_ascii_digit() || n == '.' {
+                    i += 1;
+                } else if (n == '+' || n == '-') && matches!(bytes[i - 1] as char, 'e' | 'E') {
+                    // sign of an exponent
+                    i += 1;
+                } else if n == 'e' || n == 'E' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            if let Ok(num) = d[start..i].parse::<f64>() {
+                tokens.push(PathToken::Num(num));
+            }
+        } else {
+            // whitespace, comma, or other separator
+            i += 1;
+        }
+    }
+    tokens
+}
+
+/// Compute the bounding box of an SVG path `d` string.
+///
+/// Pikchr emits absolute `M`, `L`, `A` (arc) and `Z` commands. Only segment
+/// endpoints contribute to the box; arc radii and flags do not, so those are
+/// skipped. Control points of any (unexpected) curve commands are included,
+/// which only ever *over*-estimates the box — safe for overlap detection.
+fn path_bounds(d: &str) -> Option<BBox> {
+    let tokens = tokenize_path(d);
+    let mut bx = BBox {
+        min_x: f64::MAX,
+        min_y: f64::MAX,
+        max_x: f64::MIN,
+        max_y: f64::MIN,
+    };
+    let mut any = false;
+    let mut add = |x: f64, y: f64| {
+        bx.min_x = bx.min_x.min(x);
+        bx.min_y = bx.min_y.min(y);
+        bx.max_x = bx.max_x.max(x);
+        bx.max_y = bx.max_y.max(y);
+        any = true;
+    };
+
+    let mut i = 0;
+    let mut cmd = ' ';
+    while i < tokens.len() {
+        match tokens[i] {
+            PathToken::Cmd(c) => {
+                cmd = c;
+                i += 1;
+            }
+            PathToken::Num(_) => {
+                // Collect the run of numbers following the current command.
+                let mut nums = Vec::new();
+                while i < tokens.len() {
+                    if let PathToken::Num(n) = tokens[i] {
+                        nums.push(n);
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+                match cmd.to_ascii_uppercase() {
+                    'A' => {
+                        // groups of 7: (rx ry rot large sweep x y) — endpoint only
+                        for g in nums.chunks(7) {
+                            if g.len() == 7 {
+                                add(g[5], g[6]);
+                            }
+                        }
+                    }
+                    'Z' => {}
+                    // M, L and any other command: treat as coordinate pairs.
+                    _ => {
+                        for pair in nums.chunks(2) {
+                            if pair.len() == 2 {
+                                add(pair[0], pair[1]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if any {
+        Some(bx)
+    } else {
+        None
+    }
+}
+
+/// Extract closed box-like shapes from a Pikchr SVG.
+///
+/// Boxes/ovals render as *closed* `<path>` elements (the `d` ends in `Z`);
+/// arrow shafts are open paths and arrowheads are `<polygon>`, so both are
+/// naturally excluded. Plain `<rect>` elements are included too.
+fn extract_shapes(svg: &str) -> Vec<BBox> {
+    use regex::Regex;
+    static PATH_RE: OnceLock<Regex> = OnceLock::new();
+    static RECT_RE: OnceLock<Regex> = OnceLock::new();
+    let path_re = PATH_RE.get_or_init(|| Regex::new(r#"<path\b[^>]*\bd="([^"]*)"[^>]*>"#).unwrap());
+    let rect_re = RECT_RE.get_or_init(|| Regex::new(r#"<rect\b([^>]*)>"#).unwrap());
+
+    let mut shapes = Vec::new();
+
+    for caps in path_re.captures_iter(svg) {
+        let d = &caps[1];
+        let closed = d.trim_end().ends_with(['Z', 'z']);
+        if !closed {
+            continue;
+        }
+        if let Some(b) = path_bounds(d) {
+            if b.width() > MIN_OVERLAP_PX && b.height() > MIN_OVERLAP_PX {
+                shapes.push(b);
+            }
+        }
+    }
+
+    for caps in rect_re.captures_iter(svg) {
+        let attrs = &caps[1];
+        let x = attr_f64(attrs, "x").unwrap_or(0.0);
+        let y = attr_f64(attrs, "y").unwrap_or(0.0);
+        let (Some(w), Some(h)) = (attr_f64(attrs, "width"), attr_f64(attrs, "height")) else {
+            continue;
+        };
+        if w > MIN_OVERLAP_PX && h > MIN_OVERLAP_PX {
+            shapes.push(BBox {
+                min_x: x,
+                min_y: y,
+                max_x: x + w,
+                max_y: y + h,
+            });
+        }
+    }
+
+    shapes
+}
+
+/// Extract `<text>` labels (anchor point + content) from a Pikchr SVG.
+fn extract_labels(svg: &str) -> Vec<SvgLabel> {
+    use regex::Regex;
+    static TEXT_RE: OnceLock<Regex> = OnceLock::new();
+    let text_re = TEXT_RE.get_or_init(|| Regex::new(r#"<text\b([^>]*)>([^<]*)</text>"#).unwrap());
+
+    let mut labels = Vec::new();
+    for caps in text_re.captures_iter(svg) {
+        let attrs = &caps[1];
+        let (Some(x), Some(y)) = (attr_f64(attrs, "x"), attr_f64(attrs, "y")) else {
+            continue;
+        };
+        let text = decode_xml_entities(caps[2].trim());
+        if text.is_empty() {
+            continue;
+        }
+        labels.push(SvgLabel { x, y, text });
+    }
+    labels
+}
+
+/// Read a numeric SVG attribute value out of an attribute substring.
+fn attr_f64(attrs: &str, name: &str) -> Option<f64> {
+    use regex::Regex;
+    let re = Regex::new(&format!(r#"\b{name}="([^"]*)""#)).ok()?;
+    re.captures(attrs)?
+        .get(1)?
+        .as_str()
+        .trim()
+        .parse::<f64>()
+        .ok()
+}
+
+fn decode_xml_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+}
+
+/// Attach a label to each shape by collecting the `<text>` elements whose
+/// anchor falls inside the shape, in document order.
+fn label_shapes(shapes: Vec<BBox>, labels: &[SvgLabel]) -> Vec<LabeledShape> {
+    shapes
+        .into_iter()
+        .map(|bounds| {
+            let mut parts: Vec<&str> = labels
+                .iter()
+                .filter(|l| bounds.contains(l.x, l.y))
+                .map(|l| l.text.as_str())
+                .collect();
+            // A label inside two overlapping boxes is most likely owned by the
+            // smaller / nearer one, but keeping it on both is fine for a hint.
+            let label = if parts.is_empty() {
+                None
+            } else {
+                let mut joined = String::new();
+                for (idx, p) in parts.drain(..).enumerate() {
+                    if idx > 0 {
+                        joined.push(' ');
+                    }
+                    joined.push_str(p);
+                }
+                Some(truncate_label(&joined))
+            };
+            LabeledShape { bounds, label }
+        })
+        .collect()
+}
+
+fn truncate_label(s: &str) -> String {
+    if s.chars().count() <= MAX_LABEL_CHARS {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(MAX_LABEL_CHARS).collect();
+    out.push('…');
+    out
+}
+
+/// Find pairs of box-like shapes that overlap by more than a hairline.
+fn find_overlaps(shapes: &[LabeledShape]) -> Vec<Overlap> {
+    let mut overlaps = Vec::new();
+    for a in 0..shapes.len() {
+        for b in (a + 1)..shapes.len() {
+            let (w, h) = shapes[a].bounds.overlap_extent(&shapes[b].bounds);
+            if w > MIN_OVERLAP_PX && h > MIN_OVERLAP_PX {
+                overlaps.push(Overlap {
+                    a,
+                    b,
+                    overlap_w: w,
+                    overlap_h: h,
+                });
+            }
+        }
+    }
+    overlaps
+}
+
+/// Run the full overlap analysis on a rendered Pikchr SVG.
+fn analyze_overlaps(svg: &str) -> (Vec<LabeledShape>, Vec<Overlap>) {
+    let shapes = extract_shapes(svg);
+    let labels = extract_labels(svg);
+    let labeled = label_shapes(shapes, &labels);
+    let overlaps = find_overlaps(&labeled);
+    (labeled, overlaps)
+}
+
+/// Human-readable description of one shape for the overlap summary.
+fn describe_shape(shape: &LabeledShape) -> String {
+    match &shape.label {
+        Some(label) => format!("\"{label}\""),
+        None => {
+            let (cx, cy) = shape.bounds.center();
+            format!("box near ({:.0}, {:.0})", cx, cy)
+        }
+    }
+}
+
+/// Build the text summary returned alongside the image. Text matters because
+/// not every provider forwards image content to the model, and even
+/// vision-less models can act on a textual overlap report.
+fn build_summary(width: i64, height: i64, shapes: &[LabeledShape], overlaps: &[Overlap]) -> String {
+    let mut out = format!("Rendered Pikchr diagram: {width}×{height} px.");
+    if overlaps.is_empty() {
+        out.push_str("\nNo box overlaps detected.");
+        return out;
+    }
+
+    out.push_str(&format!(
+        "\n⚠ {} overlapping shape pair(s) detected:",
+        overlaps.len()
+    ));
+    for o in overlaps {
+        out.push_str(&format!(
+            "\n- {} overlaps {} (≈ {:.0}×{:.0} px)",
+            describe_shape(&shapes[o.a]),
+            describe_shape(&shapes[o.b]),
+            o.overlap_w,
+            o.overlap_h
+        ));
+    }
+    out.push_str(
+        "\nFix overlaps by setting an explicit flow direction, using named nodes \
+with explicit anchors (e.g. `with .w at …`, `arrow from A.e to B.w`), and avoiding \
+percentage-length arrows between `fit` boxes.",
+    );
+    out
+}
+
+// =============================================================================
+// PNG rasterization
+// =============================================================================
+
+/// System font database, loaded once. resvg needs fonts to shape box labels.
+fn font_database() -> Arc<usvg::fontdb::Database> {
+    static DB: OnceLock<Arc<usvg::fontdb::Database>> = OnceLock::new();
+    DB.get_or_init(|| {
+        let mut db = usvg::fontdb::Database::new();
+        db.load_system_fonts();
+        Arc::new(db)
+    })
+    .clone()
+}
+
+/// Rasterize a Pikchr SVG to a PNG, scaled by `scale` (clamped, and reduced
+/// further if needed to stay within `MAX_RENDER_DIMENSION`). Returns the PNG
+/// bytes, or `None` if rasterization fails (the caller degrades to text-only).
+fn rasterize_svg_to_png(svg: &str, scale: f32) -> Option<Vec<u8>> {
+    let options = usvg::Options {
+        fontdb: font_database(),
+        ..Default::default()
+    };
+    let tree = match usvg::Tree::from_str(svg, &options) {
+        Ok(tree) => tree,
+        Err(e) => {
+            log::warn!("[pikchr_mcp] usvg failed to parse rendered SVG: {e}");
+            return None;
+        }
+    };
+
+    let size = tree.size();
+    let (w, h) = (size.width().max(1.0), size.height().max(1.0));
+
+    let mut s = scale.clamp(MIN_SCALE, MAX_SCALE);
+    let fit = (MAX_RENDER_DIMENSION as f32 / w).min(MAX_RENDER_DIMENSION as f32 / h);
+    if s > fit {
+        s = fit.max(MIN_SCALE / 2.0);
+    }
+
+    let px_w = ((w * s).ceil() as u32).clamp(1, MAX_RENDER_DIMENSION);
+    let px_h = ((h * s).ceil() as u32).clamp(1, MAX_RENDER_DIMENSION);
+
+    let mut pixmap = tiny_skia::Pixmap::new(px_w, px_h)?;
+    // White background so the diagram reads like the (light-mode) app preview
+    // instead of rendering on transparency.
+    pixmap.fill(tiny_skia::Color::WHITE);
+
+    resvg::render(
+        &tree,
+        tiny_skia::Transform::from_scale(s, s),
+        &mut pixmap.as_mut(),
+    );
+
+    match pixmap.encode_png() {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            log::warn!("[pikchr_mcp] failed to encode PNG: {e}");
+            None
+        }
+    }
+}
+
+// =============================================================================
+// Tool orchestration
+// =============================================================================
+
+/// Outcome of a `preview_pikchr` call, ready to turn into a `CallToolResult`.
+struct PreviewOutcome {
+    png: Option<Vec<u8>>,
+    summary: String,
+    is_error: bool,
+}
+
+/// Render + analyze, producing the content blocks for the tool result.
+/// Synchronous and self-contained so it can run on a blocking thread and be
+/// unit-tested directly. `scale` is taken as-is and clamped internally.
+fn run_preview(source: &str, scale: f32) -> PreviewOutcome {
+    if source.trim().is_empty() {
+        return PreviewOutcome {
+            png: None,
+            summary: "Pikchr source is empty — nothing to render.".to_string(),
+            is_error: true,
+        };
+    }
+    if source.len() > MAX_PIKCHR_SOURCE_LENGTH {
+        return PreviewOutcome {
+            png: None,
+            summary: format!(
+                "Pikchr source is too large to render safely ({} chars; limit {}).",
+                source.len(),
+                MAX_PIKCHR_SOURCE_LENGTH
+            ),
+            is_error: true,
+        };
+    }
+
+    let rendered = match render_pikchr_svg(source) {
+        Ok(rendered) => rendered,
+        Err(err) => {
+            return PreviewOutcome {
+                png: None,
+                summary: format!("Pikchr could not render this diagram:\n{}", err.trim()),
+                is_error: true,
+            };
+        }
+    };
+
+    let (shapes, overlaps) = analyze_overlaps(&rendered.svg);
+    let mut summary = build_summary(rendered.width, rendered.height, &shapes, &overlaps);
+
+    let png = rasterize_svg_to_png(&rendered.svg, scale);
+    if png.is_none() {
+        summary.push_str("\n(Image rasterization unavailable; reporting geometry only.)");
+    }
+
+    PreviewOutcome {
+        png,
+        summary,
+        is_error: false,
+    }
+}
+
+#[derive(Clone)]
+struct PikchrToolsHandler {
+    tool_router: ToolRouter<Self>,
+}
+
+impl PikchrToolsHandler {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl PikchrToolsHandler {
+    #[tool(
+        description = "Render Pikchr diagram source to an image so you can check the layout before \
+finalizing a note. Pass the contents of a ```pikchr fenced code block as `source`. Returns a PNG \
+preview plus a text summary with the diagram's pixel dimensions and any box overlaps detected \
+(overlapping or colliding boxes are the most common Pikchr layout mistake). On a syntax or layout \
+error, returns the Pikchr error message so you can fix the source and try again."
+    )]
+    async fn preview_pikchr(
+        &self,
+        Parameters(p): Parameters<PreviewPikchrParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let scale = p.scale.unwrap_or(DEFAULT_SCALE);
+        let outcome = tokio::task::spawn_blocking(move || run_preview(&p.source, scale))
+            .await
+            .map_err(|e| {
+                ErrorData::internal_error(format!("preview_pikchr task failed: {e}"), None)
+            })?;
+
+        let mut content = Vec::new();
+        if let Some(png) = outcome.png {
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
+            content.push(Content::image(b64, "image/png"));
+        }
+        content.push(Content::text(outcome.summary));
+
+        if outcome.is_error {
+            Ok(CallToolResult::error(content))
+        } else {
+            Ok(CallToolResult::success(content))
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for PikchrToolsHandler {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Start a local MCP HTTP server exposing the `preview_pikchr` tool.
+///
+/// Returns the bound port and a `JoinHandle`. The server runs until the handle
+/// (and its parent `LocalSet`) is dropped. Mirrors `start_project_mcp_server`
+/// but carries no state.
+pub async fn start_pikchr_mcp_server() -> Result<(u16, JoinHandle<()>), String> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("Failed to bind pikchr MCP listener: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to get local address: {e}"))?
+        .port();
+
+    let service = StreamableHttpService::new(
+        || Ok(PikchrToolsHandler::new()),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default(),
+    );
+
+    let router = Router::new().route_service("/mcp", service);
+
+    log::debug!("[pikchr_mcp] HTTP server bound on port {port}");
+
+    let handle = tokio::task::spawn(async move {
+        if let Err(e) = axum::serve(listener, router).await {
+            log::error!("[pikchr_mcp] HTTP server error: {e}");
+        }
+    });
+
+    Ok((port, handle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The known-overlapping diagram from the prior investigation note
+    /// (da951fca): percentage-length arrows between large `fit` boxes with no
+    /// explicit flow direction, producing a diagonal cascade of colliding boxes.
+    const OVERLAPPING_SOURCE: &str = r#"linerad = 4px
+box "goose-internal (OPEN SOURCE)" "typed OTel catalog → TelemetrySink facade" fit fill 0xeef6ff
+arrow down 35%
+box "Sink = OTLP exporter (Block build)" "via Tauri native export_otel_logs (CORS)" fit fill 0xfff3d6
+arrow right 60% "OTLP /v1/logs + auth" above
+box "Block OTel Collector" "OTel→UAP mapping (from CDF manifest)" fit fill 0xffe6e6
+arrow right 50%
+box "unifiedevents/batch" "→ Snowflake (UAP unchanged)" fit fill 0xffd6d6
+arrow down 30% from 1st box.s
+box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → builds anywhere" fit fill 0xe8f5e9"#;
+
+    /// The corrected version from the same note: explicit flow, named nodes,
+    /// explicit anchors, full-length arrows. Verified to have zero overlaps.
+    const CORRECTED_SOURCE: &str = r#"linerad = 8px
+boxht = 0.5
+
+GI: box "goose-internal (OPEN SOURCE)" "typed OTel catalog → TelemetrySink facade" fit fill 0xeef6ff
+
+OTLP: box "Sink = OTLP exporter (Block build)" "via Tauri native export_otel_logs (CORS)" fit fill 0xfff3d6 with .w at 1.0 right of GI.e + (0,0.45)
+NOOP: box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → builds anywhere" fit fill 0xe8f5e9 with .w at OTLP.w - (0,0.9)
+
+arrow from GI.e to OTLP.w "Block build" above
+arrow from GI.e to NOOP.w "ext. clone" below
+
+COLL: box "Block OTel Collector" "OTel→UAP mapping (from CDF manifest)" fit fill 0xffe6e6 with .w at 0.9 right of OTLP.e
+arrow from OTLP.e to COLL.w "OTLP /v1/logs + auth" above
+SNOW: box "unifiedevents/batch" "→ Snowflake (UAP unchanged)" fit fill 0xffd6d6 with .w at 0.6 right of COLL.e
+arrow from COLL.e to SNOW.w"#;
+
+    #[test]
+    fn tokenize_handles_commas_and_arcs() {
+        // From pikchr's own box output: a closed rounded rectangle.
+        let d = "M161,72L309,72A15 15 0 0 0 324 57L324,17A15 15 0 0 0 309 2L161,2A15 15 0 0 0 161 17L161,57A15 15 0 0 0 161 72Z";
+        let b = path_bounds(d).expect("closed path should have bounds");
+        // The arc radii (15) and flags (0) must not leak into the box bounds.
+        assert!((b.min_x - 161.0).abs() < 0.5, "min_x was {}", b.min_x);
+        assert!((b.min_y - 2.0).abs() < 0.5, "min_y was {}", b.min_y);
+        assert!((b.max_x - 324.0).abs() < 0.5, "max_x was {}", b.max_x);
+        assert!((b.max_y - 72.0).abs() < 0.5, "max_y was {}", b.max_y);
+    }
+
+    #[test]
+    fn overlap_detector_flags_known_overlapping_source() {
+        let rendered = render_pikchr_svg(OVERLAPPING_SOURCE).expect("source should render");
+        let (shapes, overlaps) = analyze_overlaps(&rendered.svg);
+        assert_eq!(shapes.len(), 5, "expected five boxes");
+        assert!(
+            !overlaps.is_empty(),
+            "expected overlaps for the cascade diagram, found none"
+        );
+    }
+
+    #[test]
+    fn overlap_detector_passes_corrected_source() {
+        let rendered = render_pikchr_svg(CORRECTED_SOURCE).expect("source should render");
+        let (_shapes, overlaps) = analyze_overlaps(&rendered.svg);
+        assert!(
+            overlaps.is_empty(),
+            "corrected diagram should have no overlaps, found {overlaps:?}"
+        );
+    }
+
+    #[test]
+    fn valid_source_produces_png_and_dimensions() {
+        let outcome = run_preview("box \"hello\"", DEFAULT_SCALE);
+        assert!(!outcome.is_error);
+        assert!(outcome.png.is_some(), "expected a PNG for valid source");
+        assert!(!outcome.png.unwrap().is_empty());
+        assert!(outcome.summary.contains("px"));
+    }
+
+    #[test]
+    fn malformed_source_reports_error() {
+        let outcome = run_preview("box \"unterminated", DEFAULT_SCALE);
+        assert!(outcome.is_error);
+        assert!(outcome.png.is_none());
+        assert!(outcome.summary.to_lowercase().contains("pikchr"));
+    }
+
+    #[test]
+    fn empty_source_reports_error() {
+        let outcome = run_preview("   \n  ", DEFAULT_SCALE);
+        assert!(outcome.is_error);
+        assert!(outcome.png.is_none());
+    }
+
+    #[test]
+    fn oversized_source_is_rejected() {
+        let big = "box\n".repeat(MAX_PIKCHR_SOURCE_LENGTH);
+        let outcome = run_preview(&big, DEFAULT_SCALE);
+        assert!(outcome.is_error);
+        assert!(outcome.summary.contains("too large"));
+    }
+
+    #[test]
+    fn summary_lists_overlap_count() {
+        let rendered = render_pikchr_svg(OVERLAPPING_SOURCE).unwrap();
+        let (shapes, overlaps) = analyze_overlaps(&rendered.svg);
+        let summary = build_summary(rendered.width, rendered.height, &shapes, &overlaps);
+        assert!(summary.contains("overlapping shape pair"));
+        assert!(summary.contains('⚠'));
+    }
+}

--- a/apps/staged/src-tauri/src/pikchr_mcp.rs
+++ b/apps/staged/src-tauri/src/pikchr_mcp.rs
@@ -332,9 +332,13 @@ fn extract_labels(svg: &str) -> Vec<SvgLabel> {
 /// Read a numeric SVG attribute value out of an attribute substring.
 fn attr_f64(attrs: &str, name: &str) -> Option<f64> {
     use regex::Regex;
-    let re = Regex::new(&format!(r#"\b{name}="([^"]*)""#)).ok()?;
-    re.captures(attrs)?
-        .get(1)?
+    static ATTR_RE: OnceLock<Regex> = OnceLock::new();
+    let attr_re = ATTR_RE.get_or_init(|| Regex::new(r#"\b([\w-]+)="([^"]*)""#).unwrap());
+
+    attr_re
+        .captures_iter(attrs)
+        .find(|caps| &caps[1] == name)?
+        .get(2)?
         .as_str()
         .trim()
         .parse::<f64>()

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -210,16 +210,27 @@ pub(crate) fn resolve_pikchr_grammar_reference(
     grammar_path.to_string_lossy().into_owned()
 }
 
-fn pikchr_note_guidance(reference: &str) -> String {
-    format!(
+fn pikchr_note_guidance(reference: &str, preview_available: bool) -> String {
+    let mut guidance = format!(
         "Staged notes support rendered diagrams in fenced `pikchr` code blocks. \
 If you need the Pikchr grammar while writing a diagram, read the reference at: {reference}"
-    )
+    );
+    // Phrased conditionally so it stays truthful even when the optional preview
+    // MCP server is dropped (e.g. on a provider without HTTP MCP support).
+    if preview_available {
+        guidance.push_str(
+            " If a `preview_pikchr` tool is available to you, use it to render your Pikchr \
+source to an image and check the layout — box overlaps, label collisions, arrow targets — \
+then iterate before finalizing the diagram.",
+        );
+    }
+    guidance
 }
 
 pub(crate) fn build_note_followup_message_with_pikchr_reference(
     has_parsed_note: bool,
     pikchr_grammar_reference: &str,
+    preview_available: bool,
 ) -> String {
     let visible_request = if has_parsed_note {
         "Please update the note to reflect the latest chat."
@@ -231,7 +242,7 @@ pub(crate) fn build_note_followup_message_with_pikchr_reference(
     } else {
         "write the linked note"
     };
-    let pikchr_guidance = pikchr_note_guidance(pikchr_grammar_reference);
+    let pikchr_guidance = pikchr_note_guidance(pikchr_grammar_reference, preview_available);
     let standalone_guidance = NOTE_STANDALONE_OUTPUT_GUIDANCE.trim();
 
     format!(
@@ -377,6 +388,7 @@ pub async fn start_session(
             image_ids: vec![],
             branch_id: None,
             project_id: None,
+            expose_pikchr_preview: false,
         },
         store,
         app_handle,
@@ -540,6 +552,10 @@ pub async fn resume_session(
 
     let config_branch_id = event_branch_id.clone();
     let config_project_id = event_project_id.clone().or(mcp_project_id.clone());
+    // Note follow-ups (project notes or local branch notes) get the preview
+    // tool; remote branch notes can't reach localhost.
+    let expose_pikchr_preview =
+        (project_note.is_some() || linked_note.is_some()) && workspace_name.is_none();
 
     crate::web_server::emit_to_all(
         &app_handle,
@@ -585,6 +601,7 @@ pub async fn resume_session(
             image_ids: image_ids.unwrap_or_default(),
             branch_id: config_branch_id,
             project_id: config_project_id,
+            expose_pikchr_preview,
         },
         store,
         app_handle,
@@ -652,9 +669,16 @@ pub async fn build_note_followup_message(
                 .and_then(|branch| branch.workspace_name.as_deref()),
         );
 
+        // Note follow-ups expose the preview tool on local sessions only. A
+        // project-note follow-up has no linked branch and always runs locally.
+        let preview_available = linked_branch
+            .as_ref()
+            .map_or(true, |branch| branch.workspace_name.is_none());
+
         Ok(build_note_followup_message_with_pikchr_reference(
             has_parsed_note,
             &pikchr_grammar_reference,
+            preview_available,
         ))
     })
     .await
@@ -1094,7 +1118,9 @@ repository edits directly here; use `start_repo_session` for implementation work
         ""
     };
 
-    let pikchr_guidance = pikchr_note_guidance(pikchr_grammar_reference);
+    // Project sessions always execute locally and are restricted to
+    // MCP-capable providers, so the preview tool is always attached.
+    let pikchr_guidance = pikchr_note_guidance(pikchr_grammar_reference, true);
     let standalone_guidance = NOTE_STANDALONE_OUTPUT_GUIDANCE.trim();
 
     format!(
@@ -1201,6 +1227,8 @@ pub async fn start_project_session(
             image_ids: image_ids.unwrap_or_default(),
             branch_id: None,
             project_id: Some(project_id),
+            // Project sessions are always local and write project notes.
+            expose_pikchr_preview: true,
         },
         store,
         app_handle,
@@ -1388,6 +1416,7 @@ async fn prepare_branch_session_start(
         launch_context,
         Some(&branch.base_branch),
         &pikchr_grammar_reference,
+        branch.workspace_name.is_none(),
     );
 
     // Resolve the actual workspace path for remote branches so the remote agent
@@ -1529,6 +1558,10 @@ fn launch_running_branch_session(
     let branch_id = branch.id.clone();
     let project_id = branch.project_id.clone();
     let workspace_name = branch.workspace_name.clone();
+    // Local branch note sessions get the preview tool; commit/review sessions
+    // and remote sessions do not.
+    let expose_pikchr_preview =
+        matches!(session_type, BranchSessionType::Note) && workspace_name.is_none();
 
     session_runner::emit_session_running(
         &app_handle,
@@ -1555,6 +1588,7 @@ fn launch_running_branch_session(
             image_ids,
             branch_id: Some(branch_id),
             project_id: Some(project_id),
+            expose_pikchr_preview,
         },
         store,
         app_handle,
@@ -1964,6 +1998,7 @@ async fn start_queued_session_for_branch(
         launch_context.as_ref(),
         Some(&branch.base_branch),
         &pikchr_grammar_reference,
+        branch.workspace_name.is_none(),
     );
 
     // Atomically transition session from queued to running.
@@ -2096,6 +2131,8 @@ async fn start_queued_session_for_branch(
             image_ids,
             branch_id: Some(branch_id),
             project_id: Some(branch.project_id.clone()),
+            expose_pikchr_preview: matches!(session_type, BranchSessionType::Note)
+                && branch.workspace_name.is_none(),
         },
         store,
         app_handle,
@@ -2386,6 +2423,8 @@ pub async fn trigger_auto_review(
             image_ids: vec![],
             branch_id: Some(branch_id.clone()),
             project_id: Some(branch.project_id.clone()),
+            // Auto-review sessions don't write notes.
+            expose_pikchr_preview: false,
         },
         store,
         app_handle,
@@ -3593,9 +3632,11 @@ pub(crate) fn build_full_prompt(
         launch_context,
         base_branch,
         PIKCHR_GRAMMAR_URL,
+        false,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_full_prompt_with_pikchr_reference(
     user_prompt: &str,
     project_information: &str,
@@ -3604,6 +3645,7 @@ pub(crate) fn build_full_prompt_with_pikchr_reference(
     launch_context: Option<&BranchSessionLaunchContext>,
     base_branch: Option<&str>,
     pikchr_grammar_reference: &str,
+    preview_available: bool,
 ) -> String {
     let mut action_instructions = match session_type {
         BranchSessionType::Note => [
@@ -3754,7 +3796,10 @@ Rules:\n\
 
     if matches!(session_type, BranchSessionType::Note) {
         action_instructions.push_str("\n\n");
-        action_instructions.push_str(&pikchr_note_guidance(pikchr_grammar_reference));
+        action_instructions.push_str(&pikchr_note_guidance(
+            pikchr_grammar_reference,
+            preview_available,
+        ));
     }
 
     let action_tag = format!(
@@ -4567,9 +4612,11 @@ mod tests {
             None,
             None,
             "/tmp/staged/pikchr/grammar.md",
+            true,
         );
 
         assert_pikchr_note_guidance(&prompt, "/tmp/staged/pikchr/grammar.md");
+        assert!(prompt.contains("preview_pikchr"));
     }
 
     #[test]
@@ -4577,6 +4624,7 @@ mod tests {
         let prompt = build_note_followup_message_with_pikchr_reference(
             true,
             "/Applications/Staged.app/Contents/Resources/resources/pikchr/grammar.md",
+            true,
         );
 
         assert!(prompt.contains("The user is asking you to update the linked note"));
@@ -4586,17 +4634,20 @@ mod tests {
             "/Applications/Staged.app/Contents/Resources/resources/pikchr/grammar.md",
         );
         assert_note_standalone_output_guidance(&prompt);
+        assert!(prompt.contains("preview_pikchr"));
     }
 
     #[test]
     fn note_followup_prompt_uses_supplied_remote_pikchr_reference() {
         let remote_path = generated_pikchr_grammar_remote_path();
-        let prompt = build_note_followup_message_with_pikchr_reference(false, &remote_path);
+        let prompt = build_note_followup_message_with_pikchr_reference(false, &remote_path, false);
 
         assert!(prompt.contains("The user is asking you to write the linked note"));
         assert!(prompt.contains("Please write the note for this session."));
         assert_pikchr_note_guidance(&prompt, &remote_path);
         assert_note_standalone_output_guidance(&prompt);
+        // Remote note sessions can't reach the preview server, so it isn't mentioned.
+        assert!(!prompt.contains("preview_pikchr"));
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -231,13 +231,14 @@ fn pikchr_note_guidance(reference: &str, preview_available: bool) -> String {
         "Staged notes support rendered diagrams in fenced `pikchr` code blocks. \
 If you need the Pikchr grammar while writing a diagram, read the reference at: {reference}"
     );
-    // Phrased conditionally so it stays truthful even when the optional preview
-    // MCP server is dropped (e.g. on a provider without HTTP MCP support).
+    // The preview server is a *required* MCP server for local note sessions, so
+    // when preview_available is true the tool is guaranteed present — phrase the
+    // guidance assertively rather than hedging on the tool's existence.
     if preview_available {
         guidance.push_str(
-            " If a `preview_pikchr` tool is available to you, use it to render your Pikchr \
-source to an image and check the layout — box overlaps, label collisions, arrow targets — \
-then iterate before finalizing the diagram.",
+            " Use the `preview_pikchr` tool to render your Pikchr source to an image and check \
+the layout — box overlaps, label collisions, arrow targets — then iterate before finalizing \
+the diagram.",
         );
     }
     guidance

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -210,6 +210,22 @@ pub(crate) fn resolve_pikchr_grammar_reference(
     grammar_path.to_string_lossy().into_owned()
 }
 
+/// Whether the local Pikchr `preview_pikchr` tool applies to a session.
+///
+/// The preview MCP server binds to loopback, so it's only reachable from
+/// sessions running on the local machine (`workspace_name.is_none()`), and it's
+/// only useful while writing a note. Both the prompt mention
+/// (`pikchr_note_guidance`) and the actual server attachment
+/// (`SessionConfig::expose_pikchr_preview`) must agree on this condition, so
+/// every call site derives it here rather than re-encoding it independently —
+/// that way a change like enabling remote previews only has to happen once.
+pub(crate) fn local_note_pikchr_preview_available(
+    is_note_session: bool,
+    workspace_name: Option<&str>,
+) -> bool {
+    is_note_session && workspace_name.is_none()
+}
+
 fn pikchr_note_guidance(reference: &str, preview_available: bool) -> String {
     let mut guidance = format!(
         "Staged notes support rendered diagrams in fenced `pikchr` code blocks. \
@@ -554,8 +570,10 @@ pub async fn resume_session(
     let config_project_id = event_project_id.clone().or(mcp_project_id.clone());
     // Note follow-ups (project notes or local branch notes) get the preview
     // tool; remote branch notes can't reach localhost.
-    let expose_pikchr_preview =
-        (project_note.is_some() || linked_note.is_some()) && workspace_name.is_none();
+    let expose_pikchr_preview = local_note_pikchr_preview_available(
+        project_note.is_some() || linked_note.is_some(),
+        workspace_name.as_deref(),
+    );
 
     crate::web_server::emit_to_all(
         &app_handle,
@@ -671,9 +689,12 @@ pub async fn build_note_followup_message(
 
         // Note follow-ups expose the preview tool on local sessions only. A
         // project-note follow-up has no linked branch and always runs locally.
-        let preview_available = linked_branch
-            .as_ref()
-            .map_or(true, |branch| branch.workspace_name.is_none());
+        let preview_available = local_note_pikchr_preview_available(
+            true,
+            linked_branch
+                .as_ref()
+                .and_then(|branch| branch.workspace_name.as_deref()),
+        );
 
         Ok(build_note_followup_message_with_pikchr_reference(
             has_parsed_note,
@@ -1416,7 +1437,10 @@ async fn prepare_branch_session_start(
         launch_context,
         Some(&branch.base_branch),
         &pikchr_grammar_reference,
-        branch.workspace_name.is_none(),
+        local_note_pikchr_preview_available(
+            matches!(session_type, BranchSessionType::Note),
+            branch.workspace_name.as_deref(),
+        ),
     );
 
     // Resolve the actual workspace path for remote branches so the remote agent
@@ -1560,8 +1584,10 @@ fn launch_running_branch_session(
     let workspace_name = branch.workspace_name.clone();
     // Local branch note sessions get the preview tool; commit/review sessions
     // and remote sessions do not.
-    let expose_pikchr_preview =
-        matches!(session_type, BranchSessionType::Note) && workspace_name.is_none();
+    let expose_pikchr_preview = local_note_pikchr_preview_available(
+        matches!(session_type, BranchSessionType::Note),
+        workspace_name.as_deref(),
+    );
 
     session_runner::emit_session_running(
         &app_handle,
@@ -1998,7 +2024,10 @@ async fn start_queued_session_for_branch(
         launch_context.as_ref(),
         Some(&branch.base_branch),
         &pikchr_grammar_reference,
-        branch.workspace_name.is_none(),
+        local_note_pikchr_preview_available(
+            matches!(session_type, BranchSessionType::Note),
+            branch.workspace_name.as_deref(),
+        ),
     );
 
     // Atomically transition session from queued to running.
@@ -2131,8 +2160,10 @@ async fn start_queued_session_for_branch(
             image_ids,
             branch_id: Some(branch_id),
             project_id: Some(branch.project_id.clone()),
-            expose_pikchr_preview: matches!(session_type, BranchSessionType::Note)
-                && branch.workspace_name.is_none(),
+            expose_pikchr_preview: local_note_pikchr_preview_available(
+                matches!(session_type, BranchSessionType::Note),
+                branch.workspace_name.as_deref(),
+            ),
         },
         store,
         app_handle,
@@ -4648,6 +4679,23 @@ mod tests {
         assert_note_standalone_output_guidance(&prompt);
         // Remote note sessions can't reach the preview server, so it isn't mentioned.
         assert!(!prompt.contains("preview_pikchr"));
+    }
+
+    #[test]
+    fn local_note_pikchr_preview_available_requires_note_and_local() {
+        // Available only for note sessions running on the local machine.
+        assert!(local_note_pikchr_preview_available(true, None));
+        // Remote note sessions can't reach the loopback preview server.
+        assert!(!local_note_pikchr_preview_available(
+            true,
+            Some("some-workspace")
+        ));
+        // Non-note sessions never get the note-writing preview tool.
+        assert!(!local_note_pikchr_preview_available(false, None));
+        assert!(!local_note_pikchr_preview_available(
+            false,
+            Some("some-workspace")
+        ));
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -338,6 +338,14 @@ pub struct SessionConfig {
     /// Project that owns this session. Set for both project-note sessions
     /// (directly) and branch-level sessions (via the branch's project).
     pub project_id: Option<String>,
+    /// Expose the `preview_pikchr` MCP tool to this session. Set for local,
+    /// note-writing sessions (project notes and local branch notes) so the
+    /// agent can render its Pikchr diagrams and check for overlaps before
+    /// finalizing a note. The server is attached as an *optional* MCP server,
+    /// so it is silently dropped on providers that don't support HTTP MCP and
+    /// never breaks a session. Only honored for local sessions
+    /// (`workspace_name.is_none()`); remote sessions can't reach localhost.
+    pub expose_pikchr_preview: bool,
 }
 
 /// Start a session: persist the user message, spawn the agent, stream to DB.
@@ -427,7 +435,12 @@ pub fn start_session(
 
         let local = tokio::task::LocalSet::new();
         let result = local.block_on(&rt, async {
-            // Start MCP server for project sessions, injecting it via the ACP NewSessionRequest.
+            let driver = driver.with_extra_env(config.extra_env.clone());
+
+            // Start MCP server for project sessions, injecting it via the ACP
+            // NewSessionRequest. This is a *required* server: project sessions
+            // are restricted to MCP-capable providers, so a missing transport
+            // is a hard error.
             let (driver, _mcp_handle) = if let Some(ref proj_id) = config.mcp_project_id {
                 match crate::project_mcp::start_project_mcp_server(
                     proj_id.clone(),
@@ -450,10 +463,7 @@ pub fn start_session(
                             "builderbot",
                             format!("http://127.0.0.1:{port}/mcp"),
                         ));
-                        let driver = driver
-                            .with_extra_env(config.extra_env.clone())
-                            .with_mcp_servers(vec![mcp_server]);
-                        (driver, Some(handle))
+                        (driver.with_mcp_servers(vec![mcp_server]), Some(handle))
                     }
                     Err(e) => {
                         log::error!("Failed to start MCP server: {e}");
@@ -461,9 +471,44 @@ pub fn start_session(
                     }
                 }
             } else {
-                let env = config.extra_env.clone();
-                (driver.with_extra_env(env), None)
+                (driver, None)
             };
+
+            // For local note-writing sessions, additionally attach the pikchr
+            // preview tool as an *optional* MCP server so the agent can render
+            // its diagrams and catch overlaps. Optional means it is dropped on
+            // providers without HTTP MCP support rather than failing the
+            // session, and a startup failure here is non-fatal. Skipped for
+            // remote sessions, which can't reach a localhost server.
+            let (driver, _pikchr_handle) =
+                if config.expose_pikchr_preview && config.workspace_name.is_none() {
+                    match crate::pikchr_mcp::start_pikchr_mcp_server().await {
+                        Ok((port, handle)) => {
+                            log::info!(
+                                "Session {}: pikchr preview MCP server started on port {port}",
+                                config.session_id
+                            );
+                            let pikchr_server = McpServer::Http(McpServerHttp::new(
+                                "pikchr",
+                                format!("http://127.0.0.1:{port}/mcp"),
+                            ));
+                            (
+                                driver.with_optional_mcp_servers(vec![pikchr_server]),
+                                Some(handle),
+                            )
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "Session {}: failed to start pikchr preview MCP server \
+                                 (continuing without it): {e}",
+                                config.session_id
+                            );
+                            (driver, None)
+                        }
+                    }
+                } else {
+                    (driver, None)
+                };
 
             // Read and base64-encode images for the prompt content blocks.
             let mut image_data: Vec<(String, String)> = Vec::new();
@@ -993,6 +1038,9 @@ pub fn start_pipeline_session(
                     image_ids: vec![],
                     branch_id: config.branch_id.clone(),
                     project_id: config.project_id.clone(),
+                    // Deterministic pipelines hand off to a code-focused AI step,
+                    // not a note-writing session.
+                    expose_pikchr_preview: false,
                 };
                 if let Err(e) = start_session(
                     ai_config,

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -341,9 +341,9 @@ pub struct SessionConfig {
     /// Expose the `preview_pikchr` MCP tool to this session. Set for local,
     /// note-writing sessions (project notes and local branch notes) so the
     /// agent can render its Pikchr diagrams and check for overlaps before
-    /// finalizing a note. The server is attached as an *optional* MCP server,
-    /// so it is silently dropped on providers that don't support HTTP MCP and
-    /// never breaks a session. Only honored for local sessions
+    /// finalizing a note. The server is attached as a *required* MCP server,
+    /// so a provider that doesn't support HTTP MCP fails the session rather
+    /// than silently dropping the tool. Only honored for local sessions
     /// (`workspace_name.is_none()`); remote sessions can't reach localhost.
     pub expose_pikchr_preview: bool,
 }

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -437,11 +437,19 @@ pub fn start_session(
         let result = local.block_on(&rt, async {
             let driver = driver.with_extra_env(config.extra_env.clone());
 
+            // Accumulate every *required* MCP server into a single vec and
+            // attach them in one with_mcp_servers call below. with_mcp_servers
+            // replaces the driver's server list, so calling it per-block would
+            // clobber earlier additions — and a project note sets both
+            // mcp_project_id and expose_pikchr_preview, so that collision is
+            // real.
+            let mut required_mcp_servers: Vec<McpServer> = Vec::new();
+
             // Start MCP server for project sessions, injecting it via the ACP
             // NewSessionRequest. This is a *required* server: project sessions
             // are restricted to MCP-capable providers, so a missing transport
             // is a hard error.
-            let (driver, _mcp_handle) = if let Some(ref proj_id) = config.mcp_project_id {
+            let _mcp_handle = if let Some(ref proj_id) = config.mcp_project_id {
                 match crate::project_mcp::start_project_mcp_server(
                     proj_id.clone(),
                     Arc::clone(&store),
@@ -459,11 +467,11 @@ pub fn start_session(
                             "Session {}: MCP server started on port {port}",
                             config.session_id
                         );
-                        let mcp_server = McpServer::Http(McpServerHttp::new(
+                        required_mcp_servers.push(McpServer::Http(McpServerHttp::new(
                             "builderbot",
                             format!("http://127.0.0.1:{port}/mcp"),
-                        ));
-                        (driver.with_mcp_servers(vec![mcp_server]), Some(handle))
+                        )));
+                        Some(handle)
                     }
                     Err(e) => {
                         log::error!("Failed to start MCP server: {e}");
@@ -471,44 +479,50 @@ pub fn start_session(
                     }
                 }
             } else {
-                (driver, None)
+                None
             };
 
             // For local note-writing sessions, additionally attach the pikchr
-            // preview tool as an *optional* MCP server so the agent can render
-            // its diagrams and catch overlaps. Optional means it is dropped on
-            // providers without HTTP MCP support rather than failing the
-            // session, and a startup failure here is non-fatal. Skipped for
-            // remote sessions, which can't reach a localhost server.
-            let (driver, _pikchr_handle) =
-                if config.expose_pikchr_preview && config.workspace_name.is_none() {
-                    match crate::pikchr_mcp::start_pikchr_mcp_server().await {
-                        Ok((port, handle)) => {
-                            log::info!(
-                                "Session {}: pikchr preview MCP server started on port {port}",
-                                config.session_id
-                            );
-                            let pikchr_server = McpServer::Http(McpServerHttp::new(
-                                "pikchr",
-                                format!("http://127.0.0.1:{port}/mcp"),
-                            ));
-                            (
-                                driver.with_optional_mcp_servers(vec![pikchr_server]),
-                                Some(handle),
-                            )
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "Session {}: failed to start pikchr preview MCP server \
-                                 (continuing without it): {e}",
-                                config.session_id
-                            );
-                            (driver, None)
-                        }
+            // preview tool so the agent can render its diagrams and catch
+            // overlaps. This is a *required* server too: a local note session
+            // assumes its provider speaks HTTP MCP, so an unsupported transport
+            // fails the session (via the required-transport check) rather than
+            // silently dropping the tool. Skipped for remote sessions, which
+            // can't reach a localhost server. A *startup* failure (port bind)
+            // is a local infra hiccup orthogonal to provider capability, so it
+            // stays non-fatal: log and continue without the preview aid.
+            let _pikchr_handle = if config.expose_pikchr_preview && config.workspace_name.is_none()
+            {
+                match crate::pikchr_mcp::start_pikchr_mcp_server().await {
+                    Ok((port, handle)) => {
+                        log::info!(
+                            "Session {}: pikchr preview MCP server started on port {port}",
+                            config.session_id
+                        );
+                        required_mcp_servers.push(McpServer::Http(McpServerHttp::new(
+                            "pikchr",
+                            format!("http://127.0.0.1:{port}/mcp"),
+                        )));
+                        Some(handle)
                     }
-                } else {
-                    (driver, None)
-                };
+                    Err(e) => {
+                        log::warn!(
+                            "Session {}: failed to start pikchr preview MCP server \
+                                 (continuing without it): {e}",
+                            config.session_id
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            let driver = if required_mcp_servers.is_empty() {
+                driver
+            } else {
+                driver.with_mcp_servers(required_mcp_servers)
+            };
 
             // Read and base64-encode images for the prompt content blocks.
             let mut image_data: Vec<(String, String)> = Vec::new();

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2685,6 +2685,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     image_ids: vec![],
                     branch_id: None,
                     project_id: None,
+                    expose_pikchr_preview: false,
                 },
                 store,
                 app_handle.clone(),
@@ -2816,6 +2817,10 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
 
             let config_branch_id = event_branch_id.clone();
             let config_project_id = event_project_id.clone().or(mcp_project_id.clone());
+            // Note follow-ups (project notes or local branch notes) get the
+            // preview tool; remote branch notes can't reach localhost.
+            let expose_pikchr_preview =
+                (project_note.is_some() || linked_note.is_some()) && workspace_name.is_none();
 
             emit_to_all(
                 app_handle,
@@ -2857,6 +2862,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     image_ids: image_ids.unwrap_or_default(),
                     branch_id: config_branch_id,
                     project_id: config_project_id,
+                    expose_pikchr_preview,
                 },
                 store,
                 app_handle.clone(),
@@ -2950,6 +2956,8 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     image_ids: image_ids.unwrap_or_default(),
                     branch_id: None,
                     project_id: Some(project_id),
+                    // Project sessions are always local and write project notes.
+                    expose_pikchr_preview: true,
                 },
                 store,
                 app_handle.clone(),

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2819,8 +2819,10 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
             let config_project_id = event_project_id.clone().or(mcp_project_id.clone());
             // Note follow-ups (project notes or local branch notes) get the
             // preview tool; remote branch notes can't reach localhost.
-            let expose_pikchr_preview =
-                (project_note.is_some() || linked_note.is_some()) && workspace_name.is_none();
+            let expose_pikchr_preview = session_commands::local_note_pikchr_preview_available(
+                project_note.is_some() || linked_note.is_some(),
+                workspace_name.as_deref(),
+            );
 
             emit_to_all(
                 app_handle,

--- a/crates/acp-client/src/driver.rs
+++ b/crates/acp-client/src/driver.rs
@@ -15,10 +15,11 @@ use std::time::{Duration, Instant};
 
 use agent_client_protocol::{
     Agent, ClientSideConnection, ContentBlock as AcpContentBlock, ImageContent, Implementation,
-    InitializeRequest, LoadSessionRequest, McpServer, NewSessionRequest, PermissionOptionId,
-    PromptRequest, ProtocolVersion, RequestPermissionOutcome, RequestPermissionRequest,
-    RequestPermissionResponse, SelectedPermissionOutcome, SessionConfigOption, SessionInfoUpdate,
-    SessionModelState, SessionNotification, SessionUpdate, TextContent,
+    InitializeRequest, LoadSessionRequest, McpCapabilities, McpServer, NewSessionRequest,
+    PermissionOptionId, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
+    SessionConfigOption, SessionInfoUpdate, SessionModelState, SessionNotification, SessionUpdate,
+    TextContent,
 };
 use async_trait::async_trait;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -147,7 +148,13 @@ pub struct AcpDriver {
     /// Extra environment variables to pass to the agent process.
     extra_env: Vec<(String, String)>,
     /// MCP servers to inject into the session via NewSessionRequest.
+    /// These are *required*: if the agent doesn't support a server's transport,
+    /// the session fails.
     mcp_servers: Vec<McpServer>,
+    /// Optional MCP servers — additive niceties (e.g. the pikchr preview tool).
+    /// If the agent doesn't advertise the transport these need, they are
+    /// silently dropped instead of failing the session.
+    optional_mcp_servers: Vec<McpServer>,
     /// Override the working directory sent to the remote agent.
     /// When set, this path is used in the `NewSessionRequest` instead of the
     /// local `working_dir` passed to `run()`. This is needed because the
@@ -173,6 +180,7 @@ impl AcpDriver {
                 is_remote: false,
                 extra_env: Vec::new(),
                 mcp_servers: Vec::new(),
+                optional_mcp_servers: Vec::new(),
                 remote_working_dir: None,
             })
             .ok_or_else(|| format!("Unknown or unavailable agent provider: {provider_id}"))
@@ -188,6 +196,7 @@ impl AcpDriver {
                 is_remote: false,
                 extra_env: Vec::new(),
                 mcp_servers: Vec::new(),
+                optional_mcp_servers: Vec::new(),
                 remote_working_dir: None,
             })
             .ok_or_else(|| {
@@ -212,6 +221,7 @@ impl AcpDriver {
             is_remote: true,
             extra_env: Vec::new(),
             mcp_servers: Vec::new(),
+            optional_mcp_servers: Vec::new(),
             remote_working_dir: None,
         })
     }
@@ -225,6 +235,16 @@ impl AcpDriver {
     /// Set MCP servers to inject into the session via `NewSessionRequest` or `LoadSessionRequest`.
     pub fn with_mcp_servers(mut self, servers: Vec<McpServer>) -> Self {
         self.mcp_servers = servers;
+        self
+    }
+
+    /// Set *optional* MCP servers. These are attached only if the agent
+    /// advertises support for their transport; otherwise they are dropped and
+    /// the session proceeds without them (rather than failing). Use this for
+    /// purely additive tools that must never break a session on providers that
+    /// don't support MCP over HTTP/SSE.
+    pub fn with_optional_mcp_servers(mut self, servers: Vec<McpServer>) -> Self {
+        self.optional_mcp_servers = servers;
         self
     }
 
@@ -480,6 +500,7 @@ impl AgentDriver for AcpDriver {
             result = run_acp_protocol(
                 &connection, &acp_working_dir, prompt, images, store,
                 session_id, agent_session_id, &handler, &self.mcp_servers,
+                &self.optional_mcp_servers,
             ) => result,
         };
 
@@ -1118,6 +1139,7 @@ async fn run_acp_protocol(
     acp_session_id: Option<&str>,
     handler: &Arc<AcpNotificationHandler>,
     mcp_servers: &[McpServer],
+    optional_mcp_servers: &[McpServer],
 ) -> Result<(), String> {
     let agent_session_id = tokio::time::timeout(
         ACP_SETUP_TIMEOUT,
@@ -1129,6 +1151,7 @@ async fn run_acp_protocol(
             our_session_id,
             acp_session_id,
             mcp_servers,
+            optional_mcp_servers,
         ),
     )
     .await
@@ -1182,6 +1205,19 @@ async fn run_acp_protocol(
     Ok(())
 }
 
+/// Whether the agent advertises support for the transport an MCP server needs.
+/// Stdio is always supported per the ACP spec.
+fn mcp_server_transport_supported(server: &McpServer, caps: &McpCapabilities) -> bool {
+    match server {
+        McpServer::Http(_) => caps.http,
+        McpServer::Sse(_) => caps.sse,
+        McpServer::Stdio(_) => true,
+        // `McpServer` is non_exhaustive. A transport we don't recognize can't be
+        // reasoned about, so we conservatively drop the optional server.
+        _ => false,
+    }
+}
+
 async fn setup_acp_session(
     connection: &ClientSideConnection,
     working_dir: &Path,
@@ -1190,6 +1226,7 @@ async fn setup_acp_session(
     our_session_id: &str,
     acp_session_id: Option<&str>,
     mcp_servers: &[McpServer],
+    optional_mcp_servers: &[McpServer],
 ) -> Result<String, String> {
     let client_info = Implementation::new("acp-client", env!("CARGO_PKG_VERSION"));
     let init_request = InitializeRequest::new(ProtocolVersion::LATEST).client_info(client_info);
@@ -1199,8 +1236,10 @@ async fn setup_acp_session(
         .await
         .map_err(|e| format!("ACP init failed: {e:?}"))?;
 
+    let mcp_caps = &init_response.agent_capabilities.mcp_capabilities;
+
+    // Required servers must have a supported transport, or the session fails.
     if !mcp_servers.is_empty() {
-        let mcp_caps = &init_response.agent_capabilities.mcp_capabilities;
         let requires_http = mcp_servers
             .iter()
             .any(|server| matches!(server, McpServer::Http(_)));
@@ -1218,6 +1257,24 @@ async fn setup_acp_session(
             ));
         }
     }
+
+    // Optional servers are purely additive: keep only those whose transport the
+    // agent supports, and drop the rest instead of failing the session. This is
+    // what lets the pikchr preview tool attach on MCP-capable providers while
+    // staying silently absent on providers that don't support HTTP/SSE MCP.
+    let mut effective_servers = mcp_servers.to_vec();
+    for server in optional_mcp_servers {
+        if mcp_server_transport_supported(server, mcp_caps) {
+            effective_servers.push(server.clone());
+        } else {
+            log::info!(
+                "Dropping optional MCP server (transport unsupported by agent: http={}, sse={})",
+                mcp_caps.http,
+                mcp_caps.sse
+            );
+        }
+    }
+    let mcp_servers = effective_servers;
 
     match acp_session_id {
         Some(existing_id) => {

--- a/crates/acp-client/src/driver.rs
+++ b/crates/acp-client/src/driver.rs
@@ -1218,6 +1218,7 @@ fn mcp_server_transport_supported(server: &McpServer, caps: &McpCapabilities) ->
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn setup_acp_session(
     connection: &ClientSideConnection,
     working_dir: &Path,
@@ -1238,8 +1239,14 @@ async fn setup_acp_session(
 
     let mcp_caps = &init_response.agent_capabilities.mcp_capabilities;
 
-    // Required servers must have a supported transport, or the session fails.
-    if !mcp_servers.is_empty() {
+    // Required servers must all have a supported transport, or the session
+    // fails. Route the decision through the same helper as the optional path so
+    // the transport->capability mapping lives in exactly one place — a newly
+    // added transport stays validated here instead of silently slipping through.
+    if mcp_servers
+        .iter()
+        .any(|server| !mcp_server_transport_supported(server, mcp_caps))
+    {
         let requires_http = mcp_servers
             .iter()
             .any(|server| matches!(server, McpServer::Http(_)));
@@ -1247,15 +1254,13 @@ async fn setup_acp_session(
             .iter()
             .any(|server| matches!(server, McpServer::Sse(_)));
 
-        if (requires_http && !mcp_caps.http) || (requires_sse && !mcp_caps.sse) {
-            return Err(format!(
-                "Agent does not support required MCP transports (required: http={}, sse={}; agent: http={}, sse={}). Select a provider with MCP support for project tools.",
-                requires_http,
-                requires_sse,
-                mcp_caps.http,
-                mcp_caps.sse
-            ));
-        }
+        return Err(format!(
+            "Agent does not support required MCP transports (required: http={}, sse={}; agent: http={}, sse={}). Select a provider with MCP support for project tools.",
+            requires_http,
+            requires_sse,
+            mcp_caps.http,
+            mcp_caps.sse
+        ));
     }
 
     // Optional servers are purely additive: keep only those whose transport the
@@ -1450,9 +1455,11 @@ impl MessageWriter for BasicMessageWriter {
 #[cfg(test)]
 mod tests {
     use super::{
-        consume_remote_acp_line, decode_remote_acp_line, remote_acp_segments,
-        resolve_spawn_working_dir, sanitize_remote_acp_chunk, shell_quote, RemoteLineOutcome,
+        consume_remote_acp_line, decode_remote_acp_line, mcp_server_transport_supported,
+        remote_acp_segments, resolve_spawn_working_dir, sanitize_remote_acp_chunk, shell_quote,
+        McpCapabilities, McpServer, RemoteLineOutcome,
     };
+    use agent_client_protocol::{McpServerHttp, McpServerSse, McpServerStdio};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -1578,6 +1585,28 @@ mod tests {
     #[test]
     fn shell_quote_preserves_spaces() {
         assert_eq!(shell_quote("/path/with space"), "'/path/with space'");
+    }
+
+    #[test]
+    fn mcp_transport_support_maps_each_transport_to_its_capability() {
+        let stdio = McpServer::Stdio(McpServerStdio::new("local", "/usr/bin/server"));
+        let http = McpServer::Http(McpServerHttp::new("remote", "https://example.com"));
+        let sse = McpServer::Sse(McpServerSse::new("remote", "https://example.com/events"));
+
+        // Stdio needs no capability — it is always supported, even with all caps off.
+        let none = McpCapabilities::new();
+        assert!(mcp_server_transport_supported(&stdio, &none));
+        assert!(!mcp_server_transport_supported(&http, &none));
+        assert!(!mcp_server_transport_supported(&sse, &none));
+
+        // Each remote transport is gated on its own capability.
+        let http_only = McpCapabilities::new().http(true);
+        assert!(mcp_server_transport_supported(&http, &http_only));
+        assert!(!mcp_server_transport_supported(&sse, &http_only));
+
+        let sse_only = McpCapabilities::new().sse(true);
+        assert!(mcp_server_transport_supported(&sse, &sse_only));
+        assert!(!mcp_server_transport_supported(&http, &sse_only));
     }
 
     #[tokio::test]

--- a/crates/acp-client/src/driver.rs
+++ b/crates/acp-client/src/driver.rs
@@ -151,10 +151,6 @@ pub struct AcpDriver {
     /// These are *required*: if the agent doesn't support a server's transport,
     /// the session fails.
     mcp_servers: Vec<McpServer>,
-    /// Optional MCP servers — additive niceties (e.g. the pikchr preview tool).
-    /// If the agent doesn't advertise the transport these need, they are
-    /// silently dropped instead of failing the session.
-    optional_mcp_servers: Vec<McpServer>,
     /// Override the working directory sent to the remote agent.
     /// When set, this path is used in the `NewSessionRequest` instead of the
     /// local `working_dir` passed to `run()`. This is needed because the
@@ -180,7 +176,6 @@ impl AcpDriver {
                 is_remote: false,
                 extra_env: Vec::new(),
                 mcp_servers: Vec::new(),
-                optional_mcp_servers: Vec::new(),
                 remote_working_dir: None,
             })
             .ok_or_else(|| format!("Unknown or unavailable agent provider: {provider_id}"))
@@ -196,7 +191,6 @@ impl AcpDriver {
                 is_remote: false,
                 extra_env: Vec::new(),
                 mcp_servers: Vec::new(),
-                optional_mcp_servers: Vec::new(),
                 remote_working_dir: None,
             })
             .ok_or_else(|| {
@@ -221,7 +215,6 @@ impl AcpDriver {
             is_remote: true,
             extra_env: Vec::new(),
             mcp_servers: Vec::new(),
-            optional_mcp_servers: Vec::new(),
             remote_working_dir: None,
         })
     }
@@ -235,16 +228,6 @@ impl AcpDriver {
     /// Set MCP servers to inject into the session via `NewSessionRequest` or `LoadSessionRequest`.
     pub fn with_mcp_servers(mut self, servers: Vec<McpServer>) -> Self {
         self.mcp_servers = servers;
-        self
-    }
-
-    /// Set *optional* MCP servers. These are attached only if the agent
-    /// advertises support for their transport; otherwise they are dropped and
-    /// the session proceeds without them (rather than failing). Use this for
-    /// purely additive tools that must never break a session on providers that
-    /// don't support MCP over HTTP/SSE.
-    pub fn with_optional_mcp_servers(mut self, servers: Vec<McpServer>) -> Self {
-        self.optional_mcp_servers = servers;
         self
     }
 
@@ -500,7 +483,6 @@ impl AgentDriver for AcpDriver {
             result = run_acp_protocol(
                 &connection, &acp_working_dir, prompt, images, store,
                 session_id, agent_session_id, &handler, &self.mcp_servers,
-                &self.optional_mcp_servers,
             ) => result,
         };
 
@@ -1139,7 +1121,6 @@ async fn run_acp_protocol(
     acp_session_id: Option<&str>,
     handler: &Arc<AcpNotificationHandler>,
     mcp_servers: &[McpServer],
-    optional_mcp_servers: &[McpServer],
 ) -> Result<(), String> {
     let agent_session_id = tokio::time::timeout(
         ACP_SETUP_TIMEOUT,
@@ -1151,7 +1132,6 @@ async fn run_acp_protocol(
             our_session_id,
             acp_session_id,
             mcp_servers,
-            optional_mcp_servers,
         ),
     )
     .await
@@ -1213,7 +1193,8 @@ fn mcp_server_transport_supported(server: &McpServer, caps: &McpCapabilities) ->
         McpServer::Sse(_) => caps.sse,
         McpServer::Stdio(_) => true,
         // `McpServer` is non_exhaustive. A transport we don't recognize can't be
-        // reasoned about, so we conservatively drop the optional server.
+        // reasoned about, so we conservatively treat it as unsupported, which
+        // fails the session rather than silently shipping an unvalidated server.
         _ => false,
     }
 }
@@ -1227,7 +1208,6 @@ async fn setup_acp_session(
     our_session_id: &str,
     acp_session_id: Option<&str>,
     mcp_servers: &[McpServer],
-    optional_mcp_servers: &[McpServer],
 ) -> Result<String, String> {
     let client_info = Implementation::new("acp-client", env!("CARGO_PKG_VERSION"));
     let init_request = InitializeRequest::new(ProtocolVersion::LATEST).client_info(client_info);
@@ -1240,9 +1220,9 @@ async fn setup_acp_session(
     let mcp_caps = &init_response.agent_capabilities.mcp_capabilities;
 
     // Required servers must all have a supported transport, or the session
-    // fails. Route the decision through the same helper as the optional path so
-    // the transport->capability mapping lives in exactly one place — a newly
-    // added transport stays validated here instead of silently slipping through.
+    // fails. Route the decision through mcp_server_transport_supported so the
+    // transport->capability mapping lives in exactly one place — a newly added
+    // transport stays validated here instead of silently slipping through.
     if mcp_servers
         .iter()
         .any(|server| !mcp_server_transport_supported(server, mcp_caps))
@@ -1255,31 +1235,13 @@ async fn setup_acp_session(
             .any(|server| matches!(server, McpServer::Sse(_)));
 
         return Err(format!(
-            "Agent does not support required MCP transports (required: http={}, sse={}; agent: http={}, sse={}). Select a provider with MCP support for project tools.",
+            "Agent does not support required MCP transports (required: http={}, sse={}; agent: http={}, sse={}). Select a provider that supports MCP over HTTP/SSE.",
             requires_http,
             requires_sse,
             mcp_caps.http,
             mcp_caps.sse
         ));
     }
-
-    // Optional servers are purely additive: keep only those whose transport the
-    // agent supports, and drop the rest instead of failing the session. This is
-    // what lets the pikchr preview tool attach on MCP-capable providers while
-    // staying silently absent on providers that don't support HTTP/SSE MCP.
-    let mut effective_servers = mcp_servers.to_vec();
-    for server in optional_mcp_servers {
-        if mcp_server_transport_supported(server, mcp_caps) {
-            effective_servers.push(server.clone());
-        } else {
-            log::info!(
-                "Dropping optional MCP server (transport unsupported by agent: http={}, sse={})",
-                mcp_caps.http,
-                mcp_caps.sse
-            );
-        }
-    }
-    let mcp_servers = effective_servers;
 
     match acp_session_id {
         Some(existing_id) => {


### PR DESCRIPTION
Adds a `preview_pikchr` MCP tool that lets local note-writing agent sessions
render their Pikchr diagrams and catch overlaps before finalizing a note.

Note-writing sessions previously had no way to see their diagrams (see branch
note da951fca), so agents shipped overlapping/colliding layouts with only a
grammar reference to go on. This gives them a feedback loop.

## Changes

- **`preview_pikchr` MCP tool** (new `pikchr_mcp.rs`): a stateless HTTP MCP
  server exposing `preview_pikchr(source, scale?)`. It renders Pikchr via the
  `pikchr` crate (the same pikchr.c the frontend compiles to WASM, so geometry
  matches), rasterizes to PNG with resvg/usvg/tiny-skia, and parses the SVG to
  flag overlapping box-like shapes. Returns an image block plus a text summary
  (dimensions + overlap report) so vision-less providers still benefit, and
  returns the Pikchr error text on a parse/layout failure.
- **Required-MCP wiring** (`session_runner`, `session_commands`, `web_server`):
  the tool is attached as a *required* MCP server for local note-writing
  sessions only — project notes and local branch notes. Remote branch notes
  can't reach localhost, so it's omitted there (reachability gate). The
  local-note predicate is centralized in
  `local_note_pikchr_preview_available`, and the project (builderbot) and
  pikchr servers are accumulated into a single `with_mcp_servers` call so they
  don't clobber each other.
- **Transport-capability gate** (`acp-client/driver`): there is now a single
  required MCP server list with one rule — a provider whose transport the
  required server needs (HTTP MCP for pikchr) but doesn't support **fails the
  session loudly** rather than silently degrading. The check is routed through
  the shared `mcp_server_transport_supported` helper so the transport→capability
  mapping lives in one place. **Behavior note:** HTTP MCP is now a hard
  requirement for every local note session. pikchr *startup* (port-bind)
  failure stays non-fatal — a local infra hiccup, orthogonal to provider
  capability — so it logs and continues without the preview aid.
- **Supporting refactors**: cache the `attr_f64` regex with `OnceLock` instead
  of recompiling per attribute; drop the pikchr source length cap (render
  dimensions are already bounded and the byte-vs-UTF-16 unit mismatch made the
  count misleading); and drop the rasterizer's fit-to-bounds scale floor so an
  oversized diagram is shown whole (shrunk, uncropped) rather than cropped to
  the dimension clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
