### PR TITLE
fix: show parsed search terms in tool calls

### DIFF
--- a/apps/staged/src/lib/features/sessions/sessionModalHelpers.test.ts
+++ b/apps/staged/src/lib/features/sessions/sessionModalHelpers.test.ts
@@ -49,6 +49,82 @@ describe('makePathsRelative', () => {
   });
 });
 
+describe('formatToolDisplay', () => {
+  it('uses parsed command query for search tool calls', () => {
+    const call = JSON.stringify({
+      name: 'Search fn running_branch_session_kinds in session_commands.rs',
+      input: {
+        parsed_cmd: [
+          {
+            type: 'search',
+            cmd: "rg -n 'fn running_branch_session_kinds' src-tauri/src/session_commands.rs",
+            query: 'fn running_branch_session_kinds',
+            path: 'session_commands.rs',
+          },
+        ],
+      },
+    });
+
+    expect(formatToolDisplay(call, '/repo')).toEqual({
+      verb: 'Searched',
+      detail: 'fn running_branch_session_kinds',
+    });
+  });
+
+  it('uses parsed command paths for read and write tool calls', () => {
+    const readCall = JSON.stringify({
+      name: 'Read writer.rs',
+      input: {
+        parsed_cmd: [
+          {
+            type: 'read',
+            cmd: 'sed -n "1,80p" /repo/src-tauri/src/agent/writer.rs',
+            name: 'writer.rs',
+            path: '/repo/src-tauri/src/agent/writer.rs',
+          },
+        ],
+      },
+    });
+    const writeCall = JSON.stringify({
+      name: 'Write sessionModalHelpers.ts',
+      input: {
+        parsed_cmd: [
+          {
+            type: 'write',
+            cmd: 'apply_patch src/lib/features/sessions/sessionModalHelpers.ts',
+            name: 'sessionModalHelpers.ts',
+            path: '/repo/src/lib/features/sessions/sessionModalHelpers.ts',
+          },
+        ],
+      },
+    });
+
+    expect(formatToolDisplay(readCall, '/repo')).toEqual({
+      verb: 'Read',
+      detail: 'src-tauri/src/agent/writer.rs',
+    });
+    expect(formatToolDisplay(writeCall, '/repo')).toEqual({
+      verb: 'Wrote',
+      detail: 'src/lib/features/sessions/sessionModalHelpers.ts',
+    });
+  });
+
+  it('keeps top-level search args ahead of parsed command fallbacks', () => {
+    const call = JSON.stringify({
+      name: 'Search',
+      input: {
+        query: 'top level query',
+        parsed_cmd: [{ type: 'search', query: 'parsed query' }],
+      },
+    });
+
+    expect(formatToolDisplay(call)).toEqual({
+      verb: 'Searched',
+      detail: 'top level query',
+    });
+  });
+});
+
 describe('sessionEndMessage', () => {
   it('explains project-session interruptions', () => {
     expect(sessionEndMessage({ completionReason: 'project_session_interrupted' })).toBe(

--- a/apps/staged/src/lib/features/sessions/sessionModalHelpers.ts
+++ b/apps/staged/src/lib/features/sessions/sessionModalHelpers.ts
@@ -150,28 +150,74 @@ function primaryArg(toolName: string, args: Record<string, unknown>): string {
   switch (toolName) {
     case 'Read':
     case 'ReadFile':
+      return (
+        str('file_path') ||
+        str('path') ||
+        parsedCommandString(args, ['read'], ['path', 'name']) ||
+        ''
+      );
     case 'Write':
     case 'WriteFile':
     case 'Edit':
     case 'Delete':
     case 'EditNotebook':
     case 'StrReplace':
-      return str('file_path') || str('path') || '';
+      return (
+        str('file_path') ||
+        str('path') ||
+        parsedCommandString(args, ['write', 'edit', 'delete'], ['path', 'name']) ||
+        ''
+      );
     case 'Run':
     case 'Shell':
     case 'Bash':
-      return str('command') || str('cmd') || '';
+      return str('command') || str('cmd') || parsedCommandString(args, ['unknown'], ['cmd']) || '';
     case 'Grep':
     case 'Search':
     case 'SemanticSearch':
-      return str('pattern') || str('query') || '';
+      return (
+        str('pattern') || str('query') || parsedCommandString(args, ['search'], ['query']) || ''
+      );
     case 'Glob':
-      return str('pattern') || str('glob') || '';
+      return (
+        str('pattern') ||
+        str('glob') ||
+        parsedCommandString(args, ['glob'], ['query', 'path']) ||
+        ''
+      );
     default: {
       const formatted = formatArgs(args);
       return formatted.length > 200 ? formatted.slice(0, 200) + '…' : formatted;
     }
   }
+}
+
+function parsedCommandString(
+  args: Record<string, unknown>,
+  preferredTypes: string[],
+  keys: string[]
+): string | undefined {
+  const commands = parsedCommands(args);
+  const preferred = commands.filter((command) => {
+    const type = command.type;
+    return typeof type === 'string' && preferredTypes.includes(type);
+  });
+  for (const command of [...preferred, ...commands]) {
+    for (const key of keys) {
+      const value = command[key];
+      if (typeof value === 'string' && value.trim()) return value;
+    }
+  }
+}
+
+function parsedCommands(args: Record<string, unknown>): Array<Record<string, unknown>> {
+  const value = args.parsed_cmd ?? args.parsedCmd;
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRecord);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 const TITLE_VERBS = new Set([


### PR DESCRIPTION
## Summary
- Use parsed command metadata as a fallback when formatting tool call details for search, read/write, glob, and shell-style calls.
- Preserve top-level argument precedence over parsed command fallbacks.
- Add coverage for parsed search terms and file paths in session modal helper tests.