### PR TITLE
feat(chat): unify the session composer around a taller agent config picker

### DIFF
--- a/apps/staged/src/lib/components/ui/button/button.svelte
+++ b/apps/staged/src/lib/components/ui/button/button.svelte
@@ -8,6 +8,8 @@
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        accent:
+          'appearance-none bg-[var(--ui-accent)] font-semibold text-primary-foreground shadow-none hover:bg-[var(--ui-accent-hover)] disabled:bg-[var(--ui-accent)]',
         outline:
           'border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground',
         secondary:

--- a/apps/staged/src/lib/features/agents/AcpConfigPicker.svelte
+++ b/apps/staged/src/lib/features/agents/AcpConfigPicker.svelte
@@ -30,6 +30,7 @@
     remote?: boolean;
     dropUp?: boolean;
     triggerClass?: string;
+    layout?: 'horizontal' | 'vertical';
     workingDir?: string | null;
     onSelectionChange?: (selection: AcpConfigPickerSelection) => void;
   }
@@ -39,6 +40,7 @@
     remote = false,
     dropUp = false,
     triggerClass,
+    layout = 'horizontal',
     workingDir = null,
     onSelectionChange,
   }: Props = $props();
@@ -298,6 +300,7 @@
     {disabled}
     {dropUp}
     {triggerClass}
+    {layout}
     {canOpen}
   >
     <div class="picker-column" data-picker-column="provider">

--- a/apps/staged/src/lib/features/agents/AcpConfigPickerShell.svelte
+++ b/apps/staged/src/lib/features/agents/AcpConfigPickerShell.svelte
@@ -25,6 +25,12 @@
     loading?: boolean;
     canOpen?: boolean;
     hasColumns?: boolean;
+    /**
+     * horizontal: all parts inline in the same style, separated by "·".
+     * vertical: first part is the title; later parts stack below it in
+     * smaller text.
+     */
+    layout?: 'horizontal' | 'vertical';
     children?: Snippet;
     footer?: Snippet;
   }
@@ -40,6 +46,7 @@
     loading = false,
     canOpen = true,
     hasColumns = true,
+    layout = 'horizontal',
     children,
     footer,
   }: Props = $props();
@@ -80,14 +87,15 @@
 {#snippet labelContent()}
   <span
     class="selector-label"
+    class:selector-label-vertical={layout === 'vertical'}
     aria-label={triggerLabel}
     style:width={labelWidth === null ? undefined : `${labelWidth}px`}
   >
     {#each renderedTriggerParts as part, index (part.id)}
-      {#if index > 0}
+      {#if layout === 'horizontal' && index > 0}
         <span class="trigger-separator" aria-hidden="true">·</span>
       {/if}
-      <span class="trigger-part">
+      <span class="trigger-part" class:trigger-part-subtitle={layout === 'vertical' && index > 0}>
         {#key part.label}
           <span
             class="trigger-part-value"
@@ -101,10 +109,10 @@
     {/each}
     <span class="trigger-sizer" aria-hidden="true" bind:this={labelSizerEl}>
       {#each renderedTriggerParts as part, index (part.id)}
-        {#if index > 0}
+        {#if layout === 'horizontal' && index > 0}
           <span class="trigger-separator">·</span>
         {/if}
-        <span>{part.label}</span>
+        <span class:trigger-part-subtitle={layout === 'vertical' && index > 0}>{part.label}</span>
       {/each}
     </span>
   </span>
@@ -122,11 +130,13 @@
     >
       <AgentIcon id={providerId ?? ''} size={12} />
       {@render labelContent()}
-      {#if loading}
-        <Spinner size={12} />
-      {:else}
-        <ChevronDown size={12} />
-      {/if}
+      <span class="trigger-caret" aria-hidden="true">
+        {#if loading}
+          <span class="trigger-caret-icon"><Spinner size={12} /></span>
+        {:else}
+          <span class="trigger-caret-icon"><ChevronDown size={12} /></span>
+        {/if}
+      </span>
     </DropdownMenu.Trigger>
     <DropdownMenu.Content
       bind:ref={contentEl}
@@ -182,6 +192,20 @@
     transition: width 150ms ease;
   }
 
+  .selector-label-vertical {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .selector-label-vertical .trigger-part {
+    max-width: 100%;
+    line-height: 1.25;
+  }
+
+  .trigger-part-subtitle {
+    font-size: 0.85em;
+  }
+
   .trigger-sizer {
     display: inline-flex;
     position: absolute;
@@ -191,6 +215,29 @@
     visibility: hidden;
     pointer-events: none;
     white-space: nowrap;
+  }
+
+  .selector-label-vertical .trigger-sizer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  /* Fixed-size slot so swapping the spinner for the chevron never changes
+     how much horizontal space the trailing icon takes (the icons themselves
+     could otherwise shrink unevenly when the trigger is width-constrained). */
+  .trigger-caret {
+    position: relative;
+    flex: none;
+    width: 12px;
+    height: 12px;
+  }
+
+  .trigger-caret-icon {
+    display: inline-flex;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    inset: 0;
   }
 
   .trigger-part {

--- a/apps/staged/src/lib/features/agents/AcpConfigPickerShell.svelte
+++ b/apps/staged/src/lib/features/agents/AcpConfigPickerShell.svelte
@@ -67,9 +67,17 @@
       labelWidth = null;
       return;
     }
-    const observer = new ResizeObserver(() => {
+    const observer = new ResizeObserver((entries) => {
+      // Measure from the observer entry, not getBoundingClientRect: the
+      // trigger mounts inside dialogs whose open animation scales the content
+      // (zoom-in-95), and a rect captured mid-animation is ~5% short. The
+      // sizer's local size never changes afterwards, so the observer would
+      // not fire again and the label would stay truncated. Entry sizes are in
+      // local CSS pixels, unaffected by ancestor transforms.
+      const entry = entries[entries.length - 1];
+      const width = entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
       // Round up so sub-pixel clipping never triggers part ellipsis.
-      labelWidth = Math.ceil(sizer.getBoundingClientRect().width);
+      labelWidth = Math.ceil(width);
     });
     observer.observe(sizer);
     return () => observer.disconnect();

--- a/apps/staged/src/lib/features/agents/AcpFixedConfigPicker.svelte
+++ b/apps/staged/src/lib/features/agents/AcpFixedConfigPicker.svelte
@@ -18,6 +18,7 @@
     disabled?: boolean;
     dropUp?: boolean;
     triggerClass?: string;
+    layout?: 'horizontal' | 'vertical';
     onModelChange?: (value: string) => void;
     onEffortChange?: (value: string) => void;
   }
@@ -34,6 +35,7 @@
     disabled = false,
     dropUp = false,
     triggerClass,
+    layout = 'horizontal',
     onModelChange,
     onEffortChange,
   }: Props = $props();
@@ -122,6 +124,7 @@
     {disabled}
     {dropUp}
     {triggerClass}
+    {layout}
     hasColumns={hasPickerColumns}
   >
     {#if modelSelector}

--- a/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
+++ b/apps/staged/src/lib/features/diff/DiffCommitSessionLauncher.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
-  import Send from '@lucide/svelte/icons/send';
   import Spinner from '../../shared/Spinner.svelte';
   import { Button } from '$lib/components/ui/button';
   import { toast } from 'svelte-sonner';
@@ -215,7 +214,7 @@
   <div class="composer-footer">
     <Button
       type="button"
-      variant="outline"
+      variant="accent"
       class="w-full gap-1.5"
       onclick={handleSubmit}
       disabled={starting || !draftPrompt.trim()}
@@ -224,7 +223,6 @@
         <Spinner size={14} />
         {willQueue ? 'Queueing…' : 'Starting…'}
       {:else}
-        <Send size={14} />
         {willQueue ? 'Queue commit' : 'Start commit'}
         {#if viewport.showShortcutHints}
           <span class="shortcut-badge">⌘↵</span>

--- a/apps/staged/src/lib/features/sessions/ChatComposer.svelte
+++ b/apps/staged/src/lib/features/sessions/ChatComposer.svelte
@@ -23,7 +23,6 @@
   import type { Snippet } from 'svelte';
   import X from '@lucide/svelte/icons/x';
   import CircleStop from '@lucide/svelte/icons/circle-stop';
-  import Send from '@lucide/svelte/icons/send';
   import Paperclip from '@lucide/svelte/icons/paperclip';
   import ImagePlus from '@lucide/svelte/icons/image-plus';
   import Spinner from '../../shared/Spinner.svelte';
@@ -172,8 +171,8 @@
     {:else}
       <span class="inline-flex composer-send" title="Send message">
         <Button
-          variant="default"
-          class="appearance-none gap-1.5 bg-[var(--ui-accent)] px-4 py-2 text-sm font-semibold shadow-none hover:bg-[var(--ui-accent-hover)] disabled:bg-[var(--ui-accent)] max-[640px]:min-h-11"
+          variant="accent"
+          class="gap-1.5 px-4 py-2 text-sm max-[640px]:min-h-11"
           onclick={onSend}
           disabled={sending || !value.trim()}
         >
@@ -181,7 +180,6 @@
             <Spinner size={14} />
             Sending…
           {:else}
-            <Send size={14} />
             Send
           {/if}
         </Button>

--- a/apps/staged/src/lib/features/sessions/ChatComposer.svelte
+++ b/apps/staged/src/lib/features/sessions/ChatComposer.svelte
@@ -15,10 +15,10 @@
   /** Styling for the agent config picker trigger rendered in the control row. */
   export const composerControlClass = `${controlBaseClass} px-4 py-1`;
 
-  /** Attach button — same chrome as the config picker trigger, icon-sized.
-      h-auto (not the icon size variant) so the control row can stretch it to
-      match the tallest control. */
-  const attachButtonClass = `${controlBaseClass} h-auto w-9 px-0 justify-center [&_svg]:!size-4`;
+  /** Attach button — same chrome as the config picker trigger. h-auto (not a
+      fixed-height size variant) so the control row can stretch it to match
+      the tallest control. */
+  const attachButtonClass = `${composerControlClass} h-auto [&_svg]:!size-4`;
 </script>
 
 <script lang="ts">
@@ -149,6 +149,7 @@
           disabled={isLive}
         >
           <Paperclip size={16} />
+          Attach
         </Button>
       </span>
     {/if}

--- a/apps/staged/src/lib/features/sessions/ChatComposer.svelte
+++ b/apps/staged/src/lib/features/sessions/ChatComposer.svelte
@@ -172,17 +172,17 @@
     {:else}
       <span class="inline-flex composer-send" title="Send message">
         <Button
-          variant="outline"
-          size="icon"
-          class="size-9 shrink-0 rounded-[10px] shadow-none disabled:opacity-30 [&_svg]:!size-4"
-          aria-label="Send message"
+          variant="default"
+          class="appearance-none gap-1.5 bg-[var(--ui-accent)] px-4 py-2 text-sm font-semibold shadow-none hover:bg-[var(--ui-accent-hover)] disabled:bg-[var(--ui-accent)] max-[640px]:min-h-11"
           onclick={onSend}
           disabled={sending || !value.trim()}
         >
           {#if sending}
-            <Spinner size={16} />
+            <Spinner size={14} />
+            Sending…
           {:else}
-            <Send size={16} />
+            <Send size={14} />
+            Send
           {/if}
         </Button>
       </span>

--- a/apps/staged/src/lib/features/sessions/ChatComposer.svelte
+++ b/apps/staged/src/lib/features/sessions/ChatComposer.svelte
@@ -1,0 +1,287 @@
+<!--
+  ChatComposer.svelte — Shared bottom chat input for session chat surfaces.
+
+  Houses the attached-image strip, the text input, and the control row below
+  it (agent config picker slot, attach button, send/stop button). Rendered by
+  SessionChatPane, which backs both the session dialog and the note dialog's
+  chat pane, so the composer looks and behaves identically everywhere: the
+  text input gets its own full-width row with the controls beneath it.
+-->
+<script lang="ts" module>
+  // min-h instead of h so the vertical model/effort label can grow the button.
+  const controlBaseClass =
+    'min-h-9 gap-1.5 rounded-md border border-[var(--border-muted)] bg-[var(--bg-primary)] text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-[var(--bg-hover)] hover:text-foreground max-[640px]:min-h-11 max-[640px]:justify-center';
+
+  /** Styling for the agent config picker trigger rendered in the control row. */
+  export const composerControlClass = `${controlBaseClass} px-4 py-1`;
+
+  /** Attach button — same chrome as the config picker trigger, icon-sized. */
+  const attachButtonClass = `${controlBaseClass} w-9 justify-center [&_svg]:!size-4`;
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import X from '@lucide/svelte/icons/x';
+  import CircleStop from '@lucide/svelte/icons/circle-stop';
+  import Send from '@lucide/svelte/icons/send';
+  import Paperclip from '@lucide/svelte/icons/paperclip';
+  import ImagePlus from '@lucide/svelte/icons/image-plus';
+  import Spinner from '../../shared/Spinner.svelte';
+  import { Button } from '$lib/components/ui/button';
+  import HashtagInput from './HashtagInput.svelte';
+  import type { HashtagItem } from '../../types';
+
+  interface Props {
+    /** Raw input text including #type:id tokens. */
+    value: string;
+    /** The contenteditable input element (for focus/resize from the parent). */
+    textareaEl?: HTMLElement | null;
+    placeholder?: string;
+    hashtagItems?: HashtagItem[];
+    onkeydown?: (e: KeyboardEvent) => void;
+    oninput?: (e: Event) => void;
+    /** Whether image attachment is available in this context. */
+    canAttachImages?: boolean;
+    /** IDs of images currently attached to the pending message. */
+    attachedImageIds?: string[];
+    /** Image ID → data URL previews for the attached images. */
+    imagePreviews?: Map<string, string>;
+    onAttachFiles?: (files: File[]) => void;
+    onRemoveImage?: (imageId: string) => void;
+    /** Session is running — attach/remove disabled, stop replaces send. */
+    isLive?: boolean;
+    sending?: boolean;
+    cancelling?: boolean;
+    onSend?: () => void;
+    onStop?: () => void;
+    /** Agent config picker rendered at the start of the control row. */
+    configPicker?: Snippet;
+  }
+
+  let {
+    value = $bindable(''),
+    textareaEl = $bindable(null),
+    placeholder = '',
+    hashtagItems = [],
+    onkeydown,
+    oninput,
+    canAttachImages = false,
+    attachedImageIds = [],
+    imagePreviews = new Map(),
+    onAttachFiles,
+    onRemoveImage,
+    isLive = false,
+    sending = false,
+    cancelling = false,
+    onSend,
+    onStop,
+    configPicker,
+  }: Props = $props();
+
+  let fileInputEl = $state<HTMLInputElement>();
+
+  function openImagePicker() {
+    fileInputEl?.click();
+  }
+
+  function handleImageFileSelect(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (!input.files) return;
+    onAttachFiles?.(Array.from(input.files));
+    input.value = '';
+  }
+</script>
+
+<div class="chat-composer">
+  {#if canAttachImages && attachedImageIds.length > 0}
+    <div class="reply-images">
+      {#each attachedImageIds as imageId (imageId)}
+        <div class="group/thumb reply-image-thumb">
+          {#if imagePreviews.get(imageId)}
+            <img src={imagePreviews.get(imageId)} alt="attached" />
+          {:else}
+            <div class="reply-image-placeholder"><ImagePlus size={16} /></div>
+          {/if}
+          {#if !isLive}
+            <Button
+              variant="ghost"
+              size="icon"
+              class="reply-image-remove-action absolute top-0.5 right-0.5 size-4 rounded-full bg-[var(--bg-deepest)] text-muted-foreground opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-chrome)] hover:text-foreground group-hover/thumb:opacity-100 [&_svg]:!size-2.5"
+              title="Remove image"
+              aria-label="Remove image"
+              onclick={() => onRemoveImage?.(imageId)}
+            >
+              <X size={10} />
+            </Button>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+  <HashtagInput
+    bind:textareaEl
+    bind:value
+    class="message-input"
+    {placeholder}
+    rows={1}
+    {onkeydown}
+    {oninput}
+    items={hashtagItems}
+  />
+  <div class="composer-controls">
+    {@render configPicker?.()}
+    {#if canAttachImages}
+      <input
+        bind:this={fileInputEl}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+        multiple
+        class="file-input-hidden"
+        onchange={handleImageFileSelect}
+      />
+      <span class="inline-flex" title="Attach image">
+        <Button
+          variant="outline"
+          size="icon"
+          class={attachButtonClass}
+          aria-label="Attach image"
+          onclick={openImagePicker}
+          disabled={isLive}
+        >
+          <Paperclip size={16} />
+        </Button>
+      </span>
+    {/if}
+    {#if isLive}
+      <span class="inline-flex composer-send" title="Stop session">
+        <Button
+          variant="destructive"
+          size="icon"
+          class="size-9 shrink-0 rounded-[10px] [&_svg]:!size-4"
+          aria-label="Stop session"
+          onclick={onStop}
+          disabled={cancelling}
+        >
+          {#if cancelling}
+            <Spinner size={16} />
+          {:else}
+            <CircleStop size={16} />
+          {/if}
+        </Button>
+      </span>
+    {:else}
+      <span class="inline-flex composer-send" title="Send message">
+        <Button
+          variant="outline"
+          size="icon"
+          class="size-9 shrink-0 rounded-[10px] shadow-none disabled:opacity-30 [&_svg]:!size-4"
+          aria-label="Send message"
+          onclick={onSend}
+          disabled={sending || !value.trim()}
+        >
+          {#if sending}
+            <Spinner size={16} />
+          {:else}
+            <Send size={16} />
+          {/if}
+        </Button>
+      </span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .chat-composer {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 14px;
+    border-top: 1px solid var(--border-subtle);
+    background: var(--bg-chrome);
+    flex-shrink: 0;
+  }
+
+  /* ----- Reply image previews -------------------------------------------- */
+
+  .file-input-hidden {
+    display: none;
+  }
+
+  .reply-images {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .reply-image-thumb {
+    position: relative;
+    width: 48px;
+    height: 48px;
+    border-radius: 6px;
+    overflow: hidden;
+    border: 1px solid var(--border-muted);
+    background: var(--bg-hover);
+    flex-shrink: 0;
+  }
+
+  .reply-image-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .reply-image-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: var(--text-faint);
+  }
+
+  .reply-image-thumb:focus-within :global(.reply-image-remove-action),
+  :global(.reply-image-remove-action:focus-visible) {
+    opacity: 1;
+  }
+
+  @media (hover: none), (pointer: coarse) {
+    :global(.reply-image-remove-action) {
+      opacity: 1;
+    }
+  }
+
+  /* ----- Text input -------------------------------------------------------- */
+
+  .chat-composer :global(.message-input) {
+    padding: 7px 12px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-muted);
+    border-radius: 10px;
+    color: var(--text-primary);
+    font-size: var(--size-md);
+    font-family: inherit;
+    line-height: 1.5;
+    resize: none;
+    overflow-y: hidden;
+    min-height: 36px;
+    max-height: 120px;
+  }
+
+  .chat-composer :global(.message-input):focus {
+    outline: none;
+    border-color: var(--border-emphasis);
+  }
+
+  /* ----- Control row -------------------------------------------------------- */
+
+  .composer-controls {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+  }
+
+  .composer-controls .composer-send {
+    margin-left: auto;
+  }
+</style>

--- a/apps/staged/src/lib/features/sessions/ChatComposer.svelte
+++ b/apps/staged/src/lib/features/sessions/ChatComposer.svelte
@@ -15,8 +15,10 @@
   /** Styling for the agent config picker trigger rendered in the control row. */
   export const composerControlClass = `${controlBaseClass} px-4 py-1`;
 
-  /** Attach button — same chrome as the config picker trigger, icon-sized. */
-  const attachButtonClass = `${controlBaseClass} w-9 justify-center [&_svg]:!size-4`;
+  /** Attach button — same chrome as the config picker trigger, icon-sized.
+      h-auto (not the icon size variant) so the control row can stretch it to
+      match the tallest control. */
+  const attachButtonClass = `${controlBaseClass} h-auto w-9 px-0 justify-center [&_svg]:!size-4`;
 </script>
 
 <script lang="ts">
@@ -141,7 +143,6 @@
       <span class="inline-flex" title="Attach image">
         <Button
           variant="outline"
-          size="icon"
           class={attachButtonClass}
           aria-label="Attach image"
           onclick={openImagePicker}
@@ -155,8 +156,7 @@
       <span class="inline-flex composer-send" title="Stop session">
         <Button
           variant="destructive"
-          size="icon"
-          class="size-9 shrink-0 rounded-[10px] [&_svg]:!size-4"
+          class="h-auto min-h-9 w-9 shrink-0 rounded-[10px] px-0 [&_svg]:!size-4"
           aria-label="Stop session"
           onclick={onStop}
           disabled={cancelling}
@@ -172,7 +172,7 @@
       <span class="inline-flex composer-send" title="Send message">
         <Button
           variant="accent"
-          class="gap-1.5 px-4 py-2 text-sm max-[640px]:min-h-11"
+          class="h-auto min-h-9 gap-1.5 px-4 py-1 text-sm max-[640px]:min-h-11"
           onclick={onSend}
           disabled={sending || !value.trim()}
         >
@@ -273,9 +273,11 @@
 
   /* ----- Control row -------------------------------------------------------- */
 
+  /* Stretch so every control matches the tallest one (the config picker can
+     grow to two lines for its vertical model/effort label). */
   .composer-controls {
     display: flex;
-    align-items: flex-end;
+    align-items: stretch;
     gap: 8px;
   }
 

--- a/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
+++ b/apps/staged/src/lib/features/sessions/NewSessionModal.svelte
@@ -21,7 +21,6 @@
   import GitCommitVertical from '@lucide/svelte/icons/git-commit-vertical';
   import FileText from '@lucide/svelte/icons/file-text';
   import FileSearch from '@lucide/svelte/icons/file-search';
-  import Send from '@lucide/svelte/icons/send';
   import ChevronDown from '@lucide/svelte/icons/chevron-down';
   import { tick, untrack } from 'svelte';
   import Spinner from '../../shared/Spinner.svelte';
@@ -597,8 +596,8 @@
           </Button>
           <Button
             type="submit"
-            variant="default"
-            class="appearance-none gap-1.5 bg-[var(--ui-accent)] px-4 py-2 text-sm font-semibold shadow-none hover:bg-[var(--ui-accent-hover)] disabled:bg-[var(--ui-accent)] max-[768px]:h-11 max-[768px]:flex-1 max-[768px]:justify-center"
+            variant="accent"
+            class="gap-1.5 px-4 py-2 text-sm max-[768px]:h-11 max-[768px]:flex-1 max-[768px]:justify-center"
             title={submitDisabledReason ?? undefined}
             disabled={!canSubmit}
           >
@@ -606,7 +605,6 @@
               <Spinner size={14} />
               {currentWillQueue ? 'Queueing…' : 'Starting…'}
             {:else}
-              <Send size={14} />
               {submitLabel}
             {/if}
           </Button>

--- a/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
@@ -43,9 +43,7 @@
   import Zap from '@lucide/svelte/icons/zap';
   import GitBranch from '@lucide/svelte/icons/git-branch';
   import FileText from '@lucide/svelte/icons/file-text';
-  import Paperclip from '@lucide/svelte/icons/paperclip';
   import ImagePlus from '@lucide/svelte/icons/image-plus';
-  import Plus from '@lucide/svelte/icons/plus';
   import Spinner from '../../shared/Spinner.svelte';
   import { isResumableReason } from '../../types';
   import type {
@@ -83,7 +81,7 @@
   import AcpFixedConfigPicker from '../agents/AcpFixedConfigPicker.svelte';
   import { agentState } from '../agents/agent.svelte';
   import { buildAcpConfigSelection } from '../agents/acpConfigSelection';
-  import HashtagInput from './HashtagInput.svelte';
+  import ChatComposer, { composerControlClass } from './ChatComposer.svelte';
   import {
     buildBranchHashtagItems,
     findHashtagItemForReference,
@@ -215,9 +213,6 @@
   let followupModelStateKey = $state<string | null>(null);
   let followupEffortStateKey = $state<string | null>(null);
   let followupDiscoveryRun = 0;
-  // min-h instead of h so the vertical model/effort label can grow the button.
-  const footerControlClass =
-    'min-h-9 gap-1.5 rounded-md border border-[var(--border-muted)] bg-[var(--bg-primary)] px-4 py-1 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-[var(--bg-hover)] hover:text-foreground max-[640px]:min-h-11 max-[640px]:justify-center';
 
   let isLive = $derived(session?.status === 'running');
   let hasQueuedMessages = $derived(queuedMessages.length > 0);
@@ -355,7 +350,6 @@
   let canAttachImages = $derived(!!projectId);
   let replyImageIds = $state<string[]>([]);
   let imagePreviews = $state<Map<string, string>>(new Map());
-  let imageFileInput = $state<HTMLInputElement>();
 
   // Drag-and-drop state
   let dragOver = $state(false);
@@ -413,17 +407,10 @@
     }
   });
 
-  function openImagePicker() {
-    imageFileInput?.click();
-  }
-
-  async function handleImageFileSelect(e: Event) {
-    const input = e.target as HTMLInputElement;
-    if (!input.files) return;
-    for (const file of Array.from(input.files)) {
+  async function handleAttachFiles(files: File[]) {
+    for (const file of files) {
       await addImageFile(file);
     }
-    input.value = '';
   }
 
   async function addImageFile(file: File) {
@@ -2031,7 +2018,7 @@
   <!-- Input area with queued messages and image previews -->
   <div class="input-wrapper">
     {#if isPipelinePrelude}
-      <div class="input-area pipeline-stop-area">
+      <div class="pipeline-stop-area">
         <span class="inline-flex" title="Stop workflow">
           <Button
             variant="destructive"
@@ -2115,130 +2102,43 @@
           {/each}
         </div>
       {/if}
-      {#if canAttachImages && replyImageIds.length > 0}
-        <div class="reply-images">
-          {#each replyImageIds as imageId}
-            <div class="group/thumb reply-image-thumb">
-              {#if imagePreviews.get(imageId)}
-                <img src={imagePreviews.get(imageId)} alt="attached" />
-              {:else}
-                <div class="reply-image-placeholder"><ImagePlus size={16} /></div>
-              {/if}
-              {#if !isLive}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="reply-image-remove-action absolute top-0.5 right-0.5 size-4 rounded-full bg-[var(--bg-deepest)] text-muted-foreground opacity-0 shadow-none transition-opacity hover:bg-[var(--bg-chrome)] hover:text-foreground group-hover/thumb:opacity-100 [&_svg]:!size-2.5"
-                  title="Remove image"
-                  aria-label="Remove image"
-                  onclick={() => removeReplyImage(imageId)}
-                >
-                  <X size={10} />
-                </Button>
-              {/if}
-            </div>
-          {/each}
-          {#if !isLive}
-            <Button
-              variant="outline"
-              size="icon"
-              class="size-12 shrink-0 rounded-md border border-dashed border-[var(--border-muted)] bg-transparent text-[var(--text-faint)] shadow-none hover:border-[var(--border-emphasis)] hover:bg-transparent hover:text-muted-foreground [&_svg]:!size-4"
-              title="Add image"
-              aria-label="Add image"
-              onclick={openImagePicker}
-            >
-              <Plus size={16} />
-            </Button>
-          {/if}
-        </div>
-      {/if}
-      <div class="input-area">
-        <AcpFixedConfigPicker
-          providerId={session?.provider ?? null}
-          providerLabel={followupProviderLabel}
-          modelSelector={followupModelSelector}
-          effortSelector={followupEffortSelector}
-          selectedModelValue={selectedFollowupModelValue}
-          selectedEffortValue={selectedFollowupEffortValue}
-          loading={followupConfigLoading}
-          error={followupConfigError}
-          disabled={isLive || sending}
-          dropUp
-          triggerClass={footerControlClass}
-          layout="vertical"
-          onModelChange={handleFollowupModelChange}
-          onEffortChange={handleFollowupEffortChange}
-        />
-        {#if canAttachImages}
-          <input
-            bind:this={imageFileInput}
-            type="file"
-            accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
-            multiple
-            class="file-input-hidden"
-            onchange={handleImageFileSelect}
+      <ChatComposer
+        bind:textareaEl={inputEl}
+        bind:value={inputText}
+        placeholder={isLive ? 'Type to queue a follow-up…' : 'Send a message…'}
+        {hashtagItems}
+        onkeydown={handleInputKeydown}
+        oninput={autoResize}
+        {canAttachImages}
+        attachedImageIds={replyImageIds}
+        {imagePreviews}
+        onAttachFiles={handleAttachFiles}
+        onRemoveImage={removeReplyImage}
+        {isLive}
+        {sending}
+        {cancelling}
+        onSend={handleSend}
+        onStop={handleCancel}
+      >
+        {#snippet configPicker()}
+          <AcpFixedConfigPicker
+            providerId={session?.provider ?? null}
+            providerLabel={followupProviderLabel}
+            modelSelector={followupModelSelector}
+            effortSelector={followupEffortSelector}
+            selectedModelValue={selectedFollowupModelValue}
+            selectedEffortValue={selectedFollowupEffortValue}
+            loading={followupConfigLoading}
+            error={followupConfigError}
+            disabled={isLive || sending}
+            dropUp
+            triggerClass={composerControlClass}
+            layout="vertical"
+            onModelChange={handleFollowupModelChange}
+            onEffortChange={handleFollowupEffortChange}
           />
-          {#if replyImageIds.length === 0}
-            <span class="inline-flex" title="Attach image">
-              <Button
-                variant="ghost"
-                size="icon"
-                class="size-9 shrink-0 rounded-[10px] text-muted-foreground hover:bg-[var(--bg-hover)] hover:text-foreground [&_svg]:!size-4"
-                aria-label="Attach image"
-                onclick={openImagePicker}
-                disabled={isLive}
-              >
-                <Paperclip size={16} />
-              </Button>
-            </span>
-          {/if}
-        {/if}
-        <HashtagInput
-          bind:textareaEl={inputEl}
-          bind:value={inputText}
-          class="message-input"
-          placeholder={isLive ? 'Type to queue a follow-up…' : 'Send a message…'}
-          rows={1}
-          onkeydown={handleInputKeydown}
-          oninput={autoResize}
-          items={hashtagItems}
-        />
-        {#if isLive}
-          <span class="inline-flex composer-send" title="Stop session">
-            <Button
-              variant="destructive"
-              size="icon"
-              class="size-9 shrink-0 rounded-[10px] [&_svg]:!size-4"
-              aria-label="Stop session"
-              onclick={handleCancel}
-              disabled={cancelling}
-            >
-              {#if cancelling}
-                <Spinner size={16} />
-              {:else}
-                <CircleStop size={16} />
-              {/if}
-            </Button>
-          </span>
-        {:else}
-          <span class="inline-flex composer-send" title="Send message">
-            <Button
-              variant="outline"
-              size="icon"
-              class="size-9 shrink-0 rounded-[10px] shadow-none disabled:opacity-30 [&_svg]:!size-4"
-              aria-label="Send message"
-              onclick={handleSend}
-              disabled={sending || !inputText.trim()}
-            >
-              {#if sending}
-                <Spinner size={16} />
-              {:else}
-                <Send size={16} />
-              {/if}
-            </Button>
-          </span>
-        {/if}
-      </div>
+        {/snippet}
+      </ChatComposer>
     {/if}
   </div>
 </div>
@@ -2282,28 +2182,6 @@
 
   .session-chat-pane.compact .human-bubble {
     max-width: 92%;
-  }
-
-  /* Compact panes are too narrow to fit the config picker, attach, input, and
-     send controls in one row: give the text input its own full-width row with
-     the controls beneath it. */
-  .session-chat-pane.compact .input-area {
-    padding: 8px 10px;
-    flex-wrap: wrap;
-  }
-
-  .session-chat-pane.compact .input-area :global(.hashtag-input-wrapper) {
-    order: -1;
-    flex-basis: 100%;
-  }
-
-  .session-chat-pane.compact .input-area .composer-send {
-    margin-left: auto;
-  }
-
-  .session-chat-pane.compact .queue-popover,
-  .session-chat-pane.compact .slash-command-popover {
-    margin: 0 10px;
   }
 
   /* ----- Content area (scrollable) --------------------------------------- */
@@ -2525,15 +2403,12 @@
 
   .human-bubble:focus-within :global(.message-copy-action),
   .assistant-content:focus-within :global(.message-copy-action),
-  .reply-image-thumb:focus-within :global(.reply-image-remove-action),
-  :global(.message-copy-action:focus-visible),
-  :global(.reply-image-remove-action:focus-visible) {
+  :global(.message-copy-action:focus-visible) {
     opacity: 1;
   }
 
   @media (hover: none), (pointer: coarse) {
-    :global(.message-copy-action),
-    :global(.reply-image-remove-action) {
+    :global(.message-copy-action) {
       opacity: 1;
     }
   }
@@ -2969,90 +2844,15 @@
     word-break: break-word;
   }
 
-  /* ----- Reply image previews -------------------------------------------- */
+  /* ----- Pipeline stop area ---------------------------------------------- */
 
-  .file-input-hidden {
-    display: none;
-  }
-
-  .reply-images {
+  .pipeline-stop-area {
     display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    padding: 8px 14px 0;
-    border-top: 1px solid var(--border-subtle);
-  }
-
-  .reply-images + .input-area {
-    border-top: none;
-  }
-
-  .reply-image-thumb {
-    position: relative;
-    width: 48px;
-    height: 48px;
-    border-radius: 6px;
-    overflow: hidden;
-    border: 1px solid var(--border-muted);
-    background: var(--bg-hover);
-    flex-shrink: 0;
-  }
-
-  .reply-image-thumb img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-  .reply-image-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    color: var(--text-faint);
-  }
-
-  /* ----- Input area ------------------------------------------------------ */
-
-  .input-area {
-    display: flex;
-    align-items: flex-end;
-    gap: 8px;
+    justify-content: flex-end;
     padding: 10px 14px;
     border-top: 1px solid var(--border-subtle);
     background: var(--bg-chrome);
     flex-shrink: 0;
-  }
-
-  .pipeline-stop-area {
-    justify-content: flex-end;
-  }
-
-  .input-area :global(.message-input) {
-    flex: 1;
-    padding: 7px 12px;
-    background: var(--bg-primary);
-    border: 1px solid var(--border-muted);
-    border-radius: 10px;
-    color: var(--text-primary);
-    font-size: var(--size-md);
-    font-family: inherit;
-    line-height: 1.5;
-    resize: none;
-    overflow-y: hidden;
-    min-height: 36px;
-    max-height: 120px;
-  }
-
-  .input-area :global(.message-input):focus {
-    outline: none;
-    border-color: var(--border-emphasis);
-  }
-
-  .input-area :global(.hashtag-input-wrapper) {
-    flex: 1;
   }
 
   /* ======================================================================= */

--- a/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
@@ -215,8 +215,9 @@
   let followupModelStateKey = $state<string | null>(null);
   let followupEffortStateKey = $state<string | null>(null);
   let followupDiscoveryRun = 0;
+  // min-h instead of h so the vertical model/effort label can grow the button.
   const footerControlClass =
-    'h-9 gap-1.5 rounded-md border border-[var(--border-muted)] bg-[var(--bg-primary)] px-4 py-2 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-[var(--bg-hover)] hover:text-foreground max-[640px]:h-11 max-[640px]:justify-center';
+    'min-h-9 gap-1.5 rounded-md border border-[var(--border-muted)] bg-[var(--bg-primary)] px-4 py-1 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-[var(--bg-hover)] hover:text-foreground max-[640px]:min-h-11 max-[640px]:justify-center';
 
   let isLive = $derived(session?.status === 'running');
   let hasQueuedMessages = $derived(queuedMessages.length > 0);
@@ -2164,6 +2165,7 @@
           disabled={isLive || sending}
           dropUp
           triggerClass={footerControlClass}
+          layout="vertical"
           onModelChange={handleFollowupModelChange}
           onEffortChange={handleFollowupEffortChange}
         />

--- a/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
@@ -30,7 +30,6 @@
   import AlertCircle from '@lucide/svelte/icons/alert-circle';
   import Info from '@lucide/svelte/icons/info';
   import CircleStop from '@lucide/svelte/icons/circle-stop';
-  import Send from '@lucide/svelte/icons/send';
   import Copy from '@lucide/svelte/icons/copy';
   import Check from '@lucide/svelte/icons/check';
   import Clock from '@lucide/svelte/icons/clock';
@@ -2062,9 +2061,9 @@
               </div>
               {#if !isLive}
                 <Button
-                  variant="ghost"
-                  size="icon"
-                  class="size-[22px] shrink-0 rounded text-[var(--text-faint)] hover:bg-[var(--bg-hover)] hover:text-foreground disabled:opacity-40 [&_svg]:!size-3"
+                  variant="accent"
+                  size="xs"
+                  class="shrink-0"
                   title="Send queued message"
                   aria-label="Send queued message"
                   disabled={msg.status !== 'queued' || queueActionIds.has(msg.id)}
@@ -2073,7 +2072,7 @@
                   {#if queueActionIds.has(msg.id)}
                     <Spinner size={12} />
                   {:else}
-                    <Send size={12} />
+                    Send
                   {/if}
                 </Button>
               {/if}


### PR DESCRIPTION
## Summary

The agent config picker trigger in the session chat pane gains a vertical title/subtitle layout (model as title, effort as subtitle), making it a two-line button. The rest of the composer's bottom row is reworked so every control stretches to match it, and the composer itself is extracted into one shared component used by both the note chat pane and the chat dialog.

### Config picker trigger
- Add a configurable trigger layout: horizontal (existing inline "model · effort") stays the default for new-session surfaces; the session chat pane opts into the new vertical title/subtitle style, with `min-h-9` so the two-line label can grow the button. The trailing spinner/chevron now lives in a fixed 12px slot so loading no longer squeezes the label.
- Fix the trigger label sizer measurement: read widths from the ResizeObserver entry (`borderBoxSize`/`contentRect`) instead of `getBoundingClientRect`, which included the dialog open animation's 0.95 scale and left labels permanently truncated (~5% short) when discovery resolved during the animation window.

### Shared composer
- Extract the bottom input UI of `SessionChatPane` into a new `ChatComposer` component (text input, send/stop, attach button, attached-image strip) so the note chat pane and chat dialog render the identical composer. The layout is always the note-pane style: full-width input row with controls beneath, and the attach button stays visible once images are attached.
- Introduce an `accent` Button variant (the new-session submit's blue styling) and apply it to all start/send/queue buttons — new-session submit, composer send, diff pane commit launcher, and the queued-message send — dropping the paper plane icon everywhere in favor of label-only accent buttons with an in-flight spinner.
- Switch the control row to `align-items: stretch` with an `h-auto`/`min-h-9` floor on every button so attach/send/stop match the two-line picker's height (and stay 36px when it's single-line or absent).
- Give the attach button an "Attach" label next to the paperclip so it reads like its neighbors, sharing the picker trigger's chrome via the exported `composerControlClass`.