### PR TITLE
feat: persist queued session messages

### DIFF
--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -2059,6 +2059,7 @@ pub fn run() {
                         Arc::clone(&session_registry),
                         app.handle().clone(),
                     );
+                    session_runner::recover_stale_queued_session_messages(&store_arc);
                     // Clean up images left in "pending" state from compose
                     // dialogs that were abandoned (e.g. user quit mid-dialog).
                     match store_arc.cleanup_pending_images() {
@@ -2318,6 +2319,10 @@ pub fn run() {
             session_commands::count_assistant_messages_after,
             session_commands::start_session,
             session_commands::resume_session,
+            session_commands::queue_session_message,
+            session_commands::list_queued_session_messages,
+            session_commands::delete_queued_session_message,
+            session_commands::send_queued_session_message,
             session_commands::build_note_followup_message,
             session_commands::cancel_session,
             session_commands::delete_session,

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -426,6 +426,7 @@ pub async fn start_session(
             action_registry: None,
             remote_working_dir: None,
             image_ids: vec![],
+            queued_message_id: None,
             branch_id: None,
             project_id: None,
             expose_pikchr_tools: false,
@@ -461,7 +462,34 @@ pub async fn resume_session(
     branch_id: Option<String>,
 ) -> Result<(), String> {
     let store = get_store(&store)?;
+    resume_session_for_store(
+        store,
+        Arc::clone(&registry),
+        Arc::clone(&action_executor),
+        Arc::clone(&action_registry),
+        app_handle,
+        session_id,
+        prompt,
+        image_ids,
+        branch_id,
+        None,
+    )
+    .await
+}
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn resume_session_for_store(
+    store: Arc<Store>,
+    registry: Arc<session_runner::SessionRegistry>,
+    action_executor: Arc<ActionExecutor>,
+    action_registry: Arc<ActionRegistry>,
+    app_handle: tauri::AppHandle,
+    session_id: String,
+    prompt: String,
+    image_ids: Option<Vec<String>>,
+    branch_id: Option<String>,
+    queued_message_id: Option<String>,
+) -> Result<(), String> {
     let session = store
         .get_session(&session_id)
         .map_err(|e| e.to_string())?
@@ -641,6 +669,7 @@ pub async fn resume_session(
             },
             remote_working_dir,
             image_ids: image_ids.unwrap_or_default(),
+            queued_message_id,
             branch_id: config_branch_id,
             project_id: config_project_id,
             expose_pikchr_tools,
@@ -651,6 +680,146 @@ pub async fn resume_session(
     )?;
 
     Ok(())
+}
+
+#[tauri::command]
+pub fn queue_session_message(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    session_id: String,
+    content: String,
+    image_ids: Option<Vec<String>>,
+    branch_id: Option<String>,
+) -> Result<store::QueuedSessionMessage, String> {
+    let store = get_store(&store)?;
+    let session = store
+        .get_session(&session_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Session not found: {session_id}"))?;
+    if session.status != store::SessionStatus::Running {
+        return Err("Session is not running".to_string());
+    }
+    store
+        .add_queued_session_message(
+            &session_id,
+            &content,
+            &image_ids.unwrap_or_default(),
+            branch_id.as_deref(),
+        )
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn list_queued_session_messages(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    session_id: String,
+) -> Result<Vec<store::QueuedSessionMessage>, String> {
+    get_store(&store)?
+        .list_queued_session_messages(&session_id)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_queued_session_message(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    id: String,
+) -> Result<bool, String> {
+    get_store(&store)?
+        .delete_queued_session_message(&id)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn send_queued_session_message(
+    store: tauri::State<'_, Mutex<Option<Arc<Store>>>>,
+    registry: tauri::State<'_, Arc<session_runner::SessionRegistry>>,
+    action_executor: tauri::State<'_, Arc<ActionExecutor>>,
+    action_registry: tauri::State<'_, Arc<ActionRegistry>>,
+    app_handle: tauri::AppHandle,
+    id: String,
+) -> Result<(), String> {
+    let store = get_store(&store)?;
+    send_queued_session_message_for_store(
+        store,
+        Arc::clone(&registry),
+        Arc::clone(&action_executor),
+        Arc::clone(&action_registry),
+        app_handle,
+        id,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn send_queued_session_message_for_store(
+    store: Arc<Store>,
+    registry: Arc<session_runner::SessionRegistry>,
+    action_executor: Arc<ActionExecutor>,
+    action_registry: Arc<ActionRegistry>,
+    app_handle: tauri::AppHandle,
+    id: String,
+) -> Result<(), String> {
+    let message = store
+        .claim_queued_session_message(&id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "Queued message is no longer available or session is running".to_string())?;
+
+    let result = resume_session_for_store(
+        Arc::clone(&store),
+        registry,
+        action_executor,
+        action_registry,
+        app_handle,
+        message.session_id.clone(),
+        message.content.clone(),
+        Some(message.image_ids.clone()),
+        message.branch_id.clone(),
+        Some(message.id.clone()),
+    )
+    .await;
+
+    if let Err(ref e) = result {
+        let _ = store.release_queued_session_message(&message.id, Some(e));
+    }
+
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn drain_queued_message_for_session(
+    store: Arc<Store>,
+    registry: Arc<session_runner::SessionRegistry>,
+    action_executor: Arc<ActionExecutor>,
+    action_registry: Arc<ActionRegistry>,
+    app_handle: tauri::AppHandle,
+    session_id: String,
+) -> Result<bool, String> {
+    let Some(message) = store
+        .claim_oldest_queued_session_message(&session_id)
+        .map_err(|e| e.to_string())?
+    else {
+        return Ok(false);
+    };
+
+    let result = resume_session_for_store(
+        Arc::clone(&store),
+        registry,
+        action_executor,
+        action_registry,
+        app_handle,
+        message.session_id.clone(),
+        message.content.clone(),
+        Some(message.image_ids.clone()),
+        message.branch_id.clone(),
+        Some(message.id.clone()),
+    )
+    .await;
+
+    if let Err(ref e) = result {
+        let _ = store.release_queued_session_message(&message.id, Some(e));
+        return Err(e.clone());
+    }
+
+    Ok(true)
 }
 
 pub(crate) fn infer_branch_resume_session_type(prompt: &str) -> Option<&'static str> {
@@ -1289,6 +1458,7 @@ pub async fn start_project_session(
             action_registry: Some(Arc::clone(&action_registry)),
             remote_working_dir: None,
             image_ids: image_ids.unwrap_or_default(),
+            queued_message_id: None,
             branch_id: None,
             project_id: Some(project_id),
             // Project sessions are always local and write project notes.
@@ -1655,6 +1825,7 @@ fn launch_running_branch_session(
             action_registry: None,
             remote_working_dir: prepared.remote_working_dir,
             image_ids,
+            queued_message_id: None,
             branch_id: Some(branch_id),
             project_id: Some(project_id),
             expose_pikchr_tools,
@@ -2201,6 +2372,7 @@ async fn start_queued_session_for_branch(
             action_registry: None,
             remote_working_dir,
             image_ids,
+            queued_message_id: None,
             branch_id: Some(branch_id),
             project_id: Some(branch.project_id.clone()),
             expose_pikchr_tools: local_note_pikchr_tools_available(
@@ -2552,6 +2724,7 @@ pub async fn trigger_auto_review(
             action_registry: None,
             remote_working_dir,
             image_ids: vec![],
+            queued_message_id: None,
             branch_id: Some(branch_id.clone()),
             project_id: Some(branch.project_id.clone()),
             // Auto-review sessions don't write notes.

--- a/apps/staged/src-tauri/src/session_commands.rs
+++ b/apps/staged/src-tauri/src/session_commands.rs
@@ -427,6 +427,7 @@ pub async fn start_session(
             remote_working_dir: None,
             image_ids: vec![],
             queued_message_id: None,
+            pending_auto_review_branch_id: None,
             branch_id: None,
             project_id: None,
             expose_pikchr_tools: false,
@@ -473,6 +474,7 @@ pub async fn resume_session(
         image_ids,
         branch_id,
         None,
+        None,
     )
     .await
 }
@@ -489,6 +491,7 @@ pub(crate) async fn resume_session_for_store(
     image_ids: Option<Vec<String>>,
     branch_id: Option<String>,
     queued_message_id: Option<String>,
+    pending_auto_review_branch_id: Option<String>,
 ) -> Result<(), String> {
     let session = store
         .get_session(&session_id)
@@ -670,6 +673,7 @@ pub(crate) async fn resume_session_for_store(
             remote_working_dir,
             image_ids: image_ids.unwrap_or_default(),
             queued_message_id,
+            pending_auto_review_branch_id,
             branch_id: config_branch_id,
             project_id: config_project_id,
             expose_pikchr_tools,
@@ -691,13 +695,6 @@ pub fn queue_session_message(
     branch_id: Option<String>,
 ) -> Result<store::QueuedSessionMessage, String> {
     let store = get_store(&store)?;
-    let session = store
-        .get_session(&session_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Session not found: {session_id}"))?;
-    if session.status != store::SessionStatus::Running {
-        return Err("Session is not running".to_string());
-    }
     store
         .add_queued_session_message(
             &session_id,
@@ -774,6 +771,7 @@ pub(crate) async fn send_queued_session_message_for_store(
         Some(message.image_ids.clone()),
         message.branch_id.clone(),
         Some(message.id.clone()),
+        None,
     )
     .await;
 
@@ -792,6 +790,7 @@ pub(crate) async fn drain_queued_message_for_session(
     action_registry: Arc<ActionRegistry>,
     app_handle: tauri::AppHandle,
     session_id: String,
+    pending_auto_review_branch_id: Option<String>,
 ) -> Result<bool, String> {
     let Some(message) = store
         .claim_oldest_queued_session_message(&session_id)
@@ -811,6 +810,7 @@ pub(crate) async fn drain_queued_message_for_session(
         Some(message.image_ids.clone()),
         message.branch_id.clone(),
         Some(message.id.clone()),
+        pending_auto_review_branch_id,
     )
     .await;
 
@@ -1459,6 +1459,7 @@ pub async fn start_project_session(
             remote_working_dir: None,
             image_ids: image_ids.unwrap_or_default(),
             queued_message_id: None,
+            pending_auto_review_branch_id: None,
             branch_id: None,
             project_id: Some(project_id),
             // Project sessions are always local and write project notes.
@@ -1826,6 +1827,7 @@ fn launch_running_branch_session(
             remote_working_dir: prepared.remote_working_dir,
             image_ids,
             queued_message_id: None,
+            pending_auto_review_branch_id: None,
             branch_id: Some(branch_id),
             project_id: Some(project_id),
             expose_pikchr_tools,
@@ -2373,6 +2375,7 @@ async fn start_queued_session_for_branch(
             remote_working_dir,
             image_ids,
             queued_message_id: None,
+            pending_auto_review_branch_id: None,
             branch_id: Some(branch_id),
             project_id: Some(branch.project_id.clone()),
             expose_pikchr_tools: local_note_pikchr_tools_available(
@@ -2725,6 +2728,7 @@ pub async fn trigger_auto_review(
             remote_working_dir,
             image_ids: vec![],
             queued_message_id: None,
+            pending_auto_review_branch_id: None,
             branch_id: Some(branch_id.clone()),
             project_id: Some(branch.project_id.clone()),
             // Auto-review sessions don't write notes.

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -749,10 +749,13 @@ pub fn start_session(
         // can keep using the active cancellation token.
         registry.deregister(&session_id_for_status);
 
+        let completed_successfully =
+            terminal_state_completed_successfully(new_status, &completion_reason);
+
         // Run post-completion hooks before transitioning status.
         // These detect artifacts produced by the session (commits, notes).
         // Returns the branch_id when a new commit was detected.
-        let committed_branch_id = if new_status == "completed" {
+        let committed_branch_id = if completed_successfully {
             run_post_completion_hooks(
                 &config.session_id,
                 &config.working_dir,
@@ -789,11 +792,12 @@ pub fn start_session(
 
         if transitioned {
             let branch_id = config.branch_id.clone();
-            let auto_review_branch_id = committed_branch_id
-                .clone()
-                .or_else(|| config.pending_auto_review_branch_id.clone());
-            let should_drain_queued_message =
-                new_status == "completed" && completion_reason == CompletionReason::TurnComplete;
+            let auto_review_branch_id = auto_review_branch_id_for_terminal_state(
+                committed_branch_id.clone(),
+                config.pending_auto_review_branch_id.clone(),
+                completed_successfully,
+            );
+            let should_drain_queued_message = completed_successfully;
             let session_id_for_follow_up = session_id_for_status.clone();
             let action_executor_for_follow_up = config
                 .action_executor
@@ -2486,6 +2490,26 @@ fn run_post_completion_hooks(
     committed_branch_id
 }
 
+fn terminal_state_completed_successfully(
+    status: &str,
+    completion_reason: &CompletionReason,
+) -> bool {
+    status == SessionStatus::Completed.as_str()
+        && *completion_reason == CompletionReason::TurnComplete
+}
+
+fn auto_review_branch_id_for_terminal_state(
+    committed_branch_id: Option<String>,
+    pending_auto_review_branch_id: Option<String>,
+    completed_successfully: bool,
+) -> Option<String> {
+    committed_branch_id.or_else(|| {
+        completed_successfully
+            .then_some(pending_auto_review_branch_id)
+            .flatten()
+    })
+}
+
 /// Extract note content from a single assistant message.
 ///
 /// Callers are responsible for choosing which message to pass — typically the
@@ -2984,6 +3008,34 @@ mod tests {
             image_ids: vec![],
             acp: Default::default(),
         }
+    }
+
+    #[test]
+    fn terminal_auto_review_reuses_pending_branch_only_after_successful_turn() {
+        assert_eq!(
+            auto_review_branch_id_for_terminal_state(
+                None,
+                Some("branch-pending".to_string()),
+                true,
+            ),
+            Some("branch-pending".to_string())
+        );
+        assert_eq!(
+            auto_review_branch_id_for_terminal_state(
+                None,
+                Some("branch-pending".to_string()),
+                false,
+            ),
+            None
+        );
+        assert_eq!(
+            auto_review_branch_id_for_terminal_state(
+                Some("branch-commit".to_string()),
+                Some("branch-pending".to_string()),
+                false,
+            ),
+            Some("branch-commit".to_string())
+        );
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -809,7 +809,7 @@ pub fn start_session(
                 let registry_for_follow_up = Arc::clone(&registry);
                 let app_handle_for_follow_up = app_handle.clone();
                 tauri::async_runtime::spawn(async move {
-                    let mut queued_message_started = false;
+                    let mut queued_message_blocks_auto_review = false;
                     if should_drain_queued_message {
                         match crate::session_commands::drain_queued_message_for_session(
                             Arc::clone(&store_for_follow_up),
@@ -823,13 +823,14 @@ pub fn start_session(
                         .await
                         {
                             Ok(true) => {
-                                queued_message_started = true;
+                                queued_message_blocks_auto_review = true;
                                 log::info!(
                                     "Drained queued follow-up message for session {session_id_for_follow_up}"
                                 );
                             }
                             Ok(false) => {}
                             Err(e) => {
+                                queued_message_blocks_auto_review = true;
                                 log::error!(
                                     "Failed to drain queued follow-up message for session {session_id_for_follow_up}: {e}"
                                 );
@@ -850,7 +851,7 @@ pub fn start_session(
                             Ok(true) => {
                                 log::info!("Drained next queued session for branch {branch_id}");
                             }
-                            Ok(false) if !queued_message_started => {
+                            Ok(false) if !queued_message_blocks_auto_review => {
                                 // Check if auto-review is enabled in user preferences
                                 let auto_review_enabled = crate::preferences_store_path_buf()
                                     .and_then(|path| std::fs::read_to_string(&path).ok())

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -334,6 +334,8 @@ pub struct SessionConfig {
     pub image_ids: Vec<String>,
     /// Queued follow-up row that produced this run, if any.
     pub queued_message_id: Option<String>,
+    /// Branch with a commit waiting for auto-review once queued follow-ups drain.
+    pub pending_auto_review_branch_id: Option<String>,
     /// Branch that owns this session (branch-level sessions only).
     /// Threaded through so terminal events carry the same context as start events.
     pub branch_id: Option<String>,
@@ -787,7 +789,9 @@ pub fn start_session(
 
         if transitioned {
             let branch_id = config.branch_id.clone();
-            let auto_review_branch_id = committed_branch_id.clone();
+            let auto_review_branch_id = committed_branch_id
+                .clone()
+                .or_else(|| config.pending_auto_review_branch_id.clone());
             let should_drain_queued_message =
                 new_status == "completed" && completion_reason == CompletionReason::TurnComplete;
             let session_id_for_follow_up = session_id_for_status.clone();
@@ -814,6 +818,7 @@ pub fn start_session(
                             Arc::clone(&action_registry_for_follow_up),
                             app_handle_for_follow_up.clone(),
                             session_id_for_follow_up.clone(),
+                            auto_review_branch_id.clone(),
                         )
                         .await
                         {
@@ -1167,6 +1172,7 @@ pub fn start_pipeline_session(
                     remote_working_dir: config.remote_working_dir.clone(),
                     image_ids: vec![],
                     queued_message_id: None,
+                    pending_auto_review_branch_id: None,
                     branch_id: config.branch_id.clone(),
                     project_id: config.project_id.clone(),
                     // Deterministic pipelines hand off to a code-focused AI step,
@@ -1441,6 +1447,7 @@ fn drain_queued_after_pipeline_terminal(
                 Arc::new(ActionRegistry::new()),
                 app_handle.clone(),
                 session_id.clone(),
+                None,
             )
             .await
             {

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -332,6 +332,8 @@ pub struct SessionConfig {
     /// Image IDs to include in the prompt. The runner reads the image files,
     /// base64-encodes them, and passes them as content blocks to the driver.
     pub image_ids: Vec<String>,
+    /// Queued follow-up row that produced this run, if any.
+    pub queued_message_id: Option<String>,
     /// Branch that owns this session (branch-level sessions only).
     /// Threaded through so terminal events carry the same context as start events.
     pub branch_id: Option<String>,
@@ -405,14 +407,26 @@ pub fn start_session(
     // don't appear in the branch timeline. Both operations are kept together;
     // if set_images_session_id fails we log a warning rather than aborting the
     // session, since the message was already persisted.
-    store
-        .add_session_message_with_images(
-            &config.session_id,
-            MessageRole::User,
-            &config.prompt,
-            &config.image_ids,
-        )
-        .map_err(|e| format!("Failed to persist user message: {e}"))?;
+    if let Some(ref queued_message_id) = config.queued_message_id {
+        store
+            .add_session_message_with_images_from_queue(
+                &config.session_id,
+                MessageRole::User,
+                &config.prompt,
+                &config.image_ids,
+                queued_message_id,
+            )
+            .map_err(|e| format!("Failed to persist queued user message: {e}"))?
+    } else {
+        store
+            .add_session_message_with_images(
+                &config.session_id,
+                MessageRole::User,
+                &config.prompt,
+                &config.image_ids,
+            )
+            .map_err(|e| format!("Failed to persist user message: {e}"))?
+    };
 
     if !config.image_ids.is_empty() {
         if let Err(e) = store.set_images_session_id(&config.image_ids, &config.session_id) {
@@ -774,74 +788,115 @@ pub fn start_session(
         if transitioned {
             let branch_id = config.branch_id.clone();
             let auto_review_branch_id = committed_branch_id.clone();
+            let should_drain_queued_message =
+                new_status == "completed" && completion_reason == CompletionReason::TurnComplete;
+            let session_id_for_follow_up = session_id_for_status.clone();
+            let action_executor_for_follow_up = config
+                .action_executor
+                .clone()
+                .unwrap_or_else(|| Arc::new(ActionExecutor::new()));
+            let action_registry_for_follow_up = config
+                .action_registry
+                .clone()
+                .unwrap_or_else(|| Arc::new(ActionRegistry::new()));
 
-            if let Some(branch_id) = branch_id {
+            if should_drain_queued_message || branch_id.is_some() {
                 let store_for_follow_up = Arc::clone(&store_for_status);
                 let registry_for_follow_up = Arc::clone(&registry);
                 let app_handle_for_follow_up = app_handle.clone();
                 tauri::async_runtime::spawn(async move {
-                    match crate::session_commands::drain_queued_sessions_for_branch(
-                        Arc::clone(&store_for_follow_up),
-                        Arc::clone(&registry_for_follow_up),
-                        app_handle_for_follow_up.clone(),
-                        branch_id.clone(),
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(true) => {
-                            log::info!("Drained next queued session for branch {branch_id}");
+                    let mut queued_message_started = false;
+                    if should_drain_queued_message {
+                        match crate::session_commands::drain_queued_message_for_session(
+                            Arc::clone(&store_for_follow_up),
+                            Arc::clone(&registry_for_follow_up),
+                            Arc::clone(&action_executor_for_follow_up),
+                            Arc::clone(&action_registry_for_follow_up),
+                            app_handle_for_follow_up.clone(),
+                            session_id_for_follow_up.clone(),
+                        )
+                        .await
+                        {
+                            Ok(true) => {
+                                queued_message_started = true;
+                                log::info!(
+                                    "Drained queued follow-up message for session {session_id_for_follow_up}"
+                                );
+                            }
+                            Ok(false) => {}
+                            Err(e) => {
+                                log::error!(
+                                    "Failed to drain queued follow-up message for session {session_id_for_follow_up}: {e}"
+                                );
+                            }
                         }
-                        Ok(false) => {
-                            // Check if auto-review is enabled in user preferences
-                            let auto_review_enabled = crate::preferences_store_path_buf()
-                                .and_then(|path| std::fs::read_to_string(&path).ok())
-                                .and_then(|contents| {
-                                    serde_json::from_str::<serde_json::Value>(&contents).ok()
-                                })
-                                .and_then(|json| {
-                                    json.get("auto-start-code-reviews")?
-                                        .as_str()
-                                        .map(String::from)
-                                })
-                                .map(|mode| mode != "never")
-                                .unwrap_or_else(crate::blox::is_sq_available);
+                    }
 
-                            if let Some(auto_review_branch_id) =
-                                auto_review_branch_id.filter(|_| auto_review_enabled)
-                            {
-                                // Pass None so trigger_auto_review resolves
-                                // the user's current preferred agent at
-                                // trigger time, rather than reusing the
-                                // (possibly stale) commit session provider.
-                                match crate::session_commands::trigger_auto_review(
-                                    store_for_follow_up,
-                                    registry_for_follow_up,
-                                    app_handle_for_follow_up,
-                                    auto_review_branch_id.clone(),
-                                    None,
-                                )
-                                .await
+                    if let Some(branch_id) = branch_id {
+                        match crate::session_commands::drain_queued_sessions_for_branch(
+                            Arc::clone(&store_for_follow_up),
+                            Arc::clone(&registry_for_follow_up),
+                            app_handle_for_follow_up.clone(),
+                            branch_id.clone(),
+                            None,
+                        )
+                        .await
+                        {
+                            Ok(true) => {
+                                log::info!("Drained next queued session for branch {branch_id}");
+                            }
+                            Ok(false) if !queued_message_started => {
+                                // Check if auto-review is enabled in user preferences
+                                let auto_review_enabled = crate::preferences_store_path_buf()
+                                    .and_then(|path| std::fs::read_to_string(&path).ok())
+                                    .and_then(|contents| {
+                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
+                                    })
+                                    .and_then(|json| {
+                                        json.get("auto-start-code-reviews")?
+                                            .as_str()
+                                            .map(String::from)
+                                    })
+                                    .map(|mode| mode != "never")
+                                    .unwrap_or_else(crate::blox::is_sq_available);
+
+                                if let Some(auto_review_branch_id) =
+                                    auto_review_branch_id.filter(|_| auto_review_enabled)
                                 {
-                                    Ok(resp) => {
-                                        log::info!(
-                                            "Auto review triggered for branch {auto_review_branch_id}: session={}, review={}",
-                                            resp.session_id,
-                                            resp.artifact_id,
-                                        );
-                                    }
-                                    Err(e) => {
-                                        log::error!(
-                                            "Failed to trigger auto review for branch {auto_review_branch_id}: {e}"
-                                        );
+                                    // Pass None so trigger_auto_review resolves
+                                    // the user's current preferred agent at
+                                    // trigger time, rather than reusing the
+                                    // (possibly stale) commit session provider.
+                                    match crate::session_commands::trigger_auto_review(
+                                        store_for_follow_up,
+                                        registry_for_follow_up,
+                                        app_handle_for_follow_up,
+                                        auto_review_branch_id.clone(),
+                                        None,
+                                    )
+                                    .await
+                                    {
+                                        Ok(resp) => {
+                                            log::info!(
+                                                "Auto review triggered for branch {auto_review_branch_id}: session={}, review={}",
+                                                resp.session_id,
+                                                resp.artifact_id,
+                                            );
+                                        }
+                                        Err(e) => {
+                                            log::error!(
+                                                "Failed to trigger auto review for branch {auto_review_branch_id}: {e}"
+                                            );
+                                        }
                                     }
                                 }
                             }
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "Failed to drain queued sessions for branch {branch_id}: {e}"
-                            );
+                            Ok(false) => {}
+                            Err(e) => {
+                                log::error!(
+                                    "Failed to drain queued sessions for branch {branch_id}: {e}"
+                                );
+                            }
                         }
                     }
                 });
@@ -1067,7 +1122,9 @@ pub fn start_pipeline_session(
                         Arc::clone(&store_for_status),
                         Arc::clone(&registry),
                         app_handle.clone(),
+                        session_id.clone(),
                         config.branch_id.clone(),
+                        true,
                     );
                 }
             }
@@ -1109,6 +1166,7 @@ pub fn start_pipeline_session(
                     action_registry: None,
                     remote_working_dir: config.remote_working_dir.clone(),
                     image_ids: vec![],
+                    queued_message_id: None,
                     branch_id: config.branch_id.clone(),
                     project_id: config.project_id.clone(),
                     // Deterministic pipelines hand off to a code-focused AI step,
@@ -1166,7 +1224,9 @@ pub fn start_pipeline_session(
                             Arc::clone(&store_for_status),
                             Arc::clone(&registry),
                             app_handle.clone(),
+                            session_id.clone(),
                             config.branch_id.clone(),
+                            false,
                         );
                     }
                 }
@@ -1199,7 +1259,9 @@ pub fn start_pipeline_session(
                         Arc::clone(&store_for_status),
                         Arc::clone(&registry),
                         app_handle.clone(),
+                        session_id.clone(),
                         config.branch_id.clone(),
+                        false,
                     );
                 }
             }
@@ -1231,7 +1293,9 @@ pub fn start_pipeline_session(
                         Arc::clone(&store_for_status),
                         Arc::clone(&registry),
                         app_handle.clone(),
+                        session_id.clone(),
                         config.branch_id.clone(),
+                        false,
                     );
                 }
             }
@@ -1360,27 +1424,50 @@ fn drain_queued_after_pipeline_terminal(
     store: Arc<Store>,
     registry: Arc<SessionRegistry>,
     app_handle: AppHandle,
+    session_id: String,
     branch_id: Option<String>,
+    drain_message: bool,
 ) {
-    let Some(branch_id) = branch_id else {
+    if !drain_message && branch_id.is_none() {
         return;
-    };
+    }
 
     tauri::async_runtime::spawn(async move {
-        match crate::session_commands::drain_queued_sessions_for_branch(
-            store,
-            registry,
-            app_handle,
-            branch_id.clone(),
-            None,
-        )
-        .await
-        {
-            Ok(true) => log::info!("Drained next queued session for branch {branch_id}"),
-            Ok(false) => {}
-            Err(e) => log::error!(
-                "Failed to drain queued sessions after pipeline terminal state for branch {branch_id}: {e}"
-            ),
+        if drain_message {
+            match crate::session_commands::drain_queued_message_for_session(
+                Arc::clone(&store),
+                Arc::clone(&registry),
+                Arc::new(ActionExecutor::new()),
+                Arc::new(ActionRegistry::new()),
+                app_handle.clone(),
+                session_id.clone(),
+            )
+            .await
+            {
+                Ok(true) => log::info!("Drained queued follow-up message for session {session_id}"),
+                Ok(false) => {}
+                Err(e) => log::error!(
+                    "Failed to drain queued follow-up message after pipeline terminal state for session {session_id}: {e}"
+                ),
+            }
+        }
+
+        if let Some(branch_id) = branch_id {
+            match crate::session_commands::drain_queued_sessions_for_branch(
+                store,
+                registry,
+                app_handle,
+                branch_id.clone(),
+                None,
+            )
+            .await
+            {
+                Ok(true) => log::info!("Drained next queued session for branch {branch_id}"),
+                Ok(false) => {}
+                Err(e) => log::error!(
+                    "Failed to drain queued sessions after pipeline terminal state for branch {branch_id}: {e}"
+                ),
+            }
         }
     });
 }
@@ -2052,6 +2139,42 @@ pub fn recover_dead_sessions(
                         }
                     });
                 }
+            }
+        }
+    }
+}
+
+/// On startup, return unsent queued follow-up messages claimed by dead owners
+/// to the visible queue so they can be retried manually or by a later drain.
+pub fn recover_stale_queued_session_messages(store: &Store) {
+    let messages = match store.list_sending_queued_session_messages() {
+        Ok(messages) => messages,
+        Err(e) => {
+            log::warn!("[session_runner] Failed to query sending queued messages: {e}");
+            return;
+        }
+    };
+
+    for message in messages {
+        let should_release = match message.owner_pid {
+            None => true,
+            Some(pid) if pid == std::process::id() => true,
+            Some(pid) if !is_process_alive(pid) => true,
+            Some(_) => false,
+        };
+
+        if should_release {
+            match store.release_queued_session_message(&message.id, None) {
+                Ok(true) => log::info!(
+                    "Recovered stale queued follow-up message {} for session {}",
+                    message.id,
+                    message.session_id
+                ),
+                Ok(false) => {}
+                Err(e) => log::warn!(
+                    "Failed to recover stale queued follow-up message {}: {e}",
+                    message.id
+                ),
             }
         }
     }

--- a/apps/staged/src-tauri/src/store/messages.rs
+++ b/apps/staged/src-tauri/src/store/messages.rs
@@ -14,7 +14,7 @@ const VISIBLE_MESSAGE_FILTER: &str = "NOT (content = '' AND acp_event_kind IS NO
 
 /// Parse a JSON array string into a Vec<String>, returning an empty vec on
 /// NULL or invalid JSON.
-fn parse_image_ids(raw: Option<String>) -> Vec<String> {
+pub(super) fn parse_image_ids(raw: Option<String>) -> Vec<String> {
     raw.and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
         .unwrap_or_default()
 }
@@ -25,6 +25,14 @@ fn parse_json_value(raw: Option<String>) -> Option<serde_json::Value> {
 
 fn json_column(value: Option<&serde_json::Value>) -> Option<String> {
     value.and_then(|v| serde_json::to_string(v).ok())
+}
+
+pub(super) fn image_ids_json(image_ids: &[String]) -> Option<String> {
+    if image_ids.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(image_ids).unwrap())
+    }
 }
 
 fn session_message_from_row(row: &Row<'_>) -> rusqlite::Result<SessionMessage> {
@@ -81,11 +89,7 @@ impl Store {
         image_ids: &[String],
     ) -> Result<i64, StoreError> {
         let conn = self.conn.lock().unwrap();
-        let image_ids_json: Option<String> = if image_ids.is_empty() {
-            None
-        } else {
-            Some(serde_json::to_string(image_ids).unwrap())
-        };
+        let image_ids_json = image_ids_json(image_ids);
         conn.execute(
             "INSERT INTO session_messages (session_id, role, content, created_at, image_ids)
              VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -98,6 +102,52 @@ impl Store {
             ],
         )?;
         Ok(conn.last_insert_rowid())
+    }
+
+    /// Insert a user message and atomically mark a claimed queued follow-up as sent.
+    pub fn add_session_message_with_images_from_queue(
+        &self,
+        session_id: &str,
+        role: MessageRole,
+        content: &str,
+        image_ids: &[String],
+        queued_message_id: &str,
+    ) -> Result<i64, StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let image_ids_json = image_ids_json(image_ids);
+        tx.execute(
+            "INSERT INTO session_messages (session_id, role, content, created_at, image_ids)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                role.as_str(),
+                content,
+                now_timestamp(),
+                image_ids_json
+            ],
+        )?;
+        let message_id = tx.last_insert_rowid();
+        let now = now_timestamp();
+        let rows = tx.execute(
+            "UPDATE queued_session_messages
+             SET status = 'sent',
+                 sent_message_id = ?1,
+                 last_error = NULL,
+                 updated_at = ?2
+             WHERE id = ?3
+               AND session_id = ?4
+               AND status = 'sending'
+               AND sent_message_id IS NULL",
+            params![message_id, now, queued_message_id, session_id],
+        )?;
+        if rows != 1 {
+            return Err(StoreError(format!(
+                "Queued message is no longer claimed: {queued_message_id}"
+            )));
+        }
+        tx.commit()?;
+        Ok(message_id)
     }
 
     pub fn get_session_messages(

--- a/apps/staged/src-tauri/src/store/migration_tests.rs
+++ b/apps/staged/src-tauri/src/store/migration_tests.rs
@@ -145,11 +145,12 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         )
         .unwrap();
 
-    assert_eq!(version, 18);
+    assert_eq!(version, 19);
     assert_eq!(app_version, super::APP_VERSION);
     assert!(table_exists(&conn, "projects"));
     assert!(table_exists(&conn, "project_notes"));
     assert!(table_exists(&conn, "images"));
+    assert!(table_exists(&conn, "queued_session_messages"));
     assert!(column_exists(&conn, "comments", "note_session_id"));
     assert!(column_exists(&conn, "comments", "commit_session_id"));
     assert!(column_exists(
@@ -220,13 +221,14 @@ fn test_store_repairs_github_comment_tracking_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 18);
+    assert_eq!(version, 19);
     assert!(column_exists(&conn, "sessions", "pipeline"));
     assert!(column_exists(
         &conn,
         "session_messages",
         "acp_agent_capabilities"
     ));
+    assert!(table_exists(&conn, "queued_session_messages"));
 
     cleanup_db(&path);
 }
@@ -276,7 +278,7 @@ fn test_store_repairs_pipeline_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 18);
+    assert_eq!(version, 19);
     assert!(column_exists(&conn, "comments", "github_comment_id"));
     assert!(column_exists(&conn, "comments", "github_comment_type"));
     assert!(column_exists(&conn, "comments", "github_comment_stale"));
@@ -285,6 +287,7 @@ fn test_store_repairs_pipeline_user_version() {
         "session_messages",
         "acp_agent_capabilities"
     ));
+    assert!(table_exists(&conn, "queued_session_messages"));
 
     cleanup_db(&path);
 }

--- a/apps/staged/src-tauri/src/store/migrations/0019-queued-session-messages/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0019-queued-session-messages/up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE queued_session_messages (
+    id              TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    branch_id       TEXT REFERENCES branches(id) ON DELETE SET NULL,
+    content         TEXT NOT NULL,
+    image_ids       TEXT,
+    status          TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'sending', 'sent')),
+    last_error      TEXT,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    claimed_at      INTEGER,
+    owner_pid       INTEGER,
+    sent_message_id INTEGER REFERENCES session_messages(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_queued_session_messages_session_status
+    ON queued_session_messages(session_id, status, created_at);
+CREATE INDEX idx_queued_session_messages_branch
+    ON queued_session_messages(branch_id);
+CREATE INDEX idx_queued_session_messages_sent_message
+    ON queued_session_messages(sent_message_id);

--- a/apps/staged/src-tauri/src/store/mod.rs
+++ b/apps/staged/src-tauri/src/store/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! Tables: app_metadata, projects, project_repos, branches, workdirs, commits,
 //! sessions, session_messages, notes, project_notes, reviews, images,
-//! action_contexts, repo_actions, repo_affinities.
+//! action_contexts, repo_actions, repo_affinities, queued_session_messages.
 
 pub mod models;
 
@@ -23,6 +23,7 @@ mod notes;
 mod project_notes;
 mod project_repos;
 mod projects;
+mod queued_messages;
 mod recent_repos;
 pub mod repo_affinities;
 pub mod repo_badges;

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -526,6 +526,76 @@ pub struct Session {
     pub pipeline: Option<PipelineExecution>,
 }
 
+/// Persistent follow-up message waiting to be sent to an existing session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueuedSessionMessage {
+    pub id: String,
+    pub session_id: String,
+    pub branch_id: Option<String>,
+    pub content: String,
+    pub image_ids: Vec<String>,
+    pub status: QueuedSessionMessageStatus,
+    pub last_error: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub claimed_at: Option<i64>,
+    pub owner_pid: Option<u32>,
+    pub sent_message_id: Option<i64>,
+}
+
+impl QueuedSessionMessage {
+    pub fn new(
+        session_id: &str,
+        branch_id: Option<&str>,
+        content: &str,
+        image_ids: &[String],
+    ) -> Self {
+        let now = now_timestamp();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            branch_id: branch_id.map(str::to_string),
+            content: content.to_string(),
+            image_ids: image_ids.to_vec(),
+            status: QueuedSessionMessageStatus::Queued,
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+            claimed_at: None,
+            owner_pid: None,
+            sent_message_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum QueuedSessionMessageStatus {
+    Queued,
+    Sending,
+    Sent,
+}
+
+impl QueuedSessionMessageStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Sending => "sending",
+            Self::Sent => "sent",
+        }
+    }
+
+    pub(crate) fn parse(s: &str) -> Option<Self> {
+        match s {
+            "queued" => Some(Self::Queued),
+            "sending" => Some(Self::Sending),
+            "sent" => Some(Self::Sent),
+            _ => None,
+        }
+    }
+}
+
 impl Session {
     pub fn new_running(prompt: &str, working_dir: &Path) -> Self {
         let now = now_timestamp();

--- a/apps/staged/src-tauri/src/store/queued_messages.rs
+++ b/apps/staged/src-tauri/src/store/queued_messages.rs
@@ -3,7 +3,7 @@
 use rusqlite::{params, OptionalExtension};
 
 use super::messages::{image_ids_json, parse_image_ids};
-use super::models::{QueuedSessionMessage, QueuedSessionMessageStatus};
+use super::models::{QueuedSessionMessage, QueuedSessionMessageStatus, SessionStatus};
 use super::{now_timestamp, Store, StoreError};
 
 impl Store {
@@ -16,12 +16,18 @@ impl Store {
     ) -> Result<QueuedSessionMessage, StoreError> {
         let message = QueuedSessionMessage::new(session_id, branch_id, content, image_ids);
         let image_ids_json = image_ids_json(image_ids);
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let rows = tx.execute(
             "INSERT INTO queued_session_messages (
                 id, session_id, branch_id, content, image_ids, status, last_error,
                 created_at, updated_at, claimed_at, owner_pid, sent_message_id
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+             )
+             SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12
+             WHERE EXISTS (
+                 SELECT 1 FROM sessions
+                 WHERE id = ?2 AND status = ?13
+             )",
             params![
                 message.id,
                 message.session_id,
@@ -35,8 +41,23 @@ impl Store {
                 message.claimed_at,
                 message.owner_pid,
                 message.sent_message_id,
+                SessionStatus::Running.as_str(),
             ],
         )?;
+        if rows == 0 {
+            let status = tx
+                .query_row(
+                    "SELECT status FROM sessions WHERE id = ?1",
+                    params![session_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            return match status {
+                Some(_) => Err(StoreError("Session is not running".to_string())),
+                None => Err(StoreError(format!("Session not found: {session_id}"))),
+            };
+        }
+        tx.commit()?;
         Ok(message)
     }
 

--- a/apps/staged/src-tauri/src/store/queued_messages.rs
+++ b/apps/staged/src-tauri/src/store/queued_messages.rs
@@ -57,6 +57,12 @@ impl Store {
                 None => Err(StoreError(format!("Session not found: {session_id}"))),
             };
         }
+        for image_id in image_ids {
+            tx.execute(
+                "UPDATE images SET session_id = ?1 WHERE id = ?2",
+                params![session_id, image_id],
+            )?;
+        }
         tx.commit()?;
         Ok(message)
     }

--- a/apps/staged/src-tauri/src/store/queued_messages.rs
+++ b/apps/staged/src-tauri/src/store/queued_messages.rs
@@ -1,0 +1,242 @@
+//! Persistent follow-up message queue operations.
+
+use rusqlite::{params, OptionalExtension};
+
+use super::messages::{image_ids_json, parse_image_ids};
+use super::models::{QueuedSessionMessage, QueuedSessionMessageStatus};
+use super::{now_timestamp, Store, StoreError};
+
+impl Store {
+    pub fn add_queued_session_message(
+        &self,
+        session_id: &str,
+        content: &str,
+        image_ids: &[String],
+        branch_id: Option<&str>,
+    ) -> Result<QueuedSessionMessage, StoreError> {
+        let message = QueuedSessionMessage::new(session_id, branch_id, content, image_ids);
+        let image_ids_json = image_ids_json(image_ids);
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO queued_session_messages (
+                id, session_id, branch_id, content, image_ids, status, last_error,
+                created_at, updated_at, claimed_at, owner_pid, sent_message_id
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                message.id,
+                message.session_id,
+                message.branch_id,
+                message.content,
+                image_ids_json,
+                message.status.as_str(),
+                message.last_error,
+                message.created_at,
+                message.updated_at,
+                message.claimed_at,
+                message.owner_pid,
+                message.sent_message_id,
+            ],
+        )?;
+        Ok(message)
+    }
+
+    pub fn list_queued_session_messages(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<QueuedSessionMessage>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, session_id, branch_id, content, image_ids, status, last_error,
+                    created_at, updated_at, claimed_at, owner_pid, sent_message_id
+             FROM queued_session_messages
+             WHERE session_id = ?1 AND status != 'sent'
+             ORDER BY created_at ASC, id ASC",
+        )?;
+        let rows = stmt.query_map(params![session_id], Self::row_to_queued_session_message)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn list_sending_queued_session_messages(
+        &self,
+    ) -> Result<Vec<QueuedSessionMessage>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, session_id, branch_id, content, image_ids, status, last_error,
+                    created_at, updated_at, claimed_at, owner_pid, sent_message_id
+             FROM queued_session_messages
+             WHERE status = 'sending' AND sent_message_id IS NULL
+             ORDER BY claimed_at ASC, created_at ASC, id ASC",
+        )?;
+        let rows = stmt.query_map([], Self::row_to_queued_session_message)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn delete_queued_session_message(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "DELETE FROM queued_session_messages
+             WHERE id = ?1 AND status = 'queued'",
+            params![id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    pub fn claim_queued_session_message(
+        &self,
+        id: &str,
+    ) -> Result<Option<QueuedSessionMessage>, StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let now = now_timestamp();
+        let rows = tx.execute(
+            "UPDATE queued_session_messages
+             SET status = 'sending',
+                 claimed_at = ?1,
+                 owner_pid = ?2,
+                 updated_at = ?1,
+                 last_error = NULL
+             WHERE id = ?3
+               AND status = 'queued'
+               AND sent_message_id IS NULL
+               AND EXISTS (
+                   SELECT 1 FROM sessions s
+                   WHERE s.id = queued_session_messages.session_id
+                     AND s.status != 'running'
+               )",
+            params![now, std::process::id(), id],
+        )?;
+        if rows == 0 {
+            tx.commit()?;
+            return Ok(None);
+        }
+        let message = select_queued_session_message(&tx, id)?;
+        tx.commit()?;
+        Ok(message)
+    }
+
+    pub fn claim_oldest_queued_session_message(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<QueuedSessionMessage>, StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let now = now_timestamp();
+        let id = tx
+            .query_row(
+                "SELECT q.id
+                 FROM queued_session_messages q
+                 INNER JOIN sessions s ON s.id = q.session_id
+                 WHERE q.session_id = ?1
+                   AND q.status = 'queued'
+                   AND q.sent_message_id IS NULL
+                   AND s.status != 'running'
+                 ORDER BY q.created_at ASC, q.id ASC
+                 LIMIT 1",
+                params![session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        let Some(id) = id else {
+            tx.commit()?;
+            return Ok(None);
+        };
+        let rows = tx.execute(
+            "UPDATE queued_session_messages
+             SET status = 'sending',
+                 claimed_at = ?1,
+                 owner_pid = ?2,
+                 updated_at = ?1,
+                 last_error = NULL
+             WHERE id = ?3
+               AND status = 'queued'
+               AND sent_message_id IS NULL",
+            params![now, std::process::id(), id],
+        )?;
+        if rows == 0 {
+            tx.commit()?;
+            return Ok(None);
+        }
+        let message = select_queued_session_message(&tx, &id)?;
+        tx.commit()?;
+        Ok(message)
+    }
+
+    pub fn mark_queued_session_message_sent(
+        &self,
+        id: &str,
+        sent_message_id: i64,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE queued_session_messages
+             SET status = 'sent',
+                 sent_message_id = ?1,
+                 last_error = NULL,
+                 updated_at = ?2
+             WHERE id = ?3
+               AND status = 'sending'
+               AND sent_message_id IS NULL",
+            params![sent_message_id, now_timestamp(), id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    pub fn release_queued_session_message(
+        &self,
+        id: &str,
+        error: Option<&str>,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE queued_session_messages
+             SET status = 'queued',
+                 last_error = ?1,
+                 claimed_at = NULL,
+                 owner_pid = NULL,
+                 updated_at = ?2
+             WHERE id = ?3
+               AND status = 'sending'
+               AND sent_message_id IS NULL",
+            params![error, now_timestamp(), id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    fn row_to_queued_session_message(
+        row: &rusqlite::Row,
+    ) -> rusqlite::Result<QueuedSessionMessage> {
+        let status: String = row.get(5)?;
+        let image_ids: Option<String> = row.get(4)?;
+        Ok(QueuedSessionMessage {
+            id: row.get(0)?,
+            session_id: row.get(1)?,
+            branch_id: row.get(2)?,
+            content: row.get(3)?,
+            image_ids: parse_image_ids(image_ids),
+            status: QueuedSessionMessageStatus::parse(&status)
+                .unwrap_or(QueuedSessionMessageStatus::Queued),
+            last_error: row.get(6)?,
+            created_at: row.get(7)?,
+            updated_at: row.get(8)?,
+            claimed_at: row.get(9)?,
+            owner_pid: row.get(10)?,
+            sent_message_id: row.get(11)?,
+        })
+    }
+}
+
+fn select_queued_session_message(
+    tx: &rusqlite::Transaction<'_>,
+    id: &str,
+) -> Result<Option<QueuedSessionMessage>, StoreError> {
+    tx.query_row(
+        "SELECT id, session_id, branch_id, content, image_ids, status, last_error,
+                created_at, updated_at, claimed_at, owner_pid, sent_message_id
+         FROM queued_session_messages
+         WHERE id = ?1",
+        params![id],
+        Store::row_to_queued_session_message,
+    )
+    .optional()
+    .map_err(Into::into)
+}

--- a/apps/staged/src-tauri/src/store/queued_messages.rs
+++ b/apps/staged/src-tauri/src/store/queued_messages.rs
@@ -99,13 +99,37 @@ impl Store {
     }
 
     pub fn delete_queued_session_message(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let Some(message) = select_queued_session_message(&tx, id)? else {
+            tx.commit()?;
+            return Ok(false);
+        };
+        if message.status != QueuedSessionMessageStatus::Queued {
+            tx.commit()?;
+            return Ok(false);
+        }
+
+        let rows = tx.execute(
             "DELETE FROM queued_session_messages
              WHERE id = ?1 AND status = 'queued'",
             params![id],
         )?;
-        Ok(rows > 0)
+        if rows == 0 {
+            tx.commit()?;
+            return Ok(false);
+        }
+
+        for image_id in &message.image_ids {
+            tx.execute(
+                "UPDATE images
+                 SET session_id = NULL
+                 WHERE id = ?1 AND session_id = ?2",
+                params![image_id, message.session_id],
+            )?;
+        }
+        tx.commit()?;
+        Ok(true)
     }
 
     pub fn claim_queued_session_message(

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -533,7 +533,7 @@ fn test_queued_session_messages_order_and_image_ids() {
 }
 
 #[test]
-fn test_claim_selected_queued_session_message_and_release() {
+fn test_add_queued_session_message_requires_running_session() {
     let store = Store::in_memory().unwrap();
     let session = Session::new_running("work", Path::new("/tmp"));
     store.create_session(&session).unwrap();
@@ -541,11 +541,36 @@ fn test_claim_selected_queued_session_message_and_release() {
         .update_session_status(&session.id, SessionStatus::Completed, None, None)
         .unwrap();
 
+    let err = store
+        .add_queued_session_message(&session.id, "too late", &[], None)
+        .unwrap_err();
+    assert_eq!(err.to_string(), "Session is not running");
+    assert!(store
+        .list_queued_session_messages(&session.id)
+        .unwrap()
+        .is_empty());
+
+    let err = store
+        .add_queued_session_message("missing-session", "not found", &[], None)
+        .unwrap_err();
+    assert_eq!(err.to_string(), "Session not found: missing-session");
+}
+
+#[test]
+fn test_claim_selected_queued_session_message_and_release() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+
     let oldest = store
         .add_queued_session_message(&session.id, "oldest", &[], None)
         .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
     let selected = store
         .add_queued_session_message(&session.id, "selected", &[], None)
+        .unwrap();
+    store
+        .update_session_status(&session.id, SessionStatus::Completed, None, None)
         .unwrap();
 
     let claimed = store
@@ -595,11 +620,11 @@ fn test_queued_session_message_marks_sent_with_transcript_message() {
     let store = Store::in_memory().unwrap();
     let session = Session::new_running("work", Path::new("/tmp"));
     store.create_session(&session).unwrap();
-    store
-        .update_session_status(&session.id, SessionStatus::Completed, None, None)
-        .unwrap();
     let queued = store
         .add_queued_session_message(&session.id, "follow up", &[], None)
+        .unwrap();
+    store
+        .update_session_status(&session.id, SessionStatus::Completed, None, None)
         .unwrap();
     store
         .claim_queued_session_message(&queued.id)

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -506,6 +506,143 @@ fn test_transition_queued_to_running_does_not_overwrite_cancelled_session() {
 }
 
 #[test]
+fn test_queued_session_messages_order_and_image_ids() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+
+    let first_images = vec!["img-1".to_string(), "img-2".to_string()];
+    let first = store
+        .add_queued_session_message(&session.id, "first", &first_images, None)
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    let second = store
+        .add_queued_session_message(&session.id, "second", &[], None)
+        .unwrap();
+
+    let queued = store.list_queued_session_messages(&session.id).unwrap();
+    assert_eq!(
+        queued
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![first.id.as_str(), second.id.as_str()]
+    );
+    assert_eq!(queued[0].image_ids, first_images);
+    assert!(queued[1].image_ids.is_empty());
+}
+
+#[test]
+fn test_claim_selected_queued_session_message_and_release() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+    store
+        .update_session_status(&session.id, SessionStatus::Completed, None, None)
+        .unwrap();
+
+    let oldest = store
+        .add_queued_session_message(&session.id, "oldest", &[], None)
+        .unwrap();
+    let selected = store
+        .add_queued_session_message(&session.id, "selected", &[], None)
+        .unwrap();
+
+    let claimed = store
+        .claim_queued_session_message(&selected.id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.id, selected.id);
+    assert_eq!(claimed.status, QueuedSessionMessageStatus::Sending);
+    assert_eq!(claimed.owner_pid, Some(std::process::id()));
+
+    store
+        .release_queued_session_message(&selected.id, Some("try again"))
+        .unwrap();
+    let queued = store.list_queued_session_messages(&session.id).unwrap();
+    assert_eq!(queued.len(), 2);
+    assert_eq!(queued[0].id, oldest.id);
+    assert_eq!(queued[1].id, selected.id);
+    assert_eq!(queued[1].last_error.as_deref(), Some("try again"));
+}
+
+#[test]
+fn test_claim_oldest_queued_session_message_skips_running_session() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+    store
+        .add_queued_session_message(&session.id, "queued", &[], None)
+        .unwrap();
+
+    let claimed = store
+        .claim_oldest_queued_session_message(&session.id)
+        .unwrap();
+    assert!(claimed.is_none());
+
+    store
+        .update_session_status(&session.id, SessionStatus::Completed, None, None)
+        .unwrap();
+    let claimed = store
+        .claim_oldest_queued_session_message(&session.id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.content, "queued");
+}
+
+#[test]
+fn test_queued_session_message_marks_sent_with_transcript_message() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+    store
+        .update_session_status(&session.id, SessionStatus::Completed, None, None)
+        .unwrap();
+    let queued = store
+        .add_queued_session_message(&session.id, "follow up", &[], None)
+        .unwrap();
+    store
+        .claim_queued_session_message(&queued.id)
+        .unwrap()
+        .unwrap();
+
+    let message_id = store
+        .add_session_message_with_images_from_queue(
+            &session.id,
+            MessageRole::User,
+            "follow up",
+            &[],
+            &queued.id,
+        )
+        .unwrap();
+
+    assert!(store
+        .list_queued_session_messages(&session.id)
+        .unwrap()
+        .is_empty());
+    let messages = store.get_session_messages(&session.id).unwrap();
+    assert_eq!(messages[0].id, message_id);
+    assert_eq!(messages[0].content, "follow up");
+}
+
+#[test]
+fn test_queued_session_messages_cascade_when_session_deleted() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+    store
+        .add_queued_session_message(&session.id, "follow up", &[], None)
+        .unwrap();
+
+    store.delete_session(&session.id).unwrap();
+
+    assert!(store
+        .list_queued_session_messages(&session.id)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
 fn test_queued_project_session_cancellation_records_project_session_interrupted() {
     let store = Store::in_memory().unwrap();
 

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -556,6 +556,47 @@ fn test_queued_session_message_claims_pending_images() {
 }
 
 #[test]
+fn test_delete_queued_session_message_releases_claimed_images() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let branch = Branch::new(&project.id, "feature", "main");
+    store.create_branch(&branch).unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+    let image = Image::new(
+        Some(&branch.id),
+        &project.id,
+        "screenshot.png",
+        "image/png",
+        42,
+        true,
+    );
+    store.create_image(&image).unwrap();
+    let queued = store
+        .add_queued_session_message(
+            &session.id,
+            "with image",
+            std::slice::from_ref(&image.id),
+            Some(&branch.id),
+        )
+        .unwrap();
+
+    assert!(store.delete_queued_session_message(&queued.id).unwrap());
+
+    let released = store.get_image(&image.id).unwrap().unwrap();
+    assert_eq!(released.session_id, None);
+    let branch_images = store.list_images_for_branch(&branch.id).unwrap();
+    assert_eq!(
+        branch_images
+            .iter()
+            .map(|image| image.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![image.id.as_str()]
+    );
+}
+
+#[test]
 fn test_add_queued_session_message_requires_running_session() {
     let store = Store::in_memory().unwrap();
     let session = Session::new_running("work", Path::new("/tmp"));

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -533,6 +533,29 @@ fn test_queued_session_messages_order_and_image_ids() {
 }
 
 #[test]
+fn test_queued_session_message_claims_pending_images() {
+    let store = Store::in_memory().unwrap();
+    let project = Project::new("test-owner/test-repo");
+    store.create_project(&project).unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+    let image = Image::new(None, &project.id, "screenshot.png", "image/png", 42, true);
+    store.create_image(&image).unwrap();
+
+    store
+        .add_queued_session_message(
+            &session.id,
+            "with image",
+            std::slice::from_ref(&image.id),
+            None,
+        )
+        .unwrap();
+
+    let claimed = store.get_image(&image.id).unwrap().unwrap();
+    assert_eq!(claimed.session_id.as_deref(), Some(session.id.as_str()));
+}
+
+#[test]
 fn test_add_queued_session_message_requires_running_session() {
     let store = Store::in_memory().unwrap();
     let session = Session::new_running("work", Path::new("/tmp"));

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2834,6 +2834,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     action_registry: None,
                     remote_working_dir: None,
                     image_ids: vec![],
+                    queued_message_id: None,
                     branch_id: None,
                     project_id: None,
                     expose_pikchr_tools: false,
@@ -3013,6 +3014,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     },
                     remote_working_dir,
                     image_ids: image_ids.unwrap_or_default(),
+                    queued_message_id: None,
                     branch_id: config_branch_id,
                     project_id: config_project_id,
                     expose_pikchr_tools,
@@ -3022,6 +3024,59 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                 Arc::clone(session_registry),
             )?;
 
+            Ok(Value::Null)
+        }
+        "queue_session_message" => {
+            let store = get_store(store_mutex)?;
+            let session_id: String = arg(&args, "sessionId")?;
+            let content: String = arg(&args, "content")?;
+            let image_ids: Option<Vec<String>> = opt_arg(&args, "imageIds")?;
+            let branch_id: Option<String> = opt_arg(&args, "branchId")?;
+            let session = store
+                .get_session(&session_id)
+                .map_err(|e| e.to_string())?
+                .ok_or_else(|| format!("Session not found: {session_id}"))?;
+            if session.status != store::SessionStatus::Running {
+                return Err("Session is not running".to_string());
+            }
+            let message = store
+                .add_queued_session_message(
+                    &session_id,
+                    &content,
+                    &image_ids.unwrap_or_default(),
+                    branch_id.as_deref(),
+                )
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::to_value(message).unwrap())
+        }
+        "list_queued_session_messages" => {
+            let store = get_store(store_mutex)?;
+            let session_id: String = arg(&args, "sessionId")?;
+            let messages = store
+                .list_queued_session_messages(&session_id)
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::to_value(messages).unwrap())
+        }
+        "delete_queued_session_message" => {
+            let store = get_store(store_mutex)?;
+            let id: String = arg(&args, "id")?;
+            let deleted = store
+                .delete_queued_session_message(&id)
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::to_value(deleted).unwrap())
+        }
+        "send_queued_session_message" => {
+            let store = get_store(store_mutex)?;
+            let id: String = arg(&args, "id")?;
+            session_commands::send_queued_session_message_for_store(
+                store,
+                Arc::clone(session_registry),
+                Arc::clone(action_executor),
+                Arc::clone(action_registry),
+                app_handle.clone(),
+                id,
+            )
+            .await?;
             Ok(Value::Null)
         }
         "build_note_followup_message" => {
@@ -3126,6 +3181,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     action_registry: Some(Arc::clone(action_registry)),
                     remote_working_dir: None,
                     image_ids: image_ids.unwrap_or_default(),
+                    queued_message_id: None,
                     branch_id: None,
                     project_id: Some(project_id),
                     // Project sessions are always local and write project notes.

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -2835,6 +2835,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     remote_working_dir: None,
                     image_ids: vec![],
                     queued_message_id: None,
+                    pending_auto_review_branch_id: None,
                     branch_id: None,
                     project_id: None,
                     expose_pikchr_tools: false,
@@ -3015,6 +3016,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     remote_working_dir,
                     image_ids: image_ids.unwrap_or_default(),
                     queued_message_id: None,
+                    pending_auto_review_branch_id: None,
                     branch_id: config_branch_id,
                     project_id: config_project_id,
                     expose_pikchr_tools,
@@ -3032,13 +3034,6 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
             let content: String = arg(&args, "content")?;
             let image_ids: Option<Vec<String>> = opt_arg(&args, "imageIds")?;
             let branch_id: Option<String> = opt_arg(&args, "branchId")?;
-            let session = store
-                .get_session(&session_id)
-                .map_err(|e| e.to_string())?
-                .ok_or_else(|| format!("Session not found: {session_id}"))?;
-            if session.status != store::SessionStatus::Running {
-                return Err("Session is not running".to_string());
-            }
             let message = store
                 .add_queued_session_message(
                     &session_id,
@@ -3182,6 +3177,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                     remote_working_dir: None,
                     image_ids: image_ids.unwrap_or_default(),
                     queued_message_id: None,
+                    pending_auto_review_branch_id: None,
                     branch_id: None,
                     project_id: Some(project_id),
                     // Project sessions are always local and write project notes.

--- a/apps/staged/src/lib/commands.test.ts
+++ b/apps/staged/src/lib/commands.test.ts
@@ -82,6 +82,44 @@ describe('browser-native command wrappers', () => {
       hasParsedNote: true,
     });
   });
+
+  it('routes queued follow-up message operations through backend commands', async () => {
+    const queued = { id: 'queue-1', sessionId: 'session-1', content: 'next' };
+    const invokeCommand = vi.fn().mockResolvedValue(queued);
+    vi.doMock('./transport', () => ({
+      invokeCommand,
+      isTauri: true,
+    }));
+
+    const {
+      queueSessionMessage,
+      listQueuedSessionMessages,
+      deleteQueuedSessionMessage,
+      sendQueuedSessionMessage,
+    } = await import('./commands');
+
+    await expect(queueSessionMessage('session-1', 'next', ['image-1'], 'branch-1')).resolves.toBe(
+      queued
+    );
+    await listQueuedSessionMessages('session-1');
+    await deleteQueuedSessionMessage('queue-1');
+    await sendQueuedSessionMessage('queue-1');
+
+    expect(invokeCommand.mock.calls).toEqual([
+      [
+        'queue_session_message',
+        {
+          sessionId: 'session-1',
+          content: 'next',
+          imageIds: ['image-1'],
+          branchId: 'branch-1',
+        },
+      ],
+      ['list_queued_session_messages', { sessionId: 'session-1' }],
+      ['delete_queued_session_message', { id: 'queue-1' }],
+      ['send_queued_session_message', { id: 'queue-1' }],
+    ]);
+  });
 });
 
 describe('cached mutation command wrappers', () => {

--- a/apps/staged/src/lib/commands.ts
+++ b/apps/staged/src/lib/commands.ts
@@ -27,6 +27,7 @@ import type {
   StoreIncompatibility,
   Session,
   SessionMessage,
+  QueuedSessionMessage,
   DiffFilesResponse,
   FileDiff,
   File,
@@ -763,6 +764,32 @@ export function resumeSession(
     imageIds: imageIds ?? null,
     branchId: branchId ?? null,
   });
+}
+
+export function queueSessionMessage(
+  sessionId: string,
+  content: string,
+  imageIds?: string[],
+  branchId?: string | null
+): Promise<QueuedSessionMessage> {
+  return invokeCommand('queue_session_message', {
+    sessionId,
+    content,
+    imageIds: imageIds ?? null,
+    branchId: branchId ?? null,
+  });
+}
+
+export function listQueuedSessionMessages(sessionId: string): Promise<QueuedSessionMessage[]> {
+  return invokeCommand('list_queued_session_messages', { sessionId });
+}
+
+export function deleteQueuedSessionMessage(id: string): Promise<boolean> {
+  return invokeCommand('delete_queued_session_message', { id });
+}
+
+export function sendQueuedSessionMessage(id: string): Promise<void> {
+  return invokeCommand('send_queued_session_message', { id });
 }
 
 export function buildNoteFollowupMessage(

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -186,6 +186,7 @@
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let pollInFlight = false;
   let unlistenStatus: UnlistenFn | null = null;
+  let statusEventVersion = 0;
   let closed = false;
 
   let inputText = $state('');
@@ -511,6 +512,7 @@
 
     const unlisten = listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
       if (payload.sessionId !== id) return;
+      statusEventVersion += 1;
       session =
         session?.id === id
           ? {
@@ -607,9 +609,11 @@
     pollInFlight = true;
     try {
       // Fetch session status
+      const statusVersionBeforeFetch = statusEventVersion;
       const s = await getSession(sessionId);
       if (closed) return;
-      if (s) session = s;
+      const statusEventDuringFetch = statusEventVersion !== statusVersionBeforeFetch;
+      if (s && !statusEventDuringFetch) session = s;
       await refreshQueuedMessages();
 
       // Incremental message fetch
@@ -642,8 +646,9 @@
       }
 
       // Stop polling when session is done. Backend-owned queue drain may emit
-      // a fresh running event immediately after this terminal state.
-      if (s && s.status !== 'running') {
+      // a fresh running event while this poll is in flight; that event is
+      // fresher than this status fetch and keeps polling alive.
+      if (s && s.status !== 'running' && !statusEventDuringFetch && session?.status !== 'running') {
         stopPolling();
       }
     } catch {

--- a/apps/staged/src/lib/features/sessions/SessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionModal.svelte
@@ -9,7 +9,7 @@
   Features:
   - Text input always available at the bottom
   - Send button when idle, Stop button when running
-  - Message queue: hitting Enter while running enqueues for after completion
+  - Message queue: hitting Enter while running persists a follow-up for backend drain
   - Copy button on every message
   - Tool calls show name + args preview; expand to see output
   - Fixed-size modal with proper scrolling
@@ -48,7 +48,14 @@
   import Plus from '@lucide/svelte/icons/plus';
   import Spinner from '../../shared/Spinner.svelte';
   import { isResumableReason } from '../../types';
-  import type { Session, SessionMessage, HashtagItem, ProjectRepo } from '../../types';
+  import type {
+    Session,
+    SessionMessage,
+    QueuedSessionMessage,
+    HashtagItem,
+    ProjectRepo,
+    SessionStatusPayload,
+  } from '../../types';
   import {
     buildNoteFollowupMessage,
     cancelSession,
@@ -61,8 +68,13 @@
     getSessionMessages,
     getSessionMessagesSince,
     handleExternalLinkClick,
+    deleteQueuedSessionMessage,
+    listQueuedSessionMessages,
+    queueSessionMessage,
     resumeSession,
+    sendQueuedSessionMessage,
   } from '../../api/commands';
+  import { listenToEvent, type UnlistenFn } from '../../transport';
   import HashtagInput from './HashtagInput.svelte';
   import {
     buildBranchHashtagItems,
@@ -173,17 +185,19 @@
   let inputEl: HTMLElement | null = $state(null);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let pollInFlight = false;
+  let unlistenStatus: UnlistenFn | null = null;
   let closed = false;
 
   let inputText = $state('');
-  let messageQueue = $state<string[]>([]);
+  let queuedMessages = $state<QueuedSessionMessage[]>([]);
+  let queueActionIds = $state<Set<string>>(new Set());
   let copiedId = $state<number | string | null>(null);
   let expandedTools = $state<Set<string>>(new Set());
   let displayRoots = $state<string[]>([]);
   let currentDisplayRootKey = '';
 
   let isLive = $derived(session?.status === 'running');
-  let hasQueuedMessages = $derived(messageQueue.length > 0);
+  let hasQueuedMessages = $derived(queuedMessages.length > 0);
   let noteFollowupLabel = $derived(getNoteFollowupLabel(session, messages, noteInfo));
   let assistantMarkdownContent = $derived(
     messages
@@ -294,6 +308,11 @@
         for (const id of msg.imageIds) {
           allImageIds.add(id);
         }
+      }
+    }
+    for (const msg of queuedMessages) {
+      for (const id of msg.imageIds) {
+        allImageIds.add(id);
       }
     }
     for (const id of allImageIds) {
@@ -451,6 +470,7 @@
   onDestroy(() => {
     closed = true;
     stopPolling();
+    unlistenStatus?.();
     unregisterSearchTarget?.();
   });
 
@@ -484,6 +504,38 @@
     });
   });
 
+  $effect(() => {
+    const isOpen = open;
+    const id = sessionId;
+    if (!isOpen || !id) return;
+
+    const unlisten = listenToEvent<SessionStatusPayload>('session-status-changed', (payload) => {
+      if (payload.sessionId !== id) return;
+      session =
+        session?.id === id
+          ? {
+              ...session,
+              status: payload.status,
+              errorMessage: payload.errorMessage ?? session.errorMessage,
+              completionReason: payload.completionReason ?? session.completionReason,
+              updatedAt: Date.now(),
+            }
+          : session;
+      refreshQueuedMessages();
+      if (payload.status === 'running') {
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    });
+    unlistenStatus = unlisten;
+
+    return () => {
+      unlistenStatus?.();
+      unlistenStatus = null;
+    };
+  });
+
   function isComposerFocused(): boolean {
     return document.activeElement === inputEl;
   }
@@ -507,14 +559,16 @@
       session = null;
       messages = [];
       acpMetadataMessages = [];
+      queuedMessages = [];
     }
     loading = true;
     error = null;
     try {
-      const [s, msgsResult, acpMsgs] = await Promise.all([
+      const [s, msgsResult, acpMsgs, queued] = await Promise.all([
         getSession(sessionId),
         getSessionMessages(sessionId),
         getSessionAcpMetadataMessages(sessionId),
+        listQueuedSessionMessages(sessionId),
       ]);
       if (closed) return;
       if (!s) {
@@ -523,6 +577,7 @@
       }
       session = s;
       messages = msgsResult.data;
+      queuedMessages = queued;
       if (msgsResult.revalidating) {
         msgsResult.revalidating
           .then((fresh) => {
@@ -555,6 +610,7 @@
       const s = await getSession(sessionId);
       if (closed) return;
       if (s) session = s;
+      await refreshQueuedMessages();
 
       // Incremental message fetch
       if (messages.length === 0) {
@@ -585,15 +641,24 @@
         }
       }
 
-      // Stop polling when session is done; process queued messages
+      // Stop polling when session is done. Backend-owned queue drain may emit
+      // a fresh running event immediately after this terminal state.
       if (s && s.status !== 'running') {
         stopPolling();
-        processQueue();
       }
     } catch {
       // Polling errors are expected during shutdown — silently ignore
     } finally {
       pollInFlight = false;
+    }
+  }
+
+  async function refreshQueuedMessages() {
+    if (!sessionId || closed) return;
+    try {
+      queuedMessages = await listQueuedSessionMessages(sessionId);
+    } catch (e) {
+      console.error('Failed to refresh queued messages:', e);
     }
   }
 
@@ -628,8 +693,14 @@
     tick().then(() => autoResize());
 
     if (isLive) {
-      // Session is running — queue the message for after it finishes
-      messageQueue = [...messageQueue, text];
+      try {
+        await queueSessionMessage(sessionId, text, imageIdsToSend, branchId ?? null);
+        await refreshQueuedMessages();
+      } catch (e) {
+        error = `Failed to queue: ${e instanceof Error ? e.message : String(e)}`;
+        inputText = text;
+        replyImageIds = imageIdsToSend ?? [];
+      }
       return;
     }
 
@@ -659,8 +730,6 @@
       scrollToBottom();
     } catch (e) {
       error = `Failed to send: ${e instanceof Error ? e.message : String(e)}`;
-      // Clear the queue — don't keep trying to send if the session is broken
-      messageQueue = [];
     } finally {
       if (!sendingLocked) sending = false;
     }
@@ -683,19 +752,45 @@
       await sendMessage(prompt, undefined, true, target);
     } catch (e) {
       error = `Failed to send: ${e instanceof Error ? e.message : String(e)}`;
-      messageQueue = [];
     } finally {
       noteFollowupSending = false;
       sending = false;
     }
   }
 
-  /** Process the next queued message when the session becomes idle. */
-  async function processQueue() {
-    if (messageQueue.length === 0 || isLive || error) return;
-    const [next, ...rest] = messageQueue;
-    messageQueue = rest;
-    await sendMessage(next);
+  async function handleDeleteQueuedMessage(id: string) {
+    if (queueActionIds.has(id)) return;
+    queueActionIds = new Set(queueActionIds).add(id);
+    try {
+      await deleteQueuedSessionMessage(id);
+      await refreshQueuedMessages();
+    } catch (e) {
+      error = `Failed to remove queued message: ${e instanceof Error ? e.message : String(e)}`;
+    } finally {
+      const next = new Set(queueActionIds);
+      next.delete(id);
+      queueActionIds = next;
+    }
+  }
+
+  async function handleSendQueuedMessage(id: string) {
+    if (isLive || sending || queueActionIds.has(id)) return;
+    queueActionIds = new Set(queueActionIds).add(id);
+    error = null;
+    try {
+      await sendQueuedSessionMessage(id);
+      await refreshQueuedMessages();
+      if (session) session = { ...session, status: 'running' };
+      startPolling();
+      scrollToBottom();
+    } catch (e) {
+      error = `Failed to send queued message: ${e instanceof Error ? e.message : String(e)}`;
+      await refreshQueuedMessages();
+    } finally {
+      const next = new Set(queueActionIds);
+      next.delete(id);
+      queueActionIds = next;
+    }
   }
 
   async function handleCancel() {
@@ -1697,19 +1792,53 @@
       {:else}
         {#if hasQueuedMessages}
           <div class="queue-popover">
-            {#each messageQueue as msg, i}
+            {#each queuedMessages as msg (msg.id)}
               <div class="queue-item">
-                <span class="queue-item-label">Queued</span>
-                <span class="queue-item-text">{msg}</span>
+                <span class="queue-item-label"
+                  >{msg.status === 'sending' ? 'Sending' : 'Queued'}</span
+                >
+                <div class="queue-item-body">
+                  <span class="queue-item-text">{msg.content}</span>
+                  {#if msg.imageIds.length > 0}
+                    <div class="queue-item-images">
+                      {#each msg.imageIds as imageId}
+                        {#if messageImageCache.get(imageId)}
+                          <img src={messageImageCache.get(imageId)} alt="queued attachment" />
+                        {:else}
+                          <span class="queue-item-image-placeholder"><ImagePlus size={12} /></span>
+                        {/if}
+                      {/each}
+                    </div>
+                  {/if}
+                  {#if msg.lastError}
+                    <span class="queue-item-error">{msg.lastError}</span>
+                  {/if}
+                </div>
+                {#if !isLive}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="size-[22px] shrink-0 rounded text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-foreground disabled:opacity-40 [&_svg]:!size-3"
+                    title="Send queued message"
+                    aria-label="Send queued message"
+                    disabled={msg.status !== 'queued' || queueActionIds.has(msg.id)}
+                    onclick={() => handleSendQueuedMessage(msg.id)}
+                  >
+                    {#if queueActionIds.has(msg.id)}
+                      <Spinner size={12} />
+                    {:else}
+                      <Send size={12} />
+                    {/if}
+                  </Button>
+                {/if}
                 <Button
                   variant="ghost"
                   size="icon"
                   class="size-[18px] shrink-0 rounded text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-destructive [&_svg]:!size-2.5"
                   title="Remove from queue"
                   aria-label="Remove from queue"
-                  onclick={() => {
-                    messageQueue = messageQueue.filter((_, idx) => idx !== i);
-                  }}
+                  disabled={msg.status !== 'queued' || queueActionIds.has(msg.id)}
+                  onclick={() => handleDeleteQueuedMessage(msg.id)}
                 >
                   <X size={10} />
                 </Button>
@@ -2478,7 +2607,7 @@
 
   .queue-item {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 8px;
     padding: 6px 10px;
     font-size: calc(var(--size-xs) * 0.95);
@@ -2499,13 +2628,51 @@
     letter-spacing: 0.03em;
   }
 
-  .queue-item-text {
+  .queue-item-body {
     flex: 1;
     min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .queue-item-text {
     color: var(--text-muted);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .queue-item-images {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .queue-item-images img,
+  .queue-item-image-placeholder {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    border: 1px solid var(--border-subtle);
+  }
+
+  .queue-item-images img {
+    object-fit: cover;
+  }
+
+  .queue-item-image-placeholder {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-faint);
+    background: var(--bg-hover);
+  }
+
+  .queue-item-error {
+    color: var(--ui-danger);
+    white-space: normal;
+    word-break: break-word;
   }
 
   /* ----- Reply image previews -------------------------------------------- */

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -371,6 +371,23 @@ export interface Session {
   pipeline?: PipelineExecution | null;
 }
 
+export type QueuedSessionMessageStatus = 'queued' | 'sending' | 'sent';
+
+export interface QueuedSessionMessage {
+  id: string;
+  sessionId: string;
+  branchId: string | null;
+  content: string;
+  imageIds: string[];
+  status: QueuedSessionMessageStatus;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+  claimedAt: number | null;
+  ownerPid: number | null;
+  sentMessageId: number | null;
+}
+
 // =============================================================================
 // Pipelines
 // =============================================================================


### PR DESCRIPTION
## Summary
- Persist queued session messages and add store migration, models, and lifecycle tests.
- Add queued-message commands and web-server plumbing for session follow-ups.
- Harden session runner and modal handling so queued follow-ups drain safely and auto-review is blocked after drain failures.

## Testing
- Push hooks: crates-fmt, crates-test, crates-lint, differ-ci, staged-ci.