### PR TITLE
feat(staged): enable web PR polling transport

### DIFF
--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -3608,20 +3608,13 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
 mod tests {
     use std::collections::BTreeSet;
 
-    const INTENTIONALLY_UNSUPPORTED_WEB_COMMANDS: &[&str] = &[];
-
     #[test]
     fn web_dispatch_covers_tauri_commands() {
         let tauri_commands = extract_generate_handler_commands(include_str!("lib.rs"));
         let dispatch_commands = extract_dispatch_commands(include_str!("web_server.rs"));
-        let intentionally_unsupported = INTENTIONALLY_UNSUPPORTED_WEB_COMMANDS
-            .iter()
-            .copied()
-            .collect::<BTreeSet<_>>();
 
         let missing = tauri_commands
             .difference(&dispatch_commands)
-            .filter(|command| !intentionally_unsupported.contains(command.as_str()))
             .cloned()
             .collect::<Vec<_>>();
 

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use axum::extract::ws::{Message, WebSocket};
-use axum::extract::{Path, Request, State, WebSocketUpgrade};
+use axum::extract::{Path, Query, Request, State, WebSocketUpgrade};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Json, Response};
@@ -288,15 +288,36 @@ async fn authenticate(
 // WebSocket endpoint — /api/events
 // =============================================================================
 
-async fn ws_events(ws: WebSocketUpgrade, State(state): State<WebAppState>) -> Response {
-    ws.on_upgrade(move |socket| handle_ws(socket, state))
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EventsQuery {
+    client_id: Option<String>,
+}
+
+async fn ws_events(
+    ws: WebSocketUpgrade,
+    Query(query): Query<EventsQuery>,
+    State(state): State<WebAppState>,
+) -> Response {
+    let client_id = query
+        .client_id
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty());
+    ws.on_upgrade(move |socket| handle_ws(socket, state, client_id))
 }
 
 // clippy's suggested fix (collapsing the inner `if` into a match guard) doesn't
 // compile because `data: Bytes` can't be moved out of the pattern binding into
 // the guard expression.
 #[allow(clippy::collapsible_match)]
-async fn handle_ws(mut socket: WebSocket, state: WebAppState) {
+async fn handle_ws(mut socket: WebSocket, state: WebAppState, client_id: Option<String>) {
+    let pr_scheduler = client_id.as_ref().map(|client_id| {
+        use tauri::Manager;
+        let scheduler = Arc::clone(&state.app_handle.state::<Arc<PrPollScheduler>>());
+        scheduler.touch(client_id.clone());
+        scheduler
+    });
+
     let mut rx = state.event_tx.subscribe();
     loop {
         tokio::select! {
@@ -314,11 +335,30 @@ async fn handle_ws(mut socket: WebSocket, state: WebAppState) {
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
             }
-            // Handle incoming messages (ping/pong, close)
+            // Handle incoming messages (heartbeat, ping/pong, close)
             msg = socket.recv() => {
                 let pong_data = match msg {
                     Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(Message::Ping(data))) => data,
+                    Some(Ok(Message::Text(text))) => {
+                        if is_heartbeat_message(text.as_str()) {
+                            if let (Some(scheduler), Some(client_id)) = (&pr_scheduler, &client_id) {
+                                scheduler.touch(client_id.clone());
+                            }
+                        }
+                        continue;
+                    }
+                    Some(Ok(Message::Ping(data))) => {
+                        if let (Some(scheduler), Some(client_id)) = (&pr_scheduler, &client_id) {
+                            scheduler.touch(client_id.clone());
+                        }
+                        data
+                    }
+                    Some(Ok(Message::Pong(_))) => {
+                        if let (Some(scheduler), Some(client_id)) = (&pr_scheduler, &client_id) {
+                            scheduler.touch(client_id.clone());
+                        }
+                        continue;
+                    }
                     _ => continue,
                 };
                 if socket.send(Message::Pong(pong_data)).await.is_err() {
@@ -327,6 +367,26 @@ async fn handle_ws(mut socket: WebSocket, state: WebAppState) {
             }
         }
     }
+
+    if let (Some(scheduler), Some(client_id)) = (pr_scheduler, client_id) {
+        scheduler.disconnect_client(client_id);
+    }
+}
+
+fn is_heartbeat_message(text: &str) -> bool {
+    if text == "heartbeat" {
+        return true;
+    }
+
+    serde_json::from_str::<Value>(text)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("type")
+                .and_then(Value::as_str)
+                .map(|message_type| message_type == "heartbeat")
+        })
+        .unwrap_or(false)
 }
 
 // =============================================================================

--- a/apps/staged/src/lib/services/prPollingService.test.ts
+++ b/apps/staged/src/lib/services/prPollingService.test.ts
@@ -66,4 +66,29 @@ describe('prPollingService in web mode', () => {
     expect(unlistenRefresh).toHaveBeenCalledTimes(1);
     expect(unlistenStale).toHaveBeenCalledTimes(1);
   });
+
+  it('replays the current interest hints after a web socket reconnect', async () => {
+    const service = await import('./prPollingService');
+    const clientId = service.getPrPollClientId();
+
+    service.init();
+    service.setSelectedProject('project-1');
+    service.updateChecksStatus('branch-1', 'project-1', true);
+    service.updateChecksStatus('branch-2', 'project-1', true);
+    service.updateChecksStatus('branch-2', 'project-1', false);
+
+    invokeCommand.mockClear();
+    await service.replayPrPollInterestHints();
+
+    expect(invokeCommand.mock.calls).toEqual([
+      ['set_focus', { clientId, focused: true }],
+      ['set_foreground_project', { clientId, projectId: 'project-1' }],
+      [
+        'set_branch_pending',
+        { clientId, branchId: 'branch-1', projectId: 'project-1', pending: true },
+      ],
+    ]);
+
+    service.dispose();
+  });
 });

--- a/apps/staged/src/lib/services/prPollingService.test.ts
+++ b/apps/staged/src/lib/services/prPollingService.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('prPollingService in web mode', () => {
+  let invokeCommand: ReturnType<typeof vi.fn>;
+  let listenToEvent: ReturnType<typeof vi.fn>;
+  let unlistenRefresh: ReturnType<typeof vi.fn>;
+  let unlistenStale: ReturnType<typeof vi.fn>;
+  let randomUUID: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    invokeCommand = vi.fn().mockResolvedValue(undefined);
+    unlistenRefresh = vi.fn();
+    unlistenStale = vi.fn();
+    listenToEvent = vi.fn().mockReturnValueOnce(unlistenRefresh).mockReturnValueOnce(unlistenStale);
+    randomUUID = vi.fn(() => 'web-client-1');
+
+    vi.stubGlobal('crypto', { randomUUID });
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    vi.doMock('../transport', () => ({
+      isTauri: false,
+      invokeCommand,
+      listenToEvent,
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../transport');
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps a stable browser client id and sends it with every hint', async () => {
+    const service = await import('./prPollingService');
+    const clientId = service.getPrPollClientId();
+
+    expect(clientId).toBe('web-client-1');
+    expect(service.getPrPollClientId()).toBe(clientId);
+    expect(randomUUID).toHaveBeenCalledTimes(1);
+
+    service.init();
+    service.setSelectedProject('project-1');
+    service.updateChecksStatus('branch-1', 'project-1', true);
+    service.refreshNow('project-1');
+    window.dispatchEvent(new Event('blur'));
+    window.dispatchEvent(new Event('focus'));
+    service.dispose();
+
+    expect(listenToEvent.mock.calls.map(([event]) => event)).toEqual([
+      'pr-refresh-state',
+      'pr-status-stale',
+    ]);
+    expect(invokeCommand.mock.calls).toEqual([
+      ['set_focus', { clientId, focused: true }],
+      ['set_foreground_project', { clientId, projectId: 'project-1' }],
+      [
+        'set_branch_pending',
+        { clientId, branchId: 'branch-1', projectId: 'project-1', pending: true },
+      ],
+      ['refresh_now', { clientId, projectId: 'project-1' }],
+      ['set_focus', { clientId, focused: false }],
+      ['set_focus', { clientId, focused: true }],
+      ['disconnect_client', { clientId }],
+    ]);
+    expect(unlistenRefresh).toHaveBeenCalledTimes(1);
+    expect(unlistenStale).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/staged/src/lib/services/prPollingService.ts
+++ b/apps/staged/src/lib/services/prPollingService.ts
@@ -64,6 +64,11 @@ export function getPrPollClientId(): string {
 type StaleCallback = (projectId: string, isStale: boolean) => void;
 type RefreshingCallback = (projectId: string, isRefreshing: boolean) => void;
 
+interface PendingBranchHint {
+  branchId: string;
+  projectId: string;
+}
+
 interface PrRefreshStateEvent {
   projectId: string;
   refreshing: boolean;
@@ -86,6 +91,9 @@ const refreshingCallbacks = new Set<RefreshingCallback>();
 
 /** Projects the backend currently reports as refreshing. */
 const refreshingProjects = new Set<string>();
+
+let selectedProjectId: string | null = null;
+const pendingBranchHints = new Map<string, PendingBranchHint>();
 
 let initialized = false;
 let unlistenRefreshState: UnlistenFn | null = null;
@@ -180,6 +188,8 @@ export function dispose(): void {
 
   // Drop this client's interest so the backend recomputes the union without it.
   void disconnectPrPollClient(clientId).catch(() => {});
+  selectedProjectId = null;
+  pendingBranchHints.clear();
 
   for (const projectId of [...refreshingProjects]) {
     setProjectRefreshing(projectId, false);
@@ -192,6 +202,7 @@ export function dispose(): void {
 
 /** Set the currently selected project (polls more frequently). */
 export function setSelectedProject(projectId: string | null): void {
+  selectedProjectId = projectId;
   void setForegroundProject(clientId, projectId).catch((e) =>
     console.error('[PrPollingService] set_foreground_project failed:', e)
   );
@@ -203,9 +214,31 @@ export function updateChecksStatus(
   projectId: string,
   hasPendingChecks: boolean
 ): void {
+  if (hasPendingChecks) {
+    pendingBranchHints.set(branchId, { branchId, projectId });
+  } else {
+    pendingBranchHints.delete(branchId);
+  }
   void setBranchPending(clientId, branchId, projectId, hasPendingChecks).catch((e) =>
     console.error('[PrPollingService] set_branch_pending failed:', e)
   );
+}
+
+/**
+ * Re-send this client's current interest after a browser WebSocket reconnect.
+ * The backend drops all interest on clean WS close, then recreates an empty
+ * client when the same id reconnects.
+ */
+export async function replayPrPollInterestHints(): Promise<void> {
+  if (!initialized) return;
+
+  await Promise.all([
+    setPrPollFocus(clientId, document.hasFocus()),
+    setForegroundProject(clientId, selectedProjectId),
+    ...Array.from(pendingBranchHints.values(), ({ branchId, projectId }) =>
+      setBranchPending(clientId, branchId, projectId, true)
+    ),
+  ]);
 }
 
 /** Trigger an immediate refresh for a specific project (e.g. after PR creation or push). */

--- a/apps/staged/src/lib/services/prPollingService.ts
+++ b/apps/staged/src/lib/services/prPollingService.ts
@@ -146,10 +146,10 @@ function handleBlur() {
 /**
  * Wire up the interest/hint layer: forward window focus to the backend and
  * subscribe to its refresh/stale lifecycle events. Idempotent; call once at app
- * start. No-op in web mode (the transport is stubbed in this build).
+ * start.
  */
 export function init(): void {
-  if (initialized || !isTauri) return;
+  if (initialized) return;
   initialized = true;
 
   window.addEventListener('focus', handleFocus);
@@ -192,7 +192,6 @@ export function dispose(): void {
 
 /** Set the currently selected project (polls more frequently). */
 export function setSelectedProject(projectId: string | null): void {
-  if (!isTauri) return;
   void setForegroundProject(clientId, projectId).catch((e) =>
     console.error('[PrPollingService] set_foreground_project failed:', e)
   );
@@ -204,7 +203,6 @@ export function updateChecksStatus(
   projectId: string,
   hasPendingChecks: boolean
 ): void {
-  if (!isTauri) return;
   void setBranchPending(clientId, branchId, projectId, hasPendingChecks).catch((e) =>
     console.error('[PrPollingService] set_branch_pending failed:', e)
   );
@@ -212,7 +210,6 @@ export function updateChecksStatus(
 
 /** Trigger an immediate refresh for a specific project (e.g. after PR creation or push). */
 export function refreshNow(projectId: string): void {
-  if (!isTauri) return;
   void refreshPrStatusesNow(clientId, projectId).catch((e) =>
     console.error(`[PrPollingService] refresh_now failed for project=${projectId}:`, e)
   );

--- a/apps/staged/src/lib/transport.test.ts
+++ b/apps/staged/src/lib/transport.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  closed = false;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = url.toString();
+    sockets.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({} as CloseEvent);
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  emit(data: unknown): void {
+    this.onmessage?.(
+      new MessageEvent('message', {
+        data: typeof data === 'string' ? data : JSON.stringify(data),
+      })
+    );
+  }
+}
+
+let sockets: MockWebSocket[];
+
+describe('web transport', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('crypto', { randomUUID: vi.fn(() => 'web-client-1') });
+    sockets = [];
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('posts commands to the web invoke endpoint', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ ok: true }),
+    });
+    vi.stubGlobal('fetch', fetch);
+
+    const { invokeCommand } = await import('./transport');
+
+    await expect(
+      invokeCommand('set_focus', { clientId: 'web-client-1', focused: true })
+    ).resolves.toEqual({ ok: true });
+
+    expect(fetch).toHaveBeenCalledWith('/api/invoke/set_focus', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientId: 'web-client-1', focused: true }),
+    });
+  });
+
+  it('connects events with the PR poll client id and sends browser heartbeats', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    const { listenToEvent } = await import('./transport');
+    const { getPrPollClientId } = await import('./services/prPollingService');
+    const callback = vi.fn();
+
+    const unlisten = listenToEvent('pr-refresh-state', callback);
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+
+    const socket = sockets[0];
+    const url = new URL(socket.url);
+    expect(url.pathname).toBe('/api/events');
+    expect(url.searchParams.get('clientId')).toBe(getPrPollClientId());
+
+    socket.open();
+    expect(socket.sent).toEqual([JSON.stringify({ type: 'heartbeat' })]);
+
+    vi.advanceTimersByTime(30_000);
+    expect(socket.sent).toEqual([
+      JSON.stringify({ type: 'heartbeat' }),
+      JSON.stringify({ type: 'heartbeat' }),
+    ]);
+
+    socket.emit({
+      event: 'pr-refresh-state',
+      payload: { projectId: 'project-1', refreshing: true },
+    });
+    expect(callback).toHaveBeenCalledWith({ projectId: 'project-1', refreshing: true });
+
+    unlisten();
+    expect(socket.closed).toBe(true);
+  });
+});

--- a/apps/staged/src/lib/transport.test.ts
+++ b/apps/staged/src/lib/transport.test.ts
@@ -55,6 +55,7 @@ describe('web transport', () => {
   });
 
   afterEach(() => {
+    vi.doUnmock('./services/prPollingService');
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
@@ -112,5 +113,31 @@ describe('web transport', () => {
 
     unlisten();
     expect(socket.closed).toBe(true);
+  });
+
+  it('replays PR polling interest when the browser event socket opens and reconnects', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    const replayPrPollInterestHints = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('./services/prPollingService', () => ({
+      getPrPollClientId: () => 'web-client-1',
+      replayPrPollInterestHints,
+    }));
+
+    const { listenToEvent } = await import('./transport');
+    const unlisten = listenToEvent('pr-refresh-state', vi.fn());
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+
+    sockets[0].open();
+    await vi.waitFor(() => expect(replayPrPollInterestHints).toHaveBeenCalledTimes(1));
+
+    sockets[0].close();
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.waitFor(() => expect(sockets).toHaveLength(2));
+
+    sockets[1].open();
+    await vi.waitFor(() => expect(replayPrPollInterestHints).toHaveBeenCalledTimes(2));
+
+    unlisten();
   });
 });

--- a/apps/staged/src/lib/transport.ts
+++ b/apps/staged/src/lib/transport.ts
@@ -7,8 +7,6 @@
  * - Window management (Tauri window vs no-op)
  * - Clipboard (Tauri plugin vs navigator.clipboard)
  *
- * NOTE: Web-mode implementations are intentionally stubbed out in this build.
- * TODO(web): restore web transport paths from the `mobile-web` branch.
  */
 
 // ---------------------------------------------------------------------------
@@ -23,7 +21,7 @@ export const isTauri: boolean = typeof window !== 'undefined' && '__TAURI__' in 
 
 /**
  * Invoke a backend command. In Tauri mode this calls `invoke()` from the
- * Tauri API; in web mode it is stubbed out.
+ * Tauri API; in web mode it POSTs to `/api/invoke/{command}`.
  */
 export async function invokeCommand<T>(
   command: string,
@@ -34,8 +32,27 @@ export async function invokeCommand<T>(
     return invoke<T>(command, args);
   }
 
-  // TODO(web): restore HTTP transport from the `mobile-web` branch
-  throw new Error(`[transport] Web mode is not available in this build (command: ${command})`);
+  const response = await fetch(`/api/invoke/${encodeURIComponent(command)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(args ?? {}),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    let message = text;
+    try {
+      const body = JSON.parse(text) as { error?: unknown };
+      if (typeof body.error === 'string') {
+        message = body.error;
+      }
+    } catch {
+      // Non-JSON error bodies are reported as-is below.
+    }
+    throw new Error(message || `Command failed: ${command}`);
+  }
+
+  return (await response.json()) as T;
 }
 
 // ---------------------------------------------------------------------------
@@ -46,7 +63,7 @@ export type UnlistenFn = () => void;
 
 /**
  * Listen to a backend event. In Tauri mode this delegates to the Tauri event
- * API; in web mode it is stubbed out.
+ * API; in web mode it connects to the shared WebSocket event stream.
  *
  * Returns a synchronous unlisten function. Registration happens asynchronously
  * in the background; if the unlisten is called before registration finishes,
@@ -55,15 +72,14 @@ export type UnlistenFn = () => void;
  * `Promise<UnlistenFn>` reference that could race the unmount.
  */
 export function listenToEvent<T>(event: string, callback: (payload: T) => void): UnlistenFn {
+  if (!isTauri) {
+    return webSocketListen<T>(event, callback);
+  }
+
   let cancelled = false;
   let unlisten: UnlistenFn | undefined;
 
   void (async () => {
-    if (!isTauri) {
-      // TODO(web): restore WebSocket event transport from the `mobile-web` branch
-      console.warn(`[transport] Web mode event listening stubbed out (event: ${event})`);
-      return;
-    }
     const { listen } = await import('@tauri-apps/api/event');
     const u = await listen<T>(event, (e) => callback(e.payload));
     if (cancelled) u();
@@ -75,6 +91,139 @@ export function listenToEvent<T>(event: string, callback: (payload: T) => void):
   return () => {
     cancelled = true;
     unlisten?.();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket singleton for web-mode events
+// ---------------------------------------------------------------------------
+
+interface WebSocketListener {
+  event: string;
+  callback: (payload: unknown) => void;
+}
+
+const WEB_SOCKET_HEARTBEAT_MS = 30_000;
+
+let ws: WebSocket | null = null;
+let wsListeners: WebSocketListener[] = [];
+let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let wsHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let wsConnecting = false;
+
+async function getWsUrl(): Promise<string> {
+  const { getPrPollClientId } = await import('./services/prPollingService');
+  const url = new URL('/api/events', location.href);
+  url.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.searchParams.set('clientId', getPrPollClientId());
+  return url.toString();
+}
+
+function sendHeartbeat(): void {
+  if (ws?.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: 'heartbeat' }));
+  }
+}
+
+function stopHeartbeat(): void {
+  if (wsHeartbeatTimer) {
+    clearInterval(wsHeartbeatTimer);
+    wsHeartbeatTimer = null;
+  }
+}
+
+function startHeartbeat(): void {
+  stopHeartbeat();
+  sendHeartbeat();
+  wsHeartbeatTimer = setInterval(sendHeartbeat, WEB_SOCKET_HEARTBEAT_MS);
+}
+
+async function ensureWebSocket(): Promise<void> {
+  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+    return;
+  }
+  if (wsConnecting) return;
+
+  wsConnecting = true;
+  const url = await getWsUrl();
+  if (wsListeners.length === 0) {
+    wsConnecting = false;
+    return;
+  }
+
+  const socket = new WebSocket(url);
+  ws = socket;
+
+  socket.onopen = () => {
+    wsConnecting = false;
+    startHeartbeat();
+    if (wsReconnectTimer) {
+      clearTimeout(wsReconnectTimer);
+      wsReconnectTimer = null;
+    }
+  };
+
+  socket.onmessage = (messageEvent) => {
+    try {
+      const data = JSON.parse(messageEvent.data) as { event: string; payload: unknown };
+      for (const listener of wsListeners) {
+        if (listener.event === data.event) {
+          listener.callback(data.payload);
+        }
+      }
+    } catch {
+      console.warn('[transport] Failed to parse WebSocket message:', messageEvent.data);
+    }
+  };
+
+  socket.onclose = () => {
+    wsConnecting = false;
+    stopHeartbeat();
+    if (ws === socket) {
+      ws = null;
+    }
+    if (wsListeners.length > 0 && !wsReconnectTimer) {
+      wsReconnectTimer = setTimeout(() => {
+        wsReconnectTimer = null;
+        if (wsListeners.length > 0) {
+          void ensureWebSocket().catch((e) => {
+            console.error('[transport] Failed to reconnect WebSocket:', e);
+          });
+        }
+      }, 2000);
+    }
+  };
+
+  socket.onerror = () => {
+    wsConnecting = false;
+  };
+}
+
+function webSocketListen<T>(event: string, callback: (payload: T) => void): UnlistenFn {
+  const listener: WebSocketListener = {
+    event,
+    callback: callback as (payload: unknown) => void,
+  };
+
+  wsListeners.push(listener);
+  void ensureWebSocket().catch((e) => {
+    console.error('[transport] Failed to connect WebSocket:', e);
+  });
+
+  return () => {
+    wsListeners = wsListeners.filter((l) => l !== listener);
+    if (wsListeners.length === 0) {
+      if (wsReconnectTimer) {
+        clearTimeout(wsReconnectTimer);
+        wsReconnectTimer = null;
+      }
+      stopHeartbeat();
+      if (ws) {
+        const socket = ws;
+        ws = null;
+        socket.close();
+      }
+    }
   };
 }
 

--- a/apps/staged/src/lib/transport.ts
+++ b/apps/staged/src/lib/transport.ts
@@ -138,6 +138,14 @@ function startHeartbeat(): void {
   wsHeartbeatTimer = setInterval(sendHeartbeat, WEB_SOCKET_HEARTBEAT_MS);
 }
 
+function replayCurrentPrPollInterestHints(): void {
+  void import('./services/prPollingService')
+    .then(({ replayPrPollInterestHints }) => replayPrPollInterestHints())
+    .catch((e) => {
+      console.error('[transport] Failed to replay PR polling interest:', e);
+    });
+}
+
 async function ensureWebSocket(): Promise<void> {
   if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
     return;
@@ -157,6 +165,7 @@ async function ensureWebSocket(): Promise<void> {
   socket.onopen = () => {
     wsConnecting = false;
     startHeartbeat();
+    replayCurrentPrPollInterestHints();
     if (wsReconnectTimer) {
       clearTimeout(wsReconnectTimer);
       wsReconnectTimer = null;


### PR DESCRIPTION
Summary:
- Enable web clients to receive PR polling events through the transport layer.
- Replay PR polling hints after reconnects so polling resumes reliably.
- Add coverage for web transport dispatch and PR polling behavior.

Tests:
- git push pre-push hooks: crates-fmt, crates-lint, crates-test, differ-ci, staged-ci