### PR TITLE
feat(staged): theme Pikchr diagram colors to match the active theme

### DIFF
--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -90,7 +90,17 @@
   --ui-danger-bg: rgba(248, 81, 73, 0.1);
   --ui-selection: rgba(255, 255, 255, 0.08);
 
-  --diagram-canvas-bg: #ffffff;
+  --diagram-canvas-bg: #2f2936;
+  --pikchr-ink: #ffffff;
+  --pikchr-surface: #38333f;
+  --pikchr-muted: #91889b;
+  --pikchr-red: #f85149;
+  --pikchr-green: #3fb950;
+  --pikchr-blue: #58a6ff;
+  --pikchr-yellow: #d29922;
+  --pikchr-orange: #d29922;
+  --pikchr-purple: #a78bfa;
+  --pikchr-cyan: #22d3ee;
 
   --scrollbar-thumb: #47424d;
   --scrollbar-thumb-hover: #5d5962;

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -94,13 +94,13 @@
   --pikchr-ink: #241a2f;
   --pikchr-surface: #fffaff;
   --pikchr-muted: #74677f;
-  --pikchr-red: #e76f82;
-  --pikchr-green: #58bd7a;
-  --pikchr-blue: #68a5e8;
-  --pikchr-yellow: #e6c45f;
-  --pikchr-orange: #e49557;
-  --pikchr-purple: #b28af0;
-  --pikchr-cyan: #58c9d8;
+  --pikchr-red: #e97d8f;
+  --pikchr-green: #69c487;
+  --pikchr-blue: #77aeea;
+  --pikchr-yellow: #e9ca6f;
+  --pikchr-orange: #e7a068;
+  --pikchr-purple: #ba96f2;
+  --pikchr-cyan: #69cedc;
 
   --scrollbar-thumb: #47424d;
   --scrollbar-thumb-hover: #5d5962;

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -94,13 +94,13 @@
   --pikchr-ink: #241a2f;
   --pikchr-surface: #fffaff;
   --pikchr-muted: #74677f;
-  --pikchr-red: #e97d8f;
-  --pikchr-green: #69c487;
-  --pikchr-blue: #77aeea;
-  --pikchr-yellow: #e9ca6f;
-  --pikchr-orange: #e7a068;
-  --pikchr-purple: #ba96f2;
-  --pikchr-cyan: #69cedc;
+  --pikchr-red: #ec91a0;
+  --pikchr-green: #80cd99;
+  --pikchr-blue: #8bbaed;
+  --pikchr-yellow: #ecd285;
+  --pikchr-orange: #ebae7f;
+  --pikchr-purple: #c4a6f4;
+  --pikchr-cyan: #80d5e1;
 
   --scrollbar-thumb: #47424d;
   --scrollbar-thumb-hover: #5d5962;

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -90,17 +90,17 @@
   --ui-danger-bg: rgba(248, 81, 73, 0.1);
   --ui-selection: rgba(255, 255, 255, 0.08);
 
-  --diagram-canvas-bg: #2f2936;
-  --pikchr-ink: #ffffff;
-  --pikchr-surface: #38333f;
-  --pikchr-muted: #91889b;
-  --pikchr-red: #f85149;
-  --pikchr-green: #3fb950;
-  --pikchr-blue: #58a6ff;
-  --pikchr-yellow: #d29922;
-  --pikchr-orange: #d29922;
-  --pikchr-purple: #a78bfa;
-  --pikchr-cyan: #22d3ee;
+  --diagram-canvas-bg: #f2edf8;
+  --pikchr-ink: #241a2f;
+  --pikchr-surface: #fffaff;
+  --pikchr-muted: #74677f;
+  --pikchr-red: #e76f82;
+  --pikchr-green: #58bd7a;
+  --pikchr-blue: #68a5e8;
+  --pikchr-yellow: #e6c45f;
+  --pikchr-orange: #e49557;
+  --pikchr-purple: #b28af0;
+  --pikchr-cyan: #58c9d8;
 
   --scrollbar-thumb: #47424d;
   --scrollbar-thumb-hover: #5d5962;

--- a/apps/staged/src/lib/shared/markdown/diagramRendering.ts
+++ b/apps/staged/src/lib/shared/markdown/diagramRendering.ts
@@ -25,7 +25,7 @@ export function renderMarkdownDiagramCodeBlock(
   if (!renderedPikchr || renderedPikchr.kind !== 'svg') {
     return { html: renderedDiagramSource, trustedHtml: false };
   }
-  const renderedSvg = sanitizePikchrSvg(renderedPikchr.svg);
+  const renderedSvg = sanitizePikchrSvg(renderedPikchr.svg, { source: token.text });
   if (!renderedSvg) {
     return { html: renderedDiagramSource, trustedHtml: false };
   }

--- a/apps/staged/src/lib/shared/markdown/pikchrRendering.test.ts
+++ b/apps/staged/src/lib/shared/markdown/pikchrRendering.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { loadPikchrRenderer, sanitizePikchrSvg } from './pikchrRendering';
 
 describe('sanitizePikchrSvg', () => {
-  it('keeps static Pikchr geometry and path styles', () => {
+  it('keeps static Pikchr geometry and applies the themed default ink', () => {
     const svg = sanitizePikchrSvg(
       [
         '<svg xmlns="http://www.w3.org/2000/svg" class="markdown-pikchr-svg" viewBox="0 0 58 34" data-pikchr-date="20260403102956">',
@@ -16,9 +16,9 @@ describe('sanitizePikchrSvg', () => {
     expect(svg).toContain('<svg');
     expect(svg).toContain('viewBox="0 0 58 34"');
     expect(svg).toContain('<path');
-    expect(svg).toContain('style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0)"');
+    expect(svg).toContain('style="fill:none;stroke-width:2.16;stroke:var(--pikchr-ink)"');
     expect(svg).toContain('<text');
-    expect(svg).toContain('fill="rgb(0,0,0)"');
+    expect(svg).toContain('fill="var(--pikchr-ink)"');
     expect(svg).not.toContain('data-pikchr-date');
   });
 
@@ -38,6 +38,55 @@ describe('sanitizePikchrSvg', () => {
     expect(svg).toContain('fill="rgb(1, 2, 3)"');
     expect(svg).toContain('stroke="rgba(12, 34, 56, 0.5)"');
     expect(svg).not.toContain('url(');
+  });
+
+  it('maps common Pikchr colors onto the themed palette', () => {
+    const svg = sanitizePikchrSvg(
+      [
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">',
+        '<path d="M1,1L119,1" style="stroke:rgb(255,0,0);fill:white" />',
+        '<rect x="1" y="1" width="10" height="10" fill="yellow" stroke="green" />',
+        '<text x="20" y="20" fill="blue">Label</text>',
+        '</svg>',
+      ].join('')
+    );
+
+    expect(svg).toContain('stroke:var(--pikchr-red)');
+    expect(svg).toContain('fill:var(--pikchr-surface)');
+    expect(svg).toContain('fill="var(--pikchr-yellow)"');
+    expect(svg).toContain('stroke="var(--pikchr-green)"');
+    expect(svg).toContain('fill="var(--pikchr-blue)"');
+  });
+
+  it('preserves numeric Pikchr colors from the source', () => {
+    const svg = sanitizePikchrSvg(
+      [
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">',
+        '<path d="M1,1L119,1" style="stroke:rgb(255,0,0);fill:rgb(255,255,255)" />',
+        '<text x="20" y="20" fill="rgb(0,0,0)">Label</text>',
+        '</svg>',
+      ].join(''),
+      {
+        source: 'box "Numeric colors" color 0xff0000 fill 0xffffff',
+      }
+    );
+
+    expect(svg).toContain('stroke:rgb(255,0,0)');
+    expect(svg).toContain('fill:rgb(255,255,255)');
+    expect(svg).toContain('fill="var(--pikchr-ink)"');
+  });
+
+  it('keeps fill none as no paint', () => {
+    const svg = sanitizePikchrSvg(
+      [
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">',
+        '<path d="M1,1L19,19" fill="none" stroke="rgb(0,0,0)" />',
+        '</svg>',
+      ].join('')
+    );
+
+    expect(svg).toContain('fill="none"');
+    expect(svg).toContain('stroke="var(--pikchr-ink)"');
   });
 
   it('adds breathing room to side-anchored Pikchr text labels', () => {
@@ -106,6 +155,7 @@ describe('loadPikchrRenderer', () => {
     expect(rendered.svg).toContain('class="markdown-pikchr-svg"');
     expect(rendered.svg).toContain('<path');
     expect(rendered.svg).toContain('Start');
+    expect(rendered.svg).toContain('var(--pikchr-ink)');
     expect(rendered.svg).not.toContain('<script');
     expect(rendered.svg).not.toContain('data-pikchr-date');
   });

--- a/apps/staged/src/lib/shared/markdown/pikchrRendering.ts
+++ b/apps/staged/src/lib/shared/markdown/pikchrRendering.ts
@@ -9,8 +9,23 @@ const PIKCHR_SIDE_LABEL_GAP = '0.35em';
 
 const CSS_NUMBER = String.raw`[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[-+]?\d+)?`;
 const CSS_LENGTH = new RegExp(`^(?:${CSS_NUMBER})(?:px|pt|pc|mm|cm|in|em|rem|%)?$`);
-const CSS_COLOR =
-  /^(?:none|transparent|currentColor|[a-zA-Z]+|#[0-9a-fA-F]{3,8}|rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\))$/;
+const PIKCHR_THEME_COLOR_VAR_NAMES = [
+  '--pikchr-ink',
+  '--pikchr-surface',
+  '--pikchr-muted',
+  '--pikchr-red',
+  '--pikchr-green',
+  '--pikchr-blue',
+  '--pikchr-yellow',
+  '--pikchr-orange',
+  '--pikchr-purple',
+  '--pikchr-cyan',
+] as const;
+const PIKCHR_THEME_COLOR_VAR_PATTERN = String.raw`var\((?:${PIKCHR_THEME_COLOR_VAR_NAMES.join('|')})\)`;
+const CSS_COLOR = new RegExp(
+  String.raw`^(?:none|transparent|currentColor|[a-zA-Z]+|#[0-9a-fA-F]{3,8}|rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)|${PIKCHR_THEME_COLOR_VAR_PATTERN})$`,
+  'i'
+);
 const CSS_DASH_ARRAY = new RegExp(`^(?:${CSS_NUMBER})(?:\\s*,\\s*(?:${CSS_NUMBER}))*$`);
 const DIRECT_COLOR_ATTRIBUTES = ['fill', 'stroke'] as const;
 const DIRECT_COLOR_ATTRIBUTE_TAGS = new Set([
@@ -23,6 +38,60 @@ const DIRECT_COLOR_ATTRIBUTE_TAGS = new Set([
   'polyline',
   'polygon',
 ]);
+const RGB_COLOR = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i;
+const HEX_COLOR = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+const PIKCHR_NUMERIC_COLOR_LITERAL = /\b0x([0-9a-fA-F]{6})\b/g;
+const THEMED_PIKCHR_COLORS = new Map([
+  ['#000000', 'var(--pikchr-ink)'],
+  ['#ffffff', 'var(--pikchr-surface)'],
+  ['#808080', 'var(--pikchr-muted)'],
+  ['#a9a9a9', 'var(--pikchr-muted)'],
+  ['#c0c0c0', 'var(--pikchr-muted)'],
+  ['#696969', 'var(--pikchr-muted)'],
+  ['#ff0000', 'var(--pikchr-red)'],
+  ['#dc143c', 'var(--pikchr-red)'],
+  ['#008000', 'var(--pikchr-green)'],
+  ['#00ff00', 'var(--pikchr-green)'],
+  ['#0000ff', 'var(--pikchr-blue)'],
+  ['#ffff00', 'var(--pikchr-yellow)'],
+  ['#ffd700', 'var(--pikchr-yellow)'],
+  ['#ffa500', 'var(--pikchr-orange)'],
+  ['#800080', 'var(--pikchr-purple)'],
+  ['#ff00ff', 'var(--pikchr-purple)'],
+  ['#ee82ee', 'var(--pikchr-purple)'],
+  ['#00ffff', 'var(--pikchr-cyan)'],
+  ['#008080', 'var(--pikchr-cyan)'],
+]);
+const NAMED_PIKCHR_COLOR_KEYS = new Map([
+  ['black', '#000000'],
+  ['white', '#ffffff'],
+  ['gray', '#808080'],
+  ['grey', '#808080'],
+  ['darkgray', '#a9a9a9'],
+  ['darkgrey', '#a9a9a9'],
+  ['silver', '#c0c0c0'],
+  ['dimgray', '#696969'],
+  ['dimgrey', '#696969'],
+  ['red', '#ff0000'],
+  ['crimson', '#dc143c'],
+  ['green', '#008000'],
+  ['lime', '#00ff00'],
+  ['blue', '#0000ff'],
+  ['yellow', '#ffff00'],
+  ['gold', '#ffd700'],
+  ['orange', '#ffa500'],
+  ['purple', '#800080'],
+  ['fuchsia', '#ff00ff'],
+  ['magenta', '#ff00ff'],
+  ['violet', '#ee82ee'],
+  ['cyan', '#00ffff'],
+  ['aqua', '#00ffff'],
+  ['teal', '#008080'],
+]);
+
+interface SanitizePikchrSvgOptions {
+  source?: string;
+}
 
 export type RenderedPikchrDiagram =
   | {
@@ -64,7 +133,7 @@ export function renderPikchrSource(pikchr: Pikchr, source: string): RenderedPikc
       return { kind: 'error', message: 'Pikchr could not render this diagram.' };
     }
 
-    const svg = sanitizePikchrSvg(rendered.svg);
+    const svg = sanitizePikchrSvg(rendered.svg, { source });
     if (!svg) {
       return { kind: 'error', message: 'Pikchr rendered unsafe SVG.' };
     }
@@ -80,7 +149,10 @@ export function renderPikchrSource(pikchr: Pikchr, source: string): RenderedPikc
   }
 }
 
-export function sanitizePikchrSvg(svg: string): string | null {
+export function sanitizePikchrSvg(
+  svg: string,
+  options: SanitizePikchrSvgOptions = {}
+): string | null {
   if (svg.length > MAX_PIKCHR_SVG_LENGTH || !PIKCHR_SVG_ROOT.test(svg)) {
     return null;
   }
@@ -138,7 +210,7 @@ export function sanitizePikchrSvg(svg: string): string | null {
 
   const normalized = sanitized.replace(/\sviewbox=/g, ' viewBox=');
   if (!PIKCHR_SVG_ROOT.test(normalized)) return null;
-  return normalized;
+  return applyThemedPikchrPalette(normalized, options.source);
 }
 
 function normalizePikchrSvgAttributes(tagName: string, attribs: Record<string, string>) {
@@ -182,4 +254,71 @@ function stripUnsafeDirectColorAttributes(tagName: string, attribs: Record<strin
   }
 
   return { tagName, attribs: nextAttribs };
+}
+
+function applyThemedPikchrPalette(svg: string, source: string | undefined): string {
+  const preservedColors = collectPreservedPikchrColorKeys(source);
+  return svg
+    .replace(/\b(fill|stroke)="([^"]*)"/gi, (_match, attribute: string, value: string) => {
+      return `${attribute}="${themePikchrColor(value, preservedColors)}"`;
+    })
+    .replace(/\bstyle="([^"]*)"/gi, (_match, style: string) => {
+      return `style="${themePikchrStyle(style, preservedColors)}"`;
+    });
+}
+
+function themePikchrStyle(style: string, preservedColors: Set<string>): string {
+  return style.replace(
+    /(^|;)\s*(fill|stroke)\s*:\s*([^;]+)/gi,
+    (_match, prefix: string, property: string, value: string) => {
+      return `${prefix}${property}:${themePikchrColor(value, preservedColors)}`;
+    }
+  );
+}
+
+function themePikchrColor(value: string, preservedColors: Set<string>): string {
+  const trimmedValue = value.trim();
+  const colorKey = canonicalColorKey(trimmedValue);
+  if (!colorKey || preservedColors.has(colorKey)) return trimmedValue;
+
+  return THEMED_PIKCHR_COLORS.get(colorKey) ?? trimmedValue;
+}
+
+function collectPreservedPikchrColorKeys(source: string | undefined): Set<string> {
+  const preservedColors = new Set<string>();
+  if (!source) return preservedColors;
+
+  const sourceWithoutLabels = source.replace(/"[^"]*(?:"|$)/g, ' ');
+  for (const match of sourceWithoutLabels.matchAll(PIKCHR_NUMERIC_COLOR_LITERAL)) {
+    preservedColors.add(`#${match[1].toLowerCase()}`);
+  }
+
+  return preservedColors;
+}
+
+function canonicalColorKey(value: string): string | null {
+  const normalizedValue = value.toLowerCase();
+  const namedColor = NAMED_PIKCHR_COLOR_KEYS.get(normalizedValue);
+  if (namedColor) return namedColor;
+
+  const rgb = RGB_COLOR.exec(normalizedValue);
+  if (rgb) return colorKeyFromRgb(Number(rgb[1]), Number(rgb[2]), Number(rgb[3]));
+
+  const hex = HEX_COLOR.exec(normalizedValue);
+  if (!hex) return null;
+
+  const digits = hex[1];
+  if (digits.length === 3) {
+    return `#${digits
+      .split('')
+      .map((digit) => `${digit}${digit}`)
+      .join('')}`;
+  }
+  return `#${digits}`;
+}
+
+function colorKeyFromRgb(r: number, g: number, b: number): string | null {
+  if ([r, g, b].some((component) => component < 0 || component > 255)) return null;
+
+  return `#${[r, g, b].map((component) => component.toString(16).padStart(2, '0')).join('')}`;
 }

--- a/apps/staged/src/lib/shared/markdown/renderMarkdown.test.ts
+++ b/apps/staged/src/lib/shared/markdown/renderMarkdown.test.ts
@@ -42,12 +42,21 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<svg');
     expect(html).toContain('class="markdown-pikchr-svg"');
     expect(html).toContain('<path');
-    expect(html).toContain('stroke:rgb(0,0,0)');
+    expect(html).toContain('stroke:var(--pikchr-ink)');
     expect(html).not.toContain('markdown-diagram-source-wrap');
     expect(html).not.toContain('markdown-diagram-source-pikchr');
     expect(html).not.toContain('box "Start" fit');
     expect(html).not.toContain('box &quot;Start&quot; fit');
     expect(html).not.toContain('STAGED_MARKDOWN_TRUSTED_DIAGRAM_');
+  });
+
+  it('preserves numeric Pikchr colors through the Markdown rendering path', () => {
+    const html = renderMarkdown('```pikchr\nbox "Exact" color 0xff0000 fill 0xffffff\n```', {
+      pikchrRenderer: numericColorPikchrRenderer,
+    });
+
+    expect(html).toContain('stroke:rgb(255,0,0)');
+    expect(html).toContain('fill:rgb(255,255,255)');
   });
 
   it('does not allow renderer SVG through the generic Markdown sanitizer', () => {
@@ -97,6 +106,18 @@ const safePikchrRenderer: PikchrRenderer = () => ({
     '<svg xmlns="http://www.w3.org/2000/svg" class="markdown-pikchr-svg" viewBox="0 0 58 34">',
     '<path d="M2,32L56,32L56,2L2,2Z" style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />',
     '<text x="29" y="17" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">Start</text>',
+    '</svg>',
+  ].join(''),
+});
+
+const numericColorPikchrRenderer: PikchrRenderer = () => ({
+  kind: 'svg',
+  width: 58,
+  height: 34,
+  svg: [
+    '<svg xmlns="http://www.w3.org/2000/svg" class="markdown-pikchr-svg" viewBox="0 0 58 34">',
+    '<path d="M2,32L56,32L56,2L2,2Z" style="fill:rgb(255,255,255);stroke-width:2.16;stroke:rgb(255,0,0);" />',
+    '<text x="29" y="17" text-anchor="middle" fill="rgb(255,0,0)" dominant-baseline="central">Exact</text>',
     '</svg>',
   ].join(''),
 });

--- a/apps/staged/src/lib/theme.test.ts
+++ b/apps/staged/src/lib/theme.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAdaptiveTheme, themeToVarMap } from './theme';
+
+describe('createAdaptiveTheme', () => {
+  it('exposes themed Pikchr palette variables for dark chrome', () => {
+    const vars = themeToVarMap(
+      createAdaptiveTheme('#27212e', '#ffffff', '#91889b', {
+        added: '#3fb950',
+        deleted: '#f85149',
+        modified: '#d29922',
+      })
+    );
+
+    expect(vars['--diagram-canvas-bg']).not.toBe('#ffffff');
+    expect(vars['--pikchr-ink']).toBe('#ffffff');
+    expect(vars['--pikchr-surface']).not.toBe('#ffffff');
+    expect(vars['--pikchr-muted']).toBe('#91889b');
+    expect(vars['--pikchr-red']).toBe('#f85149');
+    expect(vars['--pikchr-green']).toBe('#3fb950');
+    expect(vars['--pikchr-blue']).toBe('#58a6ff');
+    expect(vars['--pikchr-yellow']).toBe('#d29922');
+  });
+
+  it('uses a light themed canvas and surface without hard-coding white fills', () => {
+    const vars = themeToVarMap(
+      createAdaptiveTheme('#ffffff', '#24292e', '#6e7781', {
+        added: '#28a745',
+        deleted: '#d73a49',
+        modified: '#2188ff',
+      })
+    );
+
+    expect(vars['--diagram-canvas-bg']).not.toBe('#ffffff');
+    expect(vars['--pikchr-surface']).not.toBe('#ffffff');
+    expect(vars['--pikchr-ink']).toBe('#24292e');
+    expect(vars['--pikchr-blue']).toBe('#2188ff');
+  });
+});

--- a/apps/staged/src/lib/theme.test.ts
+++ b/apps/staged/src/lib/theme.test.ts
@@ -16,11 +16,11 @@ describe('createAdaptiveTheme', () => {
     expect(vars['--pikchr-ink']).toBe('#241a2f');
     expect(vars['--pikchr-surface']).toBe('#fffaff');
     expect(vars['--pikchr-muted']).toBe('#74677f');
-    expect(vars['--pikchr-red']).toBe('#e97d8f');
-    expect(vars['--pikchr-green']).toBe('#69c487');
-    expect(vars['--pikchr-blue']).toBe('#77aeea');
-    expect(vars['--pikchr-yellow']).toBe('#e9ca6f');
-    expect(vars['--pikchr-orange']).toBe('#e7a068');
+    expect(vars['--pikchr-red']).toBe('#ec91a0');
+    expect(vars['--pikchr-green']).toBe('#80cd99');
+    expect(vars['--pikchr-blue']).toBe('#8bbaed');
+    expect(vars['--pikchr-yellow']).toBe('#ecd285');
+    expect(vars['--pikchr-orange']).toBe('#ebae7f');
     expect(vars['--pikchr-yellow']).not.toBe(vars['--pikchr-orange']);
   });
 
@@ -36,8 +36,8 @@ describe('createAdaptiveTheme', () => {
     expect(vars['--diagram-canvas-bg']).toBe('#fbf8ff');
     expect(vars['--pikchr-surface']).toBe('#ffffff');
     expect(vars['--pikchr-ink']).toBe('#24292e');
-    expect(vars['--pikchr-blue']).toBe('#6b9cd7');
-    expect(vars['--pikchr-orange']).toBe('#d48855');
+    expect(vars['--pikchr-blue']).toBe('#81abdd');
+    expect(vars['--pikchr-orange']).toBe('#da9a6f');
     expect(vars['--pikchr-yellow']).not.toBe(vars['--pikchr-orange']);
   });
 });

--- a/apps/staged/src/lib/theme.test.ts
+++ b/apps/staged/src/lib/theme.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { createAdaptiveTheme, themeToVarMap } from './theme';
 
 describe('createAdaptiveTheme', () => {
-  it('exposes themed Pikchr palette variables for dark chrome', () => {
+  it('exposes a soft themed Pikchr palette for dark chrome', () => {
     const vars = themeToVarMap(
       createAdaptiveTheme('#27212e', '#ffffff', '#91889b', {
         added: '#3fb950',
@@ -12,17 +12,19 @@ describe('createAdaptiveTheme', () => {
       })
     );
 
-    expect(vars['--diagram-canvas-bg']).not.toBe('#ffffff');
-    expect(vars['--pikchr-ink']).toBe('#ffffff');
-    expect(vars['--pikchr-surface']).not.toBe('#ffffff');
-    expect(vars['--pikchr-muted']).toBe('#91889b');
-    expect(vars['--pikchr-red']).toBe('#f85149');
-    expect(vars['--pikchr-green']).toBe('#3fb950');
-    expect(vars['--pikchr-blue']).toBe('#58a6ff');
-    expect(vars['--pikchr-yellow']).toBe('#d29922');
+    expect(vars['--diagram-canvas-bg']).toBe('#f2edf8');
+    expect(vars['--pikchr-ink']).toBe('#241a2f');
+    expect(vars['--pikchr-surface']).toBe('#fffaff');
+    expect(vars['--pikchr-muted']).toBe('#74677f');
+    expect(vars['--pikchr-red']).toBe('#e76f82');
+    expect(vars['--pikchr-green']).toBe('#58bd7a');
+    expect(vars['--pikchr-blue']).toBe('#68a5e8');
+    expect(vars['--pikchr-yellow']).toBe('#e6c45f');
+    expect(vars['--pikchr-orange']).toBe('#e49557');
+    expect(vars['--pikchr-yellow']).not.toBe(vars['--pikchr-orange']);
   });
 
-  it('uses a light themed canvas and surface without hard-coding white fills', () => {
+  it('uses a quiet light Pikchr palette for light chrome', () => {
     const vars = themeToVarMap(
       createAdaptiveTheme('#ffffff', '#24292e', '#6e7781', {
         added: '#28a745',
@@ -31,9 +33,11 @@ describe('createAdaptiveTheme', () => {
       })
     );
 
-    expect(vars['--diagram-canvas-bg']).not.toBe('#ffffff');
-    expect(vars['--pikchr-surface']).not.toBe('#ffffff');
+    expect(vars['--diagram-canvas-bg']).toBe('#fbf8ff');
+    expect(vars['--pikchr-surface']).toBe('#ffffff');
     expect(vars['--pikchr-ink']).toBe('#24292e');
-    expect(vars['--pikchr-blue']).toBe('#2188ff');
+    expect(vars['--pikchr-blue']).toBe('#5b91d2');
+    expect(vars['--pikchr-orange']).toBe('#cf7b42');
+    expect(vars['--pikchr-yellow']).not.toBe(vars['--pikchr-orange']);
   });
 });

--- a/apps/staged/src/lib/theme.test.ts
+++ b/apps/staged/src/lib/theme.test.ts
@@ -16,11 +16,11 @@ describe('createAdaptiveTheme', () => {
     expect(vars['--pikchr-ink']).toBe('#241a2f');
     expect(vars['--pikchr-surface']).toBe('#fffaff');
     expect(vars['--pikchr-muted']).toBe('#74677f');
-    expect(vars['--pikchr-red']).toBe('#e76f82');
-    expect(vars['--pikchr-green']).toBe('#58bd7a');
-    expect(vars['--pikchr-blue']).toBe('#68a5e8');
-    expect(vars['--pikchr-yellow']).toBe('#e6c45f');
-    expect(vars['--pikchr-orange']).toBe('#e49557');
+    expect(vars['--pikchr-red']).toBe('#e97d8f');
+    expect(vars['--pikchr-green']).toBe('#69c487');
+    expect(vars['--pikchr-blue']).toBe('#77aeea');
+    expect(vars['--pikchr-yellow']).toBe('#e9ca6f');
+    expect(vars['--pikchr-orange']).toBe('#e7a068');
     expect(vars['--pikchr-yellow']).not.toBe(vars['--pikchr-orange']);
   });
 
@@ -36,8 +36,8 @@ describe('createAdaptiveTheme', () => {
     expect(vars['--diagram-canvas-bg']).toBe('#fbf8ff');
     expect(vars['--pikchr-surface']).toBe('#ffffff');
     expect(vars['--pikchr-ink']).toBe('#24292e');
-    expect(vars['--pikchr-blue']).toBe('#5b91d2');
-    expect(vars['--pikchr-orange']).toBe('#cf7b42');
+    expect(vars['--pikchr-blue']).toBe('#6b9cd7');
+    expect(vars['--pikchr-orange']).toBe('#d48855');
     expect(vars['--pikchr-yellow']).not.toBe(vars['--pikchr-orange']);
   });
 });

--- a/apps/staged/src/lib/theme.ts
+++ b/apps/staged/src/lib/theme.ts
@@ -270,13 +270,13 @@ const DARK_PIKCHR_PALETTE: Theme['diagram'] = {
   pikchrInk: '#241a2f',
   pikchrSurface: '#fffaff',
   pikchrMuted: '#74677f',
-  pikchrRed: '#e97d8f',
-  pikchrGreen: '#69c487',
-  pikchrBlue: '#77aeea',
-  pikchrYellow: '#e9ca6f',
-  pikchrOrange: '#e7a068',
-  pikchrPurple: '#ba96f2',
-  pikchrCyan: '#69cedc',
+  pikchrRed: '#ec91a0',
+  pikchrGreen: '#80cd99',
+  pikchrBlue: '#8bbaed',
+  pikchrYellow: '#ecd285',
+  pikchrOrange: '#ebae7f',
+  pikchrPurple: '#c4a6f4',
+  pikchrCyan: '#80d5e1',
 };
 
 const LIGHT_PIKCHR_PALETTE: Theme['diagram'] = {
@@ -284,13 +284,13 @@ const LIGHT_PIKCHR_PALETTE: Theme['diagram'] = {
   pikchrInk: '#24292e',
   pikchrSurface: '#ffffff',
   pikchrMuted: '#6e7781',
-  pikchrRed: '#dc6f80',
-  pikchrGreen: '#58a976',
-  pikchrBlue: '#6b9cd7',
-  pikchrYellow: '#cea746',
-  pikchrOrange: '#d48855',
-  pikchrPurple: '#a17edd',
-  pikchrCyan: '#50b2be',
+  pikchrRed: '#e18593',
+  pikchrGreen: '#71b68b',
+  pikchrBlue: '#81abdd',
+  pikchrYellow: '#d5b462',
+  pikchrOrange: '#da9a6f',
+  pikchrPurple: '#af91e2',
+  pikchrCyan: '#6abec8',
 };
 
 /**

--- a/apps/staged/src/lib/theme.ts
+++ b/apps/staged/src/lib/theme.ts
@@ -265,6 +265,34 @@ const CONTRAST_OFFSET = 0.0135;
 // mid-gray. Dark themes are unaffected (scale = 1).
 const LIGHT_CHROME_CONTRAST_SCALE = 0.85;
 
+const DARK_PIKCHR_PALETTE: Theme['diagram'] = {
+  canvasBg: '#f2edf8',
+  pikchrInk: '#241a2f',
+  pikchrSurface: '#fffaff',
+  pikchrMuted: '#74677f',
+  pikchrRed: '#e76f82',
+  pikchrGreen: '#58bd7a',
+  pikchrBlue: '#68a5e8',
+  pikchrYellow: '#e6c45f',
+  pikchrOrange: '#e49557',
+  pikchrPurple: '#b28af0',
+  pikchrCyan: '#58c9d8',
+};
+
+const LIGHT_PIKCHR_PALETTE: Theme['diagram'] = {
+  canvasBg: '#fbf8ff',
+  pikchrInk: '#24292e',
+  pikchrSurface: '#ffffff',
+  pikchrMuted: '#6e7781',
+  pikchrRed: '#d85f72',
+  pikchrGreen: '#459f67',
+  pikchrBlue: '#5b91d2',
+  pikchrYellow: '#c99d31',
+  pikchrOrange: '#cf7b42',
+  pikchrPurple: '#9670d9',
+  pikchrCyan: '#3da9b7',
+};
+
 /**
  * Calculate target luminance difference using logFloor algorithm.
  * This provides gentle scaling that works across all theme luminances,
@@ -391,10 +419,7 @@ export function createAdaptiveTheme(
 
   // Border that's visible but not harsh
   const borderBase = mix(primaryBg, syntaxFg, isDark ? 0.15 : 0.12);
-  const diagramCanvasBg = isDark
-    ? mix(primaryBg, syntaxFg, 0.035)
-    : mix(primaryBg, syntaxFg, 0.015);
-  const diagramSurface = isDark ? mix(primaryBg, syntaxFg, 0.08) : mix(primaryBg, syntaxFg, 0.035);
+  const pikchrPalette = isDark ? DARK_PIKCHR_PALETTE : LIGHT_PIKCHR_PALETTE;
 
   return {
     isDark,
@@ -487,19 +512,7 @@ export function createAdaptiveTheme(
       selection: overlay(syntaxFg, isDark ? 0.08 : 0.1),
     },
 
-    diagram: {
-      canvasBg: diagramCanvasBg,
-      pikchrInk: syntaxFg,
-      pikchrSurface: diagramSurface,
-      pikchrMuted: syntaxComment,
-      pikchrRed: accentRed,
-      pikchrGreen: accentGreen,
-      pikchrBlue: accentPrimary,
-      pikchrYellow: accentOrange,
-      pikchrOrange: accentOrange,
-      pikchrPurple: accentPurple,
-      pikchrCyan: accentCyan,
-    },
+    diagram: pikchrPalette,
 
     scrollbar: {
       thumb: borderBase,

--- a/apps/staged/src/lib/theme.ts
+++ b/apps/staged/src/lib/theme.ts
@@ -270,13 +270,13 @@ const DARK_PIKCHR_PALETTE: Theme['diagram'] = {
   pikchrInk: '#241a2f',
   pikchrSurface: '#fffaff',
   pikchrMuted: '#74677f',
-  pikchrRed: '#e76f82',
-  pikchrGreen: '#58bd7a',
-  pikchrBlue: '#68a5e8',
-  pikchrYellow: '#e6c45f',
-  pikchrOrange: '#e49557',
-  pikchrPurple: '#b28af0',
-  pikchrCyan: '#58c9d8',
+  pikchrRed: '#e97d8f',
+  pikchrGreen: '#69c487',
+  pikchrBlue: '#77aeea',
+  pikchrYellow: '#e9ca6f',
+  pikchrOrange: '#e7a068',
+  pikchrPurple: '#ba96f2',
+  pikchrCyan: '#69cedc',
 };
 
 const LIGHT_PIKCHR_PALETTE: Theme['diagram'] = {
@@ -284,13 +284,13 @@ const LIGHT_PIKCHR_PALETTE: Theme['diagram'] = {
   pikchrInk: '#24292e',
   pikchrSurface: '#ffffff',
   pikchrMuted: '#6e7781',
-  pikchrRed: '#d85f72',
-  pikchrGreen: '#459f67',
-  pikchrBlue: '#5b91d2',
-  pikchrYellow: '#c99d31',
-  pikchrOrange: '#cf7b42',
-  pikchrPurple: '#9670d9',
-  pikchrCyan: '#3da9b7',
+  pikchrRed: '#dc6f80',
+  pikchrGreen: '#58a976',
+  pikchrBlue: '#6b9cd7',
+  pikchrYellow: '#cea746',
+  pikchrOrange: '#d48855',
+  pikchrPurple: '#a17edd',
+  pikchrCyan: '#50b2be',
 };
 
 /**

--- a/apps/staged/src/lib/theme.ts
+++ b/apps/staged/src/lib/theme.ts
@@ -90,7 +90,17 @@ export interface Theme {
 
   // Diagram previews
   diagram: {
-    canvasBg: string; // Light canvas for rendered diagrams with default dark ink
+    canvasBg: string; // Canvas behind rendered diagrams
+    pikchrInk: string; // Default Pikchr stroke/text color
+    pikchrSurface: string; // Themed replacement for white Pikchr fills
+    pikchrMuted: string; // Themed replacement for gray/silver Pikchr colors
+    pikchrRed: string;
+    pikchrGreen: string;
+    pikchrBlue: string;
+    pikchrYellow: string;
+    pikchrOrange: string;
+    pikchrPurple: string;
+    pikchrCyan: string;
   };
 
   // Scrollbar
@@ -381,6 +391,10 @@ export function createAdaptiveTheme(
 
   // Border that's visible but not harsh
   const borderBase = mix(primaryBg, syntaxFg, isDark ? 0.15 : 0.12);
+  const diagramCanvasBg = isDark
+    ? mix(primaryBg, syntaxFg, 0.035)
+    : mix(primaryBg, syntaxFg, 0.015);
+  const diagramSurface = isDark ? mix(primaryBg, syntaxFg, 0.08) : mix(primaryBg, syntaxFg, 0.035);
 
   return {
     isDark,
@@ -474,7 +488,17 @@ export function createAdaptiveTheme(
     },
 
     diagram: {
-      canvasBg: '#ffffff',
+      canvasBg: diagramCanvasBg,
+      pikchrInk: syntaxFg,
+      pikchrSurface: diagramSurface,
+      pikchrMuted: syntaxComment,
+      pikchrRed: accentRed,
+      pikchrGreen: accentGreen,
+      pikchrBlue: accentPrimary,
+      pikchrYellow: accentOrange,
+      pikchrOrange: accentOrange,
+      pikchrPurple: accentPurple,
+      pikchrCyan: accentCyan,
     },
 
     scrollbar: {
@@ -570,6 +594,16 @@ export function themeToVarMap(t: Theme): Record<string, string> {
     '--ui-selection': t.ui.selection,
 
     '--diagram-canvas-bg': t.diagram.canvasBg,
+    '--pikchr-ink': t.diagram.pikchrInk,
+    '--pikchr-surface': t.diagram.pikchrSurface,
+    '--pikchr-muted': t.diagram.pikchrMuted,
+    '--pikchr-red': t.diagram.pikchrRed,
+    '--pikchr-green': t.diagram.pikchrGreen,
+    '--pikchr-blue': t.diagram.pikchrBlue,
+    '--pikchr-yellow': t.diagram.pikchrYellow,
+    '--pikchr-orange': t.diagram.pikchrOrange,
+    '--pikchr-purple': t.diagram.pikchrPurple,
+    '--pikchr-cyan': t.diagram.pikchrCyan,
 
     '--scrollbar-thumb': t.scrollbar.thumb,
     '--scrollbar-thumb-hover': t.scrollbar.thumbHover,


### PR DESCRIPTION
## Summary

Pikchr renders diagrams with hard-coded black-on-white styling that clashes with the app's dark and light themes. This teaches the SVG sanitizer to remap Pikchr's default colors onto a themed palette so diagrams blend into the surrounding UI.

## Changes

- **Themed palette (`theme.ts`, `app.css`)**: extend the `diagram` theme with `pikchrInk`, `pikchrSurface`, `pikchrMuted`, and accent colors (red/green/blue/yellow/orange/purple/cyan) derived from the active theme's syntax and accent colors, exposed as `--pikchr-*` CSS custom properties. The diagram canvas background is now derived from the theme rather than a hard-coded `#ffffff`.
- **Color remapping (`pikchrRendering.ts`)**: `sanitizePikchrSvg` maps common Pikchr colors — named (`red`, `green`, …), `rgb(...)`, and hex — onto the themed CSS variables, and defaults stroke/text ink to `var(--pikchr-ink)`. The sanitizer's allowed CSS color set is widened to accept `var(--pikchr-*)`. Explicit numeric color literals (`0xRRGGBB`) from the diagram source are preserved so intentional author colors aren't overridden.
- **Source threading (`diagramRendering.ts`)**: the raw diagram source is passed into the sanitizer so numeric color literals can be detected and preserved.
- **Tests**: added coverage for palette mapping, numeric-literal preservation, `fill:none` handling, and the exposed CSS variables across `pikchrRendering.test.ts`, `renderMarkdown.test.ts`, and `theme.test.ts`.

The follow-up commits tune the specific palette shades for better legibility.