### PR TITLE
fix(chat): hide the bottom pipeline Stop once the transcript has messages

### DIFF
--- a/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
@@ -9,7 +9,9 @@
   Features:
   - Text input always available at the bottom (Cmd/Ctrl+Enter sends, Enter adds a newline)
   - Send button when idle, Queue button when running; Stop lives on the Thinking row
-  - While a pipeline runs, the composer is replaced by a labeled Stop button
+  - While a pipeline runs with an empty transcript, the composer is replaced by
+    a labeled Stop button; once messages exist, Stop lives on the Thinking row
+    and the composer queues follow-ups as usual
   - Message queue: sending while running persists a follow-up for backend drain
   - Copy button on every message
   - Tool calls show name + args preview; expand to see output
@@ -2063,7 +2065,7 @@
 
   <!-- Input area with queued messages and image previews -->
   <div class="input-wrapper">
-    {#if isPipelineRunning}
+    {#if isPipelineRunning && grouped.length === 0}
       <div class="pipeline-stop-area">
         <span class="inline-flex" title="Stop workflow">
           <Button


### PR DESCRIPTION
## Summary

While a pipeline runs, the chat composer was unconditionally replaced by a large labeled Stop button — even after the transcript had messages, at which point Stop already lives on the Thinking row (#874). This left two Stop controls on screen and blocked queueing follow-ups.

- Only show the bottom pipeline Stop area when the pipeline is running **and** the transcript is still empty (`grouped.length === 0`)
- Once messages exist, Stop stays on the Thinking row and the composer remains available to queue follow-ups as usual
- Updated the component doc comment to describe the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)