### PR TITLE
feat(staged): add 48h cooling-off period to ACP tool bumps

### DIFF
--- a/.github/workflows/staged-bump-acp-tools.yml
+++ b/.github/workflows/staged-bump-acp-tools.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Reset automation branch from main
         run: git switch --force-create automation/update-acp-pins
 
+      # The recipe pins the newest releases that have aged past the script's
+      # 48-hour cooling-off window (its default), not bare `latest`, so a
+      # release that is about to be yanked or superseded never lands here.
       - name: Bump ACP tool pins
         run: just -f apps/staged/justfile bump-acp-tools
 
       # The recipe touches only the lockfile; a clean diff means no upstream
-      # releases and the run is done.
+      # releases outside the cooling-off window and the run is done.
       - name: Detect lockfile changes
         id: bump
         run: |
@@ -67,7 +70,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore(staged): bump bundled ACP tools to latest" \
+          git commit -m "chore(staged): bump bundled ACP tools" \
             -- apps/staged/acp-tools.lock.json
           git push --force origin automation/update-acp-pins
 
@@ -84,8 +87,8 @@ jobs:
             gh pr create \
               --base main \
               --head automation/update-acp-pins \
-              --title "chore(staged): bump bundled ACP tools to latest" \
-              --body "Automated daily bump of the ACP bridge tool pins in \`apps/staged/acp-tools.lock.json\` via \`just bump-acp-tools\`. The new pins were smoke-checked in the workflow run by installing them for every lockfile target with \`scripts/ensure-acp-tools.sh\`. While this PR is open, each daily run force-pushes the latest pins to this branch."
+              --title "chore(staged): bump bundled ACP tools" \
+              --body "Automated daily bump of the ACP bridge tool pins in \`apps/staged/acp-tools.lock.json\` via \`just bump-acp-tools\`, which pins the newest releases that have aged past a 48-hour cooling-off window rather than bare \`latest\`. The new pins were smoke-checked in the workflow run by installing them for every lockfile target with \`scripts/ensure-acp-tools.sh\`. While this PR is open, each daily run force-pushes the freshest eligible pins to this branch."
           else
             echo "Open PR already exists for automation/update-acp-pins; it now shows the fresh pins."
           fi

--- a/apps/staged/justfile
+++ b/apps/staged/justfile
@@ -137,7 +137,7 @@ release version:
 
     echo "Pushed tag staged/v{{version}} — CI will build and publish the release."
 
-# Query the latest npm releases of the bundled ACP bridge tools and update acp-tools.lock.json
+# Update acp-tools.lock.json to the newest npm releases of the bundled ACP bridge tools that have aged past the 48h cooling-off window
 bump-acp-tools *ARGS:
     node scripts/update-acp-tools-lock.mjs {{ ARGS }}
 

--- a/apps/staged/scripts/update-acp-tools-lock.mjs
+++ b/apps/staged/scripts/update-acp-tools-lock.mjs
@@ -16,6 +16,13 @@ const SUPPORTED_TARGETS = [
   "x86_64-unknown-linux-gnu",
 ];
 
+// Releases must age past a cooling-off window before they are eligible to
+// pin: broken or compromised releases are typically yanked or superseded
+// within a day or two of publish, so waiting out the window keeps the daily
+// bump from shipping them. When `latest` is still inside the window, the
+// newest older stable release that has aged past it is pinned instead.
+const DEFAULT_COOLING_OFF_HOURS = 48;
+
 // The Codex ACP executable stays `codex-acp`, but bundled installs must come
 // from the maintained Agent Client Protocol package rather than the stale
 // Zed package.
@@ -108,12 +115,13 @@ const npmViewCache = new Map();
 const execFileAsync = promisify(execFile);
 
 function usage() {
-  console.log(`Usage: scripts/update-acp-tools-lock.mjs [--target <triple>]... [--lock-file <path>] [--skip-smoke]
+  console.log(`Usage: scripts/update-acp-tools-lock.mjs [--target <triple>]... [--lock-file <path>] [--skip-smoke] [--cooling-off-hours <hours>]
 
-Queries npm for the latest release of each supported ACP bridge tool and
+Queries npm for the newest release of each supported ACP bridge tool that has
+aged past the cooling-off window (default ${DEFAULT_COOLING_OFF_HOURS} hours, 0 disables it) and
 writes acp-tools.lock.json. Fails loudly when a package or one of its
 per-target native dependencies cannot be resolved — never silently pins an
-older version.
+older version than the cooling-off window calls for.
 
 Before writing the lock, each tool's CLI passthrough (the subcommand doctor's
 auth/version probes rely on) is smoke-checked against the resolved release by
@@ -134,6 +142,7 @@ function parseArgs(argv) {
   const targets = [];
   let lockFile = process.env.ACP_TOOLS_LOCK_FILE ?? defaultLockFile;
   let skipSmoke = false;
+  let coolingOffHours = DEFAULT_COOLING_OFF_HOURS;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "-h" || arg === "--help") {
@@ -156,6 +165,15 @@ function parseArgs(argv) {
       skipSmoke = true;
       continue;
     }
+    if (arg === "--cooling-off-hours") {
+      const value = argv[++i];
+      if (!value) throw new Error("--cooling-off-hours requires a value");
+      coolingOffHours = Number(value);
+      if (!Number.isFinite(coolingOffHours) || coolingOffHours < 0) {
+        throw new Error("--cooling-off-hours must be a non-negative number");
+      }
+      continue;
+    }
     throw new Error(`Unknown argument: ${arg}`);
   }
 
@@ -165,7 +183,7 @@ function parseArgs(argv) {
       throw new Error(`Unsupported target '${target}'`);
     }
   }
-  return { targets: selectedTargets, lockFile, skipSmoke };
+  return { targets: selectedTargets, lockFile, skipSmoke, coolingOffHours };
 }
 
 async function npmView(spec, fields) {
@@ -218,22 +236,116 @@ function compareSemver(left, right) {
   return (left.includes("-") ? 0 : 1) - (right.includes("-") ? 0 : 1);
 }
 
+// Publish timestamp of a version from a packument `time` map, or null when
+// the registry does not report one (an unknown publish time never counts as
+// aged — the cooling-off window cannot be silently waived).
+function publishedAtMs(timeMap, version) {
+  const published = Date.parse(timeMap?.[version] ?? "");
+  return Number.isFinite(published) ? published : null;
+}
+
+function hasAged(timeMap, version, coolingOffHours, now) {
+  if (coolingOffHours <= 0) return true;
+  const published = publishedAtMs(timeMap, version);
+  return published !== null && now - published >= coolingOffHours * 3600_000;
+}
+
+// Resolve the version to pin for a package: the `latest` dist-tag once it has
+// aged past the cooling-off window, otherwise the newest older stable release
+// that has. Never resolves past `latest`, so an upstream dist-tag rollback
+// (e.g. after a bad release) is honored even when newer versions exist.
+async function resolveLatestAgedVersion(packageName, coolingOffHours, now) {
+  const packument = await npmView(packageName, [
+    "dist-tags",
+    "time",
+    "versions",
+  ]);
+  const latest = requireString(
+    packument["dist-tags"]?.latest,
+    `${packageName} dist-tags.latest`,
+  );
+  const timeMap = packument.time ?? {};
+  if (hasAged(timeMap, latest, coolingOffHours, now)) return latest;
+  // npm view returns a bare string instead of a one-element array when the
+  // package has a single version.
+  const versions = Array.isArray(packument.versions)
+    ? packument.versions
+    : [packument.versions];
+  const candidates = versions.filter(
+    (version) =>
+      typeof version === "string" &&
+      !version.includes("-") &&
+      compareSemver(version, latest) < 0 &&
+      hasAged(timeMap, version, coolingOffHours, now),
+  );
+  if (candidates.length === 0) {
+    throw new Error(
+      `${packageName} has no stable release that has aged past the ` +
+        `${coolingOffHours}h cooling-off window (latest ${latest} published ` +
+        `${timeMap[latest] ?? "at an unknown time"})`,
+    );
+  }
+  const resolved = candidates.reduce((best, candidate) =>
+    compareSemver(candidate, best) > 0 ? candidate : best,
+  );
+  console.log(
+    `${packageName}: latest ${latest} (published ${timeMap[latest]}) is ` +
+      `inside the ${coolingOffHours}h cooling-off window; pinning ` +
+      `${resolved} instead.`,
+  );
+  return resolved;
+}
+
+const coolingOffLogDedup = new Set();
+
 // npm view returns a single object when a spec matches one version, but an
 // array of per-version objects when a range matches several. Pick the highest
-// matching version so a ranged dependency still pins the newest release.
-function pickLatestMatch(metadata, label) {
-  if (!Array.isArray(metadata)) return metadata;
-  if (metadata.length === 0) {
+// matching version that has aged past the cooling-off window, so a ranged
+// dependency still pins the newest eligible release. A bridge release that
+// aged past the window had at least one in-range dependency version at
+// publish time — necessarily just as aged — so an empty result means the
+// range never matched anything, not an over-strict window.
+function pickLatestAgedMatch(metadata, label, timeMap, coolingOffHours, now) {
+  const matches = Array.isArray(metadata) ? metadata : [metadata];
+  if (matches.length === 0) {
     throw new Error(`No versions match ${label}`);
   }
-  return metadata.reduce((best, candidate) =>
-    compareSemver(
+  const pickNewest = (candidates) =>
+    candidates.reduce((best, candidate) =>
+      compareSemver(
+        requireString(candidate?.version, `${label} version`),
+        requireString(best?.version, `${label} version`),
+      ) > 0
+        ? candidate
+        : best,
+    );
+  const aged = matches.filter((candidate) =>
+    hasAged(
+      timeMap,
       requireString(candidate?.version, `${label} version`),
-      requireString(best?.version, `${label} version`),
-    ) > 0
-      ? candidate
-      : best,
+      coolingOffHours,
+      now,
+    ),
   );
+  if (aged.length === 0) {
+    throw new Error(
+      `All versions matching ${label} were published within the ` +
+        `${coolingOffHours}h cooling-off window`,
+    );
+  }
+  const best = pickNewest(aged);
+  const newest = pickNewest(matches);
+  // Deduped because this runs once per target with identical inputs.
+  if (newest.version !== best.version && !coolingOffLogDedup.has(label)) {
+    coolingOffLogDedup.add(label);
+    console.log(
+      `${label}: newest match ${newest.version} (published ` +
+        `${timeMap?.[newest.version] ?? "at an unknown time"}) is inside ` +
+        `the ${coolingOffHours}h cooling-off window; pinning ` +
+        `${best.version} instead.`,
+    );
+  }
+  return best;
 }
 
 function parseNpmAliasSpec(spec, fallbackPackage) {
@@ -251,14 +363,20 @@ function parseNpmAliasSpec(spec, fallbackPackage) {
   };
 }
 
-async function lockToolForTarget(tool, target) {
+async function lockToolForTarget(
+  tool,
+  target,
+  agedVersion,
+  coolingOffHours,
+  now,
+) {
   const npmTarget = NPM_TARGET_CONFIG[target];
   if (!npmTarget) {
     throw new Error(`No npm target mapping for ${target}`);
   }
 
   const packageName = tool.package;
-  const packageMetadata = await npmView(`${packageName}@latest`, [
+  const packageMetadata = await npmView(`${packageName}@${agedVersion}`, [
     "name",
     "version",
     "dist",
@@ -297,7 +415,7 @@ async function lockToolForTarget(tool, target) {
     packageMetadata.dependencies?.[tool.dependencyPackage],
     `${packageName} dependency ${tool.dependencyPackage}`,
   );
-  const dependencyMetadata = pickLatestMatch(
+  const dependencyMetadata = pickLatestAgedMatch(
     await npmView(`${tool.dependencyPackage}@${dependencyRange}`, [
       "name",
       "version",
@@ -306,6 +424,9 @@ async function lockToolForTarget(tool, target) {
       "claudeCodeVersion",
     ]),
     `${tool.dependencyPackage}@${dependencyRange}`,
+    await npmView(tool.dependencyPackage, ["time"]),
+    coolingOffHours,
+    now,
   );
   const dependencyVersion = requireString(
     dependencyMetadata.version,
@@ -425,11 +546,21 @@ async function smokeCheckPassthrough(tool, locked) {
 }
 
 async function main() {
-  const { targets, lockFile, skipSmoke } = parseArgs(process.argv.slice(2));
+  const { targets, lockFile, skipSmoke, coolingOffHours } = parseArgs(
+    process.argv.slice(2),
+  );
+  const now = Date.now();
   const tools = [];
   for (const tool of TOOL_SPECS) {
+    const agedVersion = await resolveLatestAgedVersion(
+      tool.package,
+      coolingOffHours,
+      now,
+    );
     for (const target of targets) {
-      tools.push(await lockToolForTarget(tool, target));
+      tools.push(
+        await lockToolForTarget(tool, target, agedVersion, coolingOffHours, now),
+      );
     }
   }
   tools.sort((left, right) =>


### PR DESCRIPTION
## Summary

The daily ACP tool bump previously pinned whatever `latest` pointed at on npm, so a broken or compromised release could land in `acp-tools.lock.json` the moment it was published. This adds a cooling-off window so releases must age before they become eligible to pin.

- `scripts/update-acp-tools-lock.mjs` now resolves the newest release that has aged past a cooling-off window (default 48 hours, configurable via `--cooling-off-hours`, `0` disables it) instead of bare `latest`. When `latest` is still inside the window, the newest older stable release that has aged past it is pinned instead — but resolution never goes past `latest`, so upstream dist-tag rollbacks are still honored.
- Ranged native dependencies get the same treatment: the newest in-range version that has aged past the window is pinned, and an unknown publish timestamp never counts as aged.
- The script fails loudly when no eligible release exists rather than silently pinning something else.
- The `staged-bump-acp-tools` workflow and justfile docs/PR copy are updated to describe the cooling-off behavior.