### PR TITLE
fix(staged): refine orchestrator note-reference guidance

### DIFF
--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1040,9 +1040,14 @@ const NOTE_STANDALONE_OUTPUT_GUIDANCE: &str =
 
 const PROJECT_SESSION_TIMELINE_REFERENCE_GUIDANCE: &str = "When referring to existing timeline \
 items in notes or repo-session instructions, use hashtag references in the form #<type>:<id>, \
-for example #note:123, #commit:<sha>, and #review:456. When starting a repo-level session from a \
-note, do not paste or rewrite the note contents; reference the note and relevant section instead, \
-for example: `Implement \"Step 5: unit tests\" from #note:123`.";
+for example #note:123, #commit:<sha>, and #review:456. When you start a repo-level session from a \
+note, reference the note (and the relevant section) and state the goal in your own words — but do \
+NOT restate, paraphrase, summarize, or copy the note's plan, recommended approach, file paths, \
+line numbers, or step-by-step instructions. The repo session is handed the note and reads it \
+itself, so duplicating its contents only adds length and risks drift. For example: \
+`Implement \"Step 5: unit tests\" from #note:123`. This restriction applies only when a note is \
+being referenced; when there is no note to point to, make the instructions as detailed and \
+self-contained as the task requires.";
 
 pub(crate) fn build_project_session_action_instructions_with_pikchr_reference(
     is_remote: bool,
@@ -4440,8 +4445,9 @@ mod tests {
         assert!(prompt.contains("#note:123"));
         assert!(prompt.contains("#commit:<sha>"));
         assert!(prompt.contains("#review:456"));
-        assert!(prompt.contains("do not paste or rewrite the note contents"));
-        assert!(prompt.contains("reference the note and relevant section instead"));
+        assert!(prompt.contains("do NOT restate, paraphrase, summarize, or copy the note's plan"));
+        assert!(prompt.contains("reference the note (and the relevant section)"));
+        assert!(prompt.contains("when there is no note to point to"));
         assert!(prompt.contains("Implement \"Step 5: unit tests\" from #note:123"));
     }
 

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1044,8 +1044,7 @@ for example #note:123, #commit:<sha>, and #review:456. When you start a repo-lev
 note, reference the note (and the relevant section) and state the goal in your own words — but do \
 NOT repeat or paraphrase the note itself. For example: \
 `Implement \"Step 5: unit tests\" from #note:123`. This restriction applies only when a note is \
-being referenced; when there is no note to point to, make the instructions as detailed and \
-self-contained as the task requires.";
+being referenced.";
 
 pub(crate) fn build_project_session_action_instructions_with_pikchr_reference(
     is_remote: bool,
@@ -4445,7 +4444,7 @@ mod tests {
         assert!(prompt.contains("#review:456"));
         assert!(prompt.contains("do NOT repeat or paraphrase the note itself"));
         assert!(prompt.contains("reference the note (and the relevant section)"));
-        assert!(prompt.contains("when there is no note to point to"));
+        assert!(prompt.contains("This restriction applies only when a note is being referenced"));
         assert!(prompt.contains("Implement \"Step 5: unit tests\" from #note:123"));
     }
 

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1041,8 +1041,8 @@ const NOTE_STANDALONE_OUTPUT_GUIDANCE: &str =
 const PROJECT_SESSION_TIMELINE_REFERENCE_GUIDANCE: &str = "When referring to existing timeline \
 items in notes or repo-session instructions, use hashtag references in the form #<type>:<id>, \
 for example #note:123, #commit:<sha>, and #review:456. When you start a repo-level session from a \
-note, reference the note (and the relevant section) and state the goal in your own words — but do \
-NOT repeat or paraphrase the note itself. For example: \
+note, reference the note (and the relevant section) and state the session's goal in your own short \
+and concise words — but do NOT repeat or paraphrase the note itself. For example: \
 `Implement \"Step 5: unit tests\" from #note:123`. This restriction applies only when a note is \
 being referenced.";
 
@@ -4443,6 +4443,7 @@ mod tests {
         assert!(prompt.contains("#commit:<sha>"));
         assert!(prompt.contains("#review:456"));
         assert!(prompt.contains("do NOT repeat or paraphrase the note itself"));
+        assert!(prompt.contains("state the session's goal in your own short and concise words"));
         assert!(prompt.contains("reference the note (and the relevant section)"));
         assert!(prompt.contains("This restriction applies only when a note is being referenced"));
         assert!(prompt.contains("Implement \"Step 5: unit tests\" from #note:123"));

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1042,7 +1042,8 @@ const PROJECT_SESSION_TIMELINE_REFERENCE_GUIDANCE: &str = "When referring to exi
 items in notes or repo-session instructions, use hashtag references in the form #<type>:<id>, \
 for example #note:123, #commit:<sha>, and #review:456. When you start a repo-level session from a \
 note, reference the note (and the relevant section) and state the session's goal in your own short \
-and concise words — but do NOT repeat or paraphrase the note itself. For example: \
+and concise words — but do NOT repeat or paraphrase the note itself. The repo session will \
+automatically be told where to read all notes, so a reference is enough. For example: \
 `Implement \"Step 5: unit tests\" from #note:123`. This restriction applies only when a note is \
 being referenced.";
 
@@ -4443,6 +4444,9 @@ mod tests {
         assert!(prompt.contains("#commit:<sha>"));
         assert!(prompt.contains("#review:456"));
         assert!(prompt.contains("do NOT repeat or paraphrase the note itself"));
+        assert!(
+            prompt.contains("The repo session will automatically be told where to read all notes")
+        );
         assert!(prompt.contains("state the session's goal in your own short and concise words"));
         assert!(prompt.contains("reference the note (and the relevant section)"));
         assert!(prompt.contains("This restriction applies only when a note is being referenced"));

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -1042,9 +1042,7 @@ const PROJECT_SESSION_TIMELINE_REFERENCE_GUIDANCE: &str = "When referring to exi
 items in notes or repo-session instructions, use hashtag references in the form #<type>:<id>, \
 for example #note:123, #commit:<sha>, and #review:456. When you start a repo-level session from a \
 note, reference the note (and the relevant section) and state the goal in your own words — but do \
-NOT restate, paraphrase, summarize, or copy the note's plan, recommended approach, file paths, \
-line numbers, or step-by-step instructions. The repo session is handed the note and reads it \
-itself, so duplicating its contents only adds length and risks drift. For example: \
+NOT repeat or paraphrase the note itself. For example: \
 `Implement \"Step 5: unit tests\" from #note:123`. This restriction applies only when a note is \
 being referenced; when there is no note to point to, make the instructions as detailed and \
 self-contained as the task requires.";
@@ -4445,7 +4443,7 @@ mod tests {
         assert!(prompt.contains("#note:123"));
         assert!(prompt.contains("#commit:<sha>"));
         assert!(prompt.contains("#review:456"));
-        assert!(prompt.contains("do NOT restate, paraphrase, summarize, or copy the note's plan"));
+        assert!(prompt.contains("do NOT repeat or paraphrase the note itself"));
         assert!(prompt.contains("reference the note (and the relevant section)"));
         assert!(prompt.contains("when there is no note to point to"));
         assert!(prompt.contains("Implement \"Step 5: unit tests\" from #note:123"));


### PR DESCRIPTION
Refines the timeline-reference guidance that repo/project sessions receive when started from a note.

The previous wording told the orchestrator to "reference the note and relevant section instead" of pasting contents. This sharpens it to:

- State the session's goal in its own short, concise words rather than repeating or paraphrasing the note.
- Note that repo sessions are automatically told where to read all notes, so a reference alone is sufficient.
- Clarify that the restriction applies only when a note is actually being referenced.

Updates the corresponding test assertions to match the new guidance text.