### PR TITLE
fix: return pikchr preview paths

### DIFF
--- a/apps/staged/src-tauri/src/pikchr_mcp.rs
+++ b/apps/staged/src-tauri/src/pikchr_mcp.rs
@@ -6,8 +6,9 @@
 //! `generate_pikchr` turns a natural-language description into validated Pikchr
 //! by running a focused internal agent sub-session that renders and repairs its
 //! own output (via [`crate::pikchr_subsession`]) before returning the final
-//! source plus a preview. Revisions pass the current diagram's source back in
-//! so the sub-agent edits real Pikchr rather than re-describing from scratch.
+//! source plus a path to a saved preview image. Revisions pass the current
+//! diagram's source back in so the sub-agent edits real Pikchr rather than
+//! re-describing from scratch.
 //! The sub-session renders and inspects candidate diagrams through the internal
 //! [`run_preview`] path — the same engine the tool ultimately hands back — so
 //! the agent never has to hand-write Pikchr or drive a separate preview step.
@@ -28,13 +29,14 @@
 //! to spin up its sub-session, so it remains safe to attach to any local
 //! session.
 
+use std::io::Write;
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use axum::Router;
-use base64::Engine;
 use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
 use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
 use rmcp::transport::streamable_http_server::{
@@ -65,6 +67,8 @@ const MIN_OVERLAP_PX: f64 = 1.0;
 const MIN_TEXT_OVERLAP_PX: f64 = 3.0;
 /// Truncate derived shape labels in the overlap summary.
 const MAX_LABEL_CHARS: usize = 48;
+/// Temp-file prefix for generated Pikchr preview PNGs.
+const TEMP_IMAGE_PREFIX: &str = "staged-pikchr-preview-";
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct GeneratePikchrParams {
@@ -593,6 +597,28 @@ the rendered SVG could not be parsed.)",
     }
 }
 
+/// Persist a generated preview image in the OS temp directory and return its
+/// path. Use `create_new` with a UUID-based filename so parallel tool calls
+/// never overwrite each other.
+fn write_png_to_temp_file(png: &[u8]) -> std::io::Result<PathBuf> {
+    let temp_dir = std::env::temp_dir();
+    loop {
+        let path = temp_dir.join(format!("{TEMP_IMAGE_PREFIX}{}.png", uuid::Uuid::new_v4()));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                file.write_all(png)?;
+                return Ok(path);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 #[derive(Clone)]
 struct PikchrToolsHandler {
     /// Provider id the `generate_pikchr` sub-session runs under (the parent
@@ -622,7 +648,7 @@ An internal Pikchr specialist writes the diagram, renders it, and repairs syntax
 before returning. Prefer this over hand-writing Pikchr. Pass a fine-grained `description` (boxes, \
 arrows, labels, layout, relationships). To revise an existing diagram, also pass its current source \
 as `previous_pikchr` so it is edited rather than redrawn. Returns the validated Pikchr source (drop \
-it into a ```pikchr fenced code block), a rendered PNG preview, and a summary that reports any \
+it into a ```pikchr fenced code block), a filesystem path to a rendered PNG preview, and a summary that reports any \
 overlapping shapes or labels. Review the preview and the summary: if the layout needs work, call \
 this again passing the returned source as `previous_pikchr` with a description that adjusts it."
     )]
@@ -699,8 +725,16 @@ this again passing the returned source as `previous_pikchr` with a description t
 
         let mut content = Vec::new();
         if let Some(png) = &outcome.png {
-            let b64 = base64::engine::general_purpose::STANDARD.encode(png);
-            content.push(Content::image(b64, "image/png"));
+            let path = write_png_to_temp_file(png).map_err(|e| {
+                ErrorData::internal_error(
+                    format!("Failed to write Pikchr preview image to temp dir: {e}"),
+                    None,
+                )
+            })?;
+            content.push(Content::text(format!(
+                "Rendered preview image path: {}",
+                path.display()
+            )));
         }
         content.push(Content::text(outcome.source));
         // Always hand back the render summary — "No overlaps detected." or the
@@ -954,6 +988,22 @@ arrow from COLL.e to SNOW.w"#;
         assert!(outcome.png.is_some(), "expected a PNG for valid source");
         assert!(!outcome.png.unwrap().is_empty());
         assert!(outcome.summary.contains("px"));
+    }
+
+    #[test]
+    fn writes_png_preview_to_unique_temp_path() {
+        let png = b"fake png bytes";
+        let temp_dir = std::env::temp_dir();
+        let first = write_png_to_temp_file(png).expect("first image should write");
+        let second = write_png_to_temp_file(png).expect("second image should write");
+
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), Some(temp_dir.as_path()));
+        assert_eq!(std::fs::read(&first).unwrap(), png);
+        assert_eq!(std::fs::read(&second).unwrap(), png);
+
+        let _ = std::fs::remove_file(first);
+        let _ = std::fs::remove_file(second);
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/pikchr_mcp.rs
+++ b/apps/staged/src-tauri/src/pikchr_mcp.rs
@@ -422,9 +422,8 @@ fn describe_element(element: &Element) -> String {
     }
 }
 
-/// Build the text summary returned alongside the image. Text matters because
-/// not every provider forwards image content to the model, and even
-/// vision-less models can act on a textual overlap report.
+/// Build the text summary used by the specialist retry loop. Text matters
+/// because vision-less models can act on a textual overlap report.
 fn build_summary(width: i64, height: i64, elements: &[Element], overlaps: &[Overlap]) -> String {
     let mut out = format!("Rendered Pikchr diagram: {width}×{height} px.");
     if overlaps.is_empty() {
@@ -446,11 +445,9 @@ fn build_summary(width: i64, height: i64, elements: &[Element], overlaps: &[Over
         ));
     }
     out.push_str(
-        "\nIf these overlaps aren't intended, call `generate_pikchr` again passing this source as \
-`previous_pikchr` with a description that separates the shapes/labels — e.g. set an explicit flow \
-direction, use named nodes with explicit anchors (`with .w at …`, `arrow from A.e to B.w`), give \
-long labels room or shorten them, and avoid percentage-length arrows between `fit` boxes. \
-Otherwise the diagram is fine to keep.",
+        "\nAdjust the diagram to separate the overlapping shapes/labels — e.g. set an explicit \
+flow direction, use named nodes with explicit anchors (`with .w at …`, `arrow from A.e to B.w`), \
+give long labels room or shorten them, and avoid percentage-length arrows between `fit` boxes.",
     );
     out
 }
@@ -533,8 +530,8 @@ fn rasterize_tree_to_png(tree: &usvg::Tree, scale: f32) -> Option<Vec<u8>> {
 // =============================================================================
 
 /// Outcome of rendering a candidate diagram: the PNG (if rasterization
-/// succeeded), a text summary of dimensions and overlaps, and whether the
-/// source failed to render at all.
+/// succeeded), a text summary of dimensions and overlaps, whether the source
+/// failed to render at all, and whether renderable geometry still overlaps.
 ///
 /// `pub(crate)` so the `generate_pikchr` sub-session loop can render and
 /// inspect candidate diagrams through this shared render/overlap path.
@@ -542,9 +539,10 @@ pub(crate) struct PreviewOutcome {
     pub(crate) png: Option<Vec<u8>>,
     pub(crate) summary: String,
     pub(crate) is_error: bool,
+    pub(crate) has_overlaps: bool,
 }
 
-/// Render + analyze, producing the content blocks for the tool result.
+/// Render + analyze a candidate Pikchr source.
 /// Synchronous and self-contained so it can run on a blocking thread and be
 /// unit-tested directly. `scale` is taken as-is and clamped internally.
 pub(crate) fn run_preview(source: &str, scale: f32) -> PreviewOutcome {
@@ -553,6 +551,7 @@ pub(crate) fn run_preview(source: &str, scale: f32) -> PreviewOutcome {
             png: None,
             summary: "Pikchr source is empty — nothing to render.".to_string(),
             is_error: true,
+            has_overlaps: false,
         };
     }
     let rendered = match render_pikchr_svg(source) {
@@ -562,6 +561,7 @@ pub(crate) fn run_preview(source: &str, scale: f32) -> PreviewOutcome {
                 png: None,
                 summary: format!("Pikchr could not render this diagram:\n{}", err.trim()),
                 is_error: true,
+                has_overlaps: false,
             };
         }
     };
@@ -579,10 +579,12 @@ the rendered SVG could not be parsed.)",
                 rendered.width, rendered.height
             ),
             is_error: false,
+            has_overlaps: false,
         };
     };
 
     let (elements, overlaps) = analyze_overlaps(&tree);
+    let has_overlaps = !overlaps.is_empty();
     let mut summary = build_summary(rendered.width, rendered.height, &elements, &overlaps);
 
     let png = rasterize_tree_to_png(&tree, scale);
@@ -594,6 +596,7 @@ the rendered SVG could not be parsed.)",
         png,
         summary,
         is_error: false,
+        has_overlaps,
     }
 }
 
@@ -644,13 +647,11 @@ impl PikchrToolsHandler {
 impl PikchrToolsHandler {
     #[tool(
         description = "Generate a validated Pikchr diagram from a natural-language description. \
-An internal Pikchr specialist writes the diagram, renders it, and repairs syntax errors on its own \
+An internal Pikchr specialist writes the diagram, renders it, and repairs syntax and layout warnings on its own \
 before returning. Prefer this over hand-writing Pikchr. Pass a fine-grained `description` (boxes, \
 arrows, labels, layout, relationships). To revise an existing diagram, also pass its current source \
 as `previous_pikchr` so it is edited rather than redrawn. Returns the validated Pikchr source (drop \
-it into a ```pikchr fenced code block), a filesystem path to a rendered PNG preview, and a summary that reports any \
-overlapping shapes or labels. Review the preview and the summary: if the layout needs work, call \
-this again passing the returned source as `previous_pikchr` with a description that adjusts it."
+it into a ```pikchr fenced code block) and a filesystem path to a rendered PNG preview."
     )]
     async fn generate_pikchr(
         &self,
@@ -737,10 +738,6 @@ this again passing the returned source as `previous_pikchr` with a description t
             )));
         }
         content.push(Content::text(outcome.source));
-        // Always hand back the render summary — "No overlaps detected." or the
-        // ⚠ overlap report — so the calling agent can review the layout and
-        // decide whether to keep the diagram or re-call to adjust it.
-        content.push(Content::text(outcome.summary));
         Ok(CallToolResult::success(content))
     }
 }
@@ -985,9 +982,18 @@ arrow from COLL.e to SNOW.w"#;
     fn valid_source_produces_png_and_dimensions() {
         let outcome = run_preview("box \"hello\"", DEFAULT_SCALE);
         assert!(!outcome.is_error);
+        assert!(!outcome.has_overlaps);
         assert!(outcome.png.is_some(), "expected a PNG for valid source");
         assert!(!outcome.png.unwrap().is_empty());
         assert!(outcome.summary.contains("px"));
+    }
+
+    #[test]
+    fn overlapping_source_sets_overlap_flag() {
+        let outcome = run_preview(OVERLAPPING_SOURCE, DEFAULT_SCALE);
+        assert!(!outcome.is_error);
+        assert!(outcome.has_overlaps);
+        assert!(outcome.summary.contains("overlapping pair"));
     }
 
     #[test]
@@ -1010,6 +1016,7 @@ arrow from COLL.e to SNOW.w"#;
     fn malformed_source_reports_error() {
         let outcome = run_preview("box \"unterminated", DEFAULT_SCALE);
         assert!(outcome.is_error);
+        assert!(!outcome.has_overlaps);
         assert!(outcome.png.is_none());
         assert!(outcome.summary.to_lowercase().contains("pikchr"));
     }
@@ -1018,6 +1025,7 @@ arrow from COLL.e to SNOW.w"#;
     fn empty_source_reports_error() {
         let outcome = run_preview("   \n  ", DEFAULT_SCALE);
         assert!(outcome.is_error);
+        assert!(!outcome.has_overlaps);
         assert!(outcome.png.is_none());
     }
 

--- a/apps/staged/src-tauri/src/pikchr_subsession.rs
+++ b/apps/staged/src-tauri/src/pikchr_subsession.rs
@@ -6,9 +6,9 @@
 //! path. On a parse error the sub-agent is re-prompted with the specific
 //! failure, resuming the *same* sub-session so the grammar and prior attempts
 //! stay in context — a diagram that doesn't render is useless to hand back. The
-//! loop is bounded by [`MAX_ATTEMPTS`]. Overlaps are *not* repaired here: the
-//! first diagram that renders is returned as-is, its summary carrying any
-//! overlap warnings for the calling note agent to review and decide on.
+//! same loop now re-prompts on overlap warnings too, so the calling note agent
+//! only receives the final source and preview path. The loop is bounded by
+//! [`MAX_ATTEMPTS`].
 //!
 //! The sub-session is deliberately **not** persisted: it uses in-memory `Store`
 //! and `MessageWriter` stubs so its transcript never pollutes the user's
@@ -25,8 +25,9 @@ use crate::agent::AgentDriver;
 use crate::pikchr_mcp::run_preview;
 
 /// Total sub-agent turns before giving up. Each parse error or empty reply
-/// consumes one. 5 leaves room for a couple of repair rounds without letting a
-/// hopeless request run the provider subprocess forever.
+/// consumes one, and each renderable-but-overlapping candidate also consumes
+/// one. 5 leaves room for a couple of repair rounds without letting a hopeless
+/// request run the provider subprocess forever.
 const MAX_ATTEMPTS: usize = 5;
 /// Synthetic session id for the sub-session. The in-memory store keys nothing
 /// meaningful on it; any stable string is fine.
@@ -38,10 +39,6 @@ pub(crate) struct GenOutcome {
     pub(crate) source: String,
     /// Rendered PNG preview, if rasterization succeeded.
     pub(crate) png: Option<Vec<u8>>,
-    /// Render summary (dimensions + any overlap warnings) for the returned
-    /// source. Overlaps are advisory: the caller reviews the summary and the
-    /// PNG and decides whether to keep the diagram or re-call to adjust it.
-    pub(crate) summary: String,
 }
 
 /// Drive the sub-agent to produce validated Pikchr for `description`.
@@ -111,17 +108,20 @@ pub(crate) async fn generate_pikchr_source<D: AgentDriver + ?Sized>(
             continue;
         }
 
-        // It renders — return it as-is. Overlaps are advisory warnings carried
-        // in the summary; the calling agent decides on them, so we don't loop
-        // or re-prompt here.
+        if preview.has_overlaps {
+            prompt = overlap_warning_prompt(&source, &preview.summary);
+            continue;
+        }
+
+        // It renders cleanly, with no overlap warnings for the caller to
+        // interpret.
         return Ok(GenOutcome {
             source,
             png: preview.png,
-            summary: preview.summary,
         });
     }
 
-    Err("The Pikchr specialist could not produce a diagram that renders successfully.".to_string())
+    Err("The Pikchr specialist could not produce a diagram that renders cleanly.".to_string())
 }
 
 /// Pull the Pikchr source out of a sub-agent reply. Prefers a real
@@ -167,6 +167,16 @@ fn parse_error_prompt(error: &str) -> String {
     format!(
         "That failed to render. Pikchr reported:\n{error}\n\
 Fix it and resend ONLY the ```pikchr code block."
+    )
+}
+
+fn overlap_warning_prompt(source: &str, summary: &str) -> String {
+    format!(
+        "That diagram rendered, but the preview analysis found layout overlap warnings:\n{summary}\n\
+\n\
+Current source:\n```pikchr\n{source}\n```\n\
+Fix the overlaps while preserving the requested diagram content. Resend ONLY the corrected \
+```pikchr code block."
     )
 }
 
@@ -258,12 +268,15 @@ box "unifiedevents/batch" "→ Snowflake (UAP unchanged)" fit fill 0xffd6d6
 arrow down 30% from 1st box.s
 box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → builds anywhere" fit fill 0xe8f5e9"#;
 
+    const CLEAN_SOURCE: &str = r#"box "Clean" fit"#;
+
     /// Scripted driver that replays canned replies turn by turn and records the
     /// `agent_session_id` it was handed each turn (to assert resumption).
     struct FakeDriver {
         replies: Vec<String>,
         calls: Mutex<usize>,
         seen_session_ids: Mutex<Vec<Option<String>>>,
+        prompts: Mutex<Vec<String>>,
     }
 
     impl FakeDriver {
@@ -272,6 +285,7 @@ box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → buil
                 replies,
                 calls: Mutex::new(0),
                 seen_session_ids: Mutex::new(Vec::new()),
+                prompts: Mutex::new(Vec::new()),
             }
         }
     }
@@ -281,7 +295,7 @@ box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → buil
         async fn run(
             &self,
             session_id: &str,
-            _prompt: &str,
+            prompt: &str,
             _images: &[(String, String)],
             _working_dir: &Path,
             store: &Arc<dyn acp_client::Store>,
@@ -299,6 +313,7 @@ box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → buil
                 .lock()
                 .unwrap()
                 .push(agent_session_id.map(str::to_string));
+            self.prompts.lock().unwrap().push(prompt.to_string());
 
             // Mimic a new-session turn: register an agent session id so the
             // loop resumes it next time.
@@ -320,8 +335,8 @@ box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → buil
     }
 
     #[tokio::test]
-    async fn returns_immediately_on_overlapping_render() {
-        let driver = FakeDriver::new(vec![fenced(OVERLAPPING_SOURCE)]);
+    async fn repairs_overlapping_render_before_returning() {
+        let driver = FakeDriver::new(vec![fenced(OVERLAPPING_SOURCE), fenced(CLEAN_SOURCE)]);
 
         let outcome = generate_pikchr_source(
             &driver,
@@ -332,20 +347,24 @@ box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → buil
             &CancellationToken::new(),
         )
         .await
-        .expect("should return the first renderable diagram");
+        .expect("should repair the overlapping render");
 
-        // Renders with overlaps — returned as-is, no retries spent on overlap.
-        assert_eq!(outcome.source, OVERLAPPING_SOURCE);
+        assert_eq!(outcome.source, CLEAN_SOURCE);
         assert!(outcome.png.is_some());
-        assert!(outcome.summary.contains("overlapping pair"));
-        assert_eq!(*driver.calls.lock().unwrap(), 1);
+        assert_eq!(*driver.calls.lock().unwrap(), 2);
+
+        let prompts = driver.prompts.lock().unwrap();
+        assert!(prompts[1].contains("overlap warnings"));
+        assert!(prompts[1].contains("overlapping pair"));
+        assert!(prompts[1].contains(OVERLAPPING_SOURCE));
     }
 
     #[tokio::test]
-    async fn repairs_parse_error_then_returns_overlapping_render() {
+    async fn repairs_parse_error_then_overlap_before_returning() {
         let driver = FakeDriver::new(vec![
             fenced("box \"unterminated"), // parse error, repaired
-            fenced(OVERLAPPING_SOURCE),   // renders with overlaps, kept
+            fenced(OVERLAPPING_SOURCE),   // renders with overlaps, repaired
+            fenced(CLEAN_SOURCE),
         ]);
 
         let outcome = generate_pikchr_source(
@@ -357,19 +376,22 @@ box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → buil
             &CancellationToken::new(),
         )
         .await
-        .expect("should repair the parse error and return the overlapping render");
+        .expect("should repair the parse error and overlap");
 
-        // Parse error repaired; overlap left for the caller to decide on.
-        assert_eq!(outcome.source, OVERLAPPING_SOURCE);
+        assert_eq!(outcome.source, CLEAN_SOURCE);
         assert!(outcome.png.is_some());
-        assert!(outcome.summary.contains("overlapping pair"));
-        assert_eq!(*driver.calls.lock().unwrap(), 2);
+        assert_eq!(*driver.calls.lock().unwrap(), 3);
 
-        // First turn starts a session; the repair turn resumes it.
+        let prompts = driver.prompts.lock().unwrap();
+        assert!(prompts[1].contains("failed to render"));
+        assert!(prompts[2].contains("overlapping pair"));
+
+        // First turn starts a session; repair turns resume it.
         let seen = driver.seen_session_ids.lock().unwrap();
-        assert_eq!(seen.len(), 2);
+        assert_eq!(seen.len(), 3);
         assert_eq!(seen[0], None);
         assert_eq!(seen[1].as_deref(), Some("fake-agent-session"));
+        assert_eq!(seen[2].as_deref(), Some("fake-agent-session"));
     }
 
     #[tokio::test]
@@ -388,6 +410,24 @@ box "Sink = NO-OP (default / external clone)" "no socket, no Block deps → buil
 
         assert!(result.is_err());
         // The loop is bounded by MAX_ATTEMPTS even when every reply fails.
+        assert_eq!(*driver.calls.lock().unwrap(), MAX_ATTEMPTS);
+    }
+
+    #[tokio::test]
+    async fn errors_when_overlaps_never_repair() {
+        let driver = FakeDriver::new(vec![fenced(OVERLAPPING_SOURCE); MAX_ATTEMPTS + 2]);
+
+        let result = generate_pikchr_source(
+            &driver,
+            "/tmp/grammar.md",
+            "impossible",
+            None,
+            2.0,
+            &CancellationToken::new(),
+        )
+        .await;
+
+        assert!(result.is_err());
         assert_eq!(*driver.calls.lock().unwrap(), MAX_ATTEMPTS);
     }
 

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -240,7 +240,7 @@ If you need the Pikchr grammar while writing a diagram, read the reference at: {
 of the diagram you want (boxes, arrows, labels, layout, relationships); when revising an existing \
 diagram, or when you want existing source validated or repaired, also pass its current Pikchr \
 source as `previous_pikchr`. It writes the diagram, renders it, and fixes syntax errors on its own, \
-then returns validated Pikchr source, a rendered preview, and a summary that flags any overlapping \
+then returns validated Pikchr source, a filesystem path to a rendered preview image, and a summary that flags any overlapping \
 shapes or labels for you to review — place the returned source in a fenced `pikchr` code block. If the layout \
 isn't what you want, call it again with the returned source as `previous_pikchr` and an adjusted \
 description. Prefer this over hand-writing Pikchr.",

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -239,11 +239,9 @@ If you need the Pikchr grammar while writing a diagram, read the reference at: {
             " To create or revise a diagram, call the `generate_pikchr` tool with a `description` \
 of the diagram you want (boxes, arrows, labels, layout, relationships); when revising an existing \
 diagram, or when you want existing source validated or repaired, also pass its current Pikchr \
-source as `previous_pikchr`. It writes the diagram, renders it, and fixes syntax errors on its own, \
-then returns validated Pikchr source, a filesystem path to a rendered preview image, and a summary that flags any overlapping \
-shapes or labels for you to review — place the returned source in a fenced `pikchr` code block. If the layout \
-isn't what you want, call it again with the returned source as `previous_pikchr` and an adjusted \
-description. Prefer this over hand-writing Pikchr.",
+source as `previous_pikchr`. It writes the diagram, renders it, and fixes syntax errors and overlap \
+warnings on its own, then returns validated Pikchr source and a filesystem path to a rendered preview \
+image — place the returned source in a fenced `pikchr` code block. Prefer this over hand-writing Pikchr.",
         );
     }
     guidance


### PR DESCRIPTION
Summary:
- Write generated Pikchr preview PNGs to unique temp files.
- Return the preview file path from the MCP tool instead of inline image content.
- Update Pikchr tool guidance and test coverage for temp-file preview output.