### PR TITLE
fix(dialog): stop dialogs from clearing text selection on mouseup

### DIFF
--- a/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -19,6 +19,11 @@
 
 <AlertDialogPortal {...portalProps}>
   <AlertDialogOverlay />
+  <!--
+    preventOverflowTextSelection is off for the same reason as dialog-content:
+    WKWebView collapses the selection when bits-ui restores user-select styles
+    on pointerup, leaving dialog text unselectable.
+  -->
   <AlertDialogPrimitive.Content
     bind:ref
     data-slot="alert-dialog-content"
@@ -27,6 +32,7 @@
       'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-[var(--bg-alert-dialog)] text-[var(--text-primary)] ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-(--z-index-overlay) grid w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 outline-none',
       className
     )}
+    preventOverflowTextSelection={false}
     {...restProps}
   />
 </AlertDialogPortal>

--- a/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/apps/staged/src/lib/components/ui/dialog/dialog-content.svelte
@@ -91,6 +91,13 @@
 
 <DialogPortal {...portalProps}>
   <Dialog.Overlay />
+  <!--
+    preventOverflowTextSelection is off: bits-ui's selection lock rewrites
+    user-select on <body> and the content on pointerup, and WKWebView collapses
+    the just-dragged selection when that style changes — making dialog text
+    unselectable in the Tauri app. The overlay already covers the page behind,
+    so selection overflow has nothing visible to leak into.
+  -->
   <DialogPrimitive.Content
     bind:ref
     data-slot="dialog-content"
@@ -104,6 +111,7 @@
     style={contentStyle}
     onOpenAutoFocus={(e) => e.preventDefault()}
     onpointerdown={handlePointerDown}
+    preventOverflowTextSelection={false}
     {...restProps}
   >
     {@render children?.()}


### PR DESCRIPTION
## Summary

Text selected inside dialogs and alert dialogs was collapsing the moment the mouse button was released, making dialog text effectively unselectable in the Tauri app.

The cause is bits-ui's `preventOverflowTextSelection` behavior: its selection lock rewrites `user-select` styles on `<body>` and the dialog content on pointerup, and WKWebView collapses the just-dragged selection when those styles change.

## Changes

- Set `preventOverflowTextSelection={false}` on `DialogPrimitive.Content` and `AlertDialogPrimitive.Content`, with comments explaining why.
- This is safe because the dialog overlay already covers the page behind, so there is nothing visible for a selection to overflow into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)