### PR TITLE
fix(staged): add missing table CSS to chat markdown

### DIFF
--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -2268,6 +2268,24 @@
     border-top: 1px solid var(--border-subtle);
   }
 
+  .markdown-content :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.75em 0;
+  }
+
+  .markdown-content :global(th),
+  .markdown-content :global(td) {
+    border: 1px solid var(--border-subtle);
+    padding: 6px 12px;
+    text-align: left;
+  }
+
+  .markdown-content :global(th) {
+    background: var(--bg-primary);
+    font-weight: 600;
+  }
+
   @media (max-width: 700px) {
     .modal-header {
       padding: 12px;


### PR DESCRIPTION
## Summary

Markdown tables rendered in the chat view of the session modal were displaying without any styling, making them effectively invisible/unreadable. This adds the missing table CSS to `SessionModal.svelte` so tables render with borders, padding, and a styled header row.

## Changes

- Add `:global` table styles to `.markdown-content`:
  - `table`: collapsed borders, full width, vertical margin
  - `th`/`td`: subtle border, padding, left-aligned text
  - `th`: primary background and bold text for header cells

## Testing

Styling-only change; verified via the CI checks that ran on push (crates-fmt, crates-test, crates-lint, differ-ci, staged-ci all passing).