### PR TITLE
fix: route note chats through note modal

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -47,6 +47,7 @@
     BranchGitState,
     BranchTimeline as BranchTimelineData,
     HashtagItem,
+    NoteTimelineItem,
     ProjectRepo,
     WorkspaceStatus,
   } from '../../types';
@@ -90,7 +91,7 @@
   } from '../../services/branchEventService';
   import { openDiffRoute } from '../layout/navigation.svelte';
   import type { WorktreeChangesPreview } from '../../commands';
-  import type { LinkedNoteContext, NoteClickInfo } from '../sessions/noteFreshness';
+  import type { NoteClickInfo } from '../sessions/noteFreshness';
   import {
     disabledReferenceNav,
     pushReferenceEntry,
@@ -174,6 +175,15 @@
     annotations: number;
     warnings: number;
     userComments: number;
+  };
+  type OpenNoteState = {
+    noteId?: string;
+    title: string;
+    content: string;
+    sessionId?: string;
+    noteUpdatedAt?: number;
+    chatOpen?: boolean;
+    nextSteps?: { commitStep: string | null; noteStep: string | null } | null;
   };
   let timelineReviewDetailsById = $state<Record<string, TimelineReviewDetails>>({});
 
@@ -470,15 +480,7 @@
   // Commit diff modal (opened by clicking a commit in the timeline)
 
   // Note modal (opened by clicking a note in the timeline)
-  let openNote = $state<{
-    noteId: string;
-    title: string;
-    content: string;
-    sessionId?: string;
-    noteUpdatedAt?: number;
-    chatOpen?: boolean;
-    nextSteps?: { commitStep: string | null; noteStep: string | null } | null;
-  } | null>(null);
+  let openNote = $state<OpenNoteState | null>(null);
 
   // Image viewer modal (opened by clicking an image in the timeline)
   let viewImageId = $state<string | null>(null);
@@ -899,17 +901,44 @@
     });
   }
 
-  /** Look up note info from timeline data by session ID (for cross-modal navigation). */
-  function findNoteForSession(sessionId: string): LinkedNoteContext | null {
-    const note = timeline?.notes.find((n) => n.sessionId === sessionId);
-    if (!note) return null;
+  /** Look up a note from timeline data by session ID. */
+  function noteForSession(sessionId: string): NoteTimelineItem | null {
+    return timeline?.notes.find((n) => n.sessionId === sessionId) ?? null;
+  }
+
+  function noteToOpenState(note: NoteTimelineItem, chatOpen = false): OpenNoteState {
     return {
-      id: note.id,
+      noteId: note.id,
       title: note.title,
       content: note.content,
-      updatedAt: note.updatedAt,
-      hasParsedNote: !!note.content.trim(),
+      sessionId: note.sessionId ?? undefined,
+      noteUpdatedAt: note.updatedAt,
+      chatOpen,
+      nextSteps: computeNoteNextSteps(note.id),
     };
+  }
+
+  function openNoteChatForSession(sessionId: string): boolean {
+    const note = noteForSession(sessionId);
+    if (note) {
+      openNote = noteToOpenState(note, true);
+      return true;
+    }
+
+    const pendingNote = getPendingSessionItems(branch.id).find(
+      (item) =>
+        item.sessionId === sessionId &&
+        (item.type === 'generating-note' || item.type === 'queued-note')
+    );
+    if (!pendingNote) return false;
+
+    openNote = {
+      title: pendingNote.title,
+      content: '',
+      sessionId,
+      chatOpen: true,
+    };
+    return true;
   }
 
   function handleCommitClick(sha: string) {
@@ -1333,35 +1362,39 @@
       return {
         kind: 'note',
         noteKind: 'branch',
-        id: openNote.noteId,
-        ref: `#note:${openNote.noteId}`,
+        id: openNote.noteId ?? openNote.sessionId ?? 'note',
+        ref: openNote.noteId ? `#note:${openNote.noteId}` : `#chat:${openNote.sessionId}`,
         title: openNote.title,
         content: openNote.content,
-        view: 'note',
+        view: openNote.chatOpen ? 'chat' : 'note',
         sessionId: openNote.sessionId,
         noteUpdatedAt: openNote.noteUpdatedAt,
         branchId: branch.id,
         projectId: branch.projectId,
+        repoDir: branch.worktreePath,
+        repoLabel,
         hashtagItems,
         diffContext: referenceDiffContext,
       };
     }
 
     if (sessionMgr.openSessionId) {
-      const noteInfo = findNoteForSession(sessionMgr.openSessionId);
-      if (noteInfo) {
+      const note = noteForSession(sessionMgr.openSessionId);
+      if (note) {
         return {
           kind: 'note',
           noteKind: 'branch',
-          id: noteInfo.id,
-          ref: `#note:${noteInfo.id}`,
-          title: noteInfo.title,
-          content: noteInfo.content,
+          id: note.id,
+          ref: `#note:${note.id}`,
+          title: note.title,
+          content: note.content,
           view: 'chat',
           sessionId: sessionMgr.openSessionId,
-          noteUpdatedAt: noteInfo.updatedAt,
+          noteUpdatedAt: note.updatedAt,
           branchId: branch.id,
           projectId: branch.projectId,
+          repoDir: branch.worktreePath,
+          repoLabel,
           hashtagItems,
           diffContext: referenceDiffContext,
         };
@@ -1731,7 +1764,11 @@
               onRetry={() => loadTimeline()}
               deletingItems={timelineDeletingItems}
               reviewCommentBreakdown={timelineReviewDetailsById}
-              onSessionClick={(sid) => sessionMgr.handleTimelineSessionClick(sid)}
+              onSessionClick={(sid) => {
+                if (!openNoteChatForSession(sid)) {
+                  sessionMgr.handleTimelineSessionClick(sid);
+                }
+              }}
               onResumeClick={(sid) => {
                 commands
                   .resumeSession(sid, 'Continue where you left off.', undefined, branch.id)
@@ -1946,21 +1983,7 @@
     branchId={branch.id}
     projectId={branch.projectId}
     {repoLabel}
-    noteInfo={findNoteForSession(sessionMgr.openSessionId)}
     referenceNav={disabledReferenceNav}
-    onOpenNote={(note) => {
-      const sid = sessionMgr.openSessionId;
-      sessionMgr.openSessionId = null;
-      openNote = {
-        noteId: note.id,
-        title: note.title,
-        content: note.content,
-        sessionId: sid ?? undefined,
-        noteUpdatedAt: note.updatedAt,
-        chatOpen: true,
-        nextSteps: computeNoteNextSteps(note.id),
-      };
-    }}
     onClose={handleSessionModalClose}
     onHashtagClick={handleHashtagClick}
   />

--- a/apps/staged/src/lib/features/diff/DiffModal.svelte
+++ b/apps/staged/src/lib/features/diff/DiffModal.svelte
@@ -561,10 +561,10 @@
 
   function handleNewNote(comment: Comment, event: MouseEvent) {
     // Route by the linked note session's state (idle → start, queued/running →
-    // open session, completed → open note).
+    // open note chat, completed → open note).
     const state = getCommentNoteState(comment);
     if ((state === 'queued' || state === 'running') && comment.noteSessionId) {
-      openSessionId = comment.noteSessionId;
+      openNoteChat(comment.noteSessionId);
       return;
     }
     if (state === 'completed' && comment.noteSessionId) {
@@ -579,6 +579,15 @@
     newSessionMode = 'note';
     newSessionPrefill = buildCommentPrompt(comment, 'note');
     showNewSessionModal = true;
+  }
+
+  function openNoteChat(sessionId: string) {
+    openNote = {
+      title: '',
+      content: '',
+      sessionId,
+      chatOpen: true,
+    };
   }
 
   function handleNewCommit(comment: Comment, event: MouseEvent) {
@@ -773,8 +782,8 @@
     try {
       const note = await commands.getBranchNoteBySession(sessionId);
       if (!note) {
-        // Link points at a session with no note — fall back to the session view.
-        openSessionId = sessionId;
+        // Link points at a note session whose note row is not available yet.
+        openNoteChat(sessionId);
         return;
       }
       openNote = {
@@ -817,11 +826,13 @@
         ref: openNote.noteId ? `#note:${openNote.noteId}` : `#chat:${openNote.sessionId}`,
         title: openNote.title,
         content: openNote.content,
-        view: 'note',
+        view: openNote.chatOpen ? 'chat' : 'note',
         sessionId: openNote.sessionId,
         noteUpdatedAt: openNote.noteUpdatedAt,
         branchId,
         projectId,
+        repoDir: branch?.worktreePath,
+        repoLabel: githubRepo ? { githubRepo, subpath: subpath ?? null, headRepo: null } : null,
         hashtagItems,
         diffContext: referenceDiffContext,
       };

--- a/apps/staged/src/lib/features/notes/NoteModal.svelte
+++ b/apps/staged/src/lib/features/notes/NoteModal.svelte
@@ -91,7 +91,9 @@
   }: Props = $props();
 
   let copied = $state(false);
-  let liveNote = $state<{ title: string; content: string; updatedAt: number } | null>(null);
+  let liveNote = $state<{ id: string; title: string; content: string; updatedAt: number } | null>(
+    null
+  );
   let assistantMessagesAfterNote = $state(0);
   let assistantMessagesAfterNoteLoadedKey = $state<string | null>(null);
   let chatAutoOpenDecisionKey = $state<string | null>(null);
@@ -101,15 +103,17 @@
   let displayTitle = $derived(liveNote?.title ?? title);
   let displayContent = $derived(liveNote?.content ?? content);
   let displayUpdatedAt = $derived(liveNote?.updatedAt ?? noteUpdatedAt);
+  let displayNoteId = $derived(liveNote?.id ?? noteId);
+  let hasNoteContent = $derived(!!displayContent.trim());
   let noteFreshnessKey = $derived(
     open && sessionId && typeof displayUpdatedAt === 'number'
-      ? `${noteId ?? 'note'}:${sessionId}:${displayUpdatedAt}`
+      ? `${displayNoteId ?? 'note'}:${sessionId}:${displayUpdatedAt}`
       : null
   );
   let noteMarkdown = $derived(noteMarkdownWithTitle(displayTitle, displayContent));
-  let splitChatOpen = $derived(chatOpen && viewport.canSplit);
-  let narrowChatOpen = $derived(chatOpen && !viewport.canSplit);
-  let noteSearchAvailable = $derived(!narrowChatOpen);
+  let splitChatOpen = $derived(chatOpen && viewport.canSplit && hasNoteContent);
+  let chatOnly = $derived(chatOpen && (!viewport.canSplit || !hasNoteContent));
+  let noteSearchAvailable = $derived(hasNoteContent && !chatOnly);
   let chatToggleLabel = $derived(
     chatOpen
       ? viewport.canSplit
@@ -132,13 +136,13 @@
     `h-[80vh] max-h-[900px] p-0 gap-0 overflow-hidden flex flex-col transition-[max-width] duration-150 ${splitChatOpen ? 'sm:max-w-[1080px]' : 'sm:max-w-[700px]'}`
   );
   let noteInfo = $derived<LinkedNoteContext | null>(
-    noteId
+    displayNoteId
       ? {
-          id: noteId,
+          id: displayNoteId,
           title: displayTitle,
           content: displayContent,
           updatedAt: displayUpdatedAt ?? 0,
-          hasParsedNote: !!displayContent.trim(),
+          hasParsedNote: hasNoteContent,
         }
       : null
   );
@@ -166,7 +170,7 @@
   let matchCount = $state(0);
   let currentMatchIndex = $state(0);
   let matchElements: HTMLElement[] = [];
-  let contentEl: HTMLDivElement;
+  let contentEl: HTMLDivElement | undefined;
   let unregisterSearchTarget: (() => void) | null = null;
 
   // Register the global search-shortcut target only while the visible note pane can be searched.
@@ -213,6 +217,7 @@
     if (!open) {
       pikchrRendererLoadFailedKey = null;
       chatAutoOpenDecisionKey = null;
+      previousSessionStatus = null;
     }
   });
 
@@ -288,6 +293,7 @@
           : await getBranchNoteBySession(sessionId);
       if (!refreshed) return;
       liveNote = {
+        id: refreshed.id,
         title: refreshed.title,
         content: refreshed.content,
         updatedAt: refreshed.updatedAt,
@@ -298,7 +304,9 @@
   }
 
   function handlePaneSessionChange(next: Session | null) {
-    if (previousSessionStatus === 'running' && next && next.status !== 'running') {
+    const wasActive = previousSessionStatus === 'running' || previousSessionStatus === 'queued';
+    const isInactive = next && next.status !== 'running' && next.status !== 'queued';
+    if ((wasActive && isInactive) || (!previousSessionStatus && isInactive && !hasNoteContent)) {
       void refreshLiveNote();
     }
     previousSessionStatus = next?.status ?? null;
@@ -532,8 +540,10 @@
             />
           {/if}
           <div class="note-header-actions">
-            {@render copyButton()}
-            {#if !splitChatOpen}
+            {#if hasNoteContent}
+              {@render copyButton()}
+            {/if}
+            {#if !splitChatOpen && (hasNoteContent || !chatOpen)}
               {@render chatToggleButton()}
             {/if}
           </div>
@@ -550,11 +560,11 @@
         {/if}
       </div>
     </Dialog.Header>
-    <div class:split-chat-open={splitChatOpen} class:chat-only={narrowChatOpen} class="modal-body">
+    <div class:split-chat-open={splitChatOpen} class:chat-only={chatOnly} class="modal-body">
       <section
         id="note-modal-note-pane"
         class="note-pane"
-        aria-hidden={narrowChatOpen}
+        aria-hidden={chatOnly}
         aria-label="Note content"
       >
         <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -565,7 +575,7 @@
           onclick={handleContentClick}
           onkeydown={handleContentKeydown}
         >
-          {#if noteMarkdown.trim()}
+          {#if hasNoteContent}
             <div class="markdown-content">
               {@html renderedNoteHtml}
             </div>

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -24,7 +24,6 @@
     type TimelineContextMenuAction,
   } from '../timeline/TimelineContextMenu.svelte';
   import NoteModal from '../notes/NoteModal.svelte';
-  import SessionModal from '../sessions/SessionModal.svelte';
   import NewSessionModal from '../sessions/NewSessionModal.svelte';
   import { agentState } from '../agents/agent.svelte';
   import { getPreferredAgent } from '../settings/preferences.svelte';
@@ -33,7 +32,6 @@
   import { createLiveSessionHints } from '../timeline/liveSessionHints';
   import { projectDisplayName } from '../../shared/utils';
   import { Button } from '$lib/components/ui/button';
-  import type { LinkedNoteContext } from '../sessions/noteFreshness';
   import { openDiffRoute } from '../layout/navigation.svelte';
   import {
     disabledReferenceNav,
@@ -278,19 +276,20 @@
     return actions;
   });
 
-  let openNote = $state<{
+  type OpenProjectNoteState = {
     noteId: string;
     title: string;
     content: string;
     sessionId?: string;
     noteUpdatedAt?: number;
     chatOpen?: boolean;
-  } | null>(null);
-  let openSessionId = $state<string | null>(null);
+  };
+
+  let openNote = $state<OpenProjectNoteState | null>(null);
 
   $effect(() => {
     const _signature = hashtagSignature;
-    if (!openNote && !openSessionId) return;
+    if (!openNote) return;
     void ensureHashtagItems();
   });
 
@@ -309,15 +308,19 @@
     openProjectSessionModal();
   }
 
-  function linkedNoteContext(note: ProjectNote | undefined): LinkedNoteContext | null {
-    if (!note) return null;
+  function projectNoteToOpenState(note: ProjectNote, chatOpen = false): OpenProjectNoteState {
     return {
-      id: note.id,
+      noteId: note.id,
       title: note.title,
       content: note.content,
-      updatedAt: note.updatedAt,
-      hasParsedNote: !!note.content.trim(),
+      sessionId: note.sessionId ?? undefined,
+      noteUpdatedAt: note.updatedAt,
+      chatOpen,
     };
+  }
+
+  function openProjectNote(note: ProjectNote, chatOpen = false) {
+    openNote = projectNoteToOpenState(note, chatOpen);
   }
 
   function currentDialogReferenceEntry(): ReferenceHistoryEntry | null {
@@ -329,38 +332,9 @@
         ref: `#project-note:${openNote.noteId}`,
         title: openNote.title,
         content: openNote.content,
-        view: 'note',
+        view: openNote.chatOpen ? 'chat' : 'note',
         sessionId: openNote.sessionId,
         noteUpdatedAt: openNote.noteUpdatedAt,
-        projectId: project.id,
-        hashtagItems,
-        diffContext: referenceDiffContext,
-      };
-    }
-
-    if (openSessionId) {
-      const note = projectNotes.find((candidate) => candidate.sessionId === openSessionId);
-      if (note) {
-        return {
-          kind: 'note',
-          noteKind: 'project',
-          id: note.id,
-          ref: `#project-note:${note.id}`,
-          title: note.title,
-          content: note.content,
-          view: 'chat',
-          sessionId: openSessionId,
-          noteUpdatedAt: note.updatedAt,
-          projectId: project.id,
-          hashtagItems,
-          diffContext: referenceDiffContext,
-        };
-      }
-
-      return {
-        kind: 'chat',
-        ref: `#chat:${openSessionId}`,
-        sessionId: openSessionId,
         projectId: project.id,
         repoDir: projectDisplayRootCandidates,
         hashtagItems,
@@ -373,7 +347,6 @@
 
   function closeReferenceDialogs() {
     openNote = null;
-    openSessionId = null;
   }
 
   function handleHashtagClick(click: HashtagClickInfo) {
@@ -479,19 +452,9 @@
               deleting={deletingNoteIds.has(note.id)}
               isLast={false}
               sessionId={note.sessionId ?? undefined}
-              onItemClick={isRunning || isFailed
-                ? undefined
-                : () => {
-                    openNote = {
-                      noteId: note.id,
-                      title: note.title,
-                      content: note.content,
-                      sessionId: note.sessionId ?? undefined,
-                      noteUpdatedAt: note.updatedAt,
-                    };
-                  }}
+              onItemClick={isRunning || isFailed ? undefined : () => openProjectNote(note)}
               onSessionClick={(sid) => {
-                openSessionId = sid;
+                openProjectNote({ ...note, sessionId: sid }, true);
               }}
               deleteDisabledReason={deletingNoteIds.has(note.id) ? 'Deleting...' : undefined}
               onDeleteClick={() => handleDeleteNote(note.id)}
@@ -581,35 +544,9 @@
     }}
     {hashtagItems}
     referenceNav={disabledReferenceNav}
-    onClose={() => (openNote = null)}
-    onHashtagClick={handleHashtagClick}
-  />
-{/if}
-
-{#if openSessionId}
-  <SessionModal
-    open={true}
-    sessionId={openSessionId}
-    repoDir={projectDisplayRootCandidates}
-    projectId={project.id}
-    {hashtagItems}
-    noteInfo={linkedNoteContext(projectNotes.find((n) => n.sessionId === openSessionId))}
-    referenceNav={disabledReferenceNav}
-    onOpenNote={(note) => {
-      const sid = openSessionId;
-      openSessionId = null;
-      openNote = {
-        noteId: note.id,
-        title: note.title,
-        content: note.content,
-        sessionId: sid ?? undefined,
-        noteUpdatedAt: note.updatedAt,
-        chatOpen: true,
-      };
-    }}
     onClose={() => {
-      openSessionId = null;
-      loadProjectNotes();
+      openNote = null;
+      void loadProjectNotes();
     }}
     onHashtagClick={handleHashtagClick}
   />

--- a/apps/staged/src/lib/features/references/ReferenceModalHost.svelte
+++ b/apps/staged/src/lib/features/references/ReferenceModalHost.svelte
@@ -4,7 +4,6 @@
   import SessionModal from '../sessions/SessionModal.svelte';
   import ImageViewerModal from '../timeline/ImageViewerModal.svelte';
   import { openDiffRoute } from '../layout/navigation.svelte';
-  import type { LinkedNoteContext } from '../sessions/noteFreshness';
   import type { HashtagItem } from '../../types';
   import {
     clearReferenceHistory,
@@ -21,6 +20,7 @@
     type HashtagClickInfo,
     type ReferenceChatEntry,
     type ReferenceHistoryEntry,
+    type ReferenceNoteEntry,
     type ReferenceNavState,
   } from './referenceHistory.svelte';
 
@@ -40,6 +40,13 @@
     return () => {
       window.removeEventListener('staged:diff-route-popped', handleDiffRoutePopped);
     };
+  });
+
+  $effect(() => {
+    if (entry?.kind !== 'chat') return;
+    const noteEntry = noteEntryForChat(entry);
+    if (!noteEntry) return;
+    replaceCurrentReferenceEntry(noteEntry);
   });
 
   function navigateBack() {
@@ -74,40 +81,25 @@
     activateEntry(target);
   }
 
-  function handleOpenNote(note: LinkedNoteContext) {
-    const current = currentReferenceEntry();
-    if (current?.kind === 'note') {
-      setCurrentNoteView('note');
-      return;
-    }
-    if (current?.kind !== 'chat') return;
-
-    replaceCurrentReferenceEntry({
-      kind: 'note',
-      noteKind: current.branchId ? 'branch' : 'project',
-      id: note.id,
-      ref: `#note:${note.id}`,
-      title: note.title,
-      content: note.content,
-      view: 'note',
-      sessionId: current.sessionId,
-      noteUpdatedAt: note.updatedAt,
-      branchId: current.branchId,
-      projectId: current.projectId,
-      hashtagItems: current.hashtagItems,
-      diffContext: current.diffContext,
-    });
-  }
-
-  function chatNoteInfo(entry: ReferenceChatEntry): LinkedNoteContext | null {
+  function noteEntryForChat(entry: ReferenceChatEntry): ReferenceNoteEntry | null {
     const note = noteItemForSession(entry.sessionId, entry.hashtagItems);
     if (!note?.noteContent && note?.noteContent !== '') return null;
     return {
+      kind: 'note',
+      noteKind: note.type === 'project-note' ? 'project' : 'branch',
       id: note.id,
+      ref: note.type === 'project-note' ? `#project-note:${note.id}` : `#note:${note.id}`,
       title: note.title,
       content: note.noteContent,
-      updatedAt: note.noteUpdatedAt ?? 0,
-      hasParsedNote: !!note.noteContent.trim(),
+      view: 'chat',
+      sessionId: entry.sessionId,
+      noteUpdatedAt: note.noteUpdatedAt,
+      branchId: note.branchId ?? entry.branchId,
+      projectId: note.projectId ?? entry.projectId,
+      repoDir: entry.repoDir,
+      repoLabel: entry.repoLabel,
+      hashtagItems: entry.hashtagItems,
+      diffContext: entry.diffContext,
     };
   }
 
@@ -131,6 +123,8 @@
     noteKind={entry.noteKind}
     branchId={entry.branchId}
     projectId={entry.projectId}
+    repoDir={entry.repoDir}
+    repoLabel={entry.repoLabel}
     chatOpen={entry.view === 'chat'}
     onChatOpenChange={(open) => setCurrentNoteView(open ? 'chat' : 'note')}
     hashtagItems={entry.hashtagItems}
@@ -139,20 +133,42 @@
     onHashtagClick={handleHashtagClick}
   />
 {:else if entry?.kind === 'chat'}
-  <SessionModal
-    open={true}
-    sessionId={entry.sessionId}
-    repoDir={entry.repoDir}
-    branchId={entry.branchId}
-    projectId={entry.projectId}
-    repoLabel={entry.repoLabel}
-    hashtagItems={entry.hashtagItems}
-    noteInfo={chatNoteInfo(entry)}
-    {referenceNav}
-    onOpenNote={handleOpenNote}
-    onClose={handleClose}
-    onHashtagClick={handleHashtagClick}
-  />
+  {@const noteEntry = noteEntryForChat(entry)}
+  {#if noteEntry}
+    <NoteModal
+      open={true}
+      title={noteEntry.title}
+      content={noteEntry.content}
+      sessionId={noteEntry.sessionId}
+      noteUpdatedAt={noteEntry.noteUpdatedAt}
+      noteId={noteEntry.id}
+      noteKind={noteEntry.noteKind}
+      branchId={noteEntry.branchId}
+      projectId={noteEntry.projectId}
+      repoDir={noteEntry.repoDir}
+      repoLabel={noteEntry.repoLabel}
+      chatOpen={true}
+      onChatOpenChange={(open) =>
+        replaceCurrentReferenceEntry({ ...noteEntry, view: open ? 'chat' : 'note' })}
+      hashtagItems={noteEntry.hashtagItems}
+      {referenceNav}
+      onClose={handleClose}
+      onHashtagClick={handleHashtagClick}
+    />
+  {:else}
+    <SessionModal
+      open={true}
+      sessionId={entry.sessionId}
+      repoDir={entry.repoDir}
+      branchId={entry.branchId}
+      projectId={entry.projectId}
+      repoLabel={entry.repoLabel}
+      hashtagItems={entry.hashtagItems}
+      {referenceNav}
+      onClose={handleClose}
+      onHashtagClick={handleHashtagClick}
+    />
+  {/if}
 {:else if entry?.kind === 'image'}
   <ImageViewerModal
     open={true}

--- a/apps/staged/src/lib/features/references/referenceHistory.svelte.ts
+++ b/apps/staged/src/lib/features/references/referenceHistory.svelte.ts
@@ -42,6 +42,8 @@ export type ReferenceNoteEntry = ReferenceDialogContext & {
   noteUpdatedAt?: number | null;
   branchId?: string | null;
   projectId?: string | null;
+  repoDir?: DisplayRootInput;
+  repoLabel?: Pick<ProjectRepo, 'githubRepo' | 'subpath' | 'headRepo'> | null;
 };
 
 export type ReferenceChatEntry = ReferenceDialogContext & {


### PR DESCRIPTION
## Summary
- Route branch, project, and diff note-chat entry points through `NoteModal`.
- Preserve note context in reference history while keeping chat open inside the note modal.
- Refresh live note content and hide note-only actions when chat opens before note content exists.

## Tests
- Push hooks passed: crates-fmt, crates-test, crates-lint, differ-ci, staged-ci.