### PR TITLE
fix(staged): run doctor checks with shell env snapshots

### DIFF
--- a/apps/staged/src-tauri/src/doctor.rs
+++ b/apps/staged/src-tauri/src/doctor.rs
@@ -2,8 +2,40 @@
 
 pub use doctor::types::{AuthStatus, InstallSource};
 pub use doctor::{
-    AgentVersionInfo, CheckStatus, DoctorCheck, DoctorReport, FixType, RunChecksOptions,
+    AgentVersionInfo, CheckStatus, DoctorCheck, DoctorReport, ExecuteFixOptions, FixType,
+    RunChecksOptions,
 };
+
+async fn doctor_env_vars() -> Vec<(String, String)> {
+    crate::shell_env::home_env_vars_with_extended_path(
+        crate::session_runner::shell_env_cache().as_ref(),
+    )
+    .await
+}
+
+fn run_checks_options(check_freshness: bool, env_vars: Vec<(String, String)>) -> RunChecksOptions {
+    RunChecksOptions {
+        check_freshness,
+        offline: false,
+        // Use the default public registries — Staged installs these agents
+        // from public npm/brew/crates.io, not an internal mirror.
+        npm_registry: None,
+        env: None,
+    }
+    .with_env_snapshot(env_vars)
+}
+
+fn execute_fix_options(
+    command_override: Option<String>,
+    env_vars: Vec<(String, String)>,
+) -> ExecuteFixOptions {
+    ExecuteFixOptions {
+        command_override,
+        npm_registry: None,
+        env: None,
+    }
+    .with_env_snapshot(env_vars)
+}
 
 /// Run all health checks and return the report.
 ///
@@ -13,7 +45,8 @@ pub use doctor::{
 /// [`run_doctor_freshness`] to fill in version/update information.
 #[tauri::command]
 pub async fn run_doctor() -> DoctorReport {
-    doctor::run_checks().await
+    let env_vars = doctor_env_vars().await;
+    doctor::run_checks_with_options(run_checks_options(false, env_vars)).await
 }
 
 /// Run all health checks with version freshness enabled.
@@ -25,15 +58,8 @@ pub async fn run_doctor() -> DoctorReport {
 /// each readout. Hits the network, so it must never block first paint.
 #[tauri::command]
 pub async fn run_doctor_freshness() -> DoctorReport {
-    doctor::run_checks_with_options(RunChecksOptions {
-        check_freshness: true,
-        offline: false,
-        // Use the default public registries — Staged installs these agents
-        // from public npm/brew/crates.io, not an internal mirror.
-        npm_registry: None,
-        env: None,
-    })
-    .await
+    let env_vars = doctor_env_vars().await;
+    doctor::run_checks_with_options(run_checks_options(true, env_vars)).await
 }
 
 /// Run a fix for a doctor check, identified by check ID and fix type.
@@ -42,7 +68,9 @@ pub async fn run_doctor_freshness() -> DoctorReport {
 /// the caller never sends a raw command string.
 #[tauri::command]
 pub async fn run_doctor_fix(check_id: String, fix_type: FixType) -> Result<(), String> {
-    doctor::execute_fix(check_id, fix_type).await
+    let env_vars = doctor_env_vars().await;
+    doctor::execute_fix_with_env_options(check_id, fix_type, execute_fix_options(None, env_vars))
+        .await
 }
 
 /// Run a source-aware update for a single readout (main CLI or ACP bridge).
@@ -63,7 +91,8 @@ pub async fn run_doctor_update(
     fix_type: FixType,
     command: String,
 ) -> Result<(), String> {
-    let expected = expected_update_command(&check_id, &fix_type).await?;
+    let env_vars = doctor_env_vars().await;
+    let expected = expected_update_command(&check_id, &fix_type, env_vars.clone()).await?;
     if expected != command {
         return Err(format!(
             "Update command mismatch for {check_id}: refusing to run a command \
@@ -74,19 +103,22 @@ pub async fn run_doctor_update(
     // They are equal past the guard above, but executing `expected` makes the
     // command that runs provably the one the backend derived — no dependence on
     // the equality check surviving future edits.
-    doctor::execute_fix_with_options(check_id, fix_type, Some(expected), None).await
+    doctor::execute_fix_with_env_options(
+        check_id,
+        fix_type,
+        execute_fix_options(Some(expected), env_vars),
+    )
+    .await
 }
 
 /// Re-run freshness and return the authoritative update command for the given
 /// check + slot, or an error if no actionable update is derivable.
-async fn expected_update_command(check_id: &str, fix_type: &FixType) -> Result<String, String> {
-    let report = doctor::run_checks_with_options(RunChecksOptions {
-        check_freshness: true,
-        offline: false,
-        npm_registry: None,
-        env: None,
-    })
-    .await;
+async fn expected_update_command(
+    check_id: &str,
+    fix_type: &FixType,
+    env_vars: Vec<(String, String)>,
+) -> Result<String, String> {
+    let report = doctor::run_checks_with_options(run_checks_options(true, env_vars)).await;
 
     let check = report
         .checks

--- a/apps/staged/src-tauri/src/doctor.rs
+++ b/apps/staged/src-tauri/src/doctor.rs
@@ -31,6 +31,7 @@ pub async fn run_doctor_freshness() -> DoctorReport {
         // Use the default public registries — Staged installs these agents
         // from public npm/brew/crates.io, not an internal mirror.
         npm_registry: None,
+        env: None,
     })
     .await
 }
@@ -83,6 +84,7 @@ async fn expected_update_command(check_id: &str, fix_type: &FixType) -> Result<S
         check_freshness: true,
         offline: false,
         npm_registry: None,
+        env: None,
     })
     .await;
 

--- a/apps/staged/src-tauri/src/shell_env.rs
+++ b/apps/staged/src-tauri/src/shell_env.rs
@@ -11,7 +11,7 @@
 //! Concurrent first-callers for the same working directory are coalesced
 //! through a `watch` channel so only one shell is spawned per (dir, miss).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -26,6 +26,7 @@ use tokio::sync::watch;
 /// cost, short enough that edits to `~/.zshrc` or `bin/activate-hermit` are
 /// picked up within an hour without an explicit invalidation.
 pub const DEFAULT_TTL: Duration = Duration::from_secs(60 * 60);
+const HOME_ENV_CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Captured environment from a single interactive login shell invocation.
 #[derive(Clone, Debug)]
@@ -64,6 +65,180 @@ impl ShellEnv {
             cmd.env(k, v);
         }
     }
+}
+
+/// Capture the user's home/global interactive login environment and return a
+/// deterministic snapshot suitable for subprocesses that clear their env.
+///
+/// This sanitizes only the returned clone. The underlying per-directory cache
+/// remains raw so project/git callers keep directory-scoped tool-manager state
+/// for their exact working directory.
+pub async fn home_env_vars_with_extended_path(cache: &ShellEnvCache) -> Vec<(String, String)> {
+    let shell_env = capture_home_interactive_env(cache).await;
+    env_vars_with_extended_path(&shell_env)
+}
+
+pub async fn capture_home_interactive_env(cache: &ShellEnvCache) -> HashMap<String, String> {
+    let Some(home) = home_dir_from_env() else {
+        return HashMap::new();
+    };
+    capture_home_interactive_env_for_dir(cache, &home, HOME_ENV_CAPTURE_TIMEOUT).await
+}
+
+fn home_dir_from_env() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+}
+
+async fn capture_home_interactive_env_for_dir(
+    cache: &ShellEnvCache,
+    home: &Path,
+    timeout_duration: Duration,
+) -> HashMap<String, String> {
+    let mut env = match tokio::time::timeout(timeout_duration, cache.get(home)).await {
+        Ok(Ok(snapshot)) => snapshot.vars().iter().cloned().collect(),
+        Ok(Err(error)) => {
+            log::warn!(
+                "Failed to capture home shell env for {}: {error}",
+                home.display()
+            );
+            HashMap::new()
+        }
+        Err(_) => {
+            log::warn!(
+                "Timed out after {:?} capturing home shell env for {}",
+                timeout_duration,
+                home.display()
+            );
+            HashMap::new()
+        }
+    };
+    sanitize_shell_env(&mut env);
+    env
+}
+
+pub fn sanitize_shell_env(env: &mut HashMap<String, String>) {
+    env.retain(|key, value| !should_remove_shell_env_var(key, value));
+}
+
+fn should_remove_shell_env_var(key: &str, value: &str) -> bool {
+    let upper_key = key.to_ascii_uppercase();
+
+    if upper_key.starts_with("HERMIT_") {
+        return true;
+    }
+
+    if matches!(
+        upper_key.as_str(),
+        "NPM_CONFIG_PREFIX" | "NPM_CONFIG_CACHE" | "COREPACK_HOME"
+    ) {
+        return true;
+    }
+
+    if upper_key == "PATH" {
+        return false;
+    }
+
+    value.contains("/.hermit/") || value.ends_with("/.hermit")
+}
+
+fn push_existing_path(paths: &mut Vec<PathBuf>, path: &str) {
+    paths.extend(std::env::split_paths(path).filter(|p| {
+        !p.to_string_lossy().contains(".hermit") && !p.join("activate-hermit").exists()
+    }));
+}
+
+pub fn build_extended_path_from_path(path: Option<&str>) -> String {
+    let mut paths: Vec<PathBuf> = Vec::new();
+
+    if let Some(path) = path {
+        push_existing_path(&mut paths, path);
+    } else if let Ok(system_path) = std::env::var("PATH") {
+        push_existing_path(&mut paths, &system_path);
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".amp/bin"));
+        paths.push(home.join(".local/bin"));
+        paths.push(home.join(".npm-global/bin"));
+        paths.push(home.join(".local/share/mise/shims"));
+        paths.push(home.join(".volta/bin"));
+        paths.push(home.join(".asdf/shims"));
+    }
+
+    paths.push(PathBuf::from("/usr/local/bin"));
+
+    #[cfg(target_os = "macos")]
+    {
+        paths.push(PathBuf::from("/opt/homebrew/bin"));
+        paths.push(PathBuf::from("/opt/local/bin"));
+    }
+
+    if cfg!(windows) {
+        if let Some(appdata) = dirs::data_dir() {
+            paths.push(appdata.join("npm"));
+        }
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        let nvm_dir = home.join(".nvm/versions/node");
+        if nvm_dir.exists() {
+            if let Ok(entries) = std::fs::read_dir(&nvm_dir) {
+                let mut versions: Vec<_> = entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                    .collect();
+                versions.sort_by_key(|b| std::cmp::Reverse(b.file_name()));
+                if let Some(latest) = versions.first() {
+                    paths.push(latest.path().join("bin"));
+                }
+            }
+        }
+
+        let fnm_dir = home.join(".local/share/fnm/node-versions");
+        if fnm_dir.exists() {
+            if let Ok(entries) = std::fs::read_dir(&fnm_dir) {
+                let mut versions: Vec<_> = entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                    .collect();
+                versions.sort_by_key(|b| std::cmp::Reverse(b.file_name()));
+                if let Some(latest) = versions.first() {
+                    paths.push(latest.path().join("installation/bin"));
+                }
+            }
+        }
+    }
+
+    let mut seen = HashSet::new();
+    paths.retain(|p| seen.insert(p.clone()));
+
+    std::env::join_paths(paths)
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Build a deterministic environment snapshot with PATH normalized through
+/// [`build_extended_path_from_path`].
+///
+/// If home env capture failed, fall back to the current process environment so
+/// callers that clear child environments still preserve essential variables.
+pub fn env_vars_with_extended_path(shell_env: &HashMap<String, String>) -> Vec<(String, String)> {
+    let mut env = if shell_env.is_empty() {
+        std::env::vars().collect()
+    } else {
+        shell_env.clone()
+    };
+    sanitize_shell_env(&mut env);
+    let extended_path = build_extended_path_from_path(env.get("PATH").map(String::as_str));
+    env.insert("PATH".to_string(), extended_path);
+
+    let mut vars: Vec<_> = env.into_iter().collect();
+    vars.sort_by(|(left, _), (right, _)| left.cmp(right));
+    vars
 }
 
 #[derive(Clone)]
@@ -647,6 +822,129 @@ mod tests {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    #[test]
+    fn sanitize_shell_env_removes_repo_tool_manager_state() {
+        let mut env = HashMap::from([
+            ("HOME".to_string(), "/Users/morganm".to_string()),
+            (
+                "HERMIT_ENV".to_string(),
+                "/Users/morganm/Development/repo".to_string(),
+            ),
+            (
+                "NPM_CONFIG_PREFIX".to_string(),
+                "/Users/morganm/Development/repo/.hermit/node".to_string(),
+            ),
+            (
+                "NPM_CONFIG_CACHE".to_string(),
+                "/Users/morganm/Development/repo/.hermit/cache".to_string(),
+            ),
+            (
+                "COREPACK_HOME".to_string(),
+                "/Users/morganm/Development/repo/.hermit/node".to_string(),
+            ),
+            (
+                "PATH".to_string(),
+                "/Users/morganm/Development/repo/.hermit/bin:/usr/bin".to_string(),
+            ),
+            (
+                "CUSTOM_TOOL_HOME".to_string(),
+                "/Users/morganm/Development/repo/.hermit/custom".to_string(),
+            ),
+        ]);
+
+        sanitize_shell_env(&mut env);
+
+        assert_eq!(env.get("HOME"), Some(&"/Users/morganm".to_string()));
+        assert_eq!(
+            env.get("PATH"),
+            Some(&"/Users/morganm/Development/repo/.hermit/bin:/usr/bin".to_string())
+        );
+        assert!(!env.contains_key("HERMIT_ENV"));
+        assert!(!env.contains_key("NPM_CONFIG_PREFIX"));
+        assert!(!env.contains_key("NPM_CONFIG_CACHE"));
+        assert!(!env.contains_key("COREPACK_HOME"));
+        assert!(!env.contains_key("CUSTOM_TOOL_HOME"));
+    }
+
+    #[test]
+    fn extended_path_starts_with_shell_path_and_filters_hermit_entries() {
+        let path = build_extended_path_from_path(Some(
+            "/shell/bin:/repo/.hermit/bin:/another/bin:/shell/bin",
+        ));
+        let paths: Vec<_> = std::env::split_paths(&path).collect();
+
+        assert_eq!(
+            paths.first().map(|p| p.as_path()),
+            Some(Path::new("/shell/bin"))
+        );
+        assert!(paths.iter().any(|p| p == Path::new("/another/bin")));
+        assert_eq!(
+            paths
+                .iter()
+                .filter(|p| p.as_path() == Path::new("/shell/bin"))
+                .count(),
+            1
+        );
+        assert!(!paths.iter().any(|p| p == Path::new("/repo/.hermit/bin")));
+        assert!(paths.iter().any(|p| p.ends_with(".local/share/mise/shims")));
+        assert!(paths.iter().any(|p| p.ends_with(".amp/bin")));
+        assert!(paths.iter().any(|p| p.ends_with(".volta/bin")));
+        assert!(paths.iter().any(|p| p.ends_with(".asdf/shims")));
+    }
+
+    #[test]
+    fn env_vars_with_extended_path_sanitizes_and_normalizes_path() {
+        let env = HashMap::from([
+            (
+                "PATH".to_string(),
+                "/repo/.hermit/bin:/shell/bin".to_string(),
+            ),
+            ("HERMIT_ENV".to_string(), "/repo".to_string()),
+            ("LANG".to_string(), "en_US.UTF-8".to_string()),
+        ]);
+
+        let vars = env_vars_with_extended_path(&env);
+        let map: HashMap<_, _> = vars.into_iter().collect();
+        let path = map.get("PATH").expect("PATH");
+        let paths: Vec<_> = std::env::split_paths(path).collect();
+
+        assert_eq!(map.get("LANG"), Some(&"en_US.UTF-8".to_string()));
+        assert!(!map.contains_key("HERMIT_ENV"));
+        assert!(paths.iter().any(|p| p == Path::new("/shell/bin")));
+        assert!(!paths.iter().any(|p| p == Path::new("/repo/.hermit/bin")));
+        assert!(paths.iter().any(|p| p.ends_with(".asdf/shims")));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn home_interactive_env_sanitizes_clone_but_keeps_raw_cache() {
+        let shell = write_fake_shell(
+            "#!/bin/sh\nPATH='/repo/.hermit/bin:/usr/bin'\nHERMIT_ENV=/repo\nNPM_CONFIG_PREFIX=/repo/.hermit/node\nCUSTOM_VAR=present\nexport PATH HERMIT_ENV NPM_CONFIG_PREFIX CUSTOM_VAR\nexec /bin/sh -s\n",
+        );
+        let cache =
+            ShellEnvCache::with_shell_and_ttl(shell.to_path_buf(), Duration::from_secs(3600));
+        let home = tempfile::tempdir().expect("home");
+
+        let sanitized =
+            capture_home_interactive_env_for_dir(&cache, home.path(), Duration::from_secs(1)).await;
+
+        assert_eq!(sanitized.get("CUSTOM_VAR"), Some(&"present".to_string()));
+        assert!(!sanitized.contains_key("HERMIT_ENV"));
+        assert!(!sanitized.contains_key("NPM_CONFIG_PREFIX"));
+        assert_eq!(
+            sanitized.get("PATH"),
+            Some(&"/repo/.hermit/bin:/usr/bin".to_string())
+        );
+
+        let raw = cache.get(home.path()).await.expect("cached raw env");
+        let raw_map: HashMap<_, _> = raw.vars().iter().cloned().collect();
+        assert_eq!(raw_map.get("HERMIT_ENV"), Some(&"/repo".to_string()));
+        assert_eq!(
+            raw_map.get("PATH"),
+            Some(&"/repo/.hermit/bin:/usr/bin".to_string())
+        );
     }
 
     // ---------------------------------------------------------------------

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -3519,7 +3519,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
         // Doctor
         // =====================================================================
         "run_doctor" => {
-            let report = doctor::run_checks().await;
+            let report = crate::doctor::run_doctor().await;
             Ok(serde_json::to_value(report).unwrap())
         }
         "run_doctor_freshness" => {
@@ -3529,7 +3529,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
         "run_doctor_fix" => {
             let check_id: String = arg(&args, "checkId")?;
             let fix_type: doctor::FixType = arg(&args, "fixType")?;
-            doctor::execute_fix(check_id, fix_type).await?;
+            crate::doctor::run_doctor_fix(check_id, fix_type).await?;
             Ok(Value::Null)
         }
         "run_doctor_update" => {

--- a/crates/doctor/src/agents.rs
+++ b/crates/doctor/src/agents.rs
@@ -6,12 +6,13 @@ use crate::checks::CLONEFILE_FIX_COMMAND;
 use crate::command::{
     run_command_with_timeout, CommandError, CommandTimeout, DEFAULT_PROBE_TIMEOUT,
 };
+use crate::environment::{apply_doctor_env, DoctorEnv};
 use crate::resolve::format_command_output;
 use crate::timeout_check::{command_timeout_check, TimeoutCheck};
 use crate::types::{
     AgentVersionInfo, AuthStatus, CheckStatus, DoctorCheck, FixType, InstallSource, ResolvedBinary,
 };
-use crate::{execute_command_with_path_prefix, ExecOutcome};
+use crate::ExecOutcome;
 
 /// Metadata for an individual AI agent check.
 pub struct AgentCheckInfo {
@@ -280,6 +281,7 @@ pub fn check_single_ai_agent(
     resolved_cmds: &[ResolvedBinary],
     resolved_main: Option<&ResolvedBinary>,
     npm_registry: Option<&str>,
+    env: Option<&DoctorEnv>,
 ) -> DoctorCheck {
     let header = format!(
         "# Check: {} — verify {} agent is installed",
@@ -308,6 +310,7 @@ pub fn check_single_ai_agent(
         if info.id == "ai-agent-goose" {
             let mut command = std::process::Command::new(path_str);
             command.arg("acp").arg("--help");
+            apply_doctor_env(&mut command, env);
             match run_command_with_timeout(command, "goose acp --help", DEFAULT_PROBE_TIMEOUT) {
                 Ok(output) if output.status.success() => {
                     let raw = format!(
@@ -439,7 +442,11 @@ pub fn check_single_ai_agent(
             let auth_path_prefix = collect_resolved_bin_dirs(resolved_main, resolved_cmds);
 
             let (auth_status, auth_output) = match info.auth_status_command {
-                Some(cmd) => match execute_command_with_path_prefix(cmd, &auth_path_prefix) {
+                Some(cmd) => match crate::execute_command_with_path_prefix_with_env(
+                    cmd,
+                    &auth_path_prefix,
+                    env,
+                ) {
                     ExecOutcome::Ok => (
                         Some(AuthStatus::Authenticated),
                         Some(format!("$ {cmd}\n(exit 0)")),
@@ -666,6 +673,7 @@ mod tests {
             std::slice::from_ref(&bridge),
             Some(&main),
             None,
+            None,
         );
 
         let m = check.main.expect("main readout present");
@@ -694,6 +702,7 @@ mod tests {
             std::slice::from_ref(&bridge_missing),
             Some(&main),
             None,
+            None,
         );
 
         let m = check.main.expect("main readout present");
@@ -718,6 +727,7 @@ mod tests {
             std::slice::from_ref(&single),
             None,
             None,
+            None,
         );
 
         let m = check.main.expect("main readout present");
@@ -735,6 +745,7 @@ mod tests {
             false,
             std::slice::from_ref(&missing),
             Some(&missing),
+            None,
             None,
         );
         assert!(check.main.is_none());
@@ -853,6 +864,7 @@ mod tests {
             true,
             std::slice::from_ref(&bridge),
             Some(&main),
+            None,
             None,
         );
         let raw = check.raw_output.expect("raw_output set");

--- a/crates/doctor/src/checks.rs
+++ b/crates/doctor/src/checks.rs
@@ -3,6 +3,7 @@
 use std::process::Command;
 
 use crate::command::{run_command_with_timeout, CommandError, DEFAULT_PROBE_TIMEOUT};
+use crate::environment::{apply_doctor_env, DoctorEnv};
 use crate::resolve::format_command_output;
 use crate::timeout_check::{command_timeout_check, TimeoutCheck};
 use crate::types::{CheckStatus, DoctorCheck, FixType, ResolvedBinary};
@@ -11,7 +12,7 @@ use crate::types::{CheckStatus, DoctorCheck, FixType, ResolvedBinary};
 pub(crate) const CLONEFILE_FIX_COMMAND: &str = "git config --global core.clonefile true";
 
 /// Check that `git` is installed and reachable.
-pub fn check_git(resolved: &ResolvedBinary) -> DoctorCheck {
+pub fn check_git(resolved: &ResolvedBinary, env: Option<&DoctorEnv>) -> DoctorCheck {
     let label = "Git".to_string();
     let id = "git".to_string();
     let search = &resolved.search_output;
@@ -46,6 +47,7 @@ pub fn check_git(resolved: &ResolvedBinary) -> DoctorCheck {
 
     let mut command = Command::new(git_path);
     command.arg("--version");
+    apply_doctor_env(&mut command, env);
     match run_command_with_timeout(command, "git --version", DEFAULT_PROBE_TIMEOUT) {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -132,7 +134,7 @@ pub fn check_git(resolved: &ResolvedBinary) -> DoctorCheck {
 }
 
 /// Check that the GitHub CLI (`gh`) is installed.
-pub fn check_gh(resolved: &ResolvedBinary) -> DoctorCheck {
+pub fn check_gh(resolved: &ResolvedBinary, env: Option<&DoctorEnv>) -> DoctorCheck {
     let label = "GitHub CLI".to_string();
     let id = "gh".to_string();
     let search = &resolved.search_output;
@@ -167,6 +169,7 @@ pub fn check_gh(resolved: &ResolvedBinary) -> DoctorCheck {
 
     let mut command = Command::new(gh_path);
     command.arg("--version");
+    apply_doctor_env(&mut command, env);
     match run_command_with_timeout(command, "gh --version", DEFAULT_PROBE_TIMEOUT) {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout);
@@ -254,7 +257,7 @@ pub fn check_gh(resolved: &ResolvedBinary) -> DoctorCheck {
 }
 
 /// Check that `gh auth status` succeeds (user is logged in).
-pub fn check_gh_auth(gh: &ResolvedBinary) -> DoctorCheck {
+pub fn check_gh_auth(gh: &ResolvedBinary, env: Option<&DoctorEnv>) -> DoctorCheck {
     let label = "GitHub Auth".to_string();
     let id = "gh-auth".to_string();
     let header = "# Check: GitHub Auth — verify user is logged in to GitHub";
@@ -287,6 +290,7 @@ pub fn check_gh_auth(gh: &ResolvedBinary) -> DoctorCheck {
 
     let mut command = Command::new(gh_path);
     command.args(["auth", "status"]);
+    apply_doctor_env(&mut command, env);
     match run_command_with_timeout(command, "gh auth status", DEFAULT_PROBE_TIMEOUT) {
         Ok(output) => {
             let raw = format!(
@@ -371,7 +375,11 @@ pub fn check_gh_auth(gh: &ResolvedBinary) -> DoctorCheck {
 }
 
 /// Check that Git LFS is installed.
-pub fn check_git_lfs(git: &ResolvedBinary, git_lfs: &ResolvedBinary) -> DoctorCheck {
+pub fn check_git_lfs(
+    git: &ResolvedBinary,
+    git_lfs: &ResolvedBinary,
+    env: Option<&DoctorEnv>,
+) -> DoctorCheck {
     let label = "Git LFS".to_string();
     let id = "git-lfs".to_string();
     let search = &git_lfs.search_output;
@@ -408,6 +416,7 @@ pub fn check_git_lfs(git: &ResolvedBinary, git_lfs: &ResolvedBinary) -> DoctorCh
 
     let mut command = Command::new(git_path);
     command.args(["lfs", "version"]);
+    apply_doctor_env(&mut command, env);
     match run_command_with_timeout(command, "git lfs version", DEFAULT_PROBE_TIMEOUT) {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -503,7 +512,7 @@ pub fn check_git_lfs(git: &ResolvedBinary, git_lfs: &ResolvedBinary) -> DoctorCh
 }
 
 /// Check that `core.clonefile` is enabled in the global git config.
-pub fn check_clonefile(git: &ResolvedBinary) -> DoctorCheck {
+pub fn check_clonefile(git: &ResolvedBinary, env: Option<&DoctorEnv>) -> DoctorCheck {
     let label = "Copy on Write Git Clones".to_string();
     let id = "git-clonefile".to_string();
     let fix_cmd = CLONEFILE_FIX_COMMAND.to_string();
@@ -537,6 +546,7 @@ pub fn check_clonefile(git: &ResolvedBinary) -> DoctorCheck {
 
     let mut command = Command::new(git_path);
     command.args(["config", "--global", "core.clonefile"]);
+    apply_doctor_env(&mut command, env);
     match run_command_with_timeout(
         command,
         "git config --global core.clonefile",
@@ -648,5 +658,54 @@ pub fn check_clonefile(git: &ResolvedBinary) -> DoctorCheck {
             main: None,
             bridge: None,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn check_git_receives_env_snapshot() {
+        let dir = std::env::temp_dir().join(format!("doctor-check-env-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let git = dir.join("git");
+        std::fs::write(
+            &git,
+            "#!/bin/sh\n\
+             if [ \"$DOCTOR_CHECK_MARKER\" = yes ]; then\n\
+               echo 'git version 9.8.7'\n\
+               exit 0\n\
+             fi\n\
+             echo 'missing marker' >&2\n\
+             exit 42\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&git, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let resolved = ResolvedBinary {
+            path: Some(PathBuf::from(&git)),
+            search_output: "fake git resolved from test".to_string(),
+            install_source: None,
+        };
+        let env = DoctorEnv::new(vec![
+            ("DOCTOR_CHECK_MARKER".to_string(), "yes".to_string()),
+            ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ("HOME".to_string(), dir.to_string_lossy().to_string()),
+            ("USER".to_string(), "doctor-test".to_string()),
+        ]);
+
+        let check = check_git(&resolved, Some(&env));
+
+        assert_eq!(check.status, CheckStatus::Pass);
+        assert_eq!(check.message, "git version 9.8.7");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/doctor/src/environment.rs
+++ b/crates/doctor/src/environment.rs
@@ -1,0 +1,37 @@
+//! Caller-provided process environment snapshots for doctor subprocesses.
+
+use std::process::Command;
+
+/// A full environment snapshot captured by a caller.
+///
+/// When supplied to doctor APIs, subprocesses start from this snapshot instead
+/// of inheriting the current process environment. `None` preserves the legacy
+/// inherited/minimal environment behavior at each call site.
+#[derive(Debug, Clone, Default)]
+pub struct DoctorEnv {
+    pub vars: Vec<(String, String)>,
+}
+
+impl DoctorEnv {
+    pub fn new(vars: Vec<(String, String)>) -> Self {
+        Self { vars }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.vars
+            .iter()
+            .rev()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+pub(crate) fn apply_doctor_env(command: &mut Command, env: Option<&DoctorEnv>) {
+    let Some(env) = env else {
+        return;
+    };
+    command.env_clear();
+    for (key, value) in &env.vars {
+        command.env(key, value);
+    }
+}

--- a/crates/doctor/src/freshness.rs
+++ b/crates/doctor/src/freshness.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use crate::command::{
     run_command_with_timeout, CommandError, CommandTimeout, FRESHNESS_PROBE_TIMEOUT,
 };
+use crate::environment::{apply_doctor_env, DoctorEnv};
 use crate::package_ids::LatestSource;
 use crate::types::InstallSource;
 
@@ -77,6 +78,13 @@ impl FreshnessCache {
             },
         );
     }
+}
+
+pub(crate) struct FetchVersionInfoOptions<'a> {
+    pub offline: bool,
+    pub npm_registry: Option<&'a str>,
+    pub env: Option<&'a DoctorEnv>,
+    pub cache: Arc<Mutex<FreshnessCache>>,
 }
 
 /// Resolve the on-disk cache file path. Prefers `dirs::cache_dir()`; the
@@ -306,9 +314,14 @@ fn installed_version_from_package_json(
 
 /// Run `<binary> <args>` and parse the first semver-shaped token out of the
 /// combined stdout/stderr. Errors and missing tokens both yield `None`.
-fn installed_version(binary_path: &Path, version_args: &[&str]) -> ProbeResult {
+fn installed_version(
+    binary_path: &Path,
+    version_args: &[&str],
+    env: Option<&DoctorEnv>,
+) -> ProbeResult {
     let mut command = Command::new(binary_path);
     command.args(version_args);
+    apply_doctor_env(&mut command, env);
     let display_command = format!("{} {}", binary_path.display(), version_args.join(" "))
         .trim()
         .to_string();
@@ -348,24 +361,26 @@ fn latest_version(
     source: LatestSource,
     package_id: &str,
     npm_registry: Option<&str>,
+    env: Option<&DoctorEnv>,
 ) -> ProbeResult {
     match source {
-        LatestSource::Brew => latest_brew(package_id),
-        LatestSource::Npm => latest_npm(package_id, npm_registry),
+        LatestSource::Brew => latest_brew(package_id, env),
+        LatestSource::Npm => latest_npm(package_id, npm_registry, env),
         LatestSource::CratesIo => ProbeResult {
             value: latest_crates_io(package_id),
             timeouts: Vec::new(),
         },
         LatestSource::GitHubReleases => ProbeResult {
-            value: latest_github_releases(package_id),
+            value: latest_github_releases(package_id, env),
             timeouts: Vec::new(),
         },
     }
 }
 
-fn latest_brew(package_id: &str) -> ProbeResult {
+fn latest_brew(package_id: &str, env: Option<&DoctorEnv>) -> ProbeResult {
     let mut command = Command::new("brew");
     command.args(["info", "--json=v2", package_id]);
+    apply_doctor_env(&mut command, env);
     let display_command = format!("brew info --json=v2 {package_id}");
     let output = match run_command_with_timeout(command, display_command, FRESHNESS_PROBE_TIMEOUT) {
         Ok(output) => output,
@@ -412,12 +427,17 @@ pub(crate) fn parse_brew_info_v2(bytes: &[u8], _package_id: &str) -> Option<Stri
     None
 }
 
-fn latest_npm(package_id: &str, npm_registry: Option<&str>) -> ProbeResult {
+fn latest_npm(
+    package_id: &str,
+    npm_registry: Option<&str>,
+    env: Option<&DoctorEnv>,
+) -> ProbeResult {
     let mut cmd = Command::new("npm");
     cmd.args(["view", package_id, "version"]);
     if let Some(registry) = npm_registry {
         cmd.args(["--registry", registry]);
     }
+    apply_doctor_env(&mut cmd, env);
     let display_command = if let Some(registry) = npm_registry {
         format!("npm view {package_id} version --registry {registry}")
     } else {
@@ -473,7 +493,7 @@ fn latest_crates_io(package_id: &str) -> Option<String> {
 /// and never returns a hard error. A `GITHUB_TOKEN`/`GH_TOKEN` in the
 /// environment is used as a bearer credential to relax the unauthenticated
 /// rate limit, but is entirely optional.
-fn latest_github_releases(repo: &str) -> Option<String> {
+fn latest_github_releases(repo: &str, env: Option<&DoctorEnv>) -> Option<String> {
     let url = format!("https://api.github.com/repos/{repo}/releases/latest");
     let client = reqwest::blocking::Client::builder()
         // GitHub rejects requests without a User-Agent.
@@ -484,7 +504,7 @@ fn latest_github_releases(repo: &str) -> Option<String> {
     let mut req = client
         .get(&url)
         .header("Accept", "application/vnd.github+json");
-    if let Some(token) = github_token() {
+    if let Some(token) = github_token(env) {
         req = req.bearer_auth(token);
     }
     let resp = req.send().ok()?;
@@ -497,11 +517,17 @@ fn latest_github_releases(repo: &str) -> Option<String> {
 
 /// Read GitHub's optional release-auth token from the environment. Empty values
 /// are treated as absent. Kept separate so the fetcher stays testable.
-fn github_token() -> Option<String> {
-    std::env::var("GITHUB_TOKEN")
-        .ok()
-        .or_else(|| std::env::var("GH_TOKEN").ok())
-        .filter(|s| !s.is_empty())
+fn github_token(env: Option<&DoctorEnv>) -> Option<String> {
+    let token = if let Some(env) = env {
+        env.get("GITHUB_TOKEN")
+            .or_else(|| env.get("GH_TOKEN"))
+            .map(str::to_string)
+    } else {
+        std::env::var("GITHUB_TOKEN")
+            .ok()
+            .or_else(|| std::env::var("GH_TOKEN").ok())
+    };
+    token.filter(|s| !s.is_empty())
 }
 
 /// Pull `tag_name` out of a GitHub `releases/latest` payload, stripping a
@@ -522,14 +548,15 @@ pub(crate) async fn fetch_version_info(
     package_id: Option<&str>,
     binary_path: &Path,
     probe: InstalledProbe<'_>,
-    offline: bool,
-    npm_registry: Option<&str>,
-    cache: Arc<Mutex<FreshnessCache>>,
+    opts: FetchVersionInfoOptions<'_>,
 ) -> VersionInfo {
     let path = binary_path.to_path_buf();
     let probe = probe.to_owned_probe();
     let pkg = package_id.map(|s| s.to_string());
-    let npm_registry = npm_registry.map(|s| s.to_string());
+    let offline = opts.offline;
+    let npm_registry = opts.npm_registry.map(|s| s.to_string());
+    let env = opts.env.cloned();
+    let cache = opts.cache;
 
     let result = tokio::task::spawn_blocking(move || {
         let mut command_timeouts = Vec::new();
@@ -541,6 +568,7 @@ pub(crate) async fn fetch_version_info(
                     let result = installed_version(
                         &path,
                         &args.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
+                        env.as_ref(),
                     );
                     command_timeouts.extend(result.timeouts);
                     result.value
@@ -563,7 +591,7 @@ pub(crate) async fn fetch_version_info(
             if let Some(v) = cached {
                 Some(v)
             } else {
-                let result = latest_version(source, &pkg, npm_registry.as_deref());
+                let result = latest_version(source, &pkg, npm_registry.as_deref(), env.as_ref());
                 command_timeouts.extend(result.timeouts);
                 if let Some(v) = result.value {
                     if let Ok(mut guard) = cache.lock() {
@@ -749,6 +777,65 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    fn write_executable(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).unwrap();
+        }
+    }
+
+    #[test]
+    fn installed_version_uses_env_snapshot() {
+        let root = scratch_dir("installed-env");
+        let tool = root.join("tool");
+        write_executable(
+            &tool,
+            "#!/bin/sh\n\
+             test \"$DOCTOR_FRESHNESS_MARKER\" = yes || exit 42\n\
+             echo 'tool version 1.2.3'\n",
+        );
+        let env = DoctorEnv::new(vec![
+            ("DOCTOR_FRESHNESS_MARKER".to_string(), "yes".to_string()),
+            ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ("HOME".to_string(), root.to_string_lossy().to_string()),
+        ]);
+
+        let result = installed_version(&tool, &["--version"], Some(&env));
+
+        assert_eq!(result.value.as_deref(), Some("1.2.3"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn latest_npm_uses_env_snapshot_path_and_vars() {
+        let root = scratch_dir("latest-npm-env");
+        let npm = root.join("npm");
+        write_executable(
+            &npm,
+            "#!/bin/sh\n\
+             test \"$DOCTOR_NPM_MARKER\" = yes || exit 42\n\
+             test \"$1\" = view || exit 43\n\
+             echo '4.5.6'\n",
+        );
+        let env = DoctorEnv::new(vec![
+            ("DOCTOR_NPM_MARKER".to_string(), "yes".to_string()),
+            ("PATH".to_string(), root.to_string_lossy().to_string()),
+            ("HOME".to_string(), root.to_string_lossy().to_string()),
+        ]);
+
+        let result = latest_npm("doctor-package", None, Some(&env));
+
+        assert_eq!(result.value.as_deref(), Some("4.5.6"));
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/doctor/src/lib.rs
+++ b/crates/doctor/src/lib.rs
@@ -7,12 +7,14 @@
 pub mod agents;
 pub mod checks;
 mod command;
+mod environment;
 pub(crate) mod freshness;
 pub(crate) mod package_ids;
 pub mod resolve;
 mod timeout_check;
 pub mod types;
 
+pub use environment::DoctorEnv;
 pub use types::{AgentVersionInfo, CheckStatus, DoctorCheck, DoctorReport, FixType};
 
 use std::collections::{HashMap, HashSet};
@@ -26,6 +28,7 @@ use command::{
 };
 use freshness::{
     fetch_version_info, is_self_updating, load_cache, save_cache, select_installed_probe,
+    FetchVersionInfoOptions,
 };
 use package_ids::{lookup_package_id, LatestSource, Role};
 use resolve::resolve_binary_with_diagnostics;
@@ -72,6 +75,18 @@ pub struct RunChecksOptions {
     /// caller-supplied; the crate bakes in no registry of its own. `None`
     /// (the default) reproduces the original commands exactly.
     pub npm_registry: Option<String>,
+    /// Optional caller-provided environment snapshot. When set, doctor clears
+    /// each child command's environment and applies these variables so binary
+    /// resolution, checks, freshness probes, and fixes all see the same shell
+    /// environment. `None` preserves the previous per-call-site behavior.
+    pub env: Option<DoctorEnv>,
+}
+
+impl RunChecksOptions {
+    pub fn with_env_snapshot(mut self, vars: Vec<(String, String)>) -> Self {
+        self.env = Some(DoctorEnv::new(vars));
+        self
+    }
 }
 
 /// Run all health checks and return the report. Equivalent to
@@ -83,17 +98,27 @@ pub async fn run_checks() -> DoctorReport {
 /// Run all health checks with explicit options. Existing callers that want
 /// the cheap, no-network path should keep using [`run_checks`].
 pub async fn run_checks_with_options(opts: RunChecksOptions) -> DoctorReport {
-    let npm_registry = opts.npm_registry.as_deref();
-    let report = collect_base_report(npm_registry).await;
+    let RunChecksOptions {
+        check_freshness,
+        offline,
+        npm_registry,
+        env,
+    } = opts;
+    let env = env.map(Arc::new);
+    let npm_registry = npm_registry.as_deref();
+    let report = collect_base_report(npm_registry, env.clone()).await;
 
-    if opts.check_freshness {
-        populate_freshness(report, opts.offline, npm_registry).await
+    if check_freshness {
+        populate_freshness(report, offline, npm_registry, env).await
     } else {
         report
     }
 }
 
-async fn collect_base_report(npm_registry: Option<&str>) -> DoctorReport {
+async fn collect_base_report(
+    npm_registry: Option<&str>,
+    env: Option<Arc<DoctorEnv>>,
+) -> DoctorReport {
     let mut binary_names: Vec<&'static str> = vec!["git", "gh", "git-lfs"];
     for info in AI_AGENT_CHECKS {
         for cmd in info.commands {
@@ -111,8 +136,9 @@ async fn collect_base_report(npm_registry: Option<&str>) -> DoctorReport {
     let handles: Vec<_> = binary_names
         .iter()
         .map(|&name| {
+            let env = env.clone();
             tokio::task::spawn_blocking(move || {
-                let (resolved, timeouts) = resolve_binary_with_diagnostics(name);
+                let (resolved, timeouts) = resolve_binary_with_diagnostics(name, env.as_deref());
                 (name, resolved, timeouts)
             })
         })
@@ -158,11 +184,20 @@ async fn collect_base_report(npm_registry: Option<&str>) -> DoctorReport {
     let git_lfs_r = r_git_lfs;
     let git_r3 = r_git;
 
-    let c_git = tokio::task::spawn_blocking(move || check_git(&git_r));
-    let c_gh = tokio::task::spawn_blocking(move || check_gh(&gh_r));
-    let c_gh_auth = tokio::task::spawn_blocking(move || check_gh_auth(&gh_r2));
-    let c_git_lfs = tokio::task::spawn_blocking(move || check_git_lfs(&git_r2, &git_lfs_r));
-    let c_clonefile = tokio::task::spawn_blocking(move || check_clonefile(&git_r3));
+    let c_git_env = env.clone();
+    let c_git = tokio::task::spawn_blocking(move || check_git(&git_r, c_git_env.as_deref()));
+    let c_gh_env = env.clone();
+    let c_gh = tokio::task::spawn_blocking(move || check_gh(&gh_r, c_gh_env.as_deref()));
+    let c_gh_auth_env = env.clone();
+    let c_gh_auth =
+        tokio::task::spawn_blocking(move || check_gh_auth(&gh_r2, c_gh_auth_env.as_deref()));
+    let c_git_lfs_env = env.clone();
+    let c_git_lfs = tokio::task::spawn_blocking(move || {
+        check_git_lfs(&git_r2, &git_lfs_r, c_git_lfs_env.as_deref())
+    });
+    let c_clonefile_env = env.clone();
+    let c_clonefile =
+        tokio::task::spawn_blocking(move || check_clonefile(&git_r3, c_clonefile_env.as_deref()));
 
     let npm_registry_owned = npm_registry.map(|s| s.to_string());
     let agent_handles: Vec<_> = AI_AGENT_CHECKS
@@ -170,6 +205,7 @@ async fn collect_base_report(npm_registry: Option<&str>) -> DoctorReport {
         .map(|info| {
             let found = any_agent_found;
             let registry = npm_registry_owned.clone();
+            let env = env.clone();
             let cmds: Vec<ResolvedBinary> = info
                 .commands
                 .iter()
@@ -182,7 +218,14 @@ async fn collect_base_report(npm_registry: Option<&str>) -> DoctorReport {
                 .collect();
             let main = info.main_command.and_then(|cmd| resolved.get(cmd).cloned());
             tokio::task::spawn_blocking(move || {
-                check_single_ai_agent(info, found, &cmds, main.as_ref(), registry.as_deref())
+                check_single_ai_agent(
+                    info,
+                    found,
+                    &cmds,
+                    main.as_ref(),
+                    registry.as_deref(),
+                    env.as_deref(),
+                )
             })
         })
         .collect();
@@ -436,6 +479,7 @@ async fn populate_freshness(
     mut report: DoctorReport,
     offline: bool,
     npm_registry: Option<&str>,
+    env: Option<Arc<DoctorEnv>>,
 ) -> DoctorReport {
     let cache = Arc::new(Mutex::new(load_cache()));
     let npm_registry = npm_registry.map(|s| s.to_string());
@@ -489,6 +533,7 @@ async fn populate_freshness(
     let futures = targets.into_iter().map(|t| {
         let cache = cache.clone();
         let npm_registry = npm_registry.clone();
+        let env = env.clone();
         async move {
             // npm-distributed bridges don't honor `--version`; read their
             // installed version straight from the owning `package.json`.
@@ -498,9 +543,12 @@ async fn populate_freshness(
                 t.package_id.as_deref(),
                 &t.path,
                 probe,
-                offline,
-                npm_registry.as_deref(),
-                cache,
+                FetchVersionInfoOptions {
+                    offline,
+                    npm_registry: npm_registry.as_deref(),
+                    env: env.as_deref(),
+                    cache,
+                },
             )
             .await;
             ((t.id, t.slot), (info, t.package_id))
@@ -578,6 +626,24 @@ struct FreshnessTarget {
     install_source: Option<InstallSource>,
 }
 
+/// Options for executing a doctor fix command.
+#[derive(Debug, Clone, Default)]
+pub struct ExecuteFixOptions {
+    /// Exact command to run instead of looking up a static check fix.
+    pub command_override: Option<String>,
+    /// Optional npm registry override for npm-backed fix/update commands.
+    pub npm_registry: Option<String>,
+    /// Optional caller-provided environment snapshot for the fix subprocess.
+    pub env: Option<DoctorEnv>,
+}
+
+impl ExecuteFixOptions {
+    pub fn with_env_snapshot(mut self, vars: Vec<(String, String)>) -> Self {
+        self.env = Some(DoctorEnv::new(vars));
+        self
+    }
+}
+
 /// Run a fix command for a doctor check, identified by check ID and fix type.
 ///
 /// The actual shell command is looked up from the static check definitions —
@@ -603,8 +669,26 @@ pub async fn execute_fix_with_options(
     command_override: Option<String>,
     npm_registry: Option<&str>,
 ) -> Result<(), String> {
-    execute_fix_streaming_with_options(check_id, fix_type, command_override, npm_registry, |_| {})
-        .await
+    execute_fix_with_env_options(
+        check_id,
+        fix_type,
+        ExecuteFixOptions {
+            command_override,
+            npm_registry: npm_registry.map(str::to_string),
+            env: None,
+        },
+    )
+    .await
+}
+
+/// Like [`execute_fix_with_options`], but accepts the complete fix execution
+/// options, including a caller-provided environment snapshot.
+pub async fn execute_fix_with_env_options(
+    check_id: String,
+    fix_type: FixType,
+    opts: ExecuteFixOptions,
+) -> Result<(), String> {
+    execute_fix_streaming_with_env_options(check_id, fix_type, opts, |_| {}).await
 }
 
 /// Run a fix command and stream its output line-by-line to `on_line`.
@@ -637,17 +721,41 @@ pub async fn execute_fix_streaming_with_options<F>(
     fix_type: FixType,
     command_override: Option<String>,
     npm_registry: Option<&str>,
+    on_line: F,
+) -> Result<(), String>
+where
+    F: FnMut(&str) + Send + 'static,
+{
+    execute_fix_streaming_with_env_options(
+        check_id,
+        fix_type,
+        ExecuteFixOptions {
+            command_override,
+            npm_registry: npm_registry.map(str::to_string),
+            env: None,
+        },
+        on_line,
+    )
+    .await
+}
+
+/// Like [`execute_fix_streaming_with_options`], but accepts the complete fix
+/// execution options, including a caller-provided environment snapshot.
+pub async fn execute_fix_streaming_with_env_options<F>(
+    check_id: String,
+    fix_type: FixType,
+    opts: ExecuteFixOptions,
     mut on_line: F,
 ) -> Result<(), String>
 where
     F: FnMut(&str) + Send + 'static,
 {
-    let command = match command_override {
+    let command = match opts.command_override {
         Some(cmd) => cmd,
         None => lookup_fix_command(&check_id, &fix_type)
             .ok_or_else(|| format!("Unknown check '{check_id}' or fix type '{fix_type:?}'"))?,
     };
-    let command = agents::apply_npm_registry(&command, npm_registry);
+    let command = agents::apply_npm_registry(&command, opts.npm_registry.as_deref());
 
     // Echo the resolved command as a preamble line so downstream callers (e.g.
     // goose-internal's `run_fix`, which `info!`s every callback line and emits
@@ -659,17 +767,23 @@ where
     // Fixes are intentionally not routed through the bounded probe runner:
     // these are user-triggered install/auth/update actions and can reasonably
     // be interactive or long-running.
-    run_command_streaming(command, on_line).await
+    run_command_streaming(command, opts.env, on_line).await
 }
 
 /// Async wrapper that runs `run_command_streaming_blocking` on the blocking pool.
-pub(crate) async fn run_command_streaming<F>(command: String, on_line: F) -> Result<(), String>
+pub(crate) async fn run_command_streaming<F>(
+    command: String,
+    env: Option<DoctorEnv>,
+    on_line: F,
+) -> Result<(), String>
 where
     F: FnMut(&str) + Send + 'static,
 {
-    tokio::task::spawn_blocking(move || run_command_streaming_blocking(&command, on_line))
-        .await
-        .unwrap_or_else(|e| Err(format!("Task failed: {e}")))
+    tokio::task::spawn_blocking(move || {
+        run_command_streaming_blocking(&command, env.as_ref(), on_line)
+    })
+    .await
+    .unwrap_or_else(|e| Err(format!("Task failed: {e}")))
 }
 
 enum StreamLine {
@@ -677,35 +791,94 @@ enum StreamLine {
     Stderr(String),
 }
 
-/// Build the login-shell `Command` used by every doctor exec path. Optionally
-/// prepends `path_prefix` directories to the child `PATH` so a binary that's
-/// only findable in the resolved location (e.g. an nvm bin dir) is visible to
-/// the spawned shell even when the parent process was launched with a
-/// restricted `PATH` (the macOS Finder/launchd case). When `path_prefix` is
-/// empty the env layout is byte-identical to the previous implementation, so
-/// existing call sites are unaffected.
-fn build_shell_command(command: &str, path_prefix: &[PathBuf]) -> std::process::Command {
+/// Build the login-shell `Command` used by every doctor exec path. Without a
+/// caller env snapshot, `path_prefix` keeps the legacy behavior of prepending
+/// resolved binary dirs plus conservative fallbacks. With a snapshot, doctor
+/// preserves the snapshot environment and appends missing prefix dirs to its
+/// `PATH` so auth probes can still find resolved binaries without replacing
+/// the caller's environment.
+fn build_shell_command(
+    command: &str,
+    path_prefix: &[PathBuf],
+    env: Option<&DoctorEnv>,
+) -> std::process::Command {
     let (shell, args) = if std::path::Path::new("/bin/zsh").exists() {
         ("/bin/zsh", vec!["-l", "-c", command])
     } else {
         ("/bin/bash", vec!["-l", "-c", command])
     };
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/".to_string());
-    let user = std::env::var("USER").unwrap_or_default();
+    let home = env
+        .and_then(|e| e.get("HOME").map(str::to_string))
+        .or_else(|| std::env::var("HOME").ok())
+        .unwrap_or_else(|| "/".to_string());
+    let user = env
+        .and_then(|e| e.get("USER").map(str::to_string))
+        .or_else(|| std::env::var("USER").ok())
+        .unwrap_or_default();
 
     let mut cmd = std::process::Command::new(shell);
-    cmd.args(&args)
-        .env_clear()
-        .env("HOME", &home)
-        .env("USER", &user)
-        .env("TERM", "xterm-256color")
-        .current_dir(&home);
-    if !path_prefix.is_empty() {
-        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut path = String::new();
-        for p in path_prefix {
-            let s = p.to_string_lossy().to_string();
-            if !seen.insert(s.clone()) {
+    cmd.args(&args).env_clear();
+
+    if let Some(env) = env {
+        for (key, value) in &env.vars {
+            cmd.env(key, value);
+        }
+        if env.get("HOME").is_none() {
+            cmd.env("HOME", &home);
+        }
+        if env.get("USER").is_none() {
+            cmd.env("USER", &user);
+        }
+        cmd.env("TERM", "xterm-256color").current_dir(&home);
+        if let Some(path) = merged_snapshot_path(env.get("PATH"), path_prefix) {
+            cmd.env("PATH", path);
+        }
+    } else {
+        cmd.env("HOME", &home)
+            .env("USER", &user)
+            .env("TERM", "xterm-256color")
+            .current_dir(&home);
+        if !path_prefix.is_empty() {
+            let path = legacy_prefixed_path(path_prefix);
+            cmd.env("PATH", path);
+        }
+    }
+
+    cmd
+}
+
+fn legacy_prefixed_path(path_prefix: &[PathBuf]) -> String {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut path = String::new();
+    for p in path_prefix {
+        let s = p.to_string_lossy().to_string();
+        if !seen.insert(s.clone()) {
+            continue;
+        }
+        if !path.is_empty() {
+            path.push(':');
+        }
+        path.push_str(&s);
+    }
+    // Conservative fallback ~ what login zsh on macOS sees before
+    // /etc/zprofile augments it. Keeps the rest of the resolved-binary
+    // dir's command graph reachable (e.g. node, npm) without depending on
+    // the parent process's PATH.
+    path.push_str(":/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+    path
+}
+
+fn merged_snapshot_path(snapshot_path: Option<&str>, path_prefix: &[PathBuf]) -> Option<String> {
+    if snapshot_path.is_none() && path_prefix.is_empty() {
+        return None;
+    }
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut path = String::new();
+    if let Some(snapshot_path) = snapshot_path {
+        for entry in std::env::split_paths(snapshot_path) {
+            let s = entry.to_string_lossy().to_string();
+            if s.is_empty() || !seen.insert(s.clone()) {
                 continue;
             }
             if !path.is_empty() {
@@ -713,14 +886,18 @@ fn build_shell_command(command: &str, path_prefix: &[PathBuf]) -> std::process::
             }
             path.push_str(&s);
         }
-        // Conservative fallback ~ what login zsh on macOS sees before
-        // /etc/zprofile augments it. Keeps the rest of the resolved-binary
-        // dir's command graph reachable (e.g. node, npm) without depending on
-        // the parent process's PATH.
-        path.push_str(":/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin");
-        cmd.env("PATH", path);
     }
-    cmd
+    for p in path_prefix {
+        let s = p.to_string_lossy().to_string();
+        if s.is_empty() || !seen.insert(s.clone()) {
+            continue;
+        }
+        if !path.is_empty() {
+            path.push(':');
+        }
+        path.push_str(&s);
+    }
+    Some(path)
 }
 
 /// Detailed outcome of running a command. Lets the caller distinguish
@@ -746,14 +923,15 @@ pub(crate) enum ExecOutcome {
     },
 }
 
-/// Run `command` through a login shell, with the caller-supplied `path_prefix`
-/// prepended to the child `PATH`. Returns the detailed exec outcome. No
+/// Run `command` through a login shell, merging the caller-supplied
+/// `path_prefix` into the child `PATH`. Returns the detailed exec outcome. No
 /// streaming — used by the auth probe which wants a single sync result.
-pub(crate) fn execute_command_with_path_prefix(
+pub(crate) fn execute_command_with_path_prefix_with_env(
     command: &str,
     path_prefix: &[PathBuf],
+    env: Option<&DoctorEnv>,
 ) -> ExecOutcome {
-    let cmd = build_shell_command(command, path_prefix);
+    let cmd = build_shell_command(command, path_prefix, env);
     let output = match run_command_with_timeout(cmd, command, DEFAULT_PROBE_TIMEOUT) {
         Ok(output) => output,
         Err(CommandError::Spawn { source, .. } | CommandError::Wait { source, .. }) => {
@@ -779,13 +957,17 @@ pub(crate) fn execute_command_with_path_prefix(
 /// actions and may prompt or run package managers. Stderr lines are also
 /// accumulated so a non-zero exit can surface a useful error message (matching
 /// the non-streaming behavior of the previous `execute_command`).
-fn run_command_streaming_blocking<F>(command: &str, mut on_line: F) -> Result<(), String>
+fn run_command_streaming_blocking<F>(
+    command: &str,
+    env: Option<&DoctorEnv>,
+    mut on_line: F,
+) -> Result<(), String>
 where
     F: FnMut(&str),
 {
     use std::io::{BufRead, BufReader};
 
-    let mut child = build_shell_command(command, &[])
+    let mut child = build_shell_command(command, &[], env)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -853,11 +1035,40 @@ where
 mod tests {
     use super::*;
 
+    use std::path::Path;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     fn timeout(label: &str, command: &str) -> CommandTimeout {
         CommandTimeout::new(label, command, Duration::from_secs(15))
+    }
+
+    fn unique_tmp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "doctor-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_executable(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).unwrap();
+        }
     }
 
     #[test]
@@ -910,6 +1121,7 @@ mod tests {
 
         let result = run_command_streaming(
             "echo doctor-streaming-marker-hello && echo doctor-streaming-marker-world".to_string(),
+            None,
             move |line| {
                 lines_clone.lock().unwrap().push(line.to_string());
             },
@@ -950,7 +1162,7 @@ mod tests {
     #[tokio::test]
     async fn exec_command_not_found_reports_exit_127() {
         let outcome = tokio::task::spawn_blocking(|| {
-            execute_command_with_path_prefix("doctor-nonexistent-xyz-12345", &[])
+            execute_command_with_path_prefix_with_env("doctor-nonexistent-xyz-12345", &[], None)
         })
         .await
         .unwrap();
@@ -991,7 +1203,7 @@ mod tests {
 
         let prefix = vec![tmp.clone()];
         let outcome = tokio::task::spawn_blocking(move || {
-            execute_command_with_path_prefix(script_name, &prefix)
+            execute_command_with_path_prefix_with_env(script_name, &prefix, None)
         })
         .await
         .unwrap();
@@ -1001,6 +1213,37 @@ mod tests {
             other => {
                 panic!("expected Ok with the script reachable via path prefix; got {other:?}",)
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn exec_command_with_path_prefix_merges_env_snapshot() {
+        let tmp = unique_tmp_dir("auth-env-merge");
+        let script_name = "doctor-auth-env-probe";
+        let script = tmp.join(script_name);
+        write_executable(
+            &script,
+            "#!/bin/sh\n\
+             test \"$DOCTOR_AUTH_MARKER\" = yes\n",
+        );
+        let env = DoctorEnv::new(vec![
+            ("DOCTOR_AUTH_MARKER".to_string(), "yes".to_string()),
+            ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ("HOME".to_string(), tmp.to_string_lossy().to_string()),
+            ("USER".to_string(), "doctor-test".to_string()),
+        ]);
+        let prefix = vec![tmp.clone()];
+
+        let outcome = tokio::task::spawn_blocking(move || {
+            execute_command_with_path_prefix_with_env(script_name, &prefix, Some(&env))
+        })
+        .await
+        .unwrap();
+
+        let _ = std::fs::remove_dir_all(&tmp);
+        match outcome {
+            ExecOutcome::Ok => {}
+            other => panic!("expected Ok with prefix PATH and env marker merged; got {other:?}"),
         }
     }
 
@@ -1148,6 +1391,55 @@ mod tests {
         assert!(
             captured.iter().any(|l| l == "hello"),
             "subprocess output line should follow the preamble; captured: {captured:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_fix_streaming_with_env_options_uses_snapshot_path() {
+        let tmp = unique_tmp_dir("fix-env-path");
+        let script_name = "doctor-fix-env-probe";
+        let script = tmp.join(script_name);
+        write_executable(
+            &script,
+            "#!/bin/sh\n\
+             test \"$DOCTOR_FIX_MARKER\" = yes || exit 42\n\
+             echo fix-env-ok\n",
+        );
+        let mut path = tmp.to_string_lossy().to_string();
+        if let Ok(existing) = std::env::var("PATH") {
+            path.push(':');
+            path.push_str(&existing);
+        }
+        let env = DoctorEnv::new(vec![
+            ("DOCTOR_FIX_MARKER".to_string(), "yes".to_string()),
+            ("PATH".to_string(), path),
+            ("HOME".to_string(), tmp.to_string_lossy().to_string()),
+            ("USER".to_string(), "doctor-test".to_string()),
+            ("ZDOTDIR".to_string(), tmp.to_string_lossy().to_string()),
+        ]);
+        let lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let lines_clone = lines.clone();
+
+        let result = execute_fix_streaming_with_env_options(
+            "ai-agent-claude".to_string(),
+            FixType::UpdateMain,
+            ExecuteFixOptions {
+                command_override: Some(script_name.to_string()),
+                npm_registry: None,
+                env: Some(env),
+            },
+            move |line| {
+                lines_clone.lock().unwrap().push(line.to_string());
+            },
+        )
+        .await;
+
+        let captured = lines.lock().unwrap().clone();
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(result.is_ok(), "snapshot PATH command failed: {result:?}");
+        assert!(
+            captured.iter().any(|line| line == "fix-env-ok"),
+            "expected command output from snapshot PATH script; captured: {captured:?}",
         );
     }
 

--- a/crates/doctor/src/resolve.rs
+++ b/crates/doctor/src/resolve.rs
@@ -6,18 +6,36 @@ use std::process::Command;
 use crate::command::{
     format_duration, run_command_with_timeout, CommandError, CommandTimeout, DEFAULT_PROBE_TIMEOUT,
 };
+use crate::environment::{apply_doctor_env, DoctorEnv};
 
 use super::types::{InstallSource, ResolvedBinary};
 
 /// Resolve a binary by trying login shell path lookup, common install paths,
 /// then npm global install dirs.
 pub fn resolve_binary(cmd: &str) -> ResolvedBinary {
-    resolve_binary_with_diagnostics(cmd).0
+    resolve_binary_with_diagnostics(cmd, None).0
 }
 
-pub(crate) fn resolve_binary_with_diagnostics(cmd: &str) -> (ResolvedBinary, Vec<CommandTimeout>) {
+/// Resolve a binary using a caller-provided environment snapshot.
+pub fn resolve_binary_with_env(cmd: &str, env: &DoctorEnv) -> ResolvedBinary {
+    resolve_binary_with_diagnostics(cmd, Some(env)).0
+}
+
+pub(crate) fn resolve_binary_with_diagnostics(
+    cmd: &str,
+    env: Option<&DoctorEnv>,
+) -> (ResolvedBinary, Vec<CommandTimeout>) {
     let mut lines = vec![format!("resolve '{cmd}':")];
     let mut timeouts = Vec::new();
+
+    if let Some(path_value) = env.and_then(|env| env.get("PATH")) {
+        lines.push("  strategy 0 — caller environment PATH:".to_string());
+        if let Some(path) = resolve_from_path(cmd, path_value) {
+            lines.push(format!("    PATH => {} (resolved)", path.display()));
+            return resolved_binary(path, &lines, timeouts, env);
+        }
+        lines.push("    PATH => not found".to_string());
+    }
 
     // Strategy 1: Login shell path lookup (primary)
     lines.push("  strategy 1 — login shell path lookup:".to_string());
@@ -25,6 +43,7 @@ pub(crate) fn resolve_binary_with_diagnostics(cmd: &str) -> (ResolvedBinary, Vec
         let display_command = format!("{shell} -l -c '{lookup_cmd}'");
         let mut command = Command::new(shell);
         command.args(["-l", "-c", &lookup_cmd]);
+        apply_doctor_env(&mut command, env);
         match run_command_with_timeout(command, &display_command, DEFAULT_PROBE_TIMEOUT) {
             Ok(output) => {
                 let stdout = String::from_utf8_lossy(&output.stdout);
@@ -43,7 +62,7 @@ pub(crate) fn resolve_binary_with_diagnostics(cmd: &str) -> (ResolvedBinary, Vec
                         "    {shell} -l -c '{lookup_cmd}' => {} (resolved)",
                         path.display()
                     ));
-                    return resolved_binary(path.clone(), &lines, timeouts);
+                    return resolved_binary(path.clone(), &lines, timeouts, env);
                 }
 
                 if let Some(path) = candidate_paths.first() {
@@ -88,7 +107,7 @@ pub(crate) fn resolve_binary_with_diagnostics(cmd: &str) -> (ResolvedBinary, Vec
         let path = PathBuf::from(dir).join(cmd);
         if is_executable_file(&path) {
             lines.push(format!("    {} => found (resolved)", path.display()));
-            return resolved_binary(path, &lines, timeouts);
+            return resolved_binary(path, &lines, timeouts, env);
         }
         lines.push(format!("    {} => not found", path.display()));
     }
@@ -101,13 +120,15 @@ pub(crate) fn resolve_binary_with_diagnostics(cmd: &str) -> (ResolvedBinary, Vec
     // npm-only installs are "found" by goose-internal's ACP inventory but
     // reported missing by doctor.
     lines.push("  strategy 3 — npm global install dirs:".to_string());
-    let home = std::env::home_dir();
+    let home = env
+        .and_then(|env| env.get("HOME").map(PathBuf::from))
+        .or_else(std::env::home_dir);
     if let Some(home) = home.as_deref() {
         for dir in npm_search_dirs(home) {
             let path = dir.join(cmd);
             if path.exists() {
                 lines.push(format!("    {} => found (resolved)", path.display()));
-                return resolved_binary(path, &lines, timeouts);
+                return resolved_binary(path, &lines, timeouts, env);
             }
             lines.push(format!("    {} => not found", path.display()));
         }
@@ -119,11 +140,11 @@ pub(crate) fn resolve_binary_with_diagnostics(cmd: &str) -> (ResolvedBinary, Vec
     // but costs one subprocess — only invoked when the static probes above
     // didn't find the binary). `npm prefix -g` is the version-stable
     // equivalent of the older `npm bin -g`; the bin dir is `<prefix>/bin`.
-    if let Some(npm_bin_dir) = npm_global_bin_dir(&mut lines, &mut timeouts) {
+    if let Some(npm_bin_dir) = npm_global_bin_dir(&mut lines, &mut timeouts, env) {
         let path = npm_bin_dir.join(cmd);
         if path.exists() {
             lines.push(format!("    {} => found (resolved)", path.display()));
-            return resolved_binary(path, &lines, timeouts);
+            return resolved_binary(path, &lines, timeouts, env);
         }
         lines.push(format!("    {} => not found", path.display()));
     }
@@ -139,12 +160,19 @@ pub(crate) fn resolve_binary_with_diagnostics(cmd: &str) -> (ResolvedBinary, Vec
     )
 }
 
+fn resolve_from_path(cmd: &str, path_value: &str) -> Option<PathBuf> {
+    std::env::split_paths(path_value)
+        .map(|dir| dir.join(cmd))
+        .find(|path| is_executable_file(path))
+}
+
 fn resolved_binary(
     path: PathBuf,
     lines: &[String],
     timeouts: Vec<CommandTimeout>,
+    env: Option<&DoctorEnv>,
 ) -> (ResolvedBinary, Vec<CommandTimeout>) {
-    let install_source = Some(detect_install_source(&path));
+    let install_source = Some(detect_install_source_with_env(&path, env));
     (
         ResolvedBinary {
             path: Some(path),
@@ -153,6 +181,28 @@ fn resolved_binary(
         },
         timeouts,
     )
+}
+
+/// Infer how a binary was installed. First applies path-prefix heuristics (no
+/// subprocess or network probes) covering Brew, Cargo, Mise, Asdf, Npm
+/// (mirroring the dirs in [`npm_search_dirs`]), and the System dirs. When those
+/// fall through to [`InstallSource::Unknown`] for a binary in a user-local bin
+/// dir, a cheap filesystem fingerprint (see [`fingerprint_curl_pipe`]) is
+/// attempted to recognise curl/native installers (Claude native, Cursor, Amp),
+/// using the caller snapshot's `HOME` when one is supplied.
+fn detect_install_source_with_env(path: &Path, env: Option<&DoctorEnv>) -> InstallSource {
+    let home = env
+        .and_then(|env| env.get("HOME").map(PathBuf::from))
+        .or_else(std::env::home_dir);
+    let base = detect_install_source_with_home(path, home.as_deref());
+    if base == InstallSource::Unknown {
+        if let Some(home) = home.as_deref() {
+            if fingerprint_curl_pipe(path, home) {
+                return InstallSource::CurlPipe;
+            }
+        }
+    }
+    base
 }
 
 fn shell_lookup_commands(cmd: &str) -> [(&'static str, String); 2] {
@@ -241,9 +291,11 @@ fn read_subdirs(parent: &Path) -> Vec<PathBuf> {
 fn npm_global_bin_dir(
     lines: &mut Vec<String>,
     timeouts: &mut Vec<CommandTimeout>,
+    env: Option<&DoctorEnv>,
 ) -> Option<PathBuf> {
     let mut command = Command::new("npm");
     command.args(["prefix", "-g"]);
+    apply_doctor_env(&mut command, env);
     let output = match run_command_with_timeout(command, "npm prefix -g", DEFAULT_PROBE_TIMEOUT) {
         Ok(output) => output,
         Err(CommandError::Timeout { command, timeout }) => {
@@ -271,27 +323,6 @@ fn npm_global_bin_dir(
     let bin = PathBuf::from(prefix).join("bin");
     lines.push(format!("    npm prefix -g => {}", bin.display()));
     Some(bin)
-}
-
-/// Infer how a binary was installed. First applies path-prefix heuristics (no
-/// subprocess or network probes) covering Brew, Cargo, Mise, Asdf, Npm
-/// (mirroring the dirs in [`npm_search_dirs`]), and the System dirs. When those
-/// fall through to [`InstallSource::Unknown`] for a binary in a user-local bin
-/// dir, a cheap filesystem fingerprint (see [`fingerprint_curl_pipe`]) is
-/// attempted to recognise curl/native installers (Claude native, Cursor, Amp),
-/// which land in `~/.local/bin`/`~/bin`. [`InstallSource::Unknown`] remains the
-/// honest fallback when no fingerprint matches.
-pub(crate) fn detect_install_source(path: &Path) -> InstallSource {
-    let home = std::env::home_dir();
-    let base = detect_install_source_with_home(path, home.as_deref());
-    if base == InstallSource::Unknown {
-        if let Some(home) = home.as_deref() {
-            if fingerprint_curl_pipe(path, home) {
-                return InstallSource::CurlPipe;
-            }
-        }
-    }
-    base
 }
 
 /// A known curl/native installer footprint for a binary that lands in a
@@ -569,6 +600,38 @@ mod tests {
         }
 
         assert!(!is_executable_file(&dir));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resolve_binary_with_env_finds_binary_only_in_snapshot_path() {
+        let dir =
+            std::env::temp_dir().join(format!("doctor-resolve-env-path-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let bin = dir.join("doctor-env-only-tool");
+        fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let env = crate::DoctorEnv::new(vec![
+            ("PATH".to_string(), dir.to_string_lossy().to_string()),
+            ("HOME".to_string(), dir.to_string_lossy().to_string()),
+        ]);
+        let resolved = resolve_binary_with_env("doctor-env-only-tool", &env);
+
+        assert_eq!(resolved.path.as_deref(), Some(bin.as_path()));
+        assert!(
+            resolved
+                .search_output
+                .contains("strategy 0 — caller environment PATH"),
+            "search trace should mention the snapshot PATH strategy:\n{}",
+            resolved.search_output,
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
## Summary
- add doctor environment snapshots for binary resolution, checks, freshness probes, and fix execution
- capture and sanitize Staged home shell env with an extended PATH for doctor subprocesses
- route Tauri and web doctor entry points through the snapshot-aware APIs