### PR TITLE
feat(settings): add branch prefix for inferred branch names

### DIFF
--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -837,6 +837,42 @@ pub(crate) fn infer_branch_name(project_name: &str) -> String {
     }
 }
 
+/// Read the user's configured branch prefix (General settings → Branch
+/// prefix) from the preferences store. Returns `None` when unset, blank, or
+/// consisting only of slashes.
+fn read_branch_prefix() -> Option<String> {
+    let path = crate::preferences_store_path_buf()?;
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let json = serde_json::from_str::<serde_json::Value>(&contents).ok()?;
+    let prefix = json.get("branch-prefix")?.as_str()?.trim();
+    if prefix.trim_matches('/').is_empty() {
+        return None;
+    }
+    Some(prefix.to_string())
+}
+
+/// Join the configured branch prefix onto `branch` with a `/` separator,
+/// unless the prefix already ends in `/`.
+fn apply_branch_prefix(prefix: Option<&str>, branch: &str) -> String {
+    match prefix {
+        Some(p) if p.ends_with('/') => format!("{p}{branch}"),
+        Some(p) => format!("{p}/{branch}"),
+        None => branch.to_string(),
+    }
+}
+
+/// Infer a branch name from the project name, applying the user's configured
+/// branch prefix. Used whenever a repo is added without an explicit branch
+/// name. The [`resolve_project_workspace_name`] fallback stays on the
+/// unprefixed [`infer_branch_name`] so existing workspace identities are
+/// unaffected by the setting.
+pub(crate) fn infer_prefixed_branch_name(project_name: &str) -> String {
+    apply_branch_prefix(
+        read_branch_prefix().as_deref(),
+        &infer_branch_name(project_name),
+    )
+}
+
 pub(crate) fn infer_workspace_name(branch_name: &str) -> String {
     const WORKSPACE_NAME_MAX_LENGTH: usize = 32;
     let safe = branch_name
@@ -2587,6 +2623,27 @@ pub(crate) async fn run_prerun_actions_for_branch(
 mod tests {
     use super::*;
     use crate::test_utils::TempGitRepo;
+
+    #[test]
+    fn apply_branch_prefix_joins_with_slash() {
+        assert_eq!(
+            apply_branch_prefix(Some("mtoohey"), "my-project"),
+            "mtoohey/my-project"
+        );
+    }
+
+    #[test]
+    fn apply_branch_prefix_skips_separator_when_prefix_ends_in_slash() {
+        assert_eq!(
+            apply_branch_prefix(Some("mtoohey/"), "my-project"),
+            "mtoohey/my-project"
+        );
+    }
+
+    #[test]
+    fn apply_branch_prefix_without_prefix_returns_branch_unchanged() {
+        assert_eq!(apply_branch_prefix(None, "my-project"), "my-project");
+    }
 
     #[test]
     fn local_base_ref_for_worktree_accepts_existing_origin_ref() {

--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -818,9 +818,11 @@ pub(crate) fn cleanup_branch_resources_best_effort(store: &Arc<Store>, branch: &
     }
 }
 
-pub(crate) fn infer_branch_name(project_name: &str) -> String {
-    let branch = project_name
-        .to_lowercase()
+/// Reduce `name` to a valid single branch-name component: lowercased,
+/// separators collapsed to `-`, everything else dropped. May return an empty
+/// string.
+fn normalize_branch_component(name: &str) -> String {
+    name.to_lowercase()
         .replace([' ', '_'], "-")
         .chars()
         .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '/' || *c == '.')
@@ -829,7 +831,11 @@ pub(crate) fn infer_branch_name(project_name: &str) -> String {
         .split('-')
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
-        .join("-");
+        .join("-")
+}
+
+pub(crate) fn infer_branch_name(project_name: &str) -> String {
+    let branch = normalize_branch_component(project_name);
     if branch.is_empty() {
         "feature".to_string()
     } else {
@@ -837,25 +843,39 @@ pub(crate) fn infer_branch_name(project_name: &str) -> String {
     }
 }
 
+/// Normalize a configured branch prefix with the same rules
+/// [`infer_branch_name`] applies to project names, per `/`-separated segment
+/// so multi-level prefixes like `team/mtoohey` keep their hierarchy. Empty
+/// segments are dropped, so leading, trailing, and doubled slashes cannot
+/// produce an invalid ref. Returns `None` when nothing valid remains.
+fn normalize_branch_prefix(prefix: &str) -> Option<String> {
+    let normalized = prefix
+        .split('/')
+        .map(normalize_branch_component)
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("/");
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
 /// Read the user's configured branch prefix (General settings → Branch
-/// prefix) from the preferences store. Returns `None` when unset, blank, or
-/// consisting only of slashes.
+/// prefix) from the preferences store, normalized via
+/// [`normalize_branch_prefix`]. Returns `None` when unset or when nothing
+/// valid remains after normalization.
 fn read_branch_prefix() -> Option<String> {
     let path = crate::preferences_store_path_buf()?;
     let contents = std::fs::read_to_string(&path).ok()?;
     let json = serde_json::from_str::<serde_json::Value>(&contents).ok()?;
-    let prefix = json.get("branch-prefix")?.as_str()?.trim();
-    if prefix.trim_matches('/').is_empty() {
-        return None;
-    }
-    Some(prefix.to_string())
+    normalize_branch_prefix(json.get("branch-prefix")?.as_str()?)
 }
 
-/// Join the configured branch prefix onto `branch` with a `/` separator,
-/// unless the prefix already ends in `/`.
+/// Join the normalized branch prefix onto `branch` with a `/` separator.
 fn apply_branch_prefix(prefix: Option<&str>, branch: &str) -> String {
     match prefix {
-        Some(p) if p.ends_with('/') => format!("{p}{branch}"),
         Some(p) => format!("{p}/{branch}"),
         None => branch.to_string(),
     }
@@ -2633,16 +2653,56 @@ mod tests {
     }
 
     #[test]
-    fn apply_branch_prefix_skips_separator_when_prefix_ends_in_slash() {
+    fn apply_branch_prefix_without_prefix_returns_branch_unchanged() {
+        assert_eq!(apply_branch_prefix(None, "my-project"), "my-project");
+    }
+
+    #[test]
+    fn normalize_branch_prefix_sanitizes_like_project_names() {
         assert_eq!(
-            apply_branch_prefix(Some("mtoohey/"), "my-project"),
-            "mtoohey/my-project"
+            normalize_branch_prefix("Matt Toohey"),
+            Some("matt-toohey".to_string())
+        );
+        assert_eq!(
+            normalize_branch_prefix("branch.lock"),
+            Some("branch-lock".to_string())
+        );
+        assert_eq!(
+            normalize_branch_prefix("~fix..up"),
+            Some("fix-up".to_string())
         );
     }
 
     #[test]
-    fn apply_branch_prefix_without_prefix_returns_branch_unchanged() {
-        assert_eq!(apply_branch_prefix(None, "my-project"), "my-project");
+    fn normalize_branch_prefix_preserves_multi_level_prefixes() {
+        assert_eq!(
+            normalize_branch_prefix("team/mtoohey"),
+            Some("team/mtoohey".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_branch_prefix_drops_empty_segments() {
+        assert_eq!(
+            normalize_branch_prefix("mtoohey/"),
+            Some("mtoohey".to_string())
+        );
+        assert_eq!(
+            normalize_branch_prefix("/mtoohey"),
+            Some("mtoohey".to_string())
+        );
+        assert_eq!(
+            normalize_branch_prefix("foo//bar"),
+            Some("foo/bar".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_branch_prefix_rejects_prefixes_with_nothing_valid() {
+        assert_eq!(normalize_branch_prefix(""), None);
+        assert_eq!(normalize_branch_prefix("  "), None);
+        assert_eq!(normalize_branch_prefix("///"), None);
+        assert_eq!(normalize_branch_prefix("~/.."), None);
     }
 
     #[test]

--- a/apps/staged/src-tauri/src/branches.rs
+++ b/apps/staged/src-tauri/src/branches.rs
@@ -845,7 +845,7 @@ pub(crate) fn infer_branch_name(project_name: &str) -> String {
 
 /// Normalize a configured branch prefix with the same rules
 /// [`infer_branch_name`] applies to project names, per `/`-separated segment
-/// so multi-level prefixes like `team/mtoohey` keep their hierarchy. Empty
+/// so multi-level prefixes like `team/alice` keep their hierarchy. Empty
 /// segments are dropped, so leading, trailing, and doubled slashes cannot
 /// produce an invalid ref. Returns `None` when nothing valid remains.
 fn normalize_branch_prefix(prefix: &str) -> Option<String> {
@@ -2647,8 +2647,8 @@ mod tests {
     #[test]
     fn apply_branch_prefix_joins_with_slash() {
         assert_eq!(
-            apply_branch_prefix(Some("mtoohey"), "my-project"),
-            "mtoohey/my-project"
+            apply_branch_prefix(Some("alice"), "my-project"),
+            "alice/my-project"
         );
     }
 
@@ -2660,8 +2660,8 @@ mod tests {
     #[test]
     fn normalize_branch_prefix_sanitizes_like_project_names() {
         assert_eq!(
-            normalize_branch_prefix("Matt Toohey"),
-            Some("matt-toohey".to_string())
+            normalize_branch_prefix("Alice Doe"),
+            Some("alice-doe".to_string())
         );
         assert_eq!(
             normalize_branch_prefix("branch.lock"),
@@ -2676,21 +2676,15 @@ mod tests {
     #[test]
     fn normalize_branch_prefix_preserves_multi_level_prefixes() {
         assert_eq!(
-            normalize_branch_prefix("team/mtoohey"),
-            Some("team/mtoohey".to_string())
+            normalize_branch_prefix("team/alice"),
+            Some("team/alice".to_string())
         );
     }
 
     #[test]
     fn normalize_branch_prefix_drops_empty_segments() {
-        assert_eq!(
-            normalize_branch_prefix("mtoohey/"),
-            Some("mtoohey".to_string())
-        );
-        assert_eq!(
-            normalize_branch_prefix("/mtoohey"),
-            Some("mtoohey".to_string())
-        );
+        assert_eq!(normalize_branch_prefix("alice/"), Some("alice".to_string()));
+        assert_eq!(normalize_branch_prefix("/alice"), Some("alice".to_string()));
         assert_eq!(
             normalize_branch_prefix("foo//bar"),
             Some("foo/bar".to_string())

--- a/apps/staged/src-tauri/src/lib.rs
+++ b/apps/staged/src-tauri/src/lib.rs
@@ -423,7 +423,7 @@ fn create_project(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(ToOwned::to_owned)
-        .unwrap_or_else(|| branches::infer_branch_name(trimmed));
+        .unwrap_or_else(|| branches::infer_prefixed_branch_name(trimmed));
     let mut project = store::Project::named(trimmed);
     project.location = project_location;
     if let Some(repo) = github_repo.clone() {

--- a/apps/staged/src-tauri/src/project_commands.rs
+++ b/apps/staged/src-tauri/src/project_commands.rs
@@ -31,7 +31,7 @@ pub(crate) async fn add_project_repo_impl(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(ToOwned::to_owned)
-        .unwrap_or_else(|| branches::infer_branch_name(&project.name));
+        .unwrap_or_else(|| branches::infer_prefixed_branch_name(&project.name));
     // If this github_repo is already attached to the project (i.e. being added
     // again with a different subpath), make the branch name unique by appending
     // a subpath-derived suffix.  Without this, `git worktree add -b <branch>`

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -436,6 +436,22 @@ fn get_store(store: &Mutex<Option<Arc<Store>>>) -> Result<Arc<Store>, String> {
         .ok_or_else(|| "Database not initialized".to_string())
 }
 
+/// Open the shared preferences store (`~/.staged/preferences.json`) through
+/// the store plugin. Returns the desktop frontend's already-loaded instance
+/// when one exists, so web writes can't be clobbered by a stale in-memory
+/// copy; the backend paths that read the file directly (e.g. `branch-prefix`
+/// in `branches.rs`) see web writes because every mutation is saved to disk.
+fn preferences_store(
+    app_handle: &tauri::AppHandle,
+) -> Result<Arc<tauri_plugin_store::Store<tauri::Wry>>, String> {
+    use tauri_plugin_store::StoreExt;
+    let path =
+        crate::preferences_store_path_buf().ok_or("Cannot determine preferences store path")?;
+    app_handle
+        .store(path)
+        .map_err(|e| format!("Failed to load preferences store: {e}"))
+}
+
 /// The big dispatcher. Maps command names to handler logic.
 ///
 /// Each arm extracts arguments from the JSON body and calls the same
@@ -3684,6 +3700,33 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                 .map(|p| p.to_string_lossy().to_string())
                 .ok_or("Cannot determine preferences store path")?;
             Ok(serde_json::to_value(path).unwrap())
+        }
+        "get_preference" => {
+            let key: String = arg(&args, "key")?;
+            let store = preferences_store(app_handle)?;
+            Ok(store.get(&key).unwrap_or(Value::Null))
+        }
+        "set_preference" => {
+            let key: String = arg(&args, "key")?;
+            let value = args
+                .get("value")
+                .cloned()
+                .ok_or("missing argument: value")?;
+            let store = preferences_store(app_handle)?;
+            store.set(key, value);
+            store
+                .save()
+                .map_err(|e| format!("Failed to save preferences: {e}"))?;
+            Ok(Value::Null)
+        }
+        "delete_preference" => {
+            let key: String = arg(&args, "key")?;
+            let store = preferences_store(app_handle)?;
+            store.delete(&key);
+            store
+                .save()
+                .map_err(|e| format!("Failed to save preferences: {e}"))?;
+            Ok(Value::Null)
         }
         "check_blox_auth" => {
             tauri::async_runtime::spawn_blocking(crate::blox::check_auth)

--- a/apps/staged/src-tauri/src/web_server.rs
+++ b/apps/staged/src-tauri/src/web_server.rs
@@ -498,7 +498,7 @@ async fn dispatch(command: &str, args: Value, state: &WebAppState) -> Result<Val
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(ToOwned::to_owned)
-                .unwrap_or_else(|| crate::branches::infer_branch_name(trimmed));
+                .unwrap_or_else(|| crate::branches::infer_prefixed_branch_name(trimmed));
 
             let mut project = crate::store::Project::named(trimmed);
             project.location = project_location;

--- a/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
@@ -205,7 +205,7 @@
         {#if preferences.branchPrefix.trim()}
           Branch names generated from project names will look like {branchPrefixExample}.
         {:else}
-          Prepended (with a / separator) to branch names generated from project names when a repo is
+          This prefix will be added to branch names along with a slash separator when a repo is
           added without choosing a branch.
         {/if}
       </p>

--- a/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
@@ -205,8 +205,7 @@
         {#if preferences.branchPrefix.trim()}
           Branch names generated from project names will look like {branchPrefixExample}.
         {:else}
-          This prefix will be added to branch names along with a slash separator when a repo is
-          added without choosing a branch.
+          This prefix will be added to branch names along with a slash separator.
         {/if}
       </p>
     </div>

--- a/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
@@ -195,7 +195,7 @@
       <Input
         id="branch-prefix-input"
         type="text"
-        placeholder="e.g. mtoohey"
+        placeholder="e.g. alice"
         class="max-w-[320px]"
         value={preferences.branchPrefix}
         oninput={(e) => setBranchPrefix(e.currentTarget.value)}

--- a/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/GeneralSettingsPanel.svelte
@@ -7,6 +7,7 @@
   import * as Select from '$lib/components/ui/select';
   import * as Popover from '$lib/components/ui/popover';
   import * as ToggleGroup from '$lib/components/ui/toggle-group';
+  import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
   import {
     preferences,
@@ -14,6 +15,7 @@
     selectDiffTheme,
     setMode,
     setAutoReviewMode,
+    setBranchPrefix,
     loadAllThemePreviewColors,
     isLightTheme,
     type AppMode,
@@ -60,6 +62,12 @@
     selectDiffTheme(name);
     dropdownOpen = false;
   }
+
+  const branchPrefixExample = $derived.by(() => {
+    const prefix = preferences.branchPrefix.trim();
+    if (!prefix) return 'my-project';
+    return prefix.endsWith('/') ? `${prefix}my-project` : `${prefix}/my-project`;
+  });
 </script>
 
 <div class="general-settings-panel">
@@ -176,6 +184,29 @@
           A code review will automatically start after each commit session completes.
         {:else}
           Code reviews will only start when you manually request them.
+        {/if}
+      </p>
+    </div>
+
+    <div class="field">
+      <Label for="branch-prefix-input" class="text-foreground text-sm font-semibold"
+        >Branch prefix</Label
+      >
+      <Input
+        id="branch-prefix-input"
+        type="text"
+        placeholder="e.g. mtoohey"
+        class="max-w-[320px]"
+        value={preferences.branchPrefix}
+        oninput={(e) => setBranchPrefix(e.currentTarget.value)}
+      />
+      <p class="field-description">
+        <Info size={12} />
+        {#if preferences.branchPrefix.trim()}
+          Branch names generated from project names will look like {branchPrefixExample}.
+        {:else}
+          Prepended (with a / separator) to branch names generated from project names when a repo is
+          added without choosing a branch.
         {/if}
       </p>
     </div>

--- a/apps/staged/src/lib/features/settings/preferences.svelte.ts
+++ b/apps/staged/src/lib/features/settings/preferences.svelte.ts
@@ -42,6 +42,8 @@ const DIFF_THEME_STORE_KEY = 'diff-theme';
 const APP_MODE_STORE_KEY = 'app-mode';
 const RECENT_AGENTS_STORE_KEY = 'recent-agents';
 const AUTO_REVIEW_STORE_KEY = 'auto-start-code-reviews';
+/** Prefix applied to branch names inferred from project names (backend-read). */
+const BRANCH_PREFIX_STORE_KEY = 'branch-prefix';
 /** Maximum number of recent agents to remember. */
 const RECENT_AGENTS_MAX = 10;
 
@@ -127,6 +129,12 @@ export const preferences = $state({
   recentAgents: [] as string[],
   /** Whether auto code reviews are triggered after commits */
   autoReviewMode: 'after-changes' as AutoReviewMode,
+  /**
+   * Prefix for branch names generated from project names (e.g. when adding a
+   * repo without picking a branch). Joined with a `/` unless it already ends
+   * in one. Empty means no prefix. Read by the backend from the store file.
+   */
+  branchPrefix: '',
   /** Whether all preferences have been loaded from storage */
   loaded: false,
 });
@@ -272,6 +280,12 @@ export async function initPreferences(): Promise<void> {
   } else {
     preferences.autoReviewMode = (await loadSqAvailabilityForDefault()) ? 'after-changes' : 'never';
   }
+
+  // Load branch prefix
+  const savedBranchPrefix = await getStoreValue<string>(BRANCH_PREFIX_STORE_KEY);
+  if (typeof savedBranchPrefix === 'string') {
+    preferences.branchPrefix = savedBranchPrefix;
+  }
 }
 
 // =============================================================================
@@ -316,6 +330,20 @@ export async function selectDiffTheme(name: string): Promise<void> {
 export function setAutoReviewMode(mode: AutoReviewMode): void {
   preferences.autoReviewMode = mode;
   setStoreValue(AUTO_REVIEW_STORE_KEY, mode);
+}
+
+// =============================================================================
+// Branch Prefix Actions
+// =============================================================================
+
+/**
+ * Set the branch prefix applied to branch names generated from project names.
+ * Stored trimmed; the backend reads it directly from the store file when
+ * inferring branch names.
+ */
+export function setBranchPrefix(prefix: string): void {
+  preferences.branchPrefix = prefix;
+  setStoreValue(BRANCH_PREFIX_STORE_KEY, prefix.trim());
 }
 
 // =============================================================================

--- a/apps/staged/src/lib/shared/persistentStore.ts
+++ b/apps/staged/src/lib/shared/persistentStore.ts
@@ -5,9 +5,12 @@
  * that works reliably across dev server restarts (unlike localStorage
  * which is origin-scoped and breaks when the dev port changes).
  *
- * In web mode, falls back to localStorage with JSON serialization.
+ * In web mode, proxies get/set/delete to the web server, which persists
+ * to the same store file through the same store plugin instance. This
+ * keeps server-read preferences (e.g. `branch-prefix`) in sync no matter
+ * which client wrote them.
  *
- * The store is saved to `~/.staged/preferences.json` in Tauri mode.
+ * The store is saved to `~/.staged/preferences.json` in both modes.
  */
 
 import { isTauri, invokeCommand } from '../transport';
@@ -22,15 +25,18 @@ interface TauriStoreBackend {
 }
 
 // ---------------------------------------------------------------------------
-// localStorage backend (web mode) — stubbed out
-// TODO(web): restore localStorage backend from the `mobile-web` branch
+// Web backend — preference commands served by the web server
 // ---------------------------------------------------------------------------
+
+interface WebStoreBackend {
+  kind: 'web';
+}
 
 // ---------------------------------------------------------------------------
 // Singleton
 // ---------------------------------------------------------------------------
 
-type StoreBackend = TauriStoreBackend | null;
+type StoreBackend = TauriStoreBackend | WebStoreBackend | null;
 
 let backend: StoreBackend = null;
 
@@ -50,8 +56,9 @@ export async function initPersistentStore(): Promise<void> {
       overrideDefaults: true,
     });
     backend = { kind: 'tauri', store };
+  } else {
+    backend = { kind: 'web' };
   }
-  // TODO(web): restore localStorage backend initialization for web mode
 }
 
 /**
@@ -64,7 +71,13 @@ export async function getStoreValue<T>(key: string): Promise<T | undefined> {
     return undefined;
   }
 
-  return backend.store.get<T>(key);
+  if (backend.kind === 'tauri') {
+    return backend.store.get<T>(key);
+  }
+
+  // Missing keys come back as JSON null from the server.
+  const value = await invokeCommand<T | null>('get_preference', { key });
+  return value ?? undefined;
 }
 
 /**
@@ -77,7 +90,12 @@ export async function setStoreValue<T>(key: string, value: T): Promise<void> {
     return;
   }
 
-  await backend.store.set(key, value);
+  if (backend.kind === 'tauri') {
+    await backend.store.set(key, value);
+    return;
+  }
+
+  await invokeCommand('set_preference', { key, value });
 }
 
 /**
@@ -89,5 +107,10 @@ export async function deleteStoreValue(key: string): Promise<void> {
     return;
   }
 
-  await backend.store.delete(key);
+  if (backend.kind === 'tauri') {
+    await backend.store.delete(key);
+    return;
+  }
+
+  await invokeCommand('delete_preference', { key });
 }


### PR DESCRIPTION
## Summary

Adds a **Branch prefix** setting (Settings → General) that is prepended to branch names inferred from project names — e.g. with prefix `mtoohey`, adding a repo to project "My Project" without picking a branch yields `mtoohey/my-project`.

## Changes

- **Frontend** (`preferences.svelte.ts`, `GeneralSettingsPanel.svelte`): new `branch-prefix` preference with a text input in General settings, including a live example of the resulting branch name.
- **Backend** (`branches.rs`): new `infer_prefixed_branch_name` reads the prefix from the preferences store and joins it onto the inferred name with a `/`. The prefix is sanitized per `/`-separated segment using the same normalization rules as project names, so multi-level prefixes like `team/mtoohey` keep their hierarchy while invalid characters, empty segments, and stray slashes can't produce an invalid ref.
- All three repo-add entry points (`create_project` in `lib.rs`, `add_project_repo_impl` in `project_commands.rs`, and the web server dispatch) now use the prefixed inference. The `resolve_project_workspace_name` fallback stays on the unprefixed `infer_branch_name` so existing workspace identities are unaffected.

## Testing

Unit tests cover prefix joining, sanitization, multi-level prefixes, empty-segment handling, and fully-invalid prefixes.