### PR TITLE
fix: remove project sidebar toggle

### DIFF
--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -9,8 +9,6 @@
   import AlertCircle from '@lucide/svelte/icons/alert-circle';
   import CirclePause from '@lucide/svelte/icons/circle-pause';
   import Cloud from '@lucide/svelte/icons/cloud';
-  import PanelLeftClose from '@lucide/svelte/icons/panel-left-close';
-  import PanelLeftOpen from '@lucide/svelte/icons/panel-left-open';
   import Pause from '@lucide/svelte/icons/pause';
   import Plus from '@lucide/svelte/icons/plus';
   import Trash2 from '@lucide/svelte/icons/trash-2';
@@ -39,12 +37,7 @@
   import * as AlertDialog from '$lib/components/ui/alert-dialog';
   import { Button } from '$lib/components/ui/button';
   import { toast } from 'svelte-sonner';
-  import {
-    projectsSidebarState,
-    setProjects,
-    setProjectsSidebarCollapsed,
-  } from './projectsSidebarState.svelte';
-  import { viewport } from '../../shared/viewport.svelte';
+  import { setProjects } from './projectsSidebarState.svelte';
   import { workspaceLifecycle } from './workspaceLifecycle.svelte';
   import { projectRunActionsStore } from '../../stores/projectRunActions.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
@@ -724,8 +717,6 @@
         )
       : new Set<string>()
   );
-  let sidebarOpen = $derived(!projectsSidebarState.collapsed);
-
   let reposByProject = $derived(
     new Map(
       projects.map((project) => {
@@ -1075,10 +1066,6 @@
     }
   }
 
-  function toggleProjectsSidebar() {
-    setProjectsSidebarCollapsed(!projectsSidebarState.collapsed);
-  }
-
   async function handleTopBarRepoSelected(selection: RepoPickerSelection) {
     const project = selectedProject;
     if (!project) return;
@@ -1162,37 +1149,10 @@
 
 <TopBarPortal
   title={selectedProject ? '' : 'Project'}
-  leftActions={projectTopBarLeftActions}
   center={projectTopBarCenter}
   badges={projectTopBarBadges}
   rightActions={projectTopBarRightActions}
 />
-
-{#snippet projectTopBarLeftActions()}
-  {#if !viewport.isMobile}
-    <span
-      class="inline-flex"
-      title={sidebarOpen ? 'Hide projects sidebar' : 'Show projects sidebar'}
-    >
-      <Button
-        variant="ghost"
-        size="sm"
-        class="top-bar-action gap-1.5 text-foreground hover:bg-[var(--ui-selection)] hover:text-foreground max-md:size-10 max-md:p-0 [&_svg]:size-3.5"
-        aria-label={sidebarOpen ? 'Hide projects sidebar' : 'Show projects sidebar'}
-        onclick={toggleProjectsSidebar}
-        disabled={!projectsSidebarState.hasProjects}
-      >
-        {#if !sidebarOpen || !projectsSidebarState.hasProjects}
-          <PanelLeftOpen size={14} />
-          <span class="top-bar-action-label">Show Sidebar</span>
-        {:else}
-          <PanelLeftClose size={14} />
-          <span class="top-bar-action-label">Hide Sidebar</span>
-        {/if}
-      </Button>
-    </span>
-  {/if}
-{/snippet}
 
 {#snippet projectTopBarCenter()}
   {#if selectedProject && showTopBarProjectName}

--- a/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
@@ -300,9 +300,7 @@
   let resizing = $state(false);
   let resizeStartX = 0;
   let resizeStartWidth = SIDEBAR_DEFAULT_WIDTH;
-  let sidebarVisible = $derived(
-    projectsSidebarState.hasProjects && !viewport.isMobile && !projectsSidebarState.collapsed
-  );
+  let sidebarVisible = $derived(projectsSidebarState.hasProjects && !viewport.isMobile);
   let sidebarStyle = $derived(`width: ${projectsSidebarState.width}px;`);
 
   onMount(() => {

--- a/apps/staged/src/lib/features/projects/projectsSidebarState.svelte.ts
+++ b/apps/staged/src/lib/features/projects/projectsSidebarState.svelte.ts
@@ -2,7 +2,6 @@ import type { Project } from '../../types';
 import { getStoreValue, setStoreValue } from '../../shared/persistentStore';
 
 const SIDEBAR_WIDTH_KEY = 'projects-sidebar-width';
-const SIDEBAR_COLLAPSED_KEY = 'projects-sidebar-collapsed';
 
 export const SIDEBAR_DEFAULT_WIDTH = 280;
 export const SIDEBAR_MIN_WIDTH = 220;
@@ -22,7 +21,6 @@ export const projectsList = $state<{ current: Project[] }>({ current: [] });
 
 export const projectsSidebarState = $state({
   width: SIDEBAR_DEFAULT_WIDTH,
-  collapsed: false,
   hydrated: false,
   hasProjects: true,
   scrollTop: 0,
@@ -31,16 +29,10 @@ export const projectsSidebarState = $state({
 export async function hydrateProjectsSidebarState(): Promise<void> {
   if (projectsSidebarState.hydrated) return;
 
-  const [savedWidth, savedCollapsed] = await Promise.all([
-    getStoreValue<number>(SIDEBAR_WIDTH_KEY),
-    getStoreValue<boolean>(SIDEBAR_COLLAPSED_KEY),
-  ]);
+  const savedWidth = await getStoreValue<number>(SIDEBAR_WIDTH_KEY);
 
   if (typeof savedWidth === 'number' && Number.isFinite(savedWidth)) {
     projectsSidebarState.width = clampWidth(savedWidth);
-  }
-  if (typeof savedCollapsed === 'boolean') {
-    projectsSidebarState.collapsed = savedCollapsed;
   }
 
   projectsSidebarState.hydrated = true;
@@ -64,10 +56,4 @@ export function setProjects(projects: Project[]): void {
 export function setProjectsSidebarScrollTop(scrollTop: number): void {
   if (!Number.isFinite(scrollTop)) return;
   projectsSidebarState.scrollTop = Math.max(0, scrollTop);
-}
-
-export function setProjectsSidebarCollapsed(collapsed: boolean): void {
-  if (projectsSidebarState.collapsed === collapsed) return;
-  projectsSidebarState.collapsed = collapsed;
-  void setStoreValue(SIDEBAR_COLLAPSED_KEY, collapsed);
 }


### PR DESCRIPTION
## Summary
- Remove the project sidebar collapse toggle from the project home layout.
- Keep the projects sidebar visible and remove unused collapsed state handling.

## Testing
- Push hook ran formatting, clippy, svelte-check, and Rust tests; `cargo test` failed during differ doctests with E0463 for `tauri`.