### PR TITLE
feat(staged): add daily scheduled workflow to bump ACP tool pins

### DIFF
--- a/.github/workflows/crates-ci.yml
+++ b/.github/workflows/crates-ci.yml
@@ -29,10 +29,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Install hermit (manages rust, just)
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       # Cache Cargo dependencies
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/differ-ci.yml
+++ b/.github/workflows/differ-ci.yml
@@ -35,10 +35,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Install hermit (manages node, rust, just)
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       # Enable pnpm via corepack (node ships with corepack; version comes from packageManager in package.json)
       - run: corepack enable pnpm

--- a/.github/workflows/penpal-ci.yml
+++ b/.github/workflows/penpal-ci.yml
@@ -31,10 +31,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Install hermit (manages node, rust, just, go)
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       # Cache Cargo dependencies
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/penpal-release.yml
+++ b/.github/workflows/penpal-release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Validate that the git tag version matches Cargo.toml to prevent
       # mismatched artifact names vs Homebrew URLs (see package.sh line 9).
@@ -30,7 +30,7 @@ jobs:
           fi
 
       # Install hermit (manages node, rust, just, go)
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       # Cache Cargo dependencies
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -89,7 +89,7 @@ jobs:
       contents: write
       actions: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/staged-bump-acp-tools.yml
+++ b/.github/workflows/staged-bump-acp-tools.yml
@@ -44,13 +44,23 @@ jobs:
           fi
 
       # PR CI does not consume the lockfile, so a broken pin would otherwise
-      # surface only at release time. Install the new pins (with integrity
-      # validation) before pushing them anywhere. The target is passed
-      # explicitly because the script's auto-detection needs rustc, which
-      # this job otherwise does not use.
-      - name: Smoke-check new pins
+      # surface only at release time (aarch64-apple-darwin) or on a dev
+      # machine's next `just dev`. Install the new pins (with integrity
+      # validation) for every target in the lockfile before pushing them
+      # anywhere; npm's --os/--cpu flags let this Linux runner install the
+      # foreign-platform entries too. Targets are passed explicitly because
+      # the script's auto-detection needs rustc, which this job otherwise
+      # does not use.
+      - name: Smoke-check new pins for all lockfile targets
         if: steps.bump.outputs.changed == 'true'
-        run: apps/staged/scripts/ensure-acp-tools.sh --target x86_64-unknown-linux-gnu
+        run: |
+          targets="$(node -e '
+            const { tools } = require("./apps/staged/acp-tools.lock.json");
+            process.stdout.write([...new Set(tools.map((tool) => tool.target))].sort().join("\n"));
+          ')"
+          while IFS= read -r target; do
+            apps/staged/scripts/ensure-acp-tools.sh --target "$target"
+          done <<< "$targets"
 
       - name: Commit and force-push
         if: steps.bump.outputs.changed == 'true'
@@ -75,7 +85,7 @@ jobs:
               --base main \
               --head automation/update-acp-pins \
               --title "chore(staged): bump bundled ACP tools to latest" \
-              --body "Automated daily bump of the ACP bridge tool pins in \`apps/staged/acp-tools.lock.json\` via \`just bump-acp-tools\`. The new pins were smoke-checked in the workflow run by installing them with \`scripts/ensure-acp-tools.sh\`. While this PR is open, each daily run force-pushes the latest pins to this branch."
+              --body "Automated daily bump of the ACP bridge tool pins in \`apps/staged/acp-tools.lock.json\` via \`just bump-acp-tools\`. The new pins were smoke-checked in the workflow run by installing them for every lockfile target with \`scripts/ensure-acp-tools.sh\`. While this PR is open, each daily run force-pushes the latest pins to this branch."
           else
             echo "Open PR already exists for automation/update-acp-pins; it now shows the fresh pins."
           fi

--- a/.github/workflows/staged-bump-acp-tools.yml
+++ b/.github/workflows/staged-bump-acp-tools.yml
@@ -1,0 +1,87 @@
+name: Staged Bump ACP Tools
+
+on:
+  schedule:
+    # Daily at 06:30 UTC.
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+# One run at a time so a late-finishing run cannot race a newer one.
+concurrency:
+  group: staged-bump-acp-tools
+
+env:
+  # The lockfile records registry-specific tarball URLs. Point npm at Block
+  # Artifactory so CI runs produce the same URLs as dev machines instead of
+  # rewriting them all to registry.npmjs.org.
+  npm_config_registry: https://global.block-artifacts.com/artifactory/api/npm/square-npm/
+
+jobs:
+  bump:
+    name: Bump ACP tool pins
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Install hermit (manages node, just)
+      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+
+      # The branch is bot-owned and single-commit: every run recreates it from
+      # main, so it never diverges or accumulates history.
+      - name: Reset automation branch from main
+        run: git switch --force-create automation/update-acp-pins
+
+      - name: Bump ACP tool pins
+        run: just -f apps/staged/justfile bump-acp-tools
+
+      # The recipe touches only the lockfile; a clean diff means no upstream
+      # releases and the run is done.
+      - name: Detect lockfile changes
+        id: bump
+        run: |
+          if git diff --quiet -- apps/staged/acp-tools.lock.json; then
+            echo "Lockfile unchanged; no upstream releases."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # PR CI does not consume the lockfile, so a broken pin would otherwise
+      # surface only at release time. Install the new pins (with integrity
+      # validation) before pushing them anywhere. The target is passed
+      # explicitly because the script's auto-detection needs rustc, which
+      # this job otherwise does not use.
+      - name: Smoke-check new pins
+        if: steps.bump.outputs.changed == 'true'
+        run: apps/staged/scripts/ensure-acp-tools.sh --target x86_64-unknown-linux-gnu
+
+      - name: Commit and force-push
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(staged): bump bundled ACP tools to latest" \
+            -- apps/staged/acp-tools.lock.json
+          git push --force origin automation/update-acp-pins
+
+      # Refresh-in-place: while a PR for this branch is open, the force-push
+      # above already updated it to show the fresh pins rebased on current
+      # main. Only create a PR when none is open.
+      - name: Create PR if none open
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          open_prs="$(gh pr list --head automation/update-acp-pins --state open --json number --jq length)"
+          if [ "$open_prs" = "0" ]; then
+            gh pr create \
+              --base main \
+              --head automation/update-acp-pins \
+              --title "chore(staged): bump bundled ACP tools to latest" \
+              --body "Automated daily bump of the ACP bridge tool pins in \`apps/staged/acp-tools.lock.json\` via \`just bump-acp-tools\`. The new pins were smoke-checked in the workflow run by installing them with \`scripts/ensure-acp-tools.sh\`. While this PR is open, each daily run force-pushes the latest pins to this branch."
+          else
+            echo "Open PR already exists for automation/update-acp-pins; it now shows the fresh pins."
+          fi

--- a/.github/workflows/staged-bump-acp-tools.yml
+++ b/.github/workflows/staged-bump-acp-tools.yml
@@ -10,12 +10,6 @@ on:
 concurrency:
   group: staged-bump-acp-tools
 
-env:
-  # The lockfile records registry-specific tarball URLs. Point npm at Block
-  # Artifactory so CI runs produce the same URLs as dev machines instead of
-  # rewriting them all to registry.npmjs.org.
-  npm_config_registry: https://global.block-artifacts.com/artifactory/api/npm/square-npm/
-
 jobs:
   bump:
     name: Bump ACP tool pins

--- a/.github/workflows/staged-bump-acp-tools.yml
+++ b/.github/workflows/staged-bump-acp-tools.yml
@@ -18,10 +18,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Install hermit (manages node, just)
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       # The branch is bot-owned and single-commit: every run recreates it from
       # main, so it never diverges or accumulates history.

--- a/.github/workflows/staged-ci.yml
+++ b/.github/workflows/staged-ci.yml
@@ -35,10 +35,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Install hermit (manages node, rust, just)
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       # Enable pnpm via corepack (node ships with corepack; version comes from packageManager in package.json)
       - run: corepack enable pnpm

--- a/.github/workflows/staged-release.yml
+++ b/.github/workflows/staged-release.yml
@@ -17,9 +17,9 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       - run: corepack enable pnpm
 


### PR DESCRIPTION
Adds `.github/workflows/staged-bump-acp-tools.yml`, a scheduled workflow (daily at 06:30 UTC, plus manual `workflow_dispatch`) that keeps the bundled ACP bridge tool pins in `apps/staged/acp-tools.lock.json` up to date:

- Recreates the bot-owned `automation/update-acp-pins` branch from `main` on every run so it never diverges.
- Runs `just -f apps/staged/justfile bump-acp-tools` and exits early when the lockfile is unchanged.
- Smoke-checks new pins by installing them with `apps/staged/scripts/ensure-acp-tools.sh` (with integrity validation) before pushing, since PR CI does not consume the lockfile.
- Force-pushes the branch and opens a `chore(staged)` PR when none is open; while one is open, each run refreshes it in place.

Follows up on #876, which bundled the ACP bridge tools.