### PR TITLE
feat: make note references navigable

### DIFF
--- a/apps/staged/src/App.svelte
+++ b/apps/staged/src/App.svelte
@@ -15,6 +15,7 @@
   import SessionLauncher from './lib/features/sessions/SessionLauncher.svelte';
   import SettingsPage from './lib/features/settings/SettingsPage.svelte';
   import DiffModal from './lib/features/diff/DiffModal.svelte';
+  import ReferenceModalHost from './lib/features/references/ReferenceModalHost.svelte';
   import { Toaster } from '$lib/components/ui/sonner';
   import { Button } from '$lib/components/ui/button';
   import {
@@ -600,6 +601,7 @@
     <SessionLauncher onClose={() => (showSessionLab = false)} />
   {/if}
 
+  <ReferenceModalHost />
   <Toaster position="bottom-right" visibleToasts={4} duration={8000} closeButton expand />
 {/if}
 

--- a/apps/staged/src/app.css
+++ b/apps/staged/src/app.css
@@ -253,6 +253,19 @@ mark.search-match-current {
   flex-shrink: 0;
 }
 
+.hashtag-badge[data-hashtag-ref] {
+  cursor: pointer;
+}
+
+.hashtag-badge[data-hashtag-ref]:hover {
+  filter: brightness(0.96);
+}
+
+.hashtag-badge[data-hashtag-ref]:focus-visible {
+  outline: 2px solid var(--ui-accent);
+  outline-offset: 2px;
+}
+
 /*---break---
  */
 

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -91,6 +91,14 @@
   import { openDiffRoute } from '../layout/navigation.svelte';
   import type { WorktreeChangesPreview } from '../../commands';
   import type { LinkedNoteContext, NoteClickInfo } from '../sessions/noteFreshness';
+  import {
+    disabledReferenceNav,
+    pushReferenceEntry,
+    resolveHashtagReference,
+    type HashtagClickInfo,
+    type ReferenceDiffContext,
+    type ReferenceHistoryEntry,
+  } from '../references/referenceHistory.svelte';
 
   interface Props {
     branch: Branch;
@@ -172,7 +180,17 @@
   // Hashtag items for rendering #type:id badges in timeline titles.
   // Timeline-derived items are computed reactively so badges update when timeline refreshes.
   // Project notes are loaded async separately (they don't change during note generation).
-  let timelineHashtagItems = $derived(timeline ? timelineToHashtagItems(timeline) : []);
+  let timelineHashtagItems = $derived(
+    timeline
+      ? timelineToHashtagItems(
+          timeline,
+          branch.branchName,
+          repoLabel?.headRepo ?? repoLabel?.githubRepo,
+          repoLabel?.subpath,
+          { branchId: branch.id, projectId: branch.projectId }
+        )
+      : []
+  );
   let projectNoteHashtagItems = $state<HashtagItem[]>([]);
   $effect(() => {
     const projectId = branch.projectId;
@@ -190,6 +208,16 @@
     };
   });
   let hashtagItems = $derived([...timelineHashtagItems, ...projectNoteHashtagItems]);
+  let referenceDiffContext = $derived<ReferenceDiffContext>({
+    branchId: branch.id,
+    projectId: branch.projectId,
+    commits: timeline?.commits,
+    baseBranchLabel: formatBaseBranch(branch.baseBranch),
+    branchLabel: branch.branchName,
+    projectName,
+    githubRepo: repoLabel?.headRepo ?? repoLabel?.githubRepo,
+    subpath: repoLabel?.subpath,
+  });
   let reviewDetailsLoadVersion = 0;
 
   /** True when the branch is still provisioning (local worktree or remote workspace). */
@@ -1299,6 +1327,97 @@
     }
   }
 
+  function currentDialogReferenceEntry(): ReferenceHistoryEntry | null {
+    if (openNote) {
+      return {
+        kind: 'note',
+        noteKind: 'branch',
+        id: openNote.noteId,
+        ref: `#note:${openNote.noteId}`,
+        title: openNote.title,
+        content: openNote.content,
+        view: 'note',
+        sessionId: openNote.sessionId,
+        noteUpdatedAt: openNote.noteUpdatedAt,
+        branchId: branch.id,
+        projectId: branch.projectId,
+        hashtagItems,
+        diffContext: referenceDiffContext,
+      };
+    }
+
+    if (sessionMgr.openSessionId) {
+      const noteInfo = findNoteForSession(sessionMgr.openSessionId);
+      if (noteInfo) {
+        return {
+          kind: 'note',
+          noteKind: 'branch',
+          id: noteInfo.id,
+          ref: `#note:${noteInfo.id}`,
+          title: noteInfo.title,
+          content: noteInfo.content,
+          view: 'chat',
+          sessionId: sessionMgr.openSessionId,
+          noteUpdatedAt: noteInfo.updatedAt,
+          branchId: branch.id,
+          projectId: branch.projectId,
+          hashtagItems,
+          diffContext: referenceDiffContext,
+        };
+      }
+
+      return {
+        kind: 'chat',
+        ref: `#chat:${sessionMgr.openSessionId}`,
+        sessionId: sessionMgr.openSessionId,
+        branchId: branch.id,
+        projectId: branch.projectId,
+        repoDir: branch.worktreePath,
+        repoLabel,
+        hashtagItems,
+        diffContext: referenceDiffContext,
+      };
+    }
+
+    if (viewImageId) {
+      return {
+        kind: 'image',
+        ref: `#image:${viewImageId}`,
+        imageId: viewImageId,
+        filename: viewImageFilename,
+        branchId: branch.id,
+        projectId: branch.projectId,
+        hashtagItems,
+        diffContext: referenceDiffContext,
+      };
+    }
+
+    return null;
+  }
+
+  function closeReferenceDialogs() {
+    openNote = null;
+    sessionMgr.openSessionId = null;
+    viewImageId = null;
+  }
+
+  function handleHashtagClick(click: HashtagClickInfo) {
+    const target = resolveHashtagReference(click, {
+      hashtagItems,
+      diffContext: referenceDiffContext,
+    });
+    if (!target) return;
+
+    const current = currentDialogReferenceEntry();
+    if (current) pushReferenceEntry(current);
+    pushReferenceEntry(target);
+    closeReferenceDialogs();
+
+    if (target.kind === 'diff') {
+      openDiffRoute(target.route);
+    }
+  }
+
   function handleDeleteImage(imageId: string, opts?: { altKey: boolean }) {
     const doDelete = async () => {
       confirmDelete = null;
@@ -1730,11 +1849,14 @@
     sessionId={openNote.sessionId}
     noteUpdatedAt={openNote.noteUpdatedAt}
     nextSteps={openNote.nextSteps}
+    {hashtagItems}
+    referenceNav={disabledReferenceNav}
     onClose={() => (openNote = null)}
     onOpenSession={(sid) => {
       openNote = null;
       sessionMgr.openSessionId = sid;
     }}
+    onHashtagClick={handleHashtagClick}
     onStartSession={(mode, prefill) => {
       const noteRef = openNote?.noteId ? `Re: #note:${openNote.noteId}` : '';
       openNote = null;
@@ -1748,6 +1870,7 @@
     open={true}
     imageId={viewImageId}
     filename={viewImageFilename}
+    referenceNav={disabledReferenceNav}
     onClose={() => {
       viewImageId = null;
     }}
@@ -1817,6 +1940,7 @@
     projectId={branch.projectId}
     {repoLabel}
     noteInfo={findNoteForSession(sessionMgr.openSessionId)}
+    referenceNav={disabledReferenceNav}
     onOpenNote={(note) => {
       const sid = sessionMgr.openSessionId;
       sessionMgr.openSessionId = null;
@@ -1830,6 +1954,7 @@
       };
     }}
     onClose={handleSessionModalClose}
+    onHashtagClick={handleHashtagClick}
   />
 {/if}
 

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -51,6 +51,7 @@
     CommentActionContext,
     CommentSessionState,
     CommitTimelineItem,
+    HashtagItem,
     SessionStatus,
     SmartDiffAnnotation,
     Span,
@@ -59,6 +60,7 @@
   import { findFreshAutoReview, getSession } from '../../commands';
   import * as commands from '../../api/commands';
   import { startOrQueueBranchSessionWithPending } from '../branches/branchSessionLaunch.svelte';
+  import { buildBranchHashtagItems } from '../sessions/hashtagItems';
   import {
     buildFileEntries,
     buildTree,
@@ -71,6 +73,15 @@
     type TreeNode,
   } from './diffModalHelpers';
   import TopBarPortal from '../layout/TopBarPortal.svelte';
+  import { openDiffRoute } from '../layout/navigation.svelte';
+  import {
+    disabledReferenceNav,
+    pushReferenceEntry,
+    resolveHashtagReference,
+    type HashtagClickInfo,
+    type ReferenceDiffContext,
+    type ReferenceHistoryEntry,
+  } from '../references/referenceHistory.svelte';
 
   // ==========================================================================
   // Props
@@ -446,6 +457,7 @@
   // ==========================================================================
 
   let branch = $state<Branch | null>(null);
+  let hashtagItems = $state<HashtagItem[]>([]);
 
   onMount(() => {
     commands
@@ -458,6 +470,34 @@
 
   let isRemote = $derived(branch?.branchType === 'remote');
   let hasPr = $derived(branch?.prNumber != null);
+  let referenceDiffContext = $derived<ReferenceDiffContext>({
+    branchId,
+    projectId,
+    commits,
+    baseBranchLabel,
+    branchLabel,
+    projectName,
+    githubRepo,
+    subpath,
+  });
+
+  $effect(() => {
+    let stale = false;
+    buildBranchHashtagItems(branchId, projectId ?? null, {
+      branchName: branchLabel,
+      repoSlug: githubRepo,
+      repoSubpath: subpath,
+    })
+      .then((items) => {
+        if (!stale) hashtagItems = items;
+      })
+      .catch(() => {
+        if (!stale) hashtagItems = [];
+      });
+    return () => {
+      stale = true;
+    };
+  });
 
   // ==========================================================================
   // New Session Modal state
@@ -476,6 +516,7 @@
   /** Linked session dialogs opened from a comment's Note/Commit button. */
   let openSessionId = $state<string | null>(null);
   let openNote = $state<{
+    noteId?: string;
     title: string;
     content: string;
     sessionId?: string;
@@ -736,6 +777,7 @@
         return;
       }
       openNote = {
+        noteId: note.id,
         title: note.title,
         content: note.content,
         sessionId,
@@ -762,6 +804,64 @@
       toast.error('Unable to show commit', {
         description: e instanceof Error ? e.message : String(e),
       });
+    }
+  }
+
+  function currentDialogReferenceEntry(): ReferenceHistoryEntry | null {
+    if (openNote) {
+      return {
+        kind: 'note',
+        noteKind: 'branch',
+        id: openNote.noteId ?? openNote.sessionId ?? 'note',
+        ref: openNote.noteId ? `#note:${openNote.noteId}` : `#chat:${openNote.sessionId}`,
+        title: openNote.title,
+        content: openNote.content,
+        view: 'note',
+        sessionId: openNote.sessionId,
+        noteUpdatedAt: openNote.noteUpdatedAt,
+        branchId,
+        projectId,
+        hashtagItems,
+        diffContext: referenceDiffContext,
+      };
+    }
+
+    if (openSessionId) {
+      return {
+        kind: 'chat',
+        ref: `#chat:${openSessionId}`,
+        sessionId: openSessionId,
+        branchId,
+        projectId,
+        repoDir: branch?.worktreePath,
+        repoLabel: githubRepo ? { githubRepo, subpath: subpath ?? null, headRepo: null } : null,
+        hashtagItems,
+        diffContext: referenceDiffContext,
+      };
+    }
+
+    return null;
+  }
+
+  function closeReferenceDialogs() {
+    openNote = null;
+    openSessionId = null;
+  }
+
+  function handleHashtagClick(click: HashtagClickInfo) {
+    const target = resolveHashtagReference(click, {
+      hashtagItems,
+      diffContext: referenceDiffContext,
+    });
+    if (!target) return;
+
+    const current = currentDialogReferenceEntry();
+    if (current) pushReferenceEntry(current);
+    pushReferenceEntry(target);
+    closeReferenceDialogs();
+
+    if (target.kind === 'diff') {
+      openDiffRoute(target.route);
     }
   }
 
@@ -1666,9 +1766,11 @@
     {branchId}
     {projectId}
     repoLabel={githubRepo ? { githubRepo, subpath: subpath ?? null, headRepo: null } : null}
+    referenceNav={disabledReferenceNav}
     onClose={() => {
       openSessionId = null;
     }}
+    onHashtagClick={handleHashtagClick}
   />
 
   <NoteModal
@@ -1677,6 +1779,8 @@
     content={openNote?.content ?? ''}
     sessionId={openNote?.sessionId}
     noteUpdatedAt={openNote?.noteUpdatedAt}
+    {hashtagItems}
+    referenceNav={disabledReferenceNav}
     onClose={() => {
       openNote = null;
     }}
@@ -1684,6 +1788,7 @@
       openNote = null;
       openSessionId = sid;
     }}
+    onHashtagClick={handleHashtagClick}
   />
 </div>
 

--- a/apps/staged/src/lib/features/layout/navigation.svelte.ts
+++ b/apps/staged/src/lib/features/layout/navigation.svelte.ts
@@ -284,6 +284,7 @@ export function openDiffRoute(route: Omit<DiffDetailRoute, 'kind'>): void {
 export function popDetailRoute(): void {
   if (navigation.detailStack.length <= 1) return;
 
+  const poppedRoute = currentRoute();
   const previousProjectId = navigation.selectedProjectId;
   const nextStack = navigation.detailStack.slice(0, -1);
   setDetailStack(nextStack);
@@ -294,6 +295,12 @@ export function popDetailRoute(): void {
     persistLastProject(null);
   } else if (nextRoute.kind === 'project') {
     persistLastProject(nextRoute.projectId);
+  }
+
+  if (poppedRoute.kind === 'diff') {
+    window.dispatchEvent(
+      new CustomEvent('staged:diff-route-popped', { detail: { route: poppedRoute } })
+    );
   }
 }
 

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -29,7 +29,7 @@
   import { loadPikchrRenderer, type PikchrRenderer } from '../../shared/markdown/pikchrRendering';
   import { noteMarkdownWithTitle, renderNoteMarkdown } from './noteMarkdown';
   import type { HashtagItem } from '../../types';
-  import { renderHashtagTokens } from '../sessions/hashtagItems';
+  import { findHashtagItemForReference, renderHashtagTokens } from '../sessions/hashtagItems';
   import ReferenceNavControls from '../references/ReferenceNavControls.svelte';
   import type { HashtagClickInfo, ReferenceNavState } from '../references/referenceHistory.svelte';
 
@@ -259,7 +259,7 @@
     const id = badge.dataset.hashtagId;
     const ref = badge.dataset.hashtagRef;
     if (!type || !id || !ref) return null;
-    const item = hashtagItems.find((candidate) => candidate.type === type && candidate.id === id);
+    const item = findHashtagItemForReference(hashtagItems, type, id);
     return { type, id, ref, item };
   }
 

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -28,6 +28,10 @@
   } from '../../shared/markdown/diagramViewer';
   import { loadPikchrRenderer, type PikchrRenderer } from '../../shared/markdown/pikchrRendering';
   import { noteMarkdownWithTitle, renderNoteMarkdown } from './noteMarkdown';
+  import type { HashtagItem } from '../../types';
+  import { renderHashtagTokens } from '../sessions/hashtagItems';
+  import ReferenceNavControls from '../references/ReferenceNavControls.svelte';
+  import type { HashtagClickInfo, ReferenceNavState } from '../references/referenceHistory.svelte';
 
   interface Props {
     open: boolean;
@@ -42,6 +46,9 @@
     nextSteps?: { commitStep: string | null; noteStep: string | null } | null;
     /** Called when the user clicks a next-step button. */
     onStartSession?: (mode: 'commit' | 'note', prefill: string) => void;
+    hashtagItems?: HashtagItem[];
+    referenceNav?: ReferenceNavState;
+    onHashtagClick?: (click: HashtagClickInfo) => void;
   }
 
   let {
@@ -54,6 +61,9 @@
     onOpenSession,
     nextSteps,
     onStartSession,
+    hashtagItems = [],
+    referenceNav,
+    onHashtagClick,
   }: Props = $props();
 
   let copied = $state(false);
@@ -69,7 +79,14 @@
   let pikchrRendererLoadKey = $derived(noteMarkdown);
   let pikchrRendererLoadFailedKey = $state<string | null>(null);
   let pikchrRendererLoadFailed = $derived(pikchrRendererLoadFailedKey === pikchrRendererLoadKey);
-  let renderedNoteHtml = $derived(renderNoteMarkdown(noteMarkdown, { pikchrRenderer }));
+  let renderedNoteHtml = $derived(
+    renderNoteMarkdown(noteMarkdown, {
+      pikchrRenderer,
+      renderInlineText: hashtagItems.length
+        ? (text) => renderHashtagTokens(text, hashtagItems)
+        : undefined,
+    })
+  );
   let diagramViewerSvg = $state<string | null>(null);
 
   // Search state
@@ -234,14 +251,39 @@
     return true;
   }
 
+  function hashtagClickFromTarget(target: EventTarget | null): HashtagClickInfo | null {
+    if (!(target instanceof HTMLElement)) return null;
+    const badge = target.closest<HTMLElement>('[data-hashtag-ref]');
+    if (!badge) return null;
+    const type = badge.dataset.hashtagType as HashtagItem['type'] | undefined;
+    const id = badge.dataset.hashtagId;
+    const ref = badge.dataset.hashtagRef;
+    if (!type || !id || !ref) return null;
+    const item = hashtagItems.find((candidate) => candidate.type === type && candidate.id === id);
+    return { type, id, ref, item };
+  }
+
   function handleContentClick(event: MouseEvent) {
     if (openDiagramViewerFromEvent(event)) return;
+
+    const click = hashtagClickFromTarget(event.target);
+    if (click && onHashtagClick) {
+      event.preventDefault();
+      event.stopPropagation();
+      onHashtagClick(click);
+      return;
+    }
     handleExternalLinkClick(event);
   }
 
   function handleContentKeydown(event: KeyboardEvent) {
-    if (!isMarkdownDiagramActivationKey(event)) return;
-    openDiagramViewerFromEvent(event);
+    if (isMarkdownDiagramActivationKey(event) && openDiagramViewerFromEvent(event)) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const click = hashtagClickFromTarget(event.target);
+    if (!click || !onHashtagClick) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onHashtagClick(click);
   }
 </script>
 
@@ -264,6 +306,9 @@
     <Dialog.Header
       class="flex-row items-center justify-between gap-3 px-4 py-3 border-b border-[var(--border-subtle)] flex-shrink-0"
     >
+      {#if referenceNav}
+        <ReferenceNavControls nav={referenceNav} />
+      {/if}
       <div class="header-content">
         <span class="note-title-icon" aria-hidden="true">
           <FileText size={13} />

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -287,6 +287,12 @@
   } | null>(null);
   let openSessionId = $state<string | null>(null);
 
+  $effect(() => {
+    const _signature = hashtagSignature;
+    if (!openNote && !openSessionId) return;
+    void ensureHashtagItems();
+  });
+
   function isCompletedProjectNote(note: ProjectNote): boolean {
     const isRunning = isSessionActive(note.sessionStatus);
     const isFailed = !isRunning && !!note.sessionId && !note.content.trim();

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -587,6 +587,7 @@
     sessionId={openSessionId}
     repoDir={projectDisplayRootCandidates}
     projectId={project.id}
+    {hashtagItems}
     noteInfo={linkedNoteContext(projectNotes.find((n) => n.sessionId === openSessionId))}
     referenceNav={disabledReferenceNav}
     onOpenNote={(note) => {

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -34,6 +34,15 @@
   import { projectDisplayName } from '../../shared/utils';
   import { Button } from '$lib/components/ui/button';
   import type { LinkedNoteContext } from '../sessions/noteFreshness';
+  import { openDiffRoute } from '../layout/navigation.svelte';
+  import {
+    disabledReferenceNav,
+    pushReferenceEntry,
+    resolveHashtagReference,
+    type HashtagClickInfo,
+    type ReferenceDiffContext,
+    type ReferenceHistoryEntry,
+  } from '../references/referenceHistory.svelte';
 
   interface Props {
     project: Project;
@@ -147,6 +156,10 @@
     );
 
     return [project.id, hashtagVersion, readyBranchParts.join('|'), noteParts.join('|')].join(';');
+  });
+  let referenceDiffContext = $derived<ReferenceDiffContext>({
+    projectId: project.id,
+    projectName: project.name,
   });
 
   async function ensureHashtagItems() {
@@ -266,6 +279,7 @@
   });
 
   let openNote = $state<{
+    noteId: string;
     title: string;
     content: string;
     sessionId?: string;
@@ -297,6 +311,78 @@
       updatedAt: note.updatedAt,
       hasParsedNote: !!note.content.trim(),
     };
+  }
+
+  function currentDialogReferenceEntry(): ReferenceHistoryEntry | null {
+    if (openNote) {
+      return {
+        kind: 'note',
+        noteKind: 'project',
+        id: openNote.noteId,
+        ref: `#project-note:${openNote.noteId}`,
+        title: openNote.title,
+        content: openNote.content,
+        view: 'note',
+        sessionId: openNote.sessionId,
+        noteUpdatedAt: openNote.noteUpdatedAt,
+        projectId: project.id,
+        hashtagItems,
+        diffContext: referenceDiffContext,
+      };
+    }
+
+    if (openSessionId) {
+      const note = projectNotes.find((candidate) => candidate.sessionId === openSessionId);
+      if (note) {
+        return {
+          kind: 'note',
+          noteKind: 'project',
+          id: note.id,
+          ref: `#project-note:${note.id}`,
+          title: note.title,
+          content: note.content,
+          view: 'chat',
+          sessionId: openSessionId,
+          noteUpdatedAt: note.updatedAt,
+          projectId: project.id,
+          hashtagItems,
+          diffContext: referenceDiffContext,
+        };
+      }
+
+      return {
+        kind: 'chat',
+        ref: `#chat:${openSessionId}`,
+        sessionId: openSessionId,
+        projectId: project.id,
+        repoDir: projectDisplayRootCandidates,
+        hashtagItems,
+        diffContext: referenceDiffContext,
+      };
+    }
+
+    return null;
+  }
+
+  function closeReferenceDialogs() {
+    openNote = null;
+    openSessionId = null;
+  }
+
+  function handleHashtagClick(click: HashtagClickInfo) {
+    const target = resolveHashtagReference(click, {
+      hashtagItems,
+      diffContext: referenceDiffContext,
+    });
+    if (!target) return;
+
+    const current = currentDialogReferenceEntry();
+    if (current) pushReferenceEntry(current);
+    pushReferenceEntry(target);
+    closeReferenceDialogs();
+    if (target.kind === 'diff') {
+      openDiffRoute(target.route);
+    }
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────────
@@ -390,6 +476,7 @@
                 ? undefined
                 : () => {
                     openNote = {
+                      noteId: note.id,
                       title: note.title,
                       content: note.content,
                       sessionId: note.sessionId ?? undefined,
@@ -477,11 +564,14 @@
     content={openNote.content}
     sessionId={openNote.sessionId}
     noteUpdatedAt={openNote.noteUpdatedAt}
+    {hashtagItems}
+    referenceNav={disabledReferenceNav}
     onClose={() => (openNote = null)}
     onOpenSession={(sid) => {
       openNote = null;
       openSessionId = sid;
     }}
+    onHashtagClick={handleHashtagClick}
   />
 {/if}
 
@@ -492,10 +582,12 @@
     repoDir={projectDisplayRootCandidates}
     projectId={project.id}
     noteInfo={linkedNoteContext(projectNotes.find((n) => n.sessionId === openSessionId))}
+    referenceNav={disabledReferenceNav}
     onOpenNote={(note) => {
       const sid = openSessionId;
       openSessionId = null;
       openNote = {
+        noteId: note.id,
         title: note.title,
         content: note.content,
         sessionId: sid ?? undefined,
@@ -506,6 +598,7 @@
       openSessionId = null;
       loadProjectNotes();
     }}
+    onHashtagClick={handleHashtagClick}
   />
 {/if}
 

--- a/apps/staged/src/lib/features/references/ReferenceModalHost.svelte
+++ b/apps/staged/src/lib/features/references/ReferenceModalHost.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import NoteModal from '../notes/NoteModal.svelte';
+  import SessionModal from '../sessions/SessionModal.svelte';
+  import ImageViewerModal from '../timeline/ImageViewerModal.svelte';
+  import { openDiffRoute } from '../layout/navigation.svelte';
+  import type { LinkedNoteContext } from '../sessions/noteFreshness';
+  import type { HashtagItem } from '../../types';
+  import {
+    clearReferenceHistory,
+    currentReferenceEntry,
+    moveReferenceBack,
+    moveReferenceForward,
+    pushReferenceEntry,
+    referenceCanGoBack,
+    referenceCanGoForward,
+    replaceCurrentReferenceEntry,
+    resolveHashtagReference,
+    restorePreviousReferenceAfterDiffRoute,
+    setCurrentNoteView,
+    type HashtagClickInfo,
+    type ReferenceChatEntry,
+    type ReferenceHistoryEntry,
+    type ReferenceNavState,
+    type ReferenceNoteEntry,
+  } from './referenceHistory.svelte';
+
+  let entry = $derived(currentReferenceEntry());
+  let referenceNav = $derived<ReferenceNavState>({
+    canGoBack: referenceCanGoBack(),
+    canGoForward: referenceCanGoForward(),
+    onBack: navigateBack,
+    onForward: navigateForward,
+  });
+
+  onMount(() => {
+    const handleDiffRoutePopped = () => {
+      restorePreviousReferenceAfterDiffRoute();
+    };
+    window.addEventListener('staged:diff-route-popped', handleDiffRoutePopped);
+    return () => {
+      window.removeEventListener('staged:diff-route-popped', handleDiffRoutePopped);
+    };
+  });
+
+  function navigateBack() {
+    activateEntry(moveReferenceBack());
+  }
+
+  function navigateForward() {
+    activateEntry(moveReferenceForward());
+  }
+
+  function activateEntry(next: ReferenceHistoryEntry | null) {
+    if (next?.kind === 'diff') {
+      openDiffRoute(next.route);
+    }
+  }
+
+  function handleClose() {
+    clearReferenceHistory();
+  }
+
+  function handleHashtagClick(click: HashtagClickInfo) {
+    const current = currentReferenceEntry();
+    if (!current || current.kind === 'diff') return;
+
+    const target = resolveHashtagReference(click, {
+      hashtagItems: current.hashtagItems,
+      diffContext: current.diffContext,
+    });
+    if (!target) return;
+
+    pushReferenceEntry(target);
+    activateEntry(target);
+  }
+
+  function handleOpenSession() {
+    const current = currentReferenceEntry();
+    if (current?.kind === 'note' && current.sessionId) {
+      setCurrentNoteView('chat');
+    }
+  }
+
+  function handleOpenNote(note: LinkedNoteContext) {
+    const current = currentReferenceEntry();
+    if (current?.kind === 'note') {
+      setCurrentNoteView('note');
+      return;
+    }
+    if (current?.kind !== 'chat') return;
+
+    replaceCurrentReferenceEntry({
+      kind: 'note',
+      noteKind: current.branchId ? 'branch' : 'project',
+      id: note.id,
+      ref: `#note:${note.id}`,
+      title: note.title,
+      content: note.content,
+      view: 'note',
+      sessionId: current.sessionId,
+      noteUpdatedAt: note.updatedAt,
+      branchId: current.branchId,
+      projectId: current.projectId,
+      hashtagItems: current.hashtagItems,
+      diffContext: current.diffContext,
+    });
+  }
+
+  function noteInfoFor(entry: ReferenceNoteEntry): LinkedNoteContext {
+    return {
+      id: entry.id,
+      title: entry.title,
+      content: entry.content,
+      updatedAt: entry.noteUpdatedAt ?? 0,
+      hasParsedNote: !!entry.content.trim(),
+    };
+  }
+
+  function chatNoteInfo(entry: ReferenceChatEntry): LinkedNoteContext | null {
+    const note = noteItemForSession(entry.sessionId, entry.hashtagItems);
+    if (!note?.noteContent && note?.noteContent !== '') return null;
+    return {
+      id: note.id,
+      title: note.title,
+      content: note.noteContent,
+      updatedAt: note.noteUpdatedAt ?? 0,
+      hasParsedNote: !!note.noteContent.trim(),
+    };
+  }
+
+  function noteItemForSession(sessionId: string, items: HashtagItem[] | undefined) {
+    return items?.find((item) => {
+      return (
+        (item.type === 'note' || item.type === 'project-note') && item.noteSessionId === sessionId
+      );
+    });
+  }
+</script>
+
+{#if entry?.kind === 'note' && entry.view === 'note'}
+  <NoteModal
+    open={true}
+    title={entry.title}
+    content={entry.content}
+    sessionId={entry.sessionId}
+    noteUpdatedAt={entry.noteUpdatedAt}
+    hashtagItems={entry.hashtagItems}
+    {referenceNav}
+    onClose={handleClose}
+    onOpenSession={entry.sessionId ? handleOpenSession : undefined}
+    onHashtagClick={handleHashtagClick}
+  />
+{:else if entry?.kind === 'note' && entry.view === 'chat' && entry.sessionId}
+  <SessionModal
+    open={true}
+    sessionId={entry.sessionId}
+    branchId={entry.branchId}
+    projectId={entry.projectId}
+    noteInfo={noteInfoFor(entry)}
+    {referenceNav}
+    onOpenNote={handleOpenNote}
+    onClose={handleClose}
+    onHashtagClick={handleHashtagClick}
+  />
+{:else if entry?.kind === 'chat'}
+  <SessionModal
+    open={true}
+    sessionId={entry.sessionId}
+    repoDir={entry.repoDir}
+    branchId={entry.branchId}
+    projectId={entry.projectId}
+    repoLabel={entry.repoLabel}
+    noteInfo={chatNoteInfo(entry)}
+    {referenceNav}
+    onOpenNote={handleOpenNote}
+    onClose={handleClose}
+    onHashtagClick={handleHashtagClick}
+  />
+{:else if entry?.kind === 'image'}
+  <ImageViewerModal
+    open={true}
+    imageId={entry.imageId}
+    filename={entry.filename}
+    {referenceNav}
+    onClose={handleClose}
+  />
+{/if}

--- a/apps/staged/src/lib/features/references/ReferenceModalHost.svelte
+++ b/apps/staged/src/lib/features/references/ReferenceModalHost.svelte
@@ -157,6 +157,7 @@
     sessionId={entry.sessionId}
     branchId={entry.branchId}
     projectId={entry.projectId}
+    hashtagItems={entry.hashtagItems}
     noteInfo={noteInfoFor(entry)}
     {referenceNav}
     onOpenNote={handleOpenNote}
@@ -171,6 +172,7 @@
     branchId={entry.branchId}
     projectId={entry.projectId}
     repoLabel={entry.repoLabel}
+    hashtagItems={entry.hashtagItems}
     noteInfo={chatNoteInfo(entry)}
     {referenceNav}
     onOpenNote={handleOpenNote}

--- a/apps/staged/src/lib/features/references/ReferenceNavControls.svelte
+++ b/apps/staged/src/lib/features/references/ReferenceNavControls.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+  import ChevronRight from '@lucide/svelte/icons/chevron-right';
+  import { Button } from '$lib/components/ui/button';
+  import type { ReferenceNavState } from './referenceHistory.svelte';
+
+  interface Props {
+    nav: ReferenceNavState;
+  }
+
+  let { nav }: Props = $props();
+</script>
+
+<div class="reference-nav-controls" aria-label="Reference history navigation">
+  <Button
+    variant="ghost"
+    size="icon-sm"
+    class="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-[var(--bg-hover)] hover:text-foreground disabled:opacity-35 [&_svg]:!size-4"
+    title="Back"
+    aria-label="Back"
+    disabled={!nav.canGoBack}
+    onclick={nav.onBack}
+  >
+    <ChevronLeft size={16} />
+  </Button>
+  <Button
+    variant="ghost"
+    size="icon-sm"
+    class="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-[var(--bg-hover)] hover:text-foreground disabled:opacity-35 [&_svg]:!size-4"
+    title="Forward"
+    aria-label="Forward"
+    disabled={!nav.canGoForward}
+    onclick={nav.onForward}
+  >
+    <ChevronRight size={16} />
+  </Button>
+</div>
+
+<style>
+  .reference-nav-controls {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+</style>

--- a/apps/staged/src/lib/features/references/referenceHistory.svelte.ts
+++ b/apps/staged/src/lib/features/references/referenceHistory.svelte.ts
@@ -1,0 +1,256 @@
+import type { DiffDetailRoute } from '../layout/navigation.svelte';
+import type { DisplayRootInput } from '../sessions/pathDisplayRoots';
+import type { HashtagItem, ProjectRepo } from '../../types';
+
+export type HashtagClickInfo = {
+  type: HashtagItem['type'];
+  id: string;
+  ref: string;
+  item?: HashtagItem;
+};
+
+export type ReferenceDiffContext = Partial<
+  Pick<
+    DiffDetailRoute,
+    | 'projectId'
+    | 'commits'
+    | 'baseBranchLabel'
+    | 'branchLabel'
+    | 'projectName'
+    | 'githubRepo'
+    | 'subpath'
+  >
+> & {
+  branchId?: string;
+};
+
+type ReferenceDialogContext = {
+  hashtagItems?: HashtagItem[];
+  diffContext?: ReferenceDiffContext;
+};
+
+export type ReferenceNoteEntry = ReferenceDialogContext & {
+  kind: 'note';
+  noteKind: 'branch' | 'project';
+  id: string;
+  ref: string;
+  title: string;
+  content: string;
+  view: 'note' | 'chat';
+  sessionId?: string | null;
+  noteUpdatedAt?: number | null;
+  branchId?: string | null;
+  projectId?: string | null;
+};
+
+export type ReferenceChatEntry = ReferenceDialogContext & {
+  kind: 'chat';
+  ref: string;
+  sessionId: string;
+  branchId?: string | null;
+  projectId?: string | null;
+  repoDir?: DisplayRootInput;
+  repoLabel?: Pick<ProjectRepo, 'githubRepo' | 'subpath' | 'headRepo'> | null;
+};
+
+export type ReferenceImageEntry = ReferenceDialogContext & {
+  kind: 'image';
+  ref: string;
+  imageId: string;
+  filename: string;
+  branchId?: string | null;
+  projectId?: string | null;
+};
+
+export type ReferenceDiffEntry = {
+  kind: 'diff';
+  ref: string;
+  route: Omit<DiffDetailRoute, 'kind'>;
+};
+
+export type ReferenceHistoryEntry =
+  ReferenceNoteEntry | ReferenceChatEntry | ReferenceImageEntry | ReferenceDiffEntry;
+
+export type ReferenceNavState = {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  onBack: () => void;
+  onForward: () => void;
+};
+
+export const disabledReferenceNav: ReferenceNavState = {
+  canGoBack: false,
+  canGoForward: false,
+  onBack: () => {},
+  onForward: () => {},
+};
+
+export const referenceHistory = $state({
+  entries: [] as ReferenceHistoryEntry[],
+  index: -1,
+});
+
+export function currentReferenceEntry(): ReferenceHistoryEntry | null {
+  return referenceHistory.entries[referenceHistory.index] ?? null;
+}
+
+export function referenceCanGoBack(): boolean {
+  return referenceHistory.index > 0;
+}
+
+export function referenceCanGoForward(): boolean {
+  return (
+    referenceHistory.index >= 0 && referenceHistory.index < referenceHistory.entries.length - 1
+  );
+}
+
+export function pushReferenceEntry(entry: ReferenceHistoryEntry): void {
+  const preserved = referenceHistory.entries.slice(0, referenceHistory.index + 1);
+  referenceHistory.entries = [...preserved, entry];
+  referenceHistory.index = referenceHistory.entries.length - 1;
+}
+
+export function replaceCurrentReferenceEntry(entry: ReferenceHistoryEntry): void {
+  if (referenceHistory.index < 0) {
+    pushReferenceEntry(entry);
+    return;
+  }
+
+  referenceHistory.entries = referenceHistory.entries.map((existing, index) =>
+    index === referenceHistory.index ? entry : existing
+  );
+}
+
+export function clearReferenceHistory(): void {
+  referenceHistory.entries = [];
+  referenceHistory.index = -1;
+}
+
+export function moveReferenceBack(): ReferenceHistoryEntry | null {
+  if (!referenceCanGoBack()) return currentReferenceEntry();
+  referenceHistory.index -= 1;
+  return currentReferenceEntry();
+}
+
+export function moveReferenceForward(): ReferenceHistoryEntry | null {
+  if (!referenceCanGoForward()) return currentReferenceEntry();
+  referenceHistory.index += 1;
+  return currentReferenceEntry();
+}
+
+export function restorePreviousReferenceAfterDiffRoute(): void {
+  const current = currentReferenceEntry();
+  if (current?.kind !== 'diff') return;
+  if (referenceHistory.index > 0) {
+    referenceHistory.index -= 1;
+  } else {
+    clearReferenceHistory();
+  }
+}
+
+export function setCurrentNoteView(view: 'note' | 'chat'): void {
+  const current = currentReferenceEntry();
+  if (current?.kind !== 'note') return;
+  replaceCurrentReferenceEntry({ ...current, view });
+}
+
+export function resolveHashtagReference(
+  click: HashtagClickInfo,
+  context: ReferenceDialogContext = {}
+): ReferenceHistoryEntry | null {
+  const item =
+    click.item ??
+    context.hashtagItems?.find((candidate) => {
+      return candidate.type === click.type && candidate.id === click.id;
+    });
+
+  switch (click.type) {
+    case 'note':
+    case 'project-note':
+      if (!item?.noteContent && item?.noteContent !== '') return null;
+      return {
+        kind: 'note',
+        noteKind: click.type === 'project-note' ? 'project' : 'branch',
+        id: click.id,
+        ref: click.ref,
+        title: item.title,
+        content: item.noteContent,
+        view: 'note',
+        sessionId: item.noteSessionId,
+        noteUpdatedAt: item.noteUpdatedAt,
+        branchId: item.branchId,
+        projectId: item.projectId,
+        hashtagItems: context.hashtagItems,
+        diffContext: context.diffContext,
+      };
+
+    case 'image':
+      if (!item?.imageFilename) return null;
+      return {
+        kind: 'image',
+        ref: click.ref,
+        imageId: click.id,
+        filename: item.imageFilename,
+        branchId: item.branchId,
+        projectId: item.projectId,
+        hashtagItems: context.hashtagItems,
+        diffContext: context.diffContext,
+      };
+
+    case 'commit': {
+      const route = diffRouteForHashtag(item, click, context);
+      if (!route) return null;
+      return { kind: 'diff', ref: click.ref, route };
+    }
+
+    case 'review': {
+      const route = diffRouteForHashtag(item, click, context);
+      if (!route) return null;
+      return { kind: 'diff', ref: click.ref, route };
+    }
+  }
+}
+
+function diffRouteForHashtag(
+  item: HashtagItem | undefined,
+  click: HashtagClickInfo,
+  context: ReferenceDialogContext
+): Omit<DiffDetailRoute, 'kind'> | null {
+  const branchId = item?.branchId ?? context.diffContext?.branchId;
+  if (!branchId) return null;
+
+  const projectId = item?.projectId ?? context.diffContext?.projectId;
+  const shared = {
+    projectId,
+    commits: context.diffContext?.commits,
+    baseBranchLabel: context.diffContext?.baseBranchLabel,
+    branchLabel: context.diffContext?.branchLabel,
+    projectName: context.diffContext?.projectName,
+    githubRepo: context.diffContext?.githubRepo ?? item?.repoSlug,
+    subpath: context.diffContext?.subpath ?? item?.repoSubpath,
+  };
+
+  if (click.type === 'commit') {
+    return {
+      ...shared,
+      branchId,
+      commitSha: click.id,
+      scope: 'commit',
+      beforeLabel: 'parent',
+      afterLabel: click.id.slice(0, 7),
+    };
+  }
+
+  const commitSha = item?.reviewCommitSha;
+  if (!commitSha) return null;
+  const scope = item?.reviewScope ?? 'commit';
+  return {
+    ...shared,
+    branchId,
+    commitSha,
+    scope,
+    reviewId: click.id,
+    beforeLabel: scope === 'commit' ? 'parent' : context.diffContext?.baseBranchLabel,
+    afterLabel: commitSha.slice(0, 7),
+  };
+}

--- a/apps/staged/src/lib/features/references/referenceHistory.svelte.ts
+++ b/apps/staged/src/lib/features/references/referenceHistory.svelte.ts
@@ -1,6 +1,7 @@
 import type { DiffDetailRoute } from '../layout/navigation.svelte';
 import type { DisplayRootInput } from '../sessions/pathDisplayRoots';
 import type { HashtagItem, ProjectRepo } from '../../types';
+import { findHashtagItemForReference } from '../sessions/hashtagItems';
 
 export type HashtagClickInfo = {
   type: HashtagItem['type'];
@@ -159,10 +160,7 @@ export function resolveHashtagReference(
   context: ReferenceDialogContext = {}
 ): ReferenceHistoryEntry | null {
   const item =
-    click.item ??
-    context.hashtagItems?.find((candidate) => {
-      return candidate.type === click.type && candidate.id === click.id;
-    });
+    click.item ?? findHashtagItemForReference(context.hashtagItems ?? [], click.type, click.id);
 
   switch (click.type) {
     case 'note':
@@ -170,8 +168,8 @@ export function resolveHashtagReference(
       if (!item?.noteContent && item?.noteContent !== '') return null;
       return {
         kind: 'note',
-        noteKind: click.type === 'project-note' ? 'project' : 'branch',
-        id: click.id,
+        noteKind: item.type === 'project-note' ? 'project' : 'branch',
+        id: item.id,
         ref: click.ref,
         title: item.title,
         content: item.noteContent,

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -101,6 +101,8 @@
   import { renderMarkdown as renderSharedMarkdown } from '../../shared/markdown/renderMarkdown';
   import { loadPikchrRenderer, type PikchrRenderer } from '../../shared/markdown/pikchrRendering';
   import { getNoteFollowupLabel, type LinkedNoteContext } from './noteFreshness';
+  import ReferenceNavControls from '../references/ReferenceNavControls.svelte';
+  import type { HashtagClickInfo, ReferenceNavState } from '../references/referenceHistory.svelte';
 
   interface Props {
     open: boolean;
@@ -117,6 +119,8 @@
     /** When set, shows a button to open the associated note. */
     noteInfo?: LinkedNoteContext | null;
     onOpenNote?: (note: LinkedNoteContext) => void;
+    referenceNav?: ReferenceNavState;
+    onHashtagClick?: (click: HashtagClickInfo) => void;
   }
 
   type SendMessageTarget = {
@@ -134,6 +138,8 @@
     repoLabel = null,
     noteInfo,
     onOpenNote,
+    referenceNav,
+    onHashtagClick,
   }: Props = $props();
 
   // =========================================================================
@@ -783,7 +789,12 @@
   }
 
   function renderMarkdown(content: string): string {
-    return renderSharedMarkdown(content, { pikchrRenderer });
+    return renderSharedMarkdown(content, {
+      pikchrRenderer,
+      renderInlineText: hashtagItems.length
+        ? (text) => renderHashtagTokens(text, hashtagItems)
+        : undefined,
+    });
   }
 
   function openDiagramViewerFromEvent(event: MouseEvent | KeyboardEvent): boolean {
@@ -794,16 +805,6 @@
     event.stopPropagation();
     diagramViewerSvg = svgMarkup;
     return true;
-  }
-
-  function handleMessagesClick(event: MouseEvent) {
-    if (openDiagramViewerFromEvent(event)) return;
-    handleExternalLinkClick(event);
-  }
-
-  function handleMessagesKeydown(event: KeyboardEvent) {
-    if (!isMarkdownDiagramActivationKey(event)) return;
-    openDiagramViewerFromEvent(event);
   }
 
   /** Memoized wrapper around the shared renderHashtagTokens. */
@@ -820,6 +821,41 @@
     const result = renderHashtagTokensShared(text, items);
     hashtagTokenCache.set(text, result);
     return result;
+  }
+
+  function hashtagClickFromTarget(target: EventTarget | null): HashtagClickInfo | null {
+    if (!(target instanceof HTMLElement)) return null;
+    const badge = target.closest<HTMLElement>('[data-hashtag-ref]');
+    if (!badge) return null;
+    const type = badge.dataset.hashtagType as HashtagItem['type'] | undefined;
+    const id = badge.dataset.hashtagId;
+    const ref = badge.dataset.hashtagRef;
+    if (!type || !id || !ref) return null;
+    const item = hashtagItems.find((candidate) => candidate.type === type && candidate.id === id);
+    return { type, id, ref, item };
+  }
+
+  function handleContentClick(event: MouseEvent) {
+    if (openDiagramViewerFromEvent(event)) return;
+
+    const click = hashtagClickFromTarget(event.target);
+    if (click && onHashtagClick) {
+      event.preventDefault();
+      event.stopPropagation();
+      onHashtagClick(click);
+      return;
+    }
+    handleExternalLinkClick(event);
+  }
+
+  function handleContentKeydown(event: KeyboardEvent) {
+    if (isMarkdownDiagramActivationKey(event) && openDiagramViewerFromEvent(event)) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const click = hashtagClickFromTarget(event.target);
+    if (!click || !onHashtagClick) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onHashtagClick(click);
   }
 
   // =========================================================================
@@ -1134,6 +1170,9 @@
   >
     <!-- Header -->
     <header class="modal-header">
+      {#if referenceNav}
+        <ReferenceNavControls nav={referenceNav} />
+      {/if}
       <div class="header-content">
         <Dialog.Title
           class="text-[var(--size-sm)] font-semibold text-foreground overflow-hidden text-ellipsis whitespace-nowrap"
@@ -1181,8 +1220,8 @@
       class="modal-content"
       bind:this={messagesEl}
       onscroll={handleScroll}
-      onclick={handleMessagesClick}
-      onkeydown={handleMessagesKeydown}
+      onclick={handleContentClick}
+      onkeydown={handleContentKeydown}
     >
       {#if session?.pipeline}
         <PipelineSteps {sessionId} pipeline={session.pipeline} />

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -117,6 +117,8 @@
     projectId?: string | null;
     /** Repo label for grouping branch-scoped hashtag suggestions. */
     repoLabel?: Pick<ProjectRepo, 'githubRepo' | 'subpath' | 'headRepo'> | null;
+    /** Precomputed hashtag reference items for the session context. */
+    hashtagItems?: HashtagItem[];
     /** When set, shows a button to open the associated note. */
     noteInfo?: LinkedNoteContext | null;
     onOpenNote?: (note: LinkedNoteContext) => void;
@@ -137,6 +139,7 @@
     branchId,
     projectId,
     repoLabel = null,
+    hashtagItems: providedHashtagItems,
     noteInfo,
     onOpenNote,
     referenceNav,
@@ -216,18 +219,26 @@
   // Hashtag reference items
   let hashtagItems = $state<HashtagItem[]>([]);
   $effect(() => {
-    if (branchId) {
-      let stale = false;
-      buildBranchHashtagItems(branchId, projectId ?? null, {
-        repoSlug: repoLabel?.headRepo ?? repoLabel?.githubRepo,
-        repoSubpath: repoLabel?.subpath,
-      }).then((items) => {
-        if (!stale) hashtagItems = items;
-      });
-      return () => {
-        stale = true;
-      };
+    if (providedHashtagItems) {
+      hashtagItems = providedHashtagItems;
+      return;
     }
+
+    if (!branchId) {
+      hashtagItems = [];
+      return;
+    }
+
+    let stale = false;
+    buildBranchHashtagItems(branchId, projectId ?? null, {
+      repoSlug: repoLabel?.headRepo ?? repoLabel?.githubRepo,
+      repoSubpath: repoLabel?.subpath,
+    }).then((items) => {
+      if (!stale) hashtagItems = items;
+    });
+    return () => {
+      stale = true;
+    };
   });
 
   // Image attachment state (available when project context is provided; branchId is optional)

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -60,6 +60,7 @@
   import HashtagInput from './HashtagInput.svelte';
   import {
     buildBranchHashtagItems,
+    findHashtagItemForReference,
     renderHashtagTokens as renderHashtagTokensShared,
   } from './hashtagItems';
   import * as Dialog from '$lib/components/ui/dialog';
@@ -831,7 +832,7 @@
     const id = badge.dataset.hashtagId;
     const ref = badge.dataset.hashtagRef;
     if (!type || !id || !ref) return null;
-    const item = hashtagItems.find((candidate) => candidate.type === type && candidate.id === id);
+    const item = findHashtagItemForReference(hashtagItems, type, id);
     return { type, id, ref, item };
   }
 

--- a/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Branch, BranchTimeline, ProjectNote } from '../../types';
+import type { Branch, BranchTimeline, HashtagItem, ProjectNote } from '../../types';
 import { getBranchTimeline, listProjectNotes } from '../../commands';
 import {
   buildProjectHashtagItems,
+  findHashtagItemForReference,
   projectNotesToHashtagItems,
+  renderHashtagTokens,
   timelineToHashtagItems,
 } from './hashtagItems';
 
@@ -245,6 +247,60 @@ describe('projectNotesToHashtagItems', () => {
 
     expect(items.map((item) => item.id)).toEqual(['new-project-note', 'old-project-note']);
     expect(items[0]).not.toHaveProperty('subtitle');
+  });
+});
+
+describe('findHashtagItemForReference', () => {
+  it('resolves #note project-note aliases after exact note matches', () => {
+    const items: HashtagItem[] = [
+      {
+        type: 'project-note',
+        id: 'shared-id',
+        title: 'Project note',
+        color: '--note-color',
+        bgColor: '--note-bg',
+      },
+      {
+        type: 'note',
+        id: 'shared-id',
+        title: 'Branch note',
+        color: '--note-color',
+        bgColor: '--note-bg',
+      },
+      {
+        type: 'project-note',
+        id: 'project-only',
+        title: 'Project only',
+        color: '--note-color',
+        bgColor: '--note-bg',
+      },
+    ];
+
+    expect(findHashtagItemForReference(items, 'note', 'shared-id')).toEqual(
+      expect.objectContaining({ type: 'note', title: 'Branch note' })
+    );
+    expect(findHashtagItemForReference(items, 'note', 'project-only')).toEqual(
+      expect.objectContaining({ type: 'project-note', title: 'Project only' })
+    );
+  });
+});
+
+describe('renderHashtagTokens', () => {
+  it('renders project notes from #note aliases and keeps #project-note accepted', () => {
+    const items = projectNotesToHashtagItems([
+      projectNote({ id: 'project-note-1', title: 'Project note title' }),
+    ]);
+
+    const noteAliasHtml = renderHashtagTokens('See #note:project-note-1', items);
+    expect(noteAliasHtml).toContain('Project note title');
+    expect(noteAliasHtml).toContain('data-hashtag-ref="#note:project-note-1"');
+    expect(noteAliasHtml).toContain('data-hashtag-type="project-note"');
+    expect(noteAliasHtml).toContain('data-hashtag-id="project-note-1"');
+
+    const projectNoteHtml = renderHashtagTokens('See #project-note:project-note-1', items);
+    expect(projectNoteHtml).toContain('Project note title');
+    expect(projectNoteHtml).toContain('data-hashtag-ref="#project-note:project-note-1"');
+    expect(projectNoteHtml).toContain('data-hashtag-type="project-note"');
   });
 });
 

--- a/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
@@ -302,6 +302,32 @@ describe('renderHashtagTokens', () => {
     expect(projectNoteHtml).toContain('data-hashtag-ref="#project-note:project-note-1"');
     expect(projectNoteHtml).toContain('data-hashtag-type="project-note"');
   });
+
+  it('can render presentational badges without interaction attributes', () => {
+    const html = renderHashtagTokens(
+      'See #note:note-1',
+      [
+        {
+          type: 'note',
+          id: 'note-1',
+          title: 'Note title',
+          color: '--note-color',
+          bgColor: '--note-bg',
+        },
+      ],
+      { interactive: false }
+    );
+
+    expect(html).toContain('class="hashtag-badge stable-raster stable-raster-glyphs"');
+    expect(html).toContain('Note title');
+    expect(html).toContain('viewBox="0 0 24 24"');
+    expect(html).toContain('style="background: var(--note-bg); color: var(--note-color);"');
+    expect(html).toContain('data-hashtag-type="note"');
+    expect(html).toContain('data-hashtag-id="note-1"');
+    expect(html).not.toContain('role="button"');
+    expect(html).not.toContain('tabindex="0"');
+    expect(html).not.toContain('data-hashtag-ref');
+  });
 });
 
 describe('buildProjectHashtagItems', () => {

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -339,12 +339,21 @@ function findHashtagItemInMap(
   }
 }
 
+type RenderHashtagTokenOptions = {
+  interactive?: boolean;
+};
+
 /**
  * Replace `#type:id` tokens in plain text with inline badge HTML.
  * Plain-text segments are HTML-escaped; badge spans use CSS custom-property
  * colours from `hashtagTypeColors`.
  */
-export function renderHashtagTokens(text: string, items: HashtagItem[]): string {
+export function renderHashtagTokens(
+  text: string,
+  items: HashtagItem[],
+  options: RenderHashtagTokenOptions = {}
+): string {
+  const { interactive = true } = options;
   const itemsByKey = new Map<string, HashtagItem>();
   for (const item of items) {
     itemsByKey.set(`${item.type}:${item.id}`, item);
@@ -372,8 +381,11 @@ export function renderHashtagTokens(text: string, items: HashtagItem[]): string 
         ? id.slice(0, 8) + '…'
         : id;
     const ref = `#${type}:${id}`;
+    const interactionAttributes = interactive
+      ? ` role="button" tabindex="0" data-hashtag-ref="${escapeHtml(ref)}"`
+      : '';
     parts.push(
-      `<span class="hashtag-badge stable-raster stable-raster-glyphs" role="button" tabindex="0" data-hashtag-type="${escapeHtml(targetType)}" data-hashtag-id="${escapeHtml(item?.id ?? id)}" data-hashtag-ref="${escapeHtml(ref)}" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
+      `<span class="hashtag-badge stable-raster stable-raster-glyphs"${interactionAttributes} data-hashtag-type="${escapeHtml(targetType)}" data-hashtag-id="${escapeHtml(item?.id ?? id)}" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
     );
 
     lastIndex = match.index + match[0].length;

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -41,6 +41,8 @@ type SortableHashtagItem = HashtagItem & {
 };
 
 type BranchHashtagContext = {
+  branchId?: string;
+  projectId?: string | null;
   branchName?: string;
   repoSlug?: string;
   repoSubpath?: string | null;
@@ -91,6 +93,14 @@ function stripSortMetadata(item: SortableHashtagItem): HashtagItem {
   if (item.branchName !== undefined) stripped.branchName = item.branchName;
   if (item.repoSlug !== undefined) stripped.repoSlug = item.repoSlug;
   if (item.repoSubpath !== undefined) stripped.repoSubpath = item.repoSubpath;
+  if (item.branchId !== undefined) stripped.branchId = item.branchId;
+  if (item.projectId !== undefined) stripped.projectId = item.projectId;
+  if (item.noteContent !== undefined) stripped.noteContent = item.noteContent;
+  if (item.noteSessionId !== undefined) stripped.noteSessionId = item.noteSessionId;
+  if (item.noteUpdatedAt !== undefined) stripped.noteUpdatedAt = item.noteUpdatedAt;
+  if (item.imageFilename !== undefined) stripped.imageFilename = item.imageFilename;
+  if (item.reviewCommitSha !== undefined) stripped.reviewCommitSha = item.reviewCommitSha;
+  if (item.reviewScope !== undefined) stripped.reviewScope = item.reviewScope;
 
   return stripped;
 }
@@ -108,13 +118,9 @@ export async function buildBranchHashtagItems(
     projectId ? listProjectNotes(projectId) : Promise.resolve([]),
   ]);
 
+  const branchContext = { ...context, branchId, projectId };
   return sortAndStripHashtagItems([
-    ...timelineToSortableHashtagItems(
-      timeline,
-      context.branchName,
-      context.repoSlug,
-      context.repoSubpath
-    ),
+    ...timelineToSortableHashtagItems(timeline, branchContext),
     ...projectNotesToSortableHashtagItems(projectNotes),
   ]);
 }
@@ -150,7 +156,13 @@ export async function buildProjectHashtagItems(
     const repoSlug = repo?.githubRepo;
     const repoSubpath = repo?.subpath;
     items.push(
-      ...timelineToSortableHashtagItems(timeline, branch.branchName, repoSlug, repoSubpath)
+      ...timelineToSortableHashtagItems(timeline, {
+        branchId: branch.id,
+        projectId,
+        branchName: branch.branchName,
+        repoSlug,
+        repoSubpath,
+      })
     );
   }
 
@@ -163,20 +175,20 @@ export function timelineToHashtagItems(
   timeline: BranchTimeline,
   branchName?: string,
   repoSlug?: string,
-  repoSubpath?: string | null
+  repoSubpath?: string | null,
+  context: Pick<BranchHashtagContext, 'branchId' | 'projectId'> = {}
 ): HashtagItem[] {
   return sortAndStripHashtagItems(
-    timelineToSortableHashtagItems(timeline, branchName, repoSlug, repoSubpath)
+    timelineToSortableHashtagItems(timeline, { ...context, branchName, repoSlug, repoSubpath })
   );
 }
 
 function timelineToSortableHashtagItems(
   timeline: BranchTimeline,
-  branchName?: string,
-  repoSlug?: string,
-  repoSubpath?: string | null
+  context: BranchHashtagContext = {}
 ): SortableHashtagItem[] {
   const items: SortableHashtagItem[] = [];
+  const { branchId, projectId, branchName, repoSlug, repoSubpath } = context;
 
   for (const note of timeline.notes) {
     if (!note.title.trim()) continue;
@@ -190,6 +202,11 @@ function timelineToSortableHashtagItems(
       branchName,
       repoSlug,
       repoSubpath,
+      branchId,
+      projectId,
+      noteContent: note.content,
+      noteSessionId: note.sessionId,
+      noteUpdatedAt: note.updatedAt,
       sortTimestamp: note.completedAt ?? note.createdAt,
       sortOrder: 0,
     });
@@ -206,6 +223,8 @@ function timelineToSortableHashtagItems(
       branchName,
       repoSlug,
       repoSubpath,
+      branchId,
+      projectId,
       sortTimestamp: commit.timestamp,
       sortOrder: commit.order,
     });
@@ -224,6 +243,10 @@ function timelineToSortableHashtagItems(
       branchName,
       repoSlug,
       repoSubpath,
+      branchId,
+      projectId,
+      reviewCommitSha: review.commitSha,
+      reviewScope: review.scope === 'commit' ? 'commit' : 'branch',
       sortTimestamp: review.completedAt ?? review.createdAt,
       sortOrder: 0,
     });
@@ -240,6 +263,9 @@ function timelineToSortableHashtagItems(
       branchName,
       repoSlug,
       repoSubpath,
+      branchId,
+      projectId,
+      imageFilename: image.filename,
       sortTimestamp: image.createdAt,
       sortOrder: 0,
     });
@@ -261,6 +287,10 @@ function projectNotesToSortableHashtagItems(notes: ProjectNote[]): SortableHasht
       title: n.title,
       color: '--note-color',
       bgColor: '--note-bg',
+      projectId: n.projectId,
+      noteContent: n.content,
+      noteSessionId: n.sessionId,
+      noteUpdatedAt: n.updatedAt,
       sortTimestamp: n.completedAt ?? n.createdAt,
       sortOrder: 0,
     }));
@@ -313,8 +343,9 @@ export function renderHashtagTokens(text: string, items: HashtagItem[]): string 
       : type === 'commit' && id.length > 12
         ? id.slice(0, 8) + '…'
         : id;
+    const ref = `#${type}:${id}`;
     parts.push(
-      `<span class="hashtag-badge stable-raster stable-raster-glyphs" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
+      `<span class="hashtag-badge stable-raster stable-raster-glyphs" role="button" tabindex="0" data-hashtag-type="${escapeHtml(type)}" data-hashtag-id="${escapeHtml(id)}" data-hashtag-ref="${escapeHtml(ref)}" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
     );
 
     lastIndex = match.index + match[0].length;

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -312,6 +312,33 @@ export function hasHashtagTokens(text: string): boolean {
   return re.test(text);
 }
 
+function hashtagReferenceLookupKeys(type: string, id: string): string[] {
+  const exactKey = `${type}:${id}`;
+  return type === 'note' ? [exactKey, `project-note:${id}`] : [exactKey];
+}
+
+export function findHashtagItemForReference(
+  items: readonly HashtagItem[],
+  type: string,
+  id: string
+): HashtagItem | undefined {
+  for (const key of hashtagReferenceLookupKeys(type, id)) {
+    const item = items.find((candidate) => `${candidate.type}:${candidate.id}` === key);
+    if (item) return item;
+  }
+}
+
+function findHashtagItemInMap(
+  itemsByKey: Map<string, HashtagItem>,
+  type: string,
+  id: string
+): HashtagItem | undefined {
+  for (const key of hashtagReferenceLookupKeys(type, id)) {
+    const item = itemsByKey.get(key);
+    if (item) return item;
+  }
+}
+
 /**
  * Replace `#type:id` tokens in plain text with inline badge HTML.
  * Plain-text segments are HTML-escaped; badge spans use CSS custom-property
@@ -335,9 +362,10 @@ export function renderHashtagTokens(text: string, items: HashtagItem[]): string 
 
     const type = match[1];
     const id = match[2];
-    const iconSvg = hashtagTypeIconSvg[type] ?? '';
-    const colors = hashtagTypeColors[type] ?? { color: '--text-muted', bg: '--bg-secondary' };
-    const item = itemsByKey.get(`${type}:${id}`);
+    const item = findHashtagItemInMap(itemsByKey, type, id);
+    const targetType = item?.type ?? type;
+    const iconSvg = hashtagTypeIconSvg[targetType] ?? '';
+    const colors = hashtagTypeColors[targetType] ?? { color: '--text-muted', bg: '--bg-secondary' };
     const title = item
       ? item.title
       : type === 'commit' && id.length > 12
@@ -345,7 +373,7 @@ export function renderHashtagTokens(text: string, items: HashtagItem[]): string 
         : id;
     const ref = `#${type}:${id}`;
     parts.push(
-      `<span class="hashtag-badge stable-raster stable-raster-glyphs" role="button" tabindex="0" data-hashtag-type="${escapeHtml(type)}" data-hashtag-id="${escapeHtml(id)}" data-hashtag-ref="${escapeHtml(ref)}" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
+      `<span class="hashtag-badge stable-raster stable-raster-glyphs" role="button" tabindex="0" data-hashtag-type="${escapeHtml(targetType)}" data-hashtag-id="${escapeHtml(item?.id ?? id)}" data-hashtag-ref="${escapeHtml(ref)}" style="background: var(${colors.bg}); color: var(${colors.color});">${iconSvg} ${escapeHtml(title)}</span>`
     );
 
     lastIndex = match.index + match[0].length;

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -713,7 +713,7 @@
     if (hashtagItems.length > 0) {
       for (const item of all) {
         if (hasHashtagTokens(item.title)) {
-          item.titleHtml = renderHashtagTokens(item.title, hashtagItems);
+          item.titleHtml = renderHashtagTokens(item.title, hashtagItems, { interactive: false });
         }
       }
     }
@@ -966,7 +966,7 @@
             type={item.type}
             title={item.title}
             titleHtml={hashtagItems.length > 0 && hasHashtagTokens(item.title)
-              ? renderHashtagTokens(item.title, hashtagItems)
+              ? renderHashtagTokens(item.title, hashtagItems, { interactive: false })
               : undefined}
             secondaryMeta={item.sessionId
               ? (liveSessionHints[item.sessionId] ??

--- a/apps/staged/src/lib/features/timeline/ImageViewerModal.svelte
+++ b/apps/staged/src/lib/features/timeline/ImageViewerModal.svelte
@@ -11,6 +11,8 @@
   import { Button } from '$lib/components/ui/button';
   import { getImageData } from '../../api/commands';
   import { viewport } from '../../shared/viewport.svelte';
+  import ReferenceNavControls from '../references/ReferenceNavControls.svelte';
+  import type { ReferenceNavState } from '../references/referenceHistory.svelte';
 
   interface Props {
     open: boolean;
@@ -18,9 +20,10 @@
     filename: string;
     onClose: () => void;
     onDelete?: () => void;
+    referenceNav?: ReferenceNavState;
   }
 
-  let { open, imageId, filename, onClose, onDelete }: Props = $props();
+  let { open, imageId, filename, onClose, onDelete, referenceNav }: Props = $props();
   let dataUrl = $state<string | null>(null);
   let loading = $state(true);
 
@@ -47,6 +50,9 @@
     <Dialog.Header
       class="flex-row items-center justify-between gap-3 px-4 py-3 border-b border-[var(--border-subtle)]"
     >
+      {#if referenceNav}
+        <ReferenceNavControls nav={referenceNav} />
+      {/if}
       <Dialog.Title
         class="flex-1 min-w-0 text-[var(--size-sm)] font-medium text-foreground overflow-hidden text-ellipsis whitespace-nowrap"
         >{filename}</Dialog.Title

--- a/apps/staged/src/lib/shared/markdown/renderMarkdown.test.ts
+++ b/apps/staged/src/lib/shared/markdown/renderMarkdown.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { renderHashtagTokens } from '../../features/sessions/hashtagItems';
+import type { HashtagItem } from '../../types';
 import { renderMarkdown } from './renderMarkdown';
 import type { PikchrRenderer } from './pikchrRendering';
 
@@ -49,7 +51,26 @@ describe('renderMarkdown', () => {
     expect(html).not.toContain('markdown-diagram-source-pikchr');
     expect(html).not.toContain('box "Start" fit');
     expect(html).not.toContain('box &quot;Start&quot; fit');
-    expect(html).not.toContain('STAGED_MARKDOWN_TRUSTED_DIAGRAM_');
+    expect(html).not.toContain('STAGED_MARKDOWN_TRUSTED_HTML_');
+  });
+
+  it('preserves trusted inline hashtag badge HTML through Markdown sanitization', () => {
+    const html = renderMarkdown('See #note:note-1 for context.', {
+      renderInlineText: (text) => renderHashtagTokens(text, hashtagItems),
+    });
+
+    expect(html).toContain('See ');
+    expect(html).toContain('class="hashtag-badge stable-raster stable-raster-glyphs"');
+    expect(html).toContain('role="button"');
+    expect(html).toContain('tabindex="0"');
+    expect(html).toContain('data-hashtag-ref="#note:note-1"');
+    expect(html).toContain('data-hashtag-type="note"');
+    expect(html).toContain('data-hashtag-id="note-1"');
+    expect(html).toContain('style="background: var(--note-bg); color: var(--note-color);"');
+    expect(html).toContain('<svg xmlns="http://www.w3.org/2000/svg"');
+    expect(html).toContain('<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2');
+    expect(html).toContain('Escaped &lt;title&gt; &amp; &quot;quotes&quot;');
+    expect(html).not.toContain('STAGED_MARKDOWN_TRUSTED_HTML_');
   });
 
   it('preserves numeric Pikchr colors through the Markdown rendering path', () => {
@@ -128,3 +149,13 @@ const unsafePikchrRenderer: PikchrRenderer = () => ({
   kind: 'error',
   message: 'Pikchr rendered unsafe SVG.',
 });
+
+const hashtagItems: HashtagItem[] = [
+  {
+    type: 'note',
+    id: 'note-1',
+    title: 'Escaped <title> & "quotes"',
+    color: '--note-color',
+    bgColor: '--note-bg',
+  },
+];

--- a/apps/staged/src/lib/shared/markdown/renderMarkdown.ts
+++ b/apps/staged/src/lib/shared/markdown/renderMarkdown.ts
@@ -6,7 +6,9 @@ import {
   type MarkdownDiagramRenderingOptions,
 } from './diagramRendering';
 
-export type MarkdownRenderingOptions = MarkdownDiagramRenderingOptions;
+export type MarkdownRenderingOptions = MarkdownDiagramRenderingOptions & {
+  renderInlineText?: (text: string) => string;
+};
 
 interface TrustedHtmlReplacement {
   placeholder: string;
@@ -34,6 +36,7 @@ function createMarkdownRenderer(
 ): Renderer {
   const renderer = new Renderer();
   const renderCode = renderer.code.bind(renderer);
+  const renderText = renderer.text.bind(renderer);
 
   renderer.code = (token: Tokens.Code) => {
     const rendered = renderCode(token);
@@ -42,6 +45,13 @@ function createMarkdownRenderer(
     if (!diagram.trustedHtml) return diagram.html;
 
     return stashTrustedHtml(diagram.html, trustedHtml);
+  };
+
+  renderer.text = (token: Tokens.Text) => {
+    if (!options.renderInlineText) return renderText(token);
+    if ('tokens' in token && token.tokens) return renderText(token);
+    if ('escaped' in token && token.escaped) return renderText(token);
+    return options.renderInlineText(token.text);
   };
 
   return renderer;

--- a/apps/staged/src/lib/shared/markdown/renderMarkdown.ts
+++ b/apps/staged/src/lib/shared/markdown/renderMarkdown.ts
@@ -7,6 +7,12 @@ import {
 } from './diagramRendering';
 
 export type MarkdownRenderingOptions = MarkdownDiagramRenderingOptions & {
+  /**
+   * Render trusted inline HTML for plain text tokens.
+   *
+   * The returned HTML bypasses the generic Markdown sanitizer, so callbacks
+   * must escape any user-controlled text before returning.
+   */
   renderInlineText?: (text: string) => string;
 };
 
@@ -51,14 +57,14 @@ function createMarkdownRenderer(
     if (!options.renderInlineText) return renderText(token);
     if ('tokens' in token && token.tokens) return renderText(token);
     if ('escaped' in token && token.escaped) return renderText(token);
-    return options.renderInlineText(token.text);
+    return stashTrustedHtml(options.renderInlineText(token.text), trustedHtml);
   };
 
   return renderer;
 }
 
 function stashTrustedHtml(html: string, trustedHtml: TrustedHtmlReplacement[]): string {
-  const placeholder = `STAGED_MARKDOWN_TRUSTED_DIAGRAM_${trustedHtml.length}_${createPlaceholderNonce()}`;
+  const placeholder = `STAGED_MARKDOWN_TRUSTED_HTML_${trustedHtml.length}_${createPlaceholderNonce()}`;
   trustedHtml.push({ placeholder, html });
   return placeholder;
 }

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -519,6 +519,15 @@ export interface HashtagItem {
   branchName?: string;
   repoSlug?: string;
   repoSubpath?: string | null;
+  /** Optional context used when resolving a rendered hashtag badge click. */
+  branchId?: string;
+  projectId?: string | null;
+  noteContent?: string;
+  noteSessionId?: string | null;
+  noteUpdatedAt?: number | null;
+  imageFilename?: string;
+  reviewCommitSha?: string;
+  reviewScope?: 'branch' | 'commit';
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add navigable references for hashtag-backed notes, sessions, diffs, and project sections.
- Render hashtag markdown badges as clickable links where appropriate while keeping timeline badges presentational.
- Expand hashtag item and markdown rendering coverage.