### PR TITLE
fix(staged): align badge hue slider track with OKLCH badge colors

### DIFF
--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -30,6 +30,8 @@
     type ActionType,
   } from '../actions/actions';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
+  import { darkMode } from '../../stores/isDark.svelte';
+  import { hueSliderGradient } from '../../shared/badgeColors';
   import { matchesRepoSearch } from './repoContextSearch';
   import { toast } from 'svelte-sonner';
   import { getPreferredAgent } from './preferences.svelte';
@@ -635,6 +637,7 @@
                     min="0"
                     max="359"
                     step="1"
+                    style="background: {hueSliderGradient(darkMode.value)}"
                     bind:value={badgeEditHue}
                     onchange={saveBadge}
                   />
@@ -1066,22 +1069,8 @@
     appearance: none;
     height: 16px;
     border-radius: 8px;
-    background: linear-gradient(
-      to right,
-      hsl(0, 80%, 55%),
-      hsl(30, 80%, 55%),
-      hsl(60, 80%, 55%),
-      hsl(90, 80%, 55%),
-      hsl(120, 80%, 55%),
-      hsl(150, 80%, 55%),
-      hsl(180, 80%, 55%),
-      hsl(210, 80%, 55%),
-      hsl(240, 80%, 55%),
-      hsl(270, 80%, 55%),
-      hsl(300, 80%, 55%),
-      hsl(330, 80%, 55%),
-      hsl(359, 80%, 55%)
-    );
+    /* Track gradient comes from hueSliderGradient() as an inline style so it
+       tracks the theme and stays in sync with the badge OKLCH values. */
     outline: none;
   }
 

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -1071,6 +1071,7 @@
     border-radius: 8px;
     /* Track gradient comes from hueSliderGradient() as an inline style so it
        tracks the theme and stays in sync with the badge OKLCH values. */
+    border: 1px solid var(--border-subtle);
     outline: none;
   }
 

--- a/apps/staged/src/lib/shared/badgeColors.ts
+++ b/apps/staged/src/lib/shared/badgeColors.ts
@@ -29,16 +29,23 @@ export function badgeShortcutBg(hue: number, dark: boolean): string {
   return dark ? `oklch(0.40 0.06 ${hue})` : `oklch(0.86 0.06 ${hue})`;
 }
 
+/** Slider track color: the badge hue at mid lightness, between badgeBg
+ *  (too pale to tell hues apart) and badgeFg (too dark to read as the
+ *  badge tint), with enough chroma to keep hues distinguishable. */
+function hueSliderStop(hue: number, dark: boolean): string {
+  return dark ? `oklch(0.55 0.10 ${hue})` : `oklch(0.80 0.10 ${hue})`;
+}
+
 /**
- * Track gradient for the badge hue slider, sampled from the badge
- * foreground color every 15° so the color under the thumb is the one
- * the chosen OKLCH hue actually produces (HSL hue angles don't line up
- * with OKLCH hue angles).
+ * Track gradient for the badge hue slider, sampled every 15° in OKLCH
+ * so the color under the thumb matches the badge the chosen hue
+ * actually produces (HSL hue angles don't line up with OKLCH hue
+ * angles).
  */
 export function hueSliderGradient(dark: boolean): string {
   const stops: string[] = [];
   for (let hue = 0; hue <= 360; hue += 15) {
-    stops.push(badgeFg(hue, dark));
+    stops.push(hueSliderStop(hue, dark));
   }
   return `linear-gradient(to right, ${stops.join(', ')})`;
 }

--- a/apps/staged/src/lib/shared/badgeColors.ts
+++ b/apps/staged/src/lib/shared/badgeColors.ts
@@ -28,3 +28,17 @@ export function badgeBorderHover(hue: number, dark: boolean): string {
 export function badgeShortcutBg(hue: number, dark: boolean): string {
   return dark ? `oklch(0.40 0.06 ${hue})` : `oklch(0.86 0.06 ${hue})`;
 }
+
+/**
+ * Track gradient for the badge hue slider, sampled from the badge
+ * foreground color every 15° so the color under the thumb is the one
+ * the chosen OKLCH hue actually produces (HSL hue angles don't line up
+ * with OKLCH hue angles).
+ */
+export function hueSliderGradient(dark: boolean): string {
+  const stops: string[] = [];
+  for (let hue = 0; hue <= 360; hue += 15) {
+    stops.push(badgeFg(hue, dark));
+  }
+  return `linear-gradient(to right, ${stops.join(', ')})`;
+}


### PR DESCRIPTION
## Summary

The badge hue slider in the actions settings panel used a hardcoded HSL gradient for its track, but the badge colors themselves are computed in OKLCH. HSL and OKLCH hue angles don't line up, so the color shown under the slider thumb didn't match the badge color the selected hue actually produced.

- Add `hueSliderGradient()` to `badgeColors.ts`, which builds the track gradient from OKLCH stops sampled every 15° so the track matches the real badge colors
- Use mid-lightness/mid-chroma stops (`0.55` lightness in dark mode, `0.80` in light) so hues stay distinguishable — badge background stops were too pale and foreground stops too dark
- Apply the gradient as an inline style that follows the current theme via the `darkMode` store, replacing the static CSS gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)