### PR TITLE
feat(sessions): per-type tool call detail views

### DIFF
--- a/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
+++ b/apps/staged/src/lib/features/sessions/SessionChatPane.svelte
@@ -35,18 +35,12 @@
   import CircleStop from '@lucide/svelte/icons/circle-stop';
   import Copy from '@lucide/svelte/icons/copy';
   import Check from '@lucide/svelte/icons/check';
-  import Clock from '@lucide/svelte/icons/clock';
-  import CircleAlert from '@lucide/svelte/icons/circle-alert';
-  import CircleCheck from '@lucide/svelte/icons/circle-check';
-  import CircleDot from '@lucide/svelte/icons/circle-dot';
-  import CircleSlash from '@lucide/svelte/icons/circle-slash';
   import ChevronRight from '@lucide/svelte/icons/chevron-right';
   import ChevronDown from '@lucide/svelte/icons/chevron-down';
   import Zap from '@lucide/svelte/icons/zap';
   import GitBranch from '@lucide/svelte/icons/git-branch';
   import BookOpen from '@lucide/svelte/icons/book-open';
   import FileText from '@lucide/svelte/icons/file-text';
-  import ExternalLink from '@lucide/svelte/icons/external-link';
   import ImagePlus from '@lucide/svelte/icons/image-plus';
   import Spinner from '../../shared/Spinner.svelte';
   import { isResumableReason } from '../../types';
@@ -108,22 +102,15 @@
   import { hasXmlBlocks, sessionEndMessage, XML_BLOCK_TAGS } from './sessionModalHelpers';
   import {
     buildAcpTranscriptGroups,
-    diffsFromAcpContent,
-    displayLocations,
     formatJson,
     groupRichToolsByVerb,
     isToolMetadataSettled,
     latestAvailableCommands,
-    simpleUnifiedDiff,
     stabilizeAcpTranscriptGroups,
-    terminalRefsFromAcpContent,
-    toolHasDetails,
-    toolResultText,
     transcriptGroupKey,
     type AcpCommand,
     type AcpTranscriptEvent,
     type AcpTranscriptGroup,
-    type RichToolItem,
   } from './acpTranscript';
   import {
     displayRootKey,
@@ -132,6 +119,8 @@
     type DisplayRootInput,
   } from './pathDisplayRoots';
   import PipelineSteps from './PipelineSteps.svelte';
+  import ToolCallCard from './tool-calls/ToolCallCard.svelte';
+  import ToolCallHeader from './tool-calls/ToolCallHeader.svelte';
   import { highlightMatches, clearHighlights, scrollToMatch } from '../../shared/textHighlight';
   import '../../shared/markdown/diagramStyles.css';
   import {
@@ -1739,131 +1728,11 @@
 
 <svelte:window onpaste={handleImagePaste} />
 
-{#snippet toolStatusDot(statusTone: RichToolItem['statusTone'])}
-  <span
-    class="tool-status-dot"
-    class:status-running={statusTone === 'running'}
-    class:status-success={statusTone === 'success'}
-    class:status-danger={statusTone === 'danger'}
-    class:status-cancelled={statusTone === 'cancelled'}
-  >
-    {#if statusTone === 'running'}
-      <Clock size={11} />
-    {:else if statusTone === 'success'}
-      <CircleCheck size={11} />
-    {:else if statusTone === 'danger'}
-      <CircleAlert size={11} />
-    {:else if statusTone === 'cancelled'}
-      <CircleSlash size={11} />
-    {:else}
-      <CircleDot size={11} />
-    {/if}
-  </span>
-{/snippet}
-
-{#snippet richToolCard(item: RichToolItem, nested: boolean)}
-  {@const isExpanded = expandedTools.has(item.key)}
-  {@const hasDetails = toolHasDetails(item)}
-  {@const showSessionButton = !!(item.isPikchrDiagramTool && item.innerSessionId && onOpenSession)}
-  {@const showInlineDiagram = item.pikchrRenderSource !== null}
-  <div class="tool-card" class:tool-card-nested={nested}>
-    {#if showInlineDiagram}
-      <div class="tool-diagram markdown-content">
-        {@html renderMarkdown(fencedDiagramMarkdown('pikchr', item.pikchrRenderSource!))}
-      </div>
-    {:else if showSessionButton}
-      <Button
-        variant="outline"
-        size="sm"
-        class="tool-session-button {item.statusTone === 'danger'
-          ? 'tool-session-button-danger'
-          : ''}"
-        onclick={() => onOpenSession?.(item.innerSessionId!)}
-      >
-        {@render toolStatusDot(item.statusTone)}
-        <span
-          >{item.statusTone === 'danger'
-            ? 'Open failed diagram session'
-            : 'Open diagram session'}</span
-        >
-        <ExternalLink size={12} />
-      </Button>
-    {:else}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="tool-header"
-        class:tool-header-expandable={hasDetails}
-        onclick={() => hasDetails && toggleTool(item.key)}
-      >
-        <span
-          class="tool-caret"
-          class:tool-caret-expanded={isExpanded}
-          class:tool-caret-hidden={!hasDetails}>›</span
-        >
-        {@render toolStatusDot(item.statusTone)}
-        <span class="tool-name">{item.verb}</span>
-        {#if item.detail}
-          <span class="tool-args-preview">{item.detail}</span>
-        {/if}
-      </div>
-    {/if}
-    {#if isExpanded && hasDetails && !showSessionButton && !showInlineDiagram}
-      <!-- Formatted only once expanded: pretty-printing every collapsed
-           card's raw payloads made live re-renders expensive. -->
-      {@const resultText = toolResultText(item)}
-      {@const rawInputText = formatJson(item.rawInput)}
-      {@const rawOutputText = formatJson(item.rawOutput)}
-      {@const diffs = diffsFromAcpContent(item.content, displayRoots)}
-      {@const locations = displayLocations(item.locations, displayRoots)}
-      {@const terminalRefs = terminalRefsFromAcpContent(item.content)}
-      <div class="tool-code-block" transition:slide={{ duration: SLIDE_DURATION }}>
-        {#if (item.verb === 'Ran' || item.verb === 'Running') && item.detail}
-          <div class="tool-code-command">$ {item.detail}</div>
-        {/if}
-        {#if locations.length > 0}
-          <div class="tool-meta-row">
-            {#each locations as location}
-              <span class="tool-chip">{location}</span>
-            {/each}
-          </div>
-        {/if}
-        {#if rawInputText}
-          <div class="tool-panel-label">Input</div>
-          <pre class="tool-code-output">{rawInputText}</pre>
-        {/if}
-        {#each diffs as diff}
-          <div class="tool-panel-label">{diff.path}</div>
-          <pre class="tool-code-output diff-output">{simpleUnifiedDiff(diff)}</pre>
-        {/each}
-        {#if terminalRefs.length > 0}
-          <div class="tool-panel-label">Terminal</div>
-          <div class="tool-meta-row">
-            {#each terminalRefs as terminalRef}
-              <span class="tool-chip">{terminalRef}</span>
-            {/each}
-          </div>
-        {/if}
-        {#if resultText}
-          <div class="tool-panel-label">Output</div>
-          <pre class="tool-code-output">{resultText}</pre>
-        {/if}
-        {#if rawOutputText && rawOutputText !== resultText}
-          <div class="tool-panel-label">Raw output</div>
-          <pre class="tool-code-output">{rawOutputText}</pre>
-        {/if}
-        <div
-          class="tool-code-status"
-          class:status-danger={item.statusTone === 'danger'}
-          class:status-cancelled={item.statusTone === 'cancelled'}
-        >
-          {#if item.statusTone === 'success'}
-            <Check size={11} />
-          {/if}
-          {item.statusLabel}
-        </div>
-      </div>
-    {/if}
+<!-- Lives here rather than in ToolCallCard because renderMarkdown closes over the
+     pane's pikchr renderer state; passed to ToolCallCard as its diagram snippet. -->
+{#snippet pikchrDiagram(source: string)}
+  <div class="tool-diagram markdown-content">
+    {@html renderMarkdown(fencedDiagramMarkdown('pikchr', source))}
   </div>
 {/snippet}
 
@@ -2041,27 +1910,37 @@
               <div class="message-row tool-group">
                 {#each groupRichToolsByVerb(group.items) as verbGroup (verbGroup.key)}
                   {#if verbGroup.items.length === 1}
-                    {@render richToolCard(verbGroup.items[0], false)}
+                    <ToolCallCard
+                      item={verbGroup.items[0]}
+                      {displayRoots}
+                      expanded={expandedTools.has(verbGroup.items[0].key)}
+                      slideDuration={SLIDE_DURATION}
+                      onToggle={toggleTool}
+                      {onOpenSession}
+                      diagram={pikchrDiagram}
+                    />
                   {:else}
                     {@const isGroupExpanded = expandedTools.has(verbGroup.key)}
-                    <div class="tool-card">
-                      <!-- svelte-ignore a11y_click_events_have_key_events -->
-                      <!-- svelte-ignore a11y_no_static_element_interactions -->
-                      <div
-                        class="tool-header tool-header-expandable"
-                        onclick={() => toggleTool(verbGroup.key)}
-                      >
-                        <span class="tool-caret" class:tool-caret-expanded={isGroupExpanded}>›</span
-                        >
-                        {@render toolStatusDot(verbGroup.statusTone)}
-                        <span class="tool-name">{verbGroup.verb}</span>
-                        <span class="tool-args-preview">{verbGroup.summary}</span>
-                      </div>
-                    </div>
+                    <ToolCallHeader
+                      verb={verbGroup.verb}
+                      detail={verbGroup.summary}
+                      statusTone={verbGroup.statusTone}
+                      expanded={isGroupExpanded}
+                      onToggle={() => toggleTool(verbGroup.key)}
+                    />
                     {#if isGroupExpanded}
                       <div transition:slide={{ duration: SLIDE_DURATION }}>
                         {#each verbGroup.items as item (item.key)}
-                          {@render richToolCard(item, true)}
+                          <ToolCallCard
+                            {item}
+                            {displayRoots}
+                            nested
+                            expanded={expandedTools.has(item.key)}
+                            slideDuration={SLIDE_DURATION}
+                            onToggle={toggleTool}
+                            {onOpenSession}
+                            diagram={pikchrDiagram}
+                          />
                         {/each}
                       </div>
                     {/if}
@@ -2606,61 +2485,6 @@
     min-width: 0;
   }
 
-  .tool-card {
-    overflow: hidden;
-    min-width: 0;
-  }
-
-  .tool-card-nested {
-    padding-left: 16px;
-  }
-
-  .tool-header {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 0;
-    background: none;
-    color: var(--text-muted);
-    font-size: var(--size-xs);
-    transition: background-color 0.1s;
-    cursor: default;
-    min-width: 0;
-  }
-
-  .tool-header-expandable {
-    cursor: pointer;
-  }
-
-  .tool-header-expandable:hover .tool-name {
-    text-decoration: underline;
-  }
-
-  :global(.tool-session-button) {
-    height: 26px;
-    gap: 6px;
-    border-color: var(--border-muted);
-    padding: 0 8px;
-    color: var(--text-muted);
-    font-size: var(--size-xs);
-    font-weight: 500;
-    box-shadow: none;
-  }
-
-  :global(.tool-session-button:hover) {
-    border-color: var(--border-emphasis);
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  /* A failed generate_pikchr call keeps its session button (the child session
-     records the failure); tint it so the error is visible without expanding. */
-  :global(.tool-session-button-danger),
-  :global(.tool-session-button-danger:hover) {
-    border-color: var(--ui-danger);
-    color: var(--ui-danger);
-  }
-
   /* Inline diagram from a successful render_pikchr call — rendered through the
      markdown pipeline, so it picks up the shared diagram styles (fullscreen
      zoom affordance included); only the message margins are tightened to sit
@@ -2673,157 +2497,24 @@
     display: inline-block;
     flex-shrink: 0;
     width: 8px;
-    font-size: var(--size-xs);
     color: var(--text-faint);
-    transition: transform 0.15s ease;
+    font-size: var(--size-xs);
     line-height: 1;
+    transition: transform 0.15s ease;
   }
 
   .tool-caret-expanded {
     transform: rotate(90deg);
   }
 
-  .tool-caret-hidden {
-    visibility: hidden;
-  }
-
-  .tool-name {
-    flex-shrink: 0;
-    color: var(--text-muted);
-    font-size: var(--size-xs);
-    white-space: nowrap;
-  }
-
-  .tool-status-dot {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 12px;
-    height: 12px;
-    flex-shrink: 0;
-    color: var(--text-faint);
-  }
-
-  .tool-status-dot.status-running {
-    color: var(--ui-warning);
-  }
-
-  .tool-status-dot.status-success {
-    color: var(--ui-success, var(--ui-accent));
-  }
-
-  .tool-status-dot.status-danger {
-    color: var(--ui-danger);
-  }
-
-  .tool-status-dot.status-cancelled {
-    color: var(--text-muted);
-  }
-
   .tool-args-preview {
     flex: 1;
     min-width: 0;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     color: var(--text-faint);
     font-size: var(--size-xs);
-  }
-
-  .tool-code-block {
-    background: color-mix(in srgb, var(--bg-chrome) 80%, black);
-    border-radius: 8px;
-    padding: 12px 14px;
-    margin-top: 4px;
-    max-height: 240px;
-    overflow-y: auto;
-    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
-    font-size: calc(var(--size-xs) * 0.9);
-    line-height: 1.5;
-  }
-
-  .tool-code-command {
-    color: var(--text-primary);
-    font-weight: 500;
-    margin-bottom: 6px;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
-
-  .tool-code-output {
-    margin: 0;
-    color: var(--text-muted);
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .diff-output {
-    color: var(--text-primary);
-  }
-
-  .tool-panel-label {
-    margin: 10px 0 4px;
-    color: var(--text-faint);
-    font-family: inherit;
-    font-size: calc(var(--size-xs) * 0.86);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
-  .tool-panel-label:first-child {
-    margin-top: 0;
-  }
-
-  .tool-meta-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    margin: 4px 0 8px;
-  }
-
-  .tool-chip {
-    max-width: 100%;
-    overflow: hidden;
     text-overflow: ellipsis;
-    border: 1px solid var(--border-subtle);
-    border-radius: 6px;
-    padding: 2px 6px;
-    color: var(--text-muted);
-    font-family: inherit;
-    font-size: calc(var(--size-xs) * 0.88);
     white-space: nowrap;
-  }
-
-  .tool-code-status {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 3px;
-    margin-top: 8px;
-    font-size: calc(var(--size-xs) * 0.85);
-    color: var(--text-muted);
-  }
-
-  .tool-code-status.status-danger {
-    color: var(--ui-danger);
-  }
-
-  .tool-code-status.status-cancelled {
-    color: var(--text-faint);
-  }
-
-  .tool-code-block::-webkit-scrollbar {
-    width: 4px;
-  }
-
-  .tool-code-block::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .tool-code-block::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb-transparent);
-    border-radius: 2px;
   }
 
   /* ACP metadata cards */

--- a/apps/staged/src/lib/features/sessions/acpTranscript.test.ts
+++ b/apps/staged/src/lib/features/sessions/acpTranscript.test.ts
@@ -6,7 +6,6 @@ import {
   isToolMetadataSettled,
   latestAvailableCommands,
   stabilizeAcpTranscriptGroups,
-  toolHasDetails,
   type RichToolItem,
 } from './acpTranscript';
 
@@ -783,48 +782,6 @@ describe('stabilizeAcpTranscriptGroups', () => {
     if (stabilized[0].type === 'tools') {
       expect(stabilized[0].items[0].status).toBe('completed');
     }
-  });
-});
-
-describe('toolHasDetails', () => {
-  it('matches the formatted-value emptiness checks', () => {
-    expect(toolHasDetails(richTool({ key: 'tool:1', verb: 'Ran' }))).toBe(false);
-    expect(toolHasDetails(richTool({ key: 'tool:1', verb: 'Ran', rawInput: '' }))).toBe(false);
-    expect(toolHasDetails(richTool({ key: 'tool:1', verb: 'Ran', rawInput: { a: 1 } }))).toBe(true);
-    expect(toolHasDetails(richTool({ key: 'tool:1', verb: 'Ran', rawOutput: 'ok' }))).toBe(true);
-    expect(
-      toolHasDetails(
-        richTool({
-          key: 'tool:1',
-          verb: 'Ran',
-          content: [{ type: 'diff', path: '/repo/a.ts', newText: 'new' }],
-        })
-      )
-    ).toBe(true);
-    expect(
-      toolHasDetails(
-        richTool({ key: 'tool:1', verb: 'Ran', content: [{ type: 'terminal', terminalId: 't-1' }] })
-      )
-    ).toBe(true);
-    expect(
-      toolHasDetails(
-        richTool({ key: 'tool:1', verb: 'Ran', locations: [{ path: '/repo/a.ts', line: 3 }] })
-      )
-    ).toBe(true);
-    expect(
-      toolHasDetails(
-        richTool({
-          key: 'tool:1',
-          verb: 'Ran',
-          result: message({ id: 9, role: 'tool_result', content: 'output' }),
-        })
-      )
-    ).toBe(true);
-    // Presence-only fields that the expanded card ignores stay hidden.
-    expect(
-      toolHasDetails(richTool({ key: 'tool:1', verb: 'Ran', content: [{ type: 'diff' }] }))
-    ).toBe(false);
-    expect(toolHasDetails(richTool({ key: 'tool:1', verb: 'Ran', locations: [{}] }))).toBe(false);
   });
 });
 

--- a/apps/staged/src/lib/features/sessions/acpTranscript.ts
+++ b/apps/staged/src/lib/features/sessions/acpTranscript.ts
@@ -1,12 +1,6 @@
 import type { SessionMessage } from '../../types';
 import type { DisplayRootInput } from './pathDisplayRoots';
-import {
-  formatToolDisplay,
-  makePathsRelative,
-  parseToolCall,
-  stripCodeFences,
-  verbGroupSummary,
-} from './sessionModalHelpers';
+import { formatToolDisplay, parseToolCall, verbGroupSummary } from './sessionModalHelpers';
 
 export type ToolStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled';
 
@@ -308,29 +302,6 @@ export function textFromAcpContent(content: unknown): string {
   return parts.join('\n').trim();
 }
 
-export interface AcpDiff {
-  path: string;
-  oldText: string | null;
-  newText: string;
-}
-
-export function diffsFromAcpContent(content: unknown, displayRoots?: DisplayRootInput): AcpDiff[] {
-  if (!Array.isArray(content)) return [];
-  const diffs: AcpDiff[] = [];
-  for (const item of content) {
-    if (stringProp(item, 'type') !== 'diff') continue;
-    const path = stringProp(item, 'path');
-    const newText = stringProp(item, 'newText');
-    if (!path || newText === null) continue;
-    diffs.push({
-      path: makePathsRelative(path, displayRoots),
-      oldText: stringProp(item, 'oldText'),
-      newText,
-    });
-  }
-  return diffs;
-}
-
 export function terminalRefsFromAcpContent(content: unknown): string[] {
   if (!Array.isArray(content)) return [];
   return content
@@ -366,29 +337,6 @@ export function groupRichToolsByVerb(items: RichToolItem[]): RichToolVerbGroup[]
     summary: verbGroupSummary(group),
     statusTone: groupStatusTone(group.items),
   }));
-}
-
-export function simpleUnifiedDiff(diff: AcpDiff): string {
-  const oldLines = (diff.oldText ?? '').split('\n');
-  const newLines = diff.newText.split('\n');
-  if (diff.oldText === null) {
-    return newLines.map((line) => `+${line}`).join('\n');
-  }
-  if (diff.oldText === diff.newText) return diff.newText;
-
-  const output: string[] = [];
-  const max = Math.max(oldLines.length, newLines.length);
-  for (let i = 0; i < max; i++) {
-    const oldLine = oldLines[i];
-    const newLine = newLines[i];
-    if (oldLine === newLine) {
-      if (oldLine !== undefined) output.push(` ${oldLine}`);
-    } else {
-      if (oldLine !== undefined) output.push(`-${oldLine}`);
-      if (newLine !== undefined) output.push(`+${newLine}`);
-    }
-  }
-  return output.join('\n');
 }
 
 function groupStatusTone(items: RichToolItem[]): RichToolItem['statusTone'] {
@@ -869,78 +817,4 @@ function stringProp(value: unknown, key: string): string | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const prop = (value as Record<string, unknown>)[key];
   return typeof prop === 'string' ? prop : null;
-}
-
-export function displayLocations(locations: unknown, displayRoots?: DisplayRootInput): string[] {
-  if (!Array.isArray(locations)) return [];
-  return locations
-    .map((location) => {
-      const path = stringProp(location, 'path');
-      if (!path) return null;
-      const line =
-        location && typeof location === 'object'
-          ? (location as Record<string, unknown>).line
-          : undefined;
-      const suffix = typeof line === 'number' ? `:${line}` : '';
-      return `${makePathsRelative(path, displayRoots)}${suffix}`;
-    })
-    .filter((location): location is string => !!location);
-}
-
-export function toolResultText(item: RichToolItem): string {
-  const structuredText = textFromAcpContent(item.content);
-  if (structuredText) return structuredText;
-  if (typeof item.rawOutput === 'string') return item.rawOutput;
-  if (item.rawOutput !== undefined && item.rawOutput !== null) return formatJson(item.rawOutput);
-  if (item.result?.content) return stripCodeFences(item.result.content);
-  return '';
-}
-
-/**
- * Whether an expanded tool card would have anything to show. Equivalent to
- * checking the formatted values (`formatJson`, `toolResultText`,
- * `diffsFromAcpContent`, …) for emptiness, but without building them — the
- * formatted strings are only needed once a card is actually expanded, and
- * pretty-printing large raw payloads for every collapsed card is what made
- * live-transcript re-renders expensive.
- */
-export function toolHasDetails(item: RichToolItem): boolean {
-  return (
-    hasJsonValue(item.rawInput) ||
-    hasJsonValue(item.rawOutput) ||
-    acpContentHasDiff(item.content) ||
-    acpContentHasTerminalRef(item.content) ||
-    hasLocation(item.locations) ||
-    !!toolResultText(item)
-  );
-}
-
-/** Mirrors `!!formatJson(value)`: only undefined/null/'' format to ''. */
-function hasJsonValue(value: unknown): boolean {
-  return value !== undefined && value !== null && value !== '';
-}
-
-/** Mirrors `diffsFromAcpContent(content).length > 0`. */
-function acpContentHasDiff(content: unknown): boolean {
-  if (!Array.isArray(content)) return false;
-  return content.some(
-    (item) =>
-      stringProp(item, 'type') === 'diff' &&
-      !!stringProp(item, 'path') &&
-      stringProp(item, 'newText') !== null
-  );
-}
-
-/** Mirrors `terminalRefsFromAcpContent(content).length > 0`. */
-function acpContentHasTerminalRef(content: unknown): boolean {
-  if (!Array.isArray(content)) return false;
-  return content.some(
-    (item) => stringProp(item, 'type') === 'terminal' && !!stringProp(item, 'terminalId')
-  );
-}
-
-/** Mirrors `displayLocations(locations).length > 0`. */
-function hasLocation(locations: unknown): boolean {
-  if (!Array.isArray(locations)) return false;
-  return locations.some((location) => !!stringProp(location, 'path'));
 }

--- a/apps/staged/src/lib/features/sessions/tool-calls/CommandToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/CommandToolDetails.svelte
@@ -19,8 +19,7 @@
 <div class="tool-detail-stack">
   <div class="tool-command-panel">
     <div class="tool-command-line">
-      <span class="tool-command-prefix">$</span>
-      <span class="tool-command-text">{commandText}</span>
+      <span class="tool-command-prefix">$</span><span class="tool-command-text">{commandText}</span>
     </div>
     {#if viewModel.metadata.workingDirectory || failureExitCode !== null}
       <div class="tool-field-list">

--- a/apps/staged/src/lib/features/sessions/tool-calls/CommandToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/CommandToolDetails.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { ToolCallViewModel } from '../toolCallViewModel';
+  import OutputSections from './OutputSections.svelte';
+
+  interface Props {
+    viewModel: ToolCallViewModel;
+  }
+
+  let { viewModel }: Props = $props();
+  let commandText = $derived((viewModel.metadata.command ?? viewModel.detail) || 'Command');
+</script>
+
+<div class="tool-detail-stack">
+  <div class="tool-command-panel">
+    <div class="tool-command-line">
+      <span class="tool-command-prefix">$</span>
+      <span class="tool-command-text">{commandText}</span>
+    </div>
+    <div class="tool-field-list">
+      {#if viewModel.metadata.workingDirectory}
+        <span class="tool-field-label">Directory</span>
+        <span class="tool-field-value">{viewModel.metadata.workingDirectory}</span>
+      {/if}
+      {#if viewModel.output.exitCode !== null}
+        <span class="tool-field-label">Exit</span>
+        <span class="tool-field-value">{viewModel.output.exitCode}</span>
+      {/if}
+      <span class="tool-field-label">Status</span>
+      <span class="tool-field-value">{viewModel.statusLabel}</span>
+    </div>
+  </div>
+
+  {#if viewModel.metadata.terminalRefs.length > 0}
+    <div class="tool-meta-row">
+      {#each viewModel.metadata.terminalRefs as terminalRef}
+        <span class="tool-chip">{terminalRef}</span>
+      {/each}
+    </div>
+  {/if}
+
+  <OutputSections {viewModel} copyable />
+</div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/CommandToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/CommandToolDetails.svelte
@@ -8,6 +8,12 @@
 
   let { viewModel }: Props = $props();
   let commandText = $derived((viewModel.metadata.command ?? viewModel.detail) || 'Command');
+  // Status already shows in the header dot and the footer; only surface failure exits here.
+  let failureExitCode = $derived(
+    viewModel.output.exitCode !== null && viewModel.output.exitCode !== 0
+      ? viewModel.output.exitCode
+      : null
+  );
 </script>
 
 <div class="tool-detail-stack">
@@ -16,18 +22,18 @@
       <span class="tool-command-prefix">$</span>
       <span class="tool-command-text">{commandText}</span>
     </div>
-    <div class="tool-field-list">
-      {#if viewModel.metadata.workingDirectory}
-        <span class="tool-field-label">Directory</span>
-        <span class="tool-field-value">{viewModel.metadata.workingDirectory}</span>
-      {/if}
-      {#if viewModel.output.exitCode !== null}
-        <span class="tool-field-label">Exit</span>
-        <span class="tool-field-value">{viewModel.output.exitCode}</span>
-      {/if}
-      <span class="tool-field-label">Status</span>
-      <span class="tool-field-value">{viewModel.statusLabel}</span>
-    </div>
+    {#if viewModel.metadata.workingDirectory || failureExitCode !== null}
+      <div class="tool-field-list">
+        {#if viewModel.metadata.workingDirectory}
+          <span class="tool-field-label">Directory</span>
+          <span class="tool-field-value">{viewModel.metadata.workingDirectory}</span>
+        {/if}
+        {#if failureExitCode !== null}
+          <span class="tool-field-label">Exit</span>
+          <span class="tool-field-value">{failureExitCode}</span>
+        {/if}
+      </div>
+    {/if}
   </div>
 
   {#if viewModel.metadata.terminalRefs.length > 0}

--- a/apps/staged/src/lib/features/sessions/tool-calls/EditToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/EditToolDetails.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { ToolCallViewModel } from '../toolCallViewModel';
+  import InlineToolDiff from './InlineToolDiff.svelte';
+  import OutputSections from './OutputSections.svelte';
+
+  interface Props {
+    viewModel: ToolCallViewModel;
+  }
+
+  let { viewModel }: Props = $props();
+</script>
+
+<div class="tool-detail-stack">
+  {#if viewModel.metadata.targetPath}
+    <div class="tool-primary-row">
+      <span class="tool-field-label">Path</span>
+      <span class="tool-field-value">{viewModel.metadata.targetPath}</span>
+    </div>
+  {/if}
+
+  {#if viewModel.metadata.locations.length > 0}
+    <div class="tool-meta-row">
+      {#each viewModel.metadata.locations as location}
+        <span class="tool-chip">{location.display}</span>
+      {/each}
+    </div>
+  {/if}
+
+  {#if viewModel.metadata.diffs.length > 0}
+    {#each viewModel.metadata.diffs as diff}
+      <section>
+        <div class="tool-panel-label">{diff.path}</div>
+        <InlineToolDiff {diff} />
+      </section>
+    {/each}
+  {:else if viewModel.metadata.inputText}
+    <section>
+      <div class="tool-panel-label">Input</div>
+      <pre class="tool-code-output">{viewModel.metadata.inputText}</pre>
+    </section>
+  {/if}
+
+  <OutputSections {viewModel} />
+</div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/EditToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/EditToolDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ToolCallViewModel } from '../toolCallViewModel';
+  import { summarizeToolCallLocations, type ToolCallViewModel } from '../toolCallViewModel';
   import InlineToolDiff from './InlineToolDiff.svelte';
   import OutputSections from './OutputSections.svelte';
 
@@ -13,11 +13,11 @@
     !!viewModel.metadata.targetPath &&
       !viewModel.metadata.diffs.some((diff) => diff.path === viewModel.metadata.targetPath)
   );
-  let locations = $derived(
-    viewModel.metadata.locations.filter(
-      (location) =>
-        location.display !== viewModel.metadata.targetPath &&
-        !viewModel.metadata.diffs.some((diff) => diff.path === location.display)
+  let locationSummary = $derived(
+    summarizeToolCallLocations(
+      viewModel.metadata.locations,
+      showPath ? viewModel.metadata.targetPath : null,
+      [viewModel.metadata.targetPath, ...viewModel.metadata.diffs.map((diff) => diff.path)]
     )
   );
 </script>
@@ -26,14 +26,16 @@
   {#if showPath}
     <div class="tool-primary-row">
       <span class="tool-field-label">Path</span>
-      <span class="tool-field-value">{viewModel.metadata.targetPath}</span>
+      <span class="tool-field-value"
+        >{viewModel.metadata.targetPath}{locationSummary.pathSuffix}</span
+      >
     </div>
   {/if}
 
-  {#if locations.length > 0}
+  {#if locationSummary.chips.length > 0}
     <div class="tool-meta-row">
-      {#each locations as location}
-        <span class="tool-chip">{location.display}</span>
+      {#each locationSummary.chips as chip}
+        <span class="tool-chip">{chip}</span>
       {/each}
     </div>
   {/if}

--- a/apps/staged/src/lib/features/sessions/tool-calls/EditToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/EditToolDetails.svelte
@@ -8,19 +8,31 @@
   }
 
   let { viewModel }: Props = $props();
+  // The diff header already names the file; only surface path metadata it doesn't cover.
+  let showPath = $derived(
+    !!viewModel.metadata.targetPath &&
+      !viewModel.metadata.diffs.some((diff) => diff.path === viewModel.metadata.targetPath)
+  );
+  let locations = $derived(
+    viewModel.metadata.locations.filter(
+      (location) =>
+        location.display !== viewModel.metadata.targetPath &&
+        !viewModel.metadata.diffs.some((diff) => diff.path === location.display)
+    )
+  );
 </script>
 
 <div class="tool-detail-stack">
-  {#if viewModel.metadata.targetPath}
+  {#if showPath}
     <div class="tool-primary-row">
       <span class="tool-field-label">Path</span>
       <span class="tool-field-value">{viewModel.metadata.targetPath}</span>
     </div>
   {/if}
 
-  {#if viewModel.metadata.locations.length > 0}
+  {#if locations.length > 0}
     <div class="tool-meta-row">
-      {#each viewModel.metadata.locations as location}
+      {#each locations as location}
         <span class="tool-chip">{location.display}</span>
       {/each}
     </div>
@@ -28,10 +40,7 @@
 
   {#if viewModel.metadata.diffs.length > 0}
     {#each viewModel.metadata.diffs as diff}
-      <section>
-        <div class="tool-panel-label">{diff.path}</div>
-        <InlineToolDiff {diff} />
-      </section>
+      <InlineToolDiff {diff} />
     {/each}
   {:else if viewModel.metadata.inputText}
     <section>

--- a/apps/staged/src/lib/features/sessions/tool-calls/GenericToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/GenericToolDetails.svelte
@@ -27,10 +27,7 @@
   {/if}
 
   {#each viewModel.metadata.diffs as diff}
-    <section>
-      <div class="tool-panel-label">{diff.path}</div>
-      <InlineToolDiff {diff} />
-    </section>
+    <InlineToolDiff {diff} />
   {/each}
 
   {#if viewModel.metadata.terminalRefs.length > 0}

--- a/apps/staged/src/lib/features/sessions/tool-calls/GenericToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/GenericToolDetails.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { ToolCallViewModel } from '../toolCallViewModel';
+  import InlineToolDiff from './InlineToolDiff.svelte';
+  import OutputSections from './OutputSections.svelte';
+
+  interface Props {
+    viewModel: ToolCallViewModel;
+  }
+
+  let { viewModel }: Props = $props();
+</script>
+
+<div class="tool-detail-stack">
+  {#if viewModel.metadata.locations.length > 0}
+    <div class="tool-meta-row">
+      {#each viewModel.metadata.locations as location}
+        <span class="tool-chip">{location.display}</span>
+      {/each}
+    </div>
+  {/if}
+
+  {#if viewModel.metadata.inputText}
+    <section>
+      <div class="tool-panel-label">Input</div>
+      <pre class="tool-code-output">{viewModel.metadata.inputText}</pre>
+    </section>
+  {/if}
+
+  {#each viewModel.metadata.diffs as diff}
+    <section>
+      <div class="tool-panel-label">{diff.path}</div>
+      <InlineToolDiff {diff} />
+    </section>
+  {/each}
+
+  {#if viewModel.metadata.terminalRefs.length > 0}
+    <section>
+      <div class="tool-panel-label">Terminal</div>
+      <div class="tool-meta-row">
+        {#each viewModel.metadata.terminalRefs as terminalRef}
+          <span class="tool-chip">{terminalRef}</span>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <OutputSections {viewModel} />
+</div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/InlineToolDiff.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/InlineToolDiff.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+  import { computeLineDiff, type CharHighlight } from '@builderbot/diff-viewer/utils';
+  import type { ToolCallDiff } from '../toolCallViewModel';
+
+  type DiffTone = 'context' | 'removed' | 'added' | 'modified-removed' | 'modified-added';
+
+  interface DiffRow {
+    key: string;
+    oldLine: number | null;
+    newLine: number | null;
+    marker: ' ' | '-' | '+';
+    text: string;
+    tone: DiffTone;
+    highlights: CharHighlight[];
+  }
+
+  interface Segment {
+    text: string;
+    highlighted: boolean;
+  }
+
+  interface Props {
+    diff: ToolCallDiff;
+  }
+
+  let { diff }: Props = $props();
+  let rows = $derived.by(() => buildRows(diff));
+
+  function splitLines(text: string | null): string[] {
+    if (text === null || text === '') return [];
+    return text.split('\n');
+  }
+
+  function buildRows(toolDiff: ToolCallDiff): DiffRow[] {
+    const beforeLines = splitLines(toolDiff.oldText);
+    const afterLines = splitLines(toolDiff.newText);
+    const lineDiff = computeLineDiff(beforeLines, afterLines);
+    const modifiedByBefore = new Map(
+      lineDiff.modifiedPairs.map((pair) => [pair.beforeLineIndex, pair])
+    );
+    const modifiedByAfter = new Map(
+      lineDiff.modifiedPairs.map((pair) => [pair.afterLineIndex, pair])
+    );
+    const result: DiffRow[] = [];
+    let beforeIndex = 0;
+    let afterIndex = 0;
+
+    while (beforeIndex < beforeLines.length || afterIndex < afterLines.length) {
+      const beforeClass = lineDiff.beforeLines[beforeIndex];
+      const afterClass = lineDiff.afterLines[afterIndex];
+
+      if (
+        beforeIndex < beforeLines.length &&
+        afterIndex < afterLines.length &&
+        beforeClass === 'unchanged' &&
+        afterClass === 'unchanged'
+      ) {
+        result.push({
+          key: `context:${beforeIndex}:${afterIndex}`,
+          oldLine: beforeIndex + 1,
+          newLine: afterIndex + 1,
+          marker: ' ',
+          text: beforeLines[beforeIndex],
+          tone: 'context',
+          highlights: [],
+        });
+        beforeIndex += 1;
+        afterIndex += 1;
+        continue;
+      }
+
+      const modifiedPair = modifiedByBefore.get(beforeIndex);
+      if (modifiedPair && modifiedPair.afterLineIndex === afterIndex) {
+        result.push({
+          key: `mod-before:${beforeIndex}`,
+          oldLine: beforeIndex + 1,
+          newLine: null,
+          marker: '-',
+          text: beforeLines[beforeIndex],
+          tone: 'modified-removed',
+          highlights: modifiedPair.beforeHighlights,
+        });
+        result.push({
+          key: `mod-after:${afterIndex}`,
+          oldLine: null,
+          newLine: afterIndex + 1,
+          marker: '+',
+          text: afterLines[afterIndex],
+          tone: 'modified-added',
+          highlights: modifiedPair.afterHighlights,
+        });
+        beforeIndex += 1;
+        afterIndex += 1;
+        continue;
+      }
+
+      if (beforeClass === 'removed' || (beforeClass === 'modified' && !modifiedPair)) {
+        result.push({
+          key: `removed:${beforeIndex}`,
+          oldLine: beforeIndex + 1,
+          newLine: null,
+          marker: '-',
+          text: beforeLines[beforeIndex],
+          tone: beforeClass === 'modified' ? 'modified-removed' : 'removed',
+          highlights: modifiedByBefore.get(beforeIndex)?.beforeHighlights ?? [],
+        });
+        beforeIndex += 1;
+        continue;
+      }
+
+      const afterPair = modifiedByAfter.get(afterIndex);
+      if (afterClass === 'added' || (afterClass === 'modified' && !afterPair)) {
+        result.push({
+          key: `added:${afterIndex}`,
+          oldLine: null,
+          newLine: afterIndex + 1,
+          marker: '+',
+          text: afterLines[afterIndex],
+          tone: afterClass === 'modified' ? 'modified-added' : 'added',
+          highlights: modifiedByAfter.get(afterIndex)?.afterHighlights ?? [],
+        });
+        afterIndex += 1;
+        continue;
+      }
+
+      if (beforeIndex < beforeLines.length) {
+        beforeIndex += 1;
+      }
+      if (afterIndex < afterLines.length) {
+        afterIndex += 1;
+      }
+    }
+
+    return result;
+  }
+
+  function lineNumber(value: number | null): string {
+    return value === null ? '' : String(value);
+  }
+
+  function segments(text: string, highlights: CharHighlight[]): Segment[] {
+    if (highlights.length === 0) return [{ text, highlighted: false }];
+    const result: Segment[] = [];
+    let cursor = 0;
+    for (const highlight of highlights) {
+      if (highlight.start > cursor) {
+        result.push({ text: text.slice(cursor, highlight.start), highlighted: false });
+      }
+      if (highlight.end > highlight.start) {
+        result.push({ text: text.slice(highlight.start, highlight.end), highlighted: true });
+      }
+      cursor = Math.max(cursor, highlight.end);
+    }
+    if (cursor < text.length) {
+      result.push({ text: text.slice(cursor), highlighted: false });
+    }
+    return result;
+  }
+
+  function highlightedLineHtml(text: string, highlights: CharHighlight[]): string {
+    return segments(text, highlights)
+      .map((segment) => {
+        const escaped = escapeHtml(segment.text);
+        return segment.highlighted ? `<span class="char-highlight">${escaped}</span>` : escaped;
+      })
+      .join('');
+  }
+
+  function escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+</script>
+
+<div class="inline-diff" aria-label={`${diff.path} diff`}>
+  {#if rows.length === 0}
+    <div class="inline-diff-empty">No changes</div>
+  {:else}
+    {#each rows as row (row.key)}
+      <div
+        class="diff-row"
+        class:removed={row.tone === 'removed' || row.tone === 'modified-removed'}
+        class:added={row.tone === 'added' || row.tone === 'modified-added'}
+        class:modified={row.tone === 'modified-removed' || row.tone === 'modified-added'}
+      >
+        <span class="line-number old">{lineNumber(row.oldLine)}</span>
+        <span class="line-number new">{lineNumber(row.newLine)}</span>
+        <span class="marker">{row.marker}</span>
+        <code class="line-text">{@html highlightedLineHtml(row.text, row.highlights)}</code>
+      </div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .inline-diff {
+    overflow: auto;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    background: var(--bg-primary);
+  }
+
+  .inline-diff-empty {
+    padding: 8px 10px;
+    color: var(--text-faint);
+  }
+
+  .diff-row {
+    display: grid;
+    grid-template-columns: 3.5ch 3.5ch 1.5ch minmax(0, 1fr);
+    min-width: max-content;
+    color: var(--text-muted);
+  }
+
+  .diff-row.removed {
+    background: color-mix(in srgb, var(--ui-danger) 10%, transparent);
+  }
+
+  .diff-row.added {
+    background: color-mix(in srgb, var(--ui-success, var(--ui-accent)) 10%, transparent);
+  }
+
+  .line-number,
+  .marker {
+    user-select: none;
+    color: var(--text-faint);
+    text-align: right;
+  }
+
+  .line-number {
+    padding: 0 6px;
+    border-right: 1px solid var(--border-subtle);
+  }
+
+  .marker {
+    padding: 0 6px;
+  }
+
+  .removed .marker,
+  .removed .line-text {
+    color: var(--ui-danger);
+  }
+
+  .added .marker,
+  .added .line-text {
+    color: var(--ui-success, var(--ui-accent));
+  }
+
+  .line-text {
+    display: block;
+    min-height: 1.5em;
+    padding: 0 8px 0 0;
+    color: inherit;
+    white-space: pre-wrap;
+  }
+
+  .inline-diff :global(.char-highlight) {
+    border-radius: 3px;
+    background: color-mix(in srgb, currentColor 18%, transparent);
+  }
+</style>

--- a/apps/staged/src/lib/features/sessions/tool-calls/InlineToolDiff.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/InlineToolDiff.svelte
@@ -1,18 +1,8 @@
 <script lang="ts">
-  import { computeLineDiff, type CharHighlight } from '@builderbot/diff-viewer/utils';
+  import UnfoldVertical from '@lucide/svelte/icons/unfold-vertical';
+  import type { CharHighlight } from '@builderbot/diff-viewer/utils';
   import type { ToolCallDiff } from '../toolCallViewModel';
-
-  type DiffTone = 'context' | 'removed' | 'added' | 'modified-removed' | 'modified-added';
-
-  interface DiffRow {
-    key: string;
-    oldLine: number | null;
-    newLine: number | null;
-    marker: ' ' | '-' | '+';
-    text: string;
-    tone: DiffTone;
-    highlights: CharHighlight[];
-  }
+  import { buildDiffRows, diffRowStats, groupDiffRows, type DiffRow } from './inlineDiffRows';
 
   interface Segment {
     text: string;
@@ -24,118 +14,13 @@
   }
 
   let { diff }: Props = $props();
-  let rows = $derived.by(() => buildRows(diff));
+  let rows = $derived.by(() => buildDiffRows(diff));
+  let stats = $derived(diffRowStats(rows));
+  let blocks = $derived.by(() => groupDiffRows(rows));
+  let expandedKeys = $state<string[]>([]);
 
-  function splitLines(text: string | null): string[] {
-    if (text === null || text === '') return [];
-    return text.split('\n');
-  }
-
-  function buildRows(toolDiff: ToolCallDiff): DiffRow[] {
-    const beforeLines = splitLines(toolDiff.oldText);
-    const afterLines = splitLines(toolDiff.newText);
-    const lineDiff = computeLineDiff(beforeLines, afterLines);
-    const modifiedByBefore = new Map(
-      lineDiff.modifiedPairs.map((pair) => [pair.beforeLineIndex, pair])
-    );
-    const modifiedByAfter = new Map(
-      lineDiff.modifiedPairs.map((pair) => [pair.afterLineIndex, pair])
-    );
-    const result: DiffRow[] = [];
-    let beforeIndex = 0;
-    let afterIndex = 0;
-
-    while (beforeIndex < beforeLines.length || afterIndex < afterLines.length) {
-      const beforeClass = lineDiff.beforeLines[beforeIndex];
-      const afterClass = lineDiff.afterLines[afterIndex];
-
-      if (
-        beforeIndex < beforeLines.length &&
-        afterIndex < afterLines.length &&
-        beforeClass === 'unchanged' &&
-        afterClass === 'unchanged'
-      ) {
-        result.push({
-          key: `context:${beforeIndex}:${afterIndex}`,
-          oldLine: beforeIndex + 1,
-          newLine: afterIndex + 1,
-          marker: ' ',
-          text: beforeLines[beforeIndex],
-          tone: 'context',
-          highlights: [],
-        });
-        beforeIndex += 1;
-        afterIndex += 1;
-        continue;
-      }
-
-      const modifiedPair = modifiedByBefore.get(beforeIndex);
-      if (modifiedPair && modifiedPair.afterLineIndex === afterIndex) {
-        result.push({
-          key: `mod-before:${beforeIndex}`,
-          oldLine: beforeIndex + 1,
-          newLine: null,
-          marker: '-',
-          text: beforeLines[beforeIndex],
-          tone: 'modified-removed',
-          highlights: modifiedPair.beforeHighlights,
-        });
-        result.push({
-          key: `mod-after:${afterIndex}`,
-          oldLine: null,
-          newLine: afterIndex + 1,
-          marker: '+',
-          text: afterLines[afterIndex],
-          tone: 'modified-added',
-          highlights: modifiedPair.afterHighlights,
-        });
-        beforeIndex += 1;
-        afterIndex += 1;
-        continue;
-      }
-
-      if (beforeClass === 'removed' || (beforeClass === 'modified' && !modifiedPair)) {
-        result.push({
-          key: `removed:${beforeIndex}`,
-          oldLine: beforeIndex + 1,
-          newLine: null,
-          marker: '-',
-          text: beforeLines[beforeIndex],
-          tone: beforeClass === 'modified' ? 'modified-removed' : 'removed',
-          highlights: modifiedByBefore.get(beforeIndex)?.beforeHighlights ?? [],
-        });
-        beforeIndex += 1;
-        continue;
-      }
-
-      const afterPair = modifiedByAfter.get(afterIndex);
-      if (afterClass === 'added' || (afterClass === 'modified' && !afterPair)) {
-        result.push({
-          key: `added:${afterIndex}`,
-          oldLine: null,
-          newLine: afterIndex + 1,
-          marker: '+',
-          text: afterLines[afterIndex],
-          tone: afterClass === 'modified' ? 'modified-added' : 'added',
-          highlights: modifiedByAfter.get(afterIndex)?.afterHighlights ?? [],
-        });
-        afterIndex += 1;
-        continue;
-      }
-
-      if (beforeIndex < beforeLines.length) {
-        beforeIndex += 1;
-      }
-      if (afterIndex < afterLines.length) {
-        afterIndex += 1;
-      }
-    }
-
-    return result;
-  }
-
-  function lineNumber(value: number | null): string {
-    return value === null ? '' : String(value);
+  function expand(key: string) {
+    if (!expandedKeys.includes(key)) expandedKeys = [...expandedKeys, key];
   }
 
   function segments(text: string, highlights: CharHighlight[]): Segment[] {
@@ -176,22 +61,48 @@
   }
 </script>
 
+{#snippet diffRow(row: DiffRow)}
+  <div
+    class="diff-row"
+    class:removed={row.tone === 'removed' || row.tone === 'modified-removed'}
+    class:added={row.tone === 'added' || row.tone === 'modified-added'}
+  >
+    <span class="line-number old">{row.oldLine ?? ''}</span>
+    <span class="line-number new">{row.newLine ?? ''}</span>
+    <span class="marker">{row.marker}</span>
+    <code class="line-text">{@html highlightedLineHtml(row.text, row.highlights)}</code>
+  </div>
+{/snippet}
+
 <div class="inline-diff" aria-label={`${diff.path} diff`}>
+  <div class="inline-diff-header">
+    <span class="diff-path">{diff.path}</span>
+    {#if diff.kind === 'created'}
+      <span class="diff-kind-badge created">Created</span>
+    {:else if diff.kind === 'deleted'}
+      <span class="diff-kind-badge deleted">Deleted</span>
+    {/if}
+    {#if stats.added > 0 || stats.removed > 0}
+      <span class="diff-stats">
+        {#if stats.added > 0}<span class="diff-stat-added">+{stats.added}</span>{/if}
+        {#if stats.removed > 0}<span class="diff-stat-removed">−{stats.removed}</span>{/if}
+      </span>
+    {/if}
+  </div>
   {#if rows.length === 0}
     <div class="inline-diff-empty">No changes</div>
   {:else}
-    {#each rows as row (row.key)}
-      <div
-        class="diff-row"
-        class:removed={row.tone === 'removed' || row.tone === 'modified-removed'}
-        class:added={row.tone === 'added' || row.tone === 'modified-added'}
-        class:modified={row.tone === 'modified-removed' || row.tone === 'modified-added'}
-      >
-        <span class="line-number old">{lineNumber(row.oldLine)}</span>
-        <span class="line-number new">{lineNumber(row.newLine)}</span>
-        <span class="marker">{row.marker}</span>
-        <code class="line-text">{@html highlightedLineHtml(row.text, row.highlights)}</code>
-      </div>
+    {#each blocks as block (block.key)}
+      {#if block.kind === 'visible' || expandedKeys.includes(block.key)}
+        {#each block.rows as row (row.key)}
+          {@render diffRow(row)}
+        {/each}
+      {:else}
+        <button type="button" class="diff-collapse-row" onclick={() => expand(block.key)}>
+          <UnfoldVertical size={11} />
+          {block.rows.length} unchanged {block.rows.length === 1 ? 'line' : 'lines'}
+        </button>
+      {/if}
     {/each}
   {/if}
 </div>
@@ -204,9 +115,86 @@
     background: var(--bg-primary);
   }
 
+  .inline-diff-header {
+    position: sticky;
+    left: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: color-mix(in srgb, var(--bg-chrome) 60%, var(--bg-primary));
+  }
+
+  .diff-path {
+    flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-muted);
+    font-weight: 600;
+  }
+
+  .diff-kind-badge {
+    flex-shrink: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    padding: 1px 6px;
+    font-size: calc(var(--size-xs) * 0.85);
+  }
+
+  .diff-kind-badge.created {
+    border-color: color-mix(in srgb, var(--ui-success, var(--ui-accent)) 35%, var(--border-subtle));
+    color: var(--ui-success, var(--ui-accent));
+  }
+
+  .diff-kind-badge.deleted {
+    border-color: color-mix(in srgb, var(--ui-danger) 35%, var(--border-subtle));
+    color: var(--ui-danger);
+  }
+
+  .diff-stats {
+    display: flex;
+    flex-shrink: 0;
+    gap: 6px;
+  }
+
+  .diff-stat-added {
+    color: var(--ui-success, var(--ui-accent));
+  }
+
+  .diff-stat-removed {
+    color: var(--ui-danger);
+  }
+
   .inline-diff-empty {
     padding: 8px 10px;
     color: var(--text-faint);
+  }
+
+  .diff-collapse-row {
+    position: sticky;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    border: 0;
+    border-top: 1px dashed var(--border-subtle);
+    border-bottom: 1px dashed var(--border-subtle);
+    padding: 3px 8px;
+    background: color-mix(in srgb, var(--bg-chrome) 40%, var(--bg-primary));
+    color: var(--text-faint);
+    font: inherit;
+    font-size: calc(var(--size-xs) * 0.85);
+    cursor: pointer;
+  }
+
+  .diff-collapse-row:hover,
+  .diff-collapse-row:focus-visible {
+    color: var(--text-muted);
+    outline: none;
   }
 
   .diff-row {

--- a/apps/staged/src/lib/features/sessions/tool-calls/InlineToolDiff.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/InlineToolDiff.svelte
@@ -41,24 +41,6 @@
     }
     return result;
   }
-
-  function highlightedLineHtml(text: string, highlights: CharHighlight[]): string {
-    return segments(text, highlights)
-      .map((segment) => {
-        const escaped = escapeHtml(segment.text);
-        return segment.highlighted ? `<span class="char-highlight">${escaped}</span>` : escaped;
-      })
-      .join('');
-  }
-
-  function escapeHtml(text: string): string {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
 </script>
 
 {#snippet diffRow(row: DiffRow)}
@@ -70,7 +52,11 @@
     <span class="line-number old">{row.oldLine ?? ''}</span>
     <span class="line-number new">{row.newLine ?? ''}</span>
     <span class="marker">{row.marker}</span>
-    <code class="line-text">{@html highlightedLineHtml(row.text, row.highlights)}</code>
+    <code class="line-text"
+      >{#each segments(row.text, row.highlights) as segment}{#if segment.highlighted}<span
+            class="char-highlight">{segment.text}</span
+          >{:else}{segment.text}{/if}{/each}</code
+    >
   </div>
 {/snippet}
 
@@ -246,7 +232,7 @@
     white-space: pre-wrap;
   }
 
-  .inline-diff :global(.char-highlight) {
+  .char-highlight {
     border-radius: 3px;
     background: color-mix(in srgb, currentColor 18%, transparent);
   }

--- a/apps/staged/src/lib/features/sessions/tool-calls/NetworkToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/NetworkToolDetails.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import type { RichToolItem } from '../acpTranscript';
+  import { formatJson } from '../acpTranscript';
+  import { isRecord, type ToolCallViewModel } from '../toolCallViewModel';
+  import OutputSections from './OutputSections.svelte';
+
+  interface NetworkInfo {
+    method: string | null;
+    url: string | null;
+    status: string | null;
+    statusTone: 'normal' | 'success' | 'danger';
+    title: string | null;
+    selector: string | null;
+    screenshot: string | null;
+    requestHeaders: string;
+    requestBody: string;
+    responseHeaders: string;
+    responseBody: string;
+  }
+
+  interface Props {
+    item: RichToolItem;
+    viewModel: ToolCallViewModel;
+  }
+
+  let { item, viewModel }: Props = $props();
+  let network = $derived(extractNetworkInfo(viewModel, item));
+  let hasNetworkPreview = $derived(
+    !!(
+      network.method ||
+      network.url ||
+      network.status ||
+      network.title ||
+      network.selector ||
+      network.screenshot ||
+      network.requestHeaders ||
+      network.requestBody ||
+      network.responseHeaders ||
+      network.responseBody
+    )
+  );
+
+  function extractNetworkInfo(model: ToolCallViewModel, toolItem: RichToolItem): NetworkInfo {
+    const input = model.metadata.input;
+    const rawOutput = isRecord(toolItem.rawOutput) ? toolItem.rawOutput : null;
+    const request = recordProp(input, 'request');
+    const response = recordProp(rawOutput, 'response');
+    const statusValue =
+      firstValue(rawOutput, ['status', 'statusCode', 'status_code']) ??
+      firstValue(response, ['status', 'statusCode', 'status_code']);
+    const status = statusValue === undefined || statusValue === null ? null : String(statusValue);
+
+    return {
+      method:
+        model.metadata.method ??
+        normalizeMethod(firstString(request, ['method', 'httpMethod', 'http_method'])),
+      url: model.metadata.url ?? firstString(request, ['url', 'uri', 'href']),
+      status,
+      statusTone: statusTone(statusValue),
+      title: firstString(rawOutput, ['title']) ?? firstString(response, ['title']),
+      selector: model.metadata.query,
+      screenshot: firstString(rawOutput, ['screenshot']) ?? firstString(response, ['screenshot']),
+      requestHeaders: valueText(firstValue(input, ['headers']) ?? firstValue(request, ['headers'])),
+      requestBody: valueText(firstValue(input, ['body']) ?? firstValue(request, ['body'])),
+      responseHeaders: valueText(
+        firstValue(rawOutput, ['headers']) ?? firstValue(response, ['headers'])
+      ),
+      responseBody: valueText(
+        firstValue(rawOutput, ['body', 'text', 'content']) ??
+          firstValue(response, ['body', 'text', 'content'])
+      ),
+    };
+  }
+
+  function recordProp(
+    value: Record<string, unknown> | null,
+    key: string
+  ): Record<string, unknown> | null {
+    if (!value) return null;
+    const prop = value[key];
+    return isRecord(prop) ? prop : null;
+  }
+
+  function firstString(input: Record<string, unknown> | null, keys: string[]): string | null {
+    if (!input) return null;
+    for (const key of keys) {
+      const value = input[key];
+      if (typeof value === 'string' && value.trim()) return value;
+    }
+    return null;
+  }
+
+  function firstValue(input: Record<string, unknown> | null, keys: string[]): unknown {
+    if (!input) return undefined;
+    for (const key of keys) {
+      const value = input[key];
+      if (value !== undefined && value !== null) return value;
+    }
+    return undefined;
+  }
+
+  function normalizeMethod(value: string | null): string | null {
+    return value ? value.toUpperCase() : null;
+  }
+
+  function valueText(value: unknown): string {
+    if (value === undefined || value === null) return '';
+    return typeof value === 'string' ? value : formatJson(value);
+  }
+
+  function statusTone(value: unknown): NetworkInfo['statusTone'] {
+    const status = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(status)) return 'normal';
+    if (status >= 200 && status < 400) return 'success';
+    if (status >= 400) return 'danger';
+    return 'normal';
+  }
+</script>
+
+<div class="tool-detail-stack">
+  {#if hasNetworkPreview}
+    <div class="tool-command-panel">
+      {#if network.method || network.url || network.status}
+        <div class="tool-network-line">
+          {#if network.method}
+            <span class="tool-status-badge">{network.method}</span>
+          {/if}
+          {#if network.url}
+            <span class="tool-network-url">{network.url}</span>
+          {/if}
+          {#if network.status}
+            <span
+              class="tool-status-badge"
+              class:success={network.statusTone === 'success'}
+              class:danger={network.statusTone === 'danger'}>{network.status}</span
+            >
+          {/if}
+        </div>
+      {/if}
+      <div class="tool-field-list">
+        {#if network.title}
+          <span class="tool-field-label">Title</span>
+          <span class="tool-field-value">{network.title}</span>
+        {/if}
+        {#if network.selector}
+          <span class="tool-field-label">Selector</span>
+          <span class="tool-field-value">{network.selector}</span>
+        {/if}
+        {#if network.screenshot}
+          <span class="tool-field-label">Screenshot</span>
+          <span class="tool-field-value">{network.screenshot}</span>
+        {/if}
+      </div>
+    </div>
+
+    {#if network.requestHeaders}
+      <section>
+        <div class="tool-panel-label">Request headers</div>
+        <pre class="tool-code-output">{network.requestHeaders}</pre>
+      </section>
+    {/if}
+    {#if network.requestBody}
+      <section>
+        <div class="tool-panel-label">Request body</div>
+        <pre class="tool-code-output">{network.requestBody}</pre>
+      </section>
+    {/if}
+    {#if network.responseHeaders}
+      <section>
+        <div class="tool-panel-label">Response headers</div>
+        <pre class="tool-code-output">{network.responseHeaders}</pre>
+      </section>
+    {/if}
+    {#if network.responseBody}
+      <section>
+        <div class="tool-panel-label">Response body</div>
+        <pre class="tool-code-output">{network.responseBody}</pre>
+      </section>
+    {/if}
+  {/if}
+
+  <OutputSections {viewModel} includePrimary={!network.responseBody} includeRaw />
+</div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/NetworkToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/NetworkToolDetails.svelte
@@ -25,6 +25,15 @@
 
   let { item, viewModel }: Props = $props();
   let network = $derived(extractNetworkInfo(viewModel, item));
+  let hasStructuredResponse = $derived(
+    !!(
+      network.status ||
+      network.title ||
+      network.screenshot ||
+      network.responseHeaders ||
+      network.responseBody
+    )
+  );
   let hasNetworkPreview = $derived(
     !!(
       network.method ||
@@ -179,5 +188,9 @@
     {/if}
   {/if}
 
-  <OutputSections {viewModel} includePrimary={!network.responseBody} includeRaw />
+  <OutputSections
+    {viewModel}
+    includePrimary={!network.responseBody}
+    includeRaw={!hasStructuredResponse}
+  />
 </div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -50,18 +50,15 @@
     options: Pick<Props, 'includePrimary' | 'includeRaw' | 'includeStreams'>
   ): OutputBlock[] {
     const output = model.output;
-    const emitted = new Set<string>();
     const result: OutputBlock[] = [];
     const defaultTone = model.status === 'cancelled' ? 'cancelled' : 'normal';
 
     if (output.errorText) {
       result.push({ key: 'error', label: 'Error', text: output.errorText, tone: 'danger' });
-      emitted.add(output.errorText);
     }
 
     if (options.includeStreams && output.stdout) {
       result.push({ key: 'stdout', label: 'Stdout', text: output.stdout, tone: defaultTone });
-      emitted.add(output.stdout);
     }
 
     if (options.includeStreams && output.stderr && output.stderr !== output.errorText) {
@@ -71,7 +68,6 @@
         text: output.stderr,
         tone: model.status === 'failed' ? 'danger' : defaultTone,
       });
-      emitted.add(output.stderr);
     }
 
     if (
@@ -82,10 +78,11 @@
       output.primaryText !== output.stderr
     ) {
       result.push({ key: 'output', label: 'Output', text: output.primaryText, tone: defaultTone });
-      emitted.add(output.primaryText);
     }
 
-    if (options.includeRaw && output.rawText && !emitted.has(output.rawText)) {
+    // Raw JSON is a fallback for output we could not render structurally,
+    // never a companion to structured blocks.
+    if (options.includeRaw && output.rawText && result.length === 0) {
       result.push({
         key: 'raw-output',
         label: 'Raw output',

--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -83,35 +83,47 @@
   }
 </script>
 
+{#snippet copyButton(block: OutputBlock, copyLabel: string)}
+  <button
+    type="button"
+    class="tool-copy-button"
+    title={copiedKey === block.key ? 'Copied' : `Copy ${copyLabel.toLowerCase()}`}
+    aria-label={copiedKey === block.key ? 'Copied' : `Copy ${copyLabel.toLowerCase()}`}
+    onclick={() => copyOutput(block.text, block.key)}
+  >
+    {#if copiedKey === block.key}
+      <Check size={12} />
+    {:else}
+      <Copy size={12} />
+    {/if}
+  </button>
+{/snippet}
+
 {#each blocks as block}
   {@const copyLabel = block.label || 'output'}
   <section class="tool-output-section">
-    {#if block.label || copyable}
+    {#if block.label}
       <div class="tool-output-header">
-        {#if block.label}
-          <div class="tool-panel-label">{block.label}</div>
-        {/if}
+        <div class="tool-panel-label">{block.label}</div>
         {#if copyable}
-          <button
-            type="button"
-            class="tool-copy-button"
-            title={copiedKey === block.key ? 'Copied' : `Copy ${copyLabel.toLowerCase()}`}
-            aria-label={copiedKey === block.key ? 'Copied' : `Copy ${copyLabel.toLowerCase()}`}
-            onclick={() => copyOutput(block.text, block.key)}
-          >
-            {#if copiedKey === block.key}
-              <Check size={12} />
-            {:else}
-              <Copy size={12} />
-            {/if}
-          </button>
+          {@render copyButton(block, copyLabel)}
         {/if}
       </div>
     {/if}
-    <pre
-      class="tool-code-output"
-      class:tool-output-danger={block.tone === 'danger'}
-      class:tool-output-cancelled={block.tone === 'cancelled'}>{block.text}</pre>
+    <div class="tool-output-body">
+      <!-- A label-less output gets no header row; its copy affordance tucks
+           into the top-right corner so the "$" and the button don't each eat a
+           full row. -->
+      {#if copyable && !block.label}
+        <div class="tool-output-body-actions">
+          {@render copyButton(block, copyLabel)}
+        </div>
+      {/if}
+      <pre
+        class="tool-code-output"
+        class:tool-output-danger={block.tone === 'danger'}
+        class:tool-output-cancelled={block.tone === 'cancelled'}>{block.text}</pre>
+    </div>
   </section>
 {/each}
 

--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -19,6 +19,7 @@
     includeRaw?: boolean;
     includeStatus?: boolean;
     includeStreams?: boolean;
+    primaryLabel?: string;
   }
 
   let {
@@ -28,10 +29,13 @@
     includeRaw = true,
     includeStatus = true,
     includeStreams = true,
+    primaryLabel = 'Output',
   }: Props = $props();
 
   let copiedKey = $state<string | null>(null);
-  let blocks = $derived(outputBlocks(viewModel, { includePrimary, includeRaw, includeStreams }));
+  let blocks = $derived(
+    outputBlocks(viewModel, { includePrimary, includeRaw, includeStreams, primaryLabel })
+  );
 
   async function copyOutput(text: string, key: string) {
     try {
@@ -47,7 +51,7 @@
 
   function outputBlocks(
     model: ToolCallViewModel,
-    options: Pick<Props, 'includePrimary' | 'includeRaw' | 'includeStreams'>
+    options: Pick<Props, 'includePrimary' | 'includeRaw' | 'includeStreams' | 'primaryLabel'>
   ): OutputBlock[] {
     const output = model.output;
     const result: OutputBlock[] = [];
@@ -77,7 +81,12 @@
       output.primaryText !== output.stdout &&
       output.primaryText !== output.stderr
     ) {
-      result.push({ key: 'output', label: 'Output', text: output.primaryText, tone: defaultTone });
+      result.push({
+        key: 'output',
+        label: options.primaryLabel ?? 'Output',
+        text: output.primaryText,
+        tone: defaultTone,
+      });
     }
 
     // Raw JSON is a fallback for output we could not render structurally,

--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import Check from '@lucide/svelte/icons/check';
+  import Copy from '@lucide/svelte/icons/copy';
+  import type { ToolCallViewModel } from '../toolCallViewModel';
+
+  type OutputTone = 'normal' | 'danger' | 'cancelled';
+
+  interface OutputBlock {
+    key: string;
+    label: string;
+    text: string;
+    tone: OutputTone;
+  }
+
+  interface Props {
+    viewModel: ToolCallViewModel;
+    copyable?: boolean;
+    includePrimary?: boolean;
+    includeRaw?: boolean;
+    includeStatus?: boolean;
+    includeStreams?: boolean;
+  }
+
+  let {
+    viewModel,
+    copyable = false,
+    includePrimary = true,
+    includeRaw = true,
+    includeStatus = true,
+    includeStreams = true,
+  }: Props = $props();
+
+  let copiedKey = $state<string | null>(null);
+  let blocks = $derived(outputBlocks(viewModel, { includePrimary, includeRaw, includeStreams }));
+
+  async function copyOutput(text: string, key: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      copiedKey = key;
+      setTimeout(() => {
+        if (copiedKey === key) copiedKey = null;
+      }, 1500);
+    } catch {
+      // Clipboard writes can fail outside secure browser contexts.
+    }
+  }
+
+  function outputBlocks(
+    model: ToolCallViewModel,
+    options: Pick<Props, 'includePrimary' | 'includeRaw' | 'includeStreams'>
+  ): OutputBlock[] {
+    const output = model.output;
+    const emitted = new Set<string>();
+    const result: OutputBlock[] = [];
+    const defaultTone = model.status === 'cancelled' ? 'cancelled' : 'normal';
+
+    if (output.errorText) {
+      result.push({ key: 'error', label: 'Error', text: output.errorText, tone: 'danger' });
+      emitted.add(output.errorText);
+    }
+
+    if (options.includeStreams && output.stdout) {
+      result.push({ key: 'stdout', label: 'Stdout', text: output.stdout, tone: defaultTone });
+      emitted.add(output.stdout);
+    }
+
+    if (options.includeStreams && output.stderr && output.stderr !== output.errorText) {
+      result.push({
+        key: 'stderr',
+        label: 'Stderr',
+        text: output.stderr,
+        tone: model.status === 'failed' ? 'danger' : defaultTone,
+      });
+      emitted.add(output.stderr);
+    }
+
+    if (
+      options.includePrimary &&
+      output.primaryText &&
+      output.primaryText !== output.errorText &&
+      output.primaryText !== output.stdout &&
+      output.primaryText !== output.stderr
+    ) {
+      result.push({ key: 'output', label: 'Output', text: output.primaryText, tone: defaultTone });
+      emitted.add(output.primaryText);
+    }
+
+    if (options.includeRaw && output.rawText && !emitted.has(output.rawText)) {
+      result.push({
+        key: 'raw-output',
+        label: 'Raw output',
+        text: output.rawText,
+        tone: defaultTone,
+      });
+    }
+
+    return result;
+  }
+</script>
+
+{#each blocks as block}
+  <section class="tool-output-section">
+    <div class="tool-output-header">
+      <div class="tool-panel-label">{block.label}</div>
+      {#if copyable}
+        <button
+          type="button"
+          class="tool-copy-button"
+          title={copiedKey === block.key ? 'Copied' : `Copy ${block.label.toLowerCase()}`}
+          aria-label={copiedKey === block.key ? 'Copied' : `Copy ${block.label.toLowerCase()}`}
+          onclick={() => copyOutput(block.text, block.key)}
+        >
+          {#if copiedKey === block.key}
+            <Check size={12} />
+          {:else}
+            <Copy size={12} />
+          {/if}
+        </button>
+      {/if}
+    </div>
+    <pre
+      class="tool-code-output"
+      class:tool-output-danger={block.tone === 'danger'}
+      class:tool-output-cancelled={block.tone === 'cancelled'}>{block.text}</pre>
+  </section>
+{/each}
+
+{#if viewModel.output.emptyLabel}
+  <div class="tool-empty-row">{viewModel.output.emptyLabel}</div>
+{/if}
+
+{#if includeStatus}
+  <div
+    class="tool-code-status"
+    class:status-danger={viewModel.statusTone === 'danger'}
+    class:status-cancelled={viewModel.statusTone === 'cancelled'}
+  >
+    {#if viewModel.statusTone === 'success'}
+      <Check size={11} />
+    {/if}
+    {viewModel.statusLabel}
+  </div>
+{/if}

--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -19,7 +19,6 @@
     includeRaw?: boolean;
     includeStatus?: boolean;
     includeStreams?: boolean;
-    primaryLabel?: string;
   }
 
   let {
@@ -29,13 +28,10 @@
     includeRaw = true,
     includeStatus = true,
     includeStreams = true,
-    primaryLabel = 'Output',
   }: Props = $props();
 
   let copiedKey = $state<string | null>(null);
-  let blocks = $derived(
-    outputBlocks(viewModel, { includePrimary, includeRaw, includeStreams, primaryLabel })
-  );
+  let blocks = $derived(outputBlocks(viewModel, { includePrimary, includeRaw, includeStreams }));
 
   async function copyOutput(text: string, key: string) {
     try {
@@ -54,7 +50,7 @@
   // projects them through the renderer's include options.
   function outputBlocks(
     model: ToolCallViewModel,
-    options: Pick<Props, 'includePrimary' | 'includeRaw' | 'includeStreams' | 'primaryLabel'>
+    options: Pick<Props, 'includePrimary' | 'includeRaw' | 'includeStreams'>
   ): OutputBlock[] {
     const result: OutputBlock[] = [];
     const defaultTone = model.status === 'cancelled' ? 'cancelled' : 'normal';
@@ -66,7 +62,10 @@
         if (section.source === 'primary' && !options.includePrimary) continue;
         result.push({
           key: section.source,
-          label: section.source === 'primary' ? (options.primaryLabel ?? 'Output') : section.label,
+          // The primary block is the tool's main result — a "Content"/"Output"
+          // header just restates what the card already makes obvious, so it
+          // renders bare. Stdout/stderr/error keep labels to tell them apart.
+          label: section.source === 'primary' ? '' : section.label,
           text: section.text,
           tone: section.tone,
         });
@@ -85,25 +84,30 @@
 </script>
 
 {#each blocks as block}
+  {@const copyLabel = block.label || 'output'}
   <section class="tool-output-section">
-    <div class="tool-output-header">
-      <div class="tool-panel-label">{block.label}</div>
-      {#if copyable}
-        <button
-          type="button"
-          class="tool-copy-button"
-          title={copiedKey === block.key ? 'Copied' : `Copy ${block.label.toLowerCase()}`}
-          aria-label={copiedKey === block.key ? 'Copied' : `Copy ${block.label.toLowerCase()}`}
-          onclick={() => copyOutput(block.text, block.key)}
-        >
-          {#if copiedKey === block.key}
-            <Check size={12} />
-          {:else}
-            <Copy size={12} />
-          {/if}
-        </button>
-      {/if}
-    </div>
+    {#if block.label || copyable}
+      <div class="tool-output-header">
+        {#if block.label}
+          <div class="tool-panel-label">{block.label}</div>
+        {/if}
+        {#if copyable}
+          <button
+            type="button"
+            class="tool-copy-button"
+            title={copiedKey === block.key ? 'Copied' : `Copy ${copyLabel.toLowerCase()}`}
+            aria-label={copiedKey === block.key ? 'Copied' : `Copy ${copyLabel.toLowerCase()}`}
+            onclick={() => copyOutput(block.text, block.key)}
+          >
+            {#if copiedKey === block.key}
+              <Check size={12} />
+            {:else}
+              <Copy size={12} />
+            {/if}
+          </button>
+        {/if}
+      </div>
+    {/if}
     <pre
       class="tool-code-output"
       class:tool-output-danger={block.tone === 'danger'}
@@ -115,15 +119,15 @@
   <div class="tool-empty-row">{viewModel.output.emptyLabel}</div>
 {/if}
 
-{#if includeStatus}
+<!-- A success row only echoes the green check already in the card header, so
+     the footer status shows only when it adds something (failed, cancelled,
+     still running). -->
+{#if includeStatus && viewModel.statusTone !== 'success'}
   <div
     class="tool-code-status"
     class:status-danger={viewModel.statusTone === 'danger'}
     class:status-cancelled={viewModel.statusTone === 'cancelled'}
   >
-    {#if viewModel.statusTone === 'success'}
-      <Check size={11} />
-    {/if}
     {viewModel.statusLabel}
   </div>
 {/if}

--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -49,55 +49,35 @@
     }
   }
 
+  // The view model's sections already encode which outputs to show (error /
+  // stdout / stderr precedence, raw JSON only as a fallback); this just
+  // projects them through the renderer's include options.
   function outputBlocks(
     model: ToolCallViewModel,
     options: Pick<Props, 'includePrimary' | 'includeRaw' | 'includeStreams' | 'primaryLabel'>
   ): OutputBlock[] {
-    const output = model.output;
     const result: OutputBlock[] = [];
     const defaultTone = model.status === 'cancelled' ? 'cancelled' : 'normal';
 
-    if (output.errorText) {
-      result.push({ key: 'error', label: 'Error', text: output.errorText, tone: 'danger' });
-    }
-
-    if (options.includeStreams && output.stdout) {
-      result.push({ key: 'stdout', label: 'Stdout', text: output.stdout, tone: defaultTone });
-    }
-
-    if (options.includeStreams && output.stderr && output.stderr !== output.errorText) {
-      result.push({
-        key: 'stderr',
-        label: 'Stderr',
-        text: output.stderr,
-        tone: model.status === 'failed' ? 'danger' : defaultTone,
-      });
-    }
-
-    if (
-      options.includePrimary &&
-      output.primaryText &&
-      output.primaryText !== output.errorText &&
-      output.primaryText !== output.stdout &&
-      output.primaryText !== output.stderr
-    ) {
-      result.push({
-        key: 'output',
-        label: options.primaryLabel ?? 'Output',
-        text: output.primaryText,
-        tone: defaultTone,
-      });
-    }
-
-    // Raw JSON is a fallback for output we could not render structurally,
-    // never a companion to structured blocks.
-    if (options.includeRaw && output.rawText && result.length === 0) {
-      result.push({
-        key: 'raw-output',
-        label: 'Raw output',
-        text: output.rawText,
-        tone: defaultTone,
-      });
+    for (const section of model.sections) {
+      if (section.kind === 'output') {
+        if (!options.includeStreams && (section.source === 'stdout' || section.source === 'stderr'))
+          continue;
+        if (section.source === 'primary' && !options.includePrimary) continue;
+        result.push({
+          key: section.source,
+          label: section.source === 'primary' ? (options.primaryLabel ?? 'Output') : section.label,
+          text: section.text,
+          tone: section.tone,
+        });
+      } else if (section.kind === 'raw_output' && options.includeRaw) {
+        result.push({
+          key: 'raw-output',
+          label: section.label,
+          text: section.text,
+          tone: defaultTone,
+        });
+      }
     }
 
     return result;

--- a/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import type { RichToolItem } from '../acpTranscript';
   import { formatJson } from '../acpTranscript';
-  import { isRecord, type ToolCallViewModel } from '../toolCallViewModel';
+  import type { DisplayRootInput } from '../pathDisplayRoots';
+  import { makePathsRelative } from '../sessionModalHelpers';
+  import {
+    isRecord,
+    summarizeToolCallLocations,
+    type ToolCallViewModel,
+  } from '../toolCallViewModel';
   import OutputSections from './OutputSections.svelte';
 
   interface MatchRow {
@@ -13,23 +19,24 @@
   interface Props {
     item: RichToolItem;
     viewModel: ToolCallViewModel;
+    displayRoots?: DisplayRootInput;
   }
 
-  let { item, viewModel }: Props = $props();
-  let matches = $derived(extractMatches(item.rawOutput));
-  // The Path field already names the file; only chip locations that add line info.
-  let locations = $derived(
-    viewModel.metadata.locations.filter(
-      (location) => location.display !== viewModel.metadata.targetPath
-    )
+  let { item, viewModel, displayRoots }: Props = $props();
+  let matches = $derived(extractMatches(item.rawOutput, displayRoots));
+  // The Path field names the file (with its line suffix folded in); chips only
+  // carry locations it doesn't already cover.
+  let locationSummary = $derived(
+    summarizeToolCallLocations(viewModel.metadata.locations, viewModel.metadata.targetPath)
   );
 
-  function extractMatches(rawOutput: unknown): MatchRow[] {
+  function extractMatches(rawOutput: unknown, roots?: DisplayRootInput): MatchRow[] {
     const candidates = matchCandidates(rawOutput);
     return candidates
       .map((candidate, index) => {
         if (!isRecord(candidate)) return null;
-        const path = firstString(candidate, ['path', 'file', 'file_path', 'filename']) ?? '';
+        const rawPath = firstString(candidate, ['path', 'file', 'file_path', 'filename']) ?? '';
+        const path = rawPath ? makePathsRelative(rawPath, roots) : '';
         const line = firstNumber(candidate, ['line', 'lineNumber', 'line_number']);
         const snippet = firstText(candidate, ['snippet', 'text', 'content', 'match', 'line']);
         if (!path && !snippet) return null;
@@ -83,7 +90,9 @@
   <div class="tool-field-list">
     {#if viewModel.metadata.targetPath}
       <span class="tool-field-label">Path</span>
-      <span class="tool-field-value">{viewModel.metadata.targetPath}</span>
+      <span class="tool-field-value"
+        >{viewModel.metadata.targetPath}{locationSummary.pathSuffix}</span
+      >
     {/if}
     {#if viewModel.metadata.query}
       <span class="tool-field-label">{viewModel.category === 'search' ? 'Query' : 'Selector'}</span>
@@ -91,10 +100,10 @@
     {/if}
   </div>
 
-  {#if locations.length > 0}
+  {#if locationSummary.chips.length > 0}
     <div class="tool-meta-row">
-      {#each locations as location}
-        <span class="tool-chip">{location.display}</span>
+      {#each locationSummary.chips as chip}
+        <span class="tool-chip">{chip}</span>
       {/each}
     </div>
   {/if}

--- a/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
@@ -17,6 +17,12 @@
 
   let { item, viewModel }: Props = $props();
   let matches = $derived(extractMatches(item.rawOutput));
+  // The Path field already names the file; only chip locations that add line info.
+  let locations = $derived(
+    viewModel.metadata.locations.filter(
+      (location) => location.display !== viewModel.metadata.targetPath
+    )
+  );
 
   function extractMatches(rawOutput: unknown): MatchRow[] {
     const candidates = matchCandidates(rawOutput);
@@ -85,9 +91,9 @@
     {/if}
   </div>
 
-  {#if viewModel.metadata.locations.length > 0}
+  {#if locations.length > 0}
     <div class="tool-meta-row">
-      {#each viewModel.metadata.locations as location}
+      {#each locations as location}
         <span class="tool-chip">{location.display}</span>
       {/each}
     </div>
@@ -95,7 +101,10 @@
 
   {#if matches.length > 0}
     <section>
-      <div class="tool-panel-label">Matches</div>
+      <div class="tool-panel-label">
+        {matches.length}
+        {matches.length === 1 ? 'match' : 'matches'}
+      </div>
       <div class="tool-match-list">
         {#each matches as match}
           <div class="tool-match-row">
@@ -111,5 +120,6 @@
     {viewModel}
     includePrimary={matches.length === 0}
     includeRaw={matches.length === 0}
+    primaryLabel={viewModel.category === 'read' ? 'Content' : 'Output'}
   />
 </div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
@@ -129,6 +129,5 @@
     {viewModel}
     includePrimary={matches.length === 0}
     includeRaw={matches.length === 0}
-    primaryLabel={viewModel.category === 'read' ? 'Content' : 'Output'}
   />
 </div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ReadSearchToolDetails.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import type { RichToolItem } from '../acpTranscript';
+  import { formatJson } from '../acpTranscript';
+  import { isRecord, type ToolCallViewModel } from '../toolCallViewModel';
+  import OutputSections from './OutputSections.svelte';
+
+  interface MatchRow {
+    key: string;
+    location: string;
+    snippet: string;
+  }
+
+  interface Props {
+    item: RichToolItem;
+    viewModel: ToolCallViewModel;
+  }
+
+  let { item, viewModel }: Props = $props();
+  let matches = $derived(extractMatches(item.rawOutput));
+
+  function extractMatches(rawOutput: unknown): MatchRow[] {
+    const candidates = matchCandidates(rawOutput);
+    return candidates
+      .map((candidate, index) => {
+        if (!isRecord(candidate)) return null;
+        const path = firstString(candidate, ['path', 'file', 'file_path', 'filename']) ?? '';
+        const line = firstNumber(candidate, ['line', 'lineNumber', 'line_number']);
+        const snippet = firstText(candidate, ['snippet', 'text', 'content', 'match', 'line']);
+        if (!path && !snippet) return null;
+        return {
+          key: `${path}:${line ?? ''}:${index}`,
+          location: `${path || 'match'}${line !== null ? `:${line}` : ''}`,
+          snippet,
+        };
+      })
+      .filter((match): match is MatchRow => match !== null);
+  }
+
+  function matchCandidates(value: unknown): unknown[] {
+    if (Array.isArray(value)) return value;
+    if (!isRecord(value)) return [];
+    for (const key of ['matches', 'results', 'items']) {
+      const candidate = value[key];
+      if (Array.isArray(candidate)) return candidate;
+    }
+    return [];
+  }
+
+  function firstString(input: Record<string, unknown>, keys: string[]): string | null {
+    for (const key of keys) {
+      const value = input[key];
+      if (typeof value === 'string' && value.trim()) return value;
+    }
+    return null;
+  }
+
+  function firstText(input: Record<string, unknown>, keys: string[]): string {
+    for (const key of keys) {
+      const value = input[key];
+      if (typeof value === 'string') return value;
+      if (value !== undefined && value !== null && typeof value !== 'number')
+        return formatJson(value);
+    }
+    return '';
+  }
+
+  function firstNumber(input: Record<string, unknown>, keys: string[]): number | null {
+    for (const key of keys) {
+      const value = input[key];
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+    }
+    return null;
+  }
+</script>
+
+<div class="tool-detail-stack">
+  <div class="tool-field-list">
+    {#if viewModel.metadata.targetPath}
+      <span class="tool-field-label">Path</span>
+      <span class="tool-field-value">{viewModel.metadata.targetPath}</span>
+    {/if}
+    {#if viewModel.metadata.query}
+      <span class="tool-field-label">{viewModel.category === 'search' ? 'Query' : 'Selector'}</span>
+      <span class="tool-field-value">{viewModel.metadata.query}</span>
+    {/if}
+  </div>
+
+  {#if viewModel.metadata.locations.length > 0}
+    <div class="tool-meta-row">
+      {#each viewModel.metadata.locations as location}
+        <span class="tool-chip">{location.display}</span>
+      {/each}
+    </div>
+  {/if}
+
+  {#if matches.length > 0}
+    <section>
+      <div class="tool-panel-label">Matches</div>
+      <div class="tool-match-list">
+        {#each matches as match}
+          <div class="tool-match-row">
+            <span class="tool-chip">{match.location}</span>
+            <code class="tool-match-snippet">{match.snippet}</code>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <OutputSections
+    {viewModel}
+    includePrimary={matches.length === 0}
+    includeRaw={matches.length === 0}
+  />
+</div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/ToolCallCard.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ToolCallCard.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import { slide } from 'svelte/transition';
+  import type { Snippet } from 'svelte';
+  import ExternalLink from '@lucide/svelte/icons/external-link';
+  import { Button } from '$lib/components/ui/button';
+  import type { RichToolItem } from '../acpTranscript';
+  import type { DisplayRootInput } from '../pathDisplayRoots';
+  import { buildToolCallViewModel } from '../toolCallViewModel';
+  import ToolCallDetails from './ToolCallDetails.svelte';
+  import ToolCallHeader from './ToolCallHeader.svelte';
+  import ToolStatusDot from './ToolStatusDot.svelte';
+
+  interface Props {
+    item: RichToolItem;
+    displayRoots?: DisplayRootInput;
+    nested?: boolean;
+    expanded: boolean;
+    slideDuration?: number;
+    onToggle: (key: string) => void;
+    onOpenSession?: (sessionId: string) => void;
+    /** Renders the inline diagram for a successful render_pikchr call. */
+    diagram?: Snippet<[string]>;
+  }
+
+  let {
+    item,
+    displayRoots,
+    nested = false,
+    expanded,
+    slideDuration = 150,
+    onToggle,
+    onOpenSession,
+    diagram,
+  }: Props = $props();
+
+  let viewModel = $derived(buildToolCallViewModel(item, displayRoots));
+  let showInlineDiagram = $derived(item.pikchrRenderSource !== null && !!diagram);
+  let showSessionButton = $derived(
+    !!(item.isPikchrDiagramTool && item.innerSessionId && onOpenSession)
+  );
+</script>
+
+<div class="tool-card" class:tool-card-nested={nested}>
+  {#if showInlineDiagram}
+    {@render diagram?.(item.pikchrRenderSource!)}
+  {:else if showSessionButton}
+    <Button
+      variant="outline"
+      size="sm"
+      class="tool-session-button {viewModel.statusTone === 'danger'
+        ? 'tool-session-button-danger'
+        : ''}"
+      onclick={() => onOpenSession?.(item.innerSessionId!)}
+    >
+      <ToolStatusDot statusTone={viewModel.statusTone} />
+      <span
+        >{viewModel.statusTone === 'danger'
+          ? 'Open failed diagram session'
+          : 'Open diagram session'}</span
+      >
+      <ExternalLink size={12} />
+    </Button>
+  {:else}
+    <ToolCallHeader
+      verb={viewModel.verb}
+      detail={viewModel.detail}
+      statusTone={viewModel.statusTone}
+      {expanded}
+      expandable={viewModel.hasDetails}
+      onToggle={() => onToggle(item.key)}
+    />
+  {/if}
+  {#if expanded && viewModel.hasDetails && !showInlineDiagram && !showSessionButton}
+    <div transition:slide={{ duration: slideDuration }}>
+      <ToolCallDetails {item} {viewModel} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tool-card {
+    overflow: hidden;
+    min-width: 0;
+  }
+
+  .tool-card-nested {
+    padding-left: 16px;
+  }
+
+  :global(.tool-session-button) {
+    height: 26px;
+    gap: 6px;
+    border-color: var(--border-muted);
+    padding: 0 8px;
+    color: var(--text-muted);
+    font-size: var(--size-xs);
+    font-weight: 500;
+    box-shadow: none;
+  }
+
+  :global(.tool-session-button:hover) {
+    border-color: var(--border-emphasis);
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  /* A failed generate_pikchr call keeps its session button (the child session
+     records the failure); tint it so the error is visible without expanding. */
+  :global(.tool-session-button-danger),
+  :global(.tool-session-button-danger:hover) {
+    border-color: var(--ui-danger);
+    color: var(--ui-danger);
+  }
+</style>

--- a/apps/staged/src/lib/features/sessions/tool-calls/ToolCallCard.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ToolCallCard.svelte
@@ -72,7 +72,7 @@
   {/if}
   {#if expanded && viewModel.hasDetails && !showInlineDiagram && !showSessionButton}
     <div transition:slide={{ duration: slideDuration }}>
-      <ToolCallDetails {item} {viewModel} />
+      <ToolCallDetails {item} {viewModel} {displayRoots} />
     </div>
   {/if}
 </div>

--- a/apps/staged/src/lib/features/sessions/tool-calls/ToolCallDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ToolCallDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { RichToolItem } from '../acpTranscript';
+  import type { DisplayRootInput } from '../pathDisplayRoots';
   import type { ToolCallViewModel } from '../toolCallViewModel';
   import CommandToolDetails from './CommandToolDetails.svelte';
   import EditToolDetails from './EditToolDetails.svelte';
@@ -10,9 +11,10 @@
   interface Props {
     item: RichToolItem;
     viewModel: ToolCallViewModel;
+    displayRoots?: DisplayRootInput;
   }
 
-  let { item, viewModel }: Props = $props();
+  let { item, viewModel, displayRoots }: Props = $props();
 </script>
 
 <div class="tool-code-block">
@@ -21,7 +23,7 @@
   {:else if viewModel.category === 'command'}
     <CommandToolDetails {viewModel} />
   {:else if viewModel.category === 'read' || viewModel.category === 'search'}
-    <ReadSearchToolDetails {item} {viewModel} />
+    <ReadSearchToolDetails {item} {viewModel} {displayRoots} />
   {:else if viewModel.category === 'network'}
     <NetworkToolDetails {item} {viewModel} />
   {:else}

--- a/apps/staged/src/lib/features/sessions/tool-calls/ToolCallDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ToolCallDetails.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+  import type { RichToolItem } from '../acpTranscript';
+  import type { ToolCallViewModel } from '../toolCallViewModel';
+  import CommandToolDetails from './CommandToolDetails.svelte';
+  import EditToolDetails from './EditToolDetails.svelte';
+  import GenericToolDetails from './GenericToolDetails.svelte';
+  import NetworkToolDetails from './NetworkToolDetails.svelte';
+  import ReadSearchToolDetails from './ReadSearchToolDetails.svelte';
+
+  interface Props {
+    item: RichToolItem;
+    viewModel: ToolCallViewModel;
+  }
+
+  let { item, viewModel }: Props = $props();
+</script>
+
+<div class="tool-code-block">
+  {#if viewModel.category === 'edit'}
+    <EditToolDetails {viewModel} />
+  {:else if viewModel.category === 'command'}
+    <CommandToolDetails {viewModel} />
+  {:else if viewModel.category === 'read' || viewModel.category === 'search'}
+    <ReadSearchToolDetails {item} {viewModel} />
+  {:else if viewModel.category === 'network'}
+    <NetworkToolDetails {item} {viewModel} />
+  {:else}
+    <GenericToolDetails {viewModel} />
+  {/if}
+</div>
+
+<style>
+  .tool-code-block {
+    margin-top: 4px;
+    border-radius: 8px;
+    padding: 12px 14px;
+    max-height: min(360px, 52vh);
+    overflow-y: auto;
+    background: color-mix(in srgb, var(--bg-chrome) 82%, var(--bg-primary));
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: calc(var(--size-xs) * 0.9);
+    line-height: 1.5;
+  }
+
+  .tool-code-block::-webkit-scrollbar,
+  .tool-code-block :global(.tool-code-output)::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+
+  .tool-code-block::-webkit-scrollbar-track,
+  .tool-code-block :global(.tool-code-output)::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .tool-code-block::-webkit-scrollbar-thumb,
+  .tool-code-block :global(.tool-code-output)::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background: var(--scrollbar-thumb-transparent);
+  }
+
+  .tool-code-block :global(.tool-detail-stack) {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .tool-code-block :global(.tool-primary-row),
+  .tool-code-block :global(.tool-meta-row) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .tool-code-block :global(.tool-field-list) {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 4px 8px;
+    min-width: 0;
+  }
+
+  .tool-code-block :global(.tool-field-label) {
+    color: var(--text-faint);
+    font-weight: 600;
+  }
+
+  .tool-code-block :global(.tool-field-value) {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-muted);
+  }
+
+  .tool-code-block :global(.tool-command-panel) {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 8px 10px;
+    background: var(--bg-primary);
+  }
+
+  .tool-code-block :global(.tool-command-line),
+  .tool-code-block :global(.tool-network-line) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: baseline;
+    min-width: 0;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .tool-code-block :global(.tool-command-prefix) {
+    flex-shrink: 0;
+    color: var(--text-faint);
+  }
+
+  .tool-code-block :global(.tool-command-text),
+  .tool-code-block :global(.tool-network-url) {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .tool-code-block :global(.tool-status-badge),
+  .tool-code-block :global(.tool-chip) {
+    max-width: 100%;
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    padding: 2px 6px;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: calc(var(--size-xs) * 0.88);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tool-code-block :global(.tool-status-badge.success) {
+    border-color: color-mix(in srgb, var(--ui-success, var(--ui-accent)) 35%, var(--border-subtle));
+    color: var(--ui-success, var(--ui-accent));
+  }
+
+  .tool-code-block :global(.tool-status-badge.danger) {
+    border-color: color-mix(in srgb, var(--ui-danger) 35%, var(--border-subtle));
+    color: var(--ui-danger);
+  }
+
+  .tool-code-block :global(.tool-panel-label) {
+    margin: 10px 0 4px;
+    color: var(--text-faint);
+    font-family: inherit;
+    font-size: calc(var(--size-xs) * 0.86);
+    font-weight: 600;
+    letter-spacing: 0;
+  }
+
+  .tool-code-block :global(.tool-panel-label:first-child) {
+    margin-top: 0;
+  }
+
+  .tool-code-block :global(.tool-output-section) {
+    min-width: 0;
+  }
+
+  .tool-code-block :global(.tool-output-header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 10px;
+  }
+
+  .tool-code-block :global(.tool-output-header .tool-panel-label) {
+    margin: 0 0 4px;
+  }
+
+  .tool-code-block :global(.tool-copy-button) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-faint);
+    cursor: pointer;
+  }
+
+  .tool-code-block :global(.tool-copy-button:hover),
+  .tool-code-block :global(.tool-copy-button:focus-visible) {
+    background: var(--bg-hover);
+    color: var(--text-muted);
+    outline: none;
+  }
+
+  .tool-code-block :global(.tool-code-output) {
+    margin: 0;
+    max-height: 220px;
+    overflow: auto;
+    color: var(--text-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .tool-code-block :global(.tool-code-output.tool-output-danger) {
+    color: var(--ui-danger);
+  }
+
+  .tool-code-block :global(.tool-code-output.tool-output-cancelled) {
+    color: var(--text-faint);
+  }
+
+  .tool-code-block :global(.tool-empty-row) {
+    border: 1px dashed var(--border-subtle);
+    border-radius: 8px;
+    padding: 8px 10px;
+    color: var(--text-faint);
+  }
+
+  .tool-code-block :global(.tool-match-list) {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .tool-code-block :global(.tool-match-row) {
+    display: grid;
+    grid-template-columns: minmax(120px, max-content) minmax(0, 1fr);
+    gap: 8px;
+    align-items: baseline;
+    min-width: 0;
+  }
+
+  .tool-code-block :global(.tool-match-snippet) {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-muted);
+    white-space: pre-wrap;
+  }
+
+  .tool-code-block :global(.tool-code-status) {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 3px;
+    margin-top: 8px;
+    color: var(--text-muted);
+    font-size: calc(var(--size-xs) * 0.85);
+  }
+
+  .tool-code-block :global(.tool-code-status.status-danger) {
+    color: var(--ui-danger);
+  }
+
+  .tool-code-block :global(.tool-code-status.status-cancelled) {
+    color: var(--text-faint);
+  }
+</style>

--- a/apps/staged/src/lib/features/sessions/tool-calls/ToolCallDetails.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ToolCallDetails.svelte
@@ -105,7 +105,6 @@
     background: var(--bg-primary);
   }
 
-  .tool-code-block :global(.tool-command-line),
   .tool-code-block :global(.tool-network-line) {
     display: flex;
     flex-wrap: wrap;
@@ -116,12 +115,29 @@
     font-weight: 500;
   }
 
-  .tool-code-block :global(.tool-command-prefix) {
-    flex-shrink: 0;
-    color: var(--text-faint);
+  /* Lay the command out like a terminal line: the "$" sits in a fixed-width
+     gutter and the command flows beside it, wrapping under itself with a
+     hanging indent instead of stranding the prompt on its own row. */
+  .tool-code-block :global(.tool-command-line) {
+    min-width: 0;
+    padding-left: 1.25em;
+    color: var(--text-primary);
+    font-weight: 500;
   }
 
-  .tool-code-block :global(.tool-command-text),
+  .tool-code-block :global(.tool-command-prefix) {
+    display: inline-block;
+    width: 1.25em;
+    margin-left: -1.25em;
+    color: var(--text-faint);
+    user-select: none;
+  }
+
+  .tool-code-block :global(.tool-command-text) {
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+
   .tool-code-block :global(.tool-network-url) {
     min-width: 0;
     overflow-wrap: anywhere;
@@ -168,6 +184,18 @@
     min-width: 0;
   }
 
+  .tool-code-block :global(.tool-output-body) {
+    position: relative;
+    min-width: 0;
+  }
+
+  .tool-code-block :global(.tool-output-body-actions) {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    z-index: 1;
+  }
+
   .tool-code-block :global(.tool-output-header) {
     display: flex;
     align-items: center;
@@ -199,6 +227,17 @@
     background: var(--bg-hover);
     color: var(--text-muted);
     outline: none;
+  }
+
+  /* The overlaid button sits over the top-right of the output, so give it the
+     block's own background to mask any text it covers. */
+  .tool-code-block :global(.tool-output-body-actions .tool-copy-button) {
+    background: color-mix(in srgb, var(--bg-chrome) 82%, var(--bg-primary));
+  }
+
+  .tool-code-block :global(.tool-output-body-actions .tool-copy-button:hover),
+  .tool-code-block :global(.tool-output-body-actions .tool-copy-button:focus-visible) {
+    background: var(--bg-hover);
   }
 
   .tool-code-block :global(.tool-code-output) {

--- a/apps/staged/src/lib/features/sessions/tool-calls/ToolCallHeader.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ToolCallHeader.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import type { RichToolItem } from '../acpTranscript';
+  import ToolStatusDot from './ToolStatusDot.svelte';
+
+  interface Props {
+    verb: string;
+    detail?: string;
+    statusTone: RichToolItem['statusTone'];
+    expanded?: boolean;
+    expandable?: boolean;
+    onToggle?: () => void;
+  }
+
+  let {
+    verb,
+    detail = '',
+    statusTone,
+    expanded = false,
+    expandable = true,
+    onToggle,
+  }: Props = $props();
+</script>
+
+<button
+  type="button"
+  class="tool-header"
+  class:tool-header-expandable={expandable}
+  disabled={!expandable}
+  aria-expanded={expandable ? expanded : undefined}
+  onclick={() => {
+    if (expandable) onToggle?.();
+  }}
+>
+  <span
+    class="tool-caret"
+    class:tool-caret-expanded={expanded}
+    class:tool-caret-hidden={!expandable}>›</span
+  >
+  <ToolStatusDot {statusTone} />
+  <span class="tool-name">{verb}</span>
+  {#if detail}
+    <span class="tool-args-preview">{detail}</span>
+  {/if}
+</button>
+
+<style>
+  .tool-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    min-width: 0;
+    border: 0;
+    padding: 2px 0;
+    background: transparent;
+    color: var(--text-muted);
+    font: inherit;
+    font-size: var(--size-xs);
+    text-align: left;
+    transition: background-color 0.1s;
+    cursor: default;
+    opacity: 1;
+  }
+
+  .tool-header-expandable {
+    cursor: pointer;
+  }
+
+  .tool-header-expandable:hover .tool-name {
+    text-decoration: underline;
+  }
+
+  .tool-header:focus-visible {
+    outline: 1px solid var(--border-emphasis);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  .tool-caret {
+    display: inline-block;
+    flex-shrink: 0;
+    width: 8px;
+    color: var(--text-faint);
+    font-size: var(--size-xs);
+    line-height: 1;
+    transition: transform 0.15s ease;
+  }
+
+  .tool-caret-expanded {
+    transform: rotate(90deg);
+  }
+
+  .tool-caret-hidden {
+    visibility: hidden;
+  }
+
+  .tool-name {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    font-size: var(--size-xs);
+    white-space: nowrap;
+  }
+
+  .tool-args-preview {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-faint);
+    font-size: var(--size-xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/apps/staged/src/lib/features/sessions/tool-calls/ToolStatusDot.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/ToolStatusDot.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import Clock from '@lucide/svelte/icons/clock';
+  import CircleAlert from '@lucide/svelte/icons/circle-alert';
+  import CircleCheck from '@lucide/svelte/icons/circle-check';
+  import CircleDot from '@lucide/svelte/icons/circle-dot';
+  import CircleSlash from '@lucide/svelte/icons/circle-slash';
+  import type { RichToolItem } from '../acpTranscript';
+
+  interface Props {
+    statusTone: RichToolItem['statusTone'];
+  }
+
+  let { statusTone }: Props = $props();
+</script>
+
+<span
+  class="tool-status-dot"
+  class:status-running={statusTone === 'running'}
+  class:status-success={statusTone === 'success'}
+  class:status-danger={statusTone === 'danger'}
+  class:status-cancelled={statusTone === 'cancelled'}
+>
+  {#if statusTone === 'running'}
+    <Clock size={11} />
+  {:else if statusTone === 'success'}
+    <CircleCheck size={11} />
+  {:else if statusTone === 'danger'}
+    <CircleAlert size={11} />
+  {:else if statusTone === 'cancelled'}
+    <CircleSlash size={11} />
+  {:else}
+    <CircleDot size={11} />
+  {/if}
+</span>
+
+<style>
+  .tool-status-dot {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    color: var(--text-faint);
+  }
+
+  .tool-status-dot.status-running {
+    color: var(--ui-warning);
+  }
+
+  .tool-status-dot.status-success {
+    color: var(--ui-success, var(--ui-accent));
+  }
+
+  .tool-status-dot.status-danger {
+    color: var(--ui-danger);
+  }
+
+  .tool-status-dot.status-cancelled {
+    color: var(--text-muted);
+  }
+</style>

--- a/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.test.ts
+++ b/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolCallDiff } from '../toolCallViewModel';
+import { buildDiffRows, diffRowStats, groupDiffRows, type DiffRow } from './inlineDiffRows';
+
+function diff(oldText: string | null, newText: string | null): ToolCallDiff {
+  return {
+    path: 'src/example.ts',
+    oldText,
+    newText,
+    kind: oldText === null ? 'created' : newText === null ? 'deleted' : 'modified',
+  };
+}
+
+function lines(count: number, prefix = 'line'): string {
+  return Array.from({ length: count }, (_, index) => `${prefix} ${index + 1}`).join('\n');
+}
+
+describe('buildDiffRows', () => {
+  it('pairs modified lines as removed and added rows with line numbers', () => {
+    const rows = buildDiffRows(diff('const a = 1;\nshared\n', 'const a = 2;\nshared\n'));
+
+    expect(rows[0]).toMatchObject({
+      marker: '-',
+      tone: 'modified-removed',
+      oldLine: 1,
+      newLine: null,
+      text: 'const a = 1;',
+    });
+    expect(rows[1]).toMatchObject({
+      marker: '+',
+      tone: 'modified-added',
+      oldLine: null,
+      newLine: 1,
+      text: 'const a = 2;',
+    });
+    expect(rows[2]).toMatchObject({ marker: ' ', tone: 'context', oldLine: 2, newLine: 2 });
+  });
+
+  it('marks every line added for created files', () => {
+    const rows = buildDiffRows(diff(null, 'first\nsecond'));
+
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.marker === '+' && row.oldLine === null)).toBe(true);
+  });
+});
+
+describe('diffRowStats', () => {
+  it('counts added and removed rows', () => {
+    const rows = buildDiffRows(diff('keep\nold 1\nold 2\n', 'keep\nnew 1\n'));
+
+    expect(diffRowStats(rows)).toEqual({ added: 1, removed: 2 });
+  });
+});
+
+describe('groupDiffRows', () => {
+  function toneSummary(blocks: ReturnType<typeof groupDiffRows>): string[] {
+    return blocks.map((block) =>
+      block.kind === 'collapsed' ? `collapsed:${block.rows.length}` : `visible:${block.rows.length}`
+    );
+  }
+
+  it('collapses a long unchanged run between changes, keeping context on both sides', () => {
+    const middle = lines(12, 'same');
+    const rows = buildDiffRows(
+      diff(`start old\n${middle}\nend old`, `start new\n${middle}\nend new`)
+    );
+
+    // 2 change rows, 3 context, 6 collapsed, 3 context, 2 change rows.
+    expect(toneSummary(groupDiffRows(rows))).toEqual(['visible:5', 'collapsed:6', 'visible:5']);
+  });
+
+  it('trims leading context to the rows adjacent to the first change', () => {
+    const rows = buildDiffRows(diff(`${lines(10)}\nold tail`, `${lines(10)}\nnew tail`));
+
+    const blocks = groupDiffRows(rows);
+    expect(toneSummary(blocks)).toEqual(['collapsed:7', 'visible:5']);
+    expect(blocks[1].rows.map((row) => row.marker)).toEqual([' ', ' ', ' ', '-', '+']);
+  });
+
+  it('trims trailing context to the rows adjacent to the last change', () => {
+    const rows = buildDiffRows(diff(`old head\n${lines(10)}`, `new head\n${lines(10)}`));
+
+    expect(toneSummary(groupDiffRows(rows))).toEqual(['visible:5', 'collapsed:7']);
+  });
+
+  it('keeps short unchanged runs visible instead of collapsing them', () => {
+    const rows = buildDiffRows(
+      diff(`old\n${lines(8, 'same')}\nold end`, `new\n${lines(8, 'same')}\nnew end`)
+    );
+
+    // 8 context rows minus 3+3 kept leaves 2 hidden, below the collapse threshold.
+    expect(toneSummary(groupDiffRows(rows))).toEqual(['visible:12']);
+  });
+
+  it('keeps a fully unchanged diff visible as one block', () => {
+    const rows: DiffRow[] = buildDiffRows(diff(lines(10), lines(10)));
+
+    expect(toneSummary(groupDiffRows(rows))).toEqual(['visible:10']);
+  });
+
+  it('returns no blocks for empty diffs', () => {
+    expect(groupDiffRows([])).toEqual([]);
+  });
+});

--- a/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.test.ts
+++ b/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.test.ts
@@ -42,6 +42,19 @@ describe('buildDiffRows', () => {
     expect(rows).toHaveLength(2);
     expect(rows.every((row) => row.marker === '+' && row.oldLine === null)).toBe(true);
   });
+
+  it('renders both halves of a modified pair that straddles an unchanged line', () => {
+    // 'bar' is the LCS anchor, so the similar foo(1)/foo(2) lines pair up
+    // across it and never align during the row walk.
+    const rows = buildDiffRows(diff('foo(1)\nbar', 'bar\nfoo(2)'));
+
+    expect(rows).toMatchObject([
+      { marker: '-', tone: 'modified-removed', oldLine: 1, newLine: null, text: 'foo(1)' },
+      { marker: ' ', tone: 'context', oldLine: 2, newLine: 1, text: 'bar' },
+      { marker: '+', tone: 'modified-added', oldLine: null, newLine: 2, text: 'foo(2)' },
+    ]);
+    expect(diffRowStats(rows)).toEqual({ added: 1, removed: 1 });
+  });
 });
 
 describe('diffRowStats', () => {

--- a/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.ts
+++ b/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.ts
@@ -1,0 +1,201 @@
+import { computeLineDiff, type CharHighlight } from '@builderbot/diff-viewer/utils';
+import type { ToolCallDiff } from '../toolCallViewModel';
+
+export type DiffTone = 'context' | 'removed' | 'added' | 'modified-removed' | 'modified-added';
+
+export interface DiffRow {
+  key: string;
+  oldLine: number | null;
+  newLine: number | null;
+  marker: ' ' | '-' | '+';
+  text: string;
+  tone: DiffTone;
+  highlights: CharHighlight[];
+}
+
+export type DiffRowBlock =
+  | { kind: 'visible'; key: string; rows: DiffRow[] }
+  | { kind: 'collapsed'; key: string; rows: DiffRow[] };
+
+export interface DiffRowStats {
+  added: number;
+  removed: number;
+}
+
+export interface GroupDiffRowsOptions {
+  context?: number;
+  minHidden?: number;
+}
+
+export function buildDiffRows(diff: ToolCallDiff): DiffRow[] {
+  const beforeLines = splitLines(diff.oldText);
+  const afterLines = splitLines(diff.newText);
+  const lineDiff = computeLineDiff(beforeLines, afterLines);
+  const modifiedByBefore = new Map(
+    lineDiff.modifiedPairs.map((pair) => [pair.beforeLineIndex, pair])
+  );
+  const modifiedByAfter = new Map(
+    lineDiff.modifiedPairs.map((pair) => [pair.afterLineIndex, pair])
+  );
+  const result: DiffRow[] = [];
+  let beforeIndex = 0;
+  let afterIndex = 0;
+
+  while (beforeIndex < beforeLines.length || afterIndex < afterLines.length) {
+    const beforeClass = lineDiff.beforeLines[beforeIndex];
+    const afterClass = lineDiff.afterLines[afterIndex];
+
+    if (
+      beforeIndex < beforeLines.length &&
+      afterIndex < afterLines.length &&
+      beforeClass === 'unchanged' &&
+      afterClass === 'unchanged'
+    ) {
+      result.push({
+        key: `context:${beforeIndex}:${afterIndex}`,
+        oldLine: beforeIndex + 1,
+        newLine: afterIndex + 1,
+        marker: ' ',
+        text: beforeLines[beforeIndex],
+        tone: 'context',
+        highlights: [],
+      });
+      beforeIndex += 1;
+      afterIndex += 1;
+      continue;
+    }
+
+    const modifiedPair = modifiedByBefore.get(beforeIndex);
+    if (modifiedPair && modifiedPair.afterLineIndex === afterIndex) {
+      result.push({
+        key: `mod-before:${beforeIndex}`,
+        oldLine: beforeIndex + 1,
+        newLine: null,
+        marker: '-',
+        text: beforeLines[beforeIndex],
+        tone: 'modified-removed',
+        highlights: modifiedPair.beforeHighlights,
+      });
+      result.push({
+        key: `mod-after:${afterIndex}`,
+        oldLine: null,
+        newLine: afterIndex + 1,
+        marker: '+',
+        text: afterLines[afterIndex],
+        tone: 'modified-added',
+        highlights: modifiedPair.afterHighlights,
+      });
+      beforeIndex += 1;
+      afterIndex += 1;
+      continue;
+    }
+
+    if (beforeClass === 'removed' || (beforeClass === 'modified' && !modifiedPair)) {
+      result.push({
+        key: `removed:${beforeIndex}`,
+        oldLine: beforeIndex + 1,
+        newLine: null,
+        marker: '-',
+        text: beforeLines[beforeIndex],
+        tone: beforeClass === 'modified' ? 'modified-removed' : 'removed',
+        highlights: modifiedByBefore.get(beforeIndex)?.beforeHighlights ?? [],
+      });
+      beforeIndex += 1;
+      continue;
+    }
+
+    const afterPair = modifiedByAfter.get(afterIndex);
+    if (afterClass === 'added' || (afterClass === 'modified' && !afterPair)) {
+      result.push({
+        key: `added:${afterIndex}`,
+        oldLine: null,
+        newLine: afterIndex + 1,
+        marker: '+',
+        text: afterLines[afterIndex],
+        tone: afterClass === 'modified' ? 'modified-added' : 'added',
+        highlights: modifiedByAfter.get(afterIndex)?.afterHighlights ?? [],
+      });
+      afterIndex += 1;
+      continue;
+    }
+
+    if (beforeIndex < beforeLines.length) {
+      beforeIndex += 1;
+    }
+    if (afterIndex < afterLines.length) {
+      afterIndex += 1;
+    }
+  }
+
+  return result;
+}
+
+export function diffRowStats(rows: DiffRow[]): DiffRowStats {
+  let added = 0;
+  let removed = 0;
+  for (const row of rows) {
+    if (row.marker === '+') added += 1;
+    else if (row.marker === '-') removed += 1;
+  }
+  return { added, removed };
+}
+
+export function groupDiffRows(rows: DiffRow[], options: GroupDiffRowsOptions = {}): DiffRowBlock[] {
+  const context = options.context ?? 3;
+  const minHidden = options.minHidden ?? 3;
+
+  const segments: { isContext: boolean; rows: DiffRow[] }[] = [];
+  for (const row of rows) {
+    const isContext = row.tone === 'context';
+    const last = segments[segments.length - 1];
+    if (last && last.isContext === isContext) {
+      last.rows.push(row);
+    } else {
+      segments.push({ isContext, rows: [row] });
+    }
+  }
+
+  // A diff with no changed rows has nothing to anchor context around.
+  if (!segments.some((segment) => !segment.isContext)) {
+    return rows.length > 0 ? [{ kind: 'visible', key: `visible:${rows[0].key}`, rows }] : [];
+  }
+
+  const blocks: DiffRowBlock[] = [];
+  const pushVisible = (visibleRows: DiffRow[]) => {
+    if (visibleRows.length === 0) return;
+    const last = blocks[blocks.length - 1];
+    if (last?.kind === 'visible') {
+      last.rows = [...last.rows, ...visibleRows];
+    } else {
+      blocks.push({ kind: 'visible', key: `visible:${visibleRows[0].key}`, rows: visibleRows });
+    }
+  };
+
+  segments.forEach((segment, index) => {
+    if (!segment.isContext) {
+      pushVisible(segment.rows);
+      return;
+    }
+
+    // Leading runs only pad the change below them, trailing runs the one above.
+    const head = index === 0 ? 0 : context;
+    const tail = index === segments.length - 1 ? 0 : context;
+    const hidden = segment.rows.length - head - tail;
+    if (hidden < minHidden) {
+      pushVisible(segment.rows);
+      return;
+    }
+
+    pushVisible(segment.rows.slice(0, head));
+    const hiddenRows = segment.rows.slice(head, head + hidden);
+    blocks.push({ kind: 'collapsed', key: `collapsed:${hiddenRows[0].key}`, rows: hiddenRows });
+    pushVisible(segment.rows.slice(head + hidden));
+  });
+
+  return blocks;
+}
+
+function splitLines(text: string | null): string[] {
+  if (text === null || text === '') return [];
+  return text.split('\n');
+}

--- a/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.ts
+++ b/apps/staged/src/lib/features/sessions/tool-calls/inlineDiffRows.ts
@@ -90,35 +90,67 @@ export function buildDiffRows(diff: ToolCallDiff): DiffRow[] {
       continue;
     }
 
-    if (beforeClass === 'removed' || (beforeClass === 'modified' && !modifiedPair)) {
+    if (beforeClass === 'removed') {
       result.push({
         key: `removed:${beforeIndex}`,
         oldLine: beforeIndex + 1,
         newLine: null,
         marker: '-',
         text: beforeLines[beforeIndex],
-        tone: beforeClass === 'modified' ? 'modified-removed' : 'removed',
-        highlights: modifiedByBefore.get(beforeIndex)?.beforeHighlights ?? [],
+        tone: 'removed',
+        highlights: [],
       });
       beforeIndex += 1;
       continue;
     }
 
     const afterPair = modifiedByAfter.get(afterIndex);
-    if (afterClass === 'added' || (afterClass === 'modified' && !afterPair)) {
+    if (afterClass === 'added') {
       result.push({
         key: `added:${afterIndex}`,
         oldLine: null,
         newLine: afterIndex + 1,
         marker: '+',
         text: afterLines[afterIndex],
-        tone: afterClass === 'modified' ? 'modified-added' : 'added',
-        highlights: modifiedByAfter.get(afterIndex)?.afterHighlights ?? [],
+        tone: 'added',
+        highlights: [],
       });
       afterIndex += 1;
       continue;
     }
 
+    // A modified pair can straddle an LCS anchor (e.g. a line edited while
+    // moving across an unchanged line), so it never aligns for the paired
+    // branch above. Render each half as its own row instead of dropping it.
+    if (beforeIndex < beforeLines.length && beforeClass !== 'unchanged') {
+      result.push({
+        key: `removed:${beforeIndex}`,
+        oldLine: beforeIndex + 1,
+        newLine: null,
+        marker: '-',
+        text: beforeLines[beforeIndex],
+        tone: 'modified-removed',
+        highlights: modifiedPair?.beforeHighlights ?? [],
+      });
+      beforeIndex += 1;
+      continue;
+    }
+
+    if (afterIndex < afterLines.length && afterClass !== 'unchanged') {
+      result.push({
+        key: `added:${afterIndex}`,
+        oldLine: null,
+        newLine: afterIndex + 1,
+        marker: '+',
+        text: afterLines[afterIndex],
+        tone: 'modified-added',
+        highlights: afterPair?.afterHighlights ?? [],
+      });
+      afterIndex += 1;
+      continue;
+    }
+
+    // Unreachable for well-formed line diffs; advance to guarantee progress.
     if (beforeIndex < beforeLines.length) {
       beforeIndex += 1;
     }

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
@@ -31,6 +31,9 @@ function richTool(overrides: Partial<RichToolItem> = {}): RichToolItem {
     rawOutput: undefined,
     content: undefined,
     locations: undefined,
+    isPikchrDiagramTool: false,
+    innerSessionId: null,
+    pikchrRenderSource: null,
     ...overrides,
   };
 }

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
@@ -203,6 +203,36 @@ describe('buildToolCallViewModel classification', () => {
       ])
     );
   });
+
+  it('does not treat generic status output as a network payload', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        verb: 'Processed',
+        rawOutput: { status: 'ok', id: 42, title: 'Done' },
+      })
+    );
+
+    // A stray `status`/`title` key is not network evidence, so the payload must
+    // stay generic and keep its raw fallback instead of vanishing behind the
+    // network renderer's structured-response view.
+    expect(model.category).toBe('generic');
+    expect(model.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'raw_output', text: expect.stringContaining('"id": 42') }),
+      ])
+    );
+  });
+
+  it('still classifies unknown tools as network on request/response evidence', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        verb: 'Processed',
+        rawOutput: { response: { status: 200, body: 'ok' } },
+      })
+    );
+
+    expect(model.category).toBe('network');
+  });
 });
 
 describe('buildToolCallViewModel output handling', () => {
@@ -312,6 +342,28 @@ describe('buildToolCallViewModel output handling', () => {
     const model = buildToolCallViewModel(richTool({ rawInput: { option: 'value' } }));
 
     expect(model.hasDetails).toBe(true);
+  });
+
+  it('defers raw output JSON formatting until the value is read', () => {
+    let reads = 0;
+    const rawOutput = {
+      get payload() {
+        reads += 1;
+        return 'value';
+      },
+    };
+
+    const model = buildToolCallViewModel(richTool({ verb: 'Processed', rawOutput }));
+
+    // Building the view model for a collapsed card must not pretty-print the
+    // raw output; that only happens once an expanded card reads `rawText`.
+    expect(reads).toBe(0);
+    expect(model.output.hasRawText).toBe(true);
+    expect(model.hasDetails).toBe(true);
+    expect(reads).toBe(0);
+
+    expect(model.output.rawText).toContain('value');
+    expect(reads).toBe(1);
   });
 });
 

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionMessage } from '../../types';
+import type { RichToolItem, ToolStatus } from './acpTranscript';
+import { buildToolCallViewModel } from './toolCallViewModel';
+
+function message(
+  overrides: Partial<SessionMessage> & Pick<SessionMessage, 'id' | 'role'>
+): SessionMessage {
+  return {
+    sessionId: 'session-1',
+    content: overrides.content ?? '',
+    createdAt: overrides.id,
+    ...overrides,
+  };
+}
+
+function richTool(overrides: Partial<RichToolItem> = {}): RichToolItem {
+  const status = overrides.status ?? 'completed';
+  return {
+    key: 'tool:tc-1',
+    call: message({ id: 1, role: 'tool_call', content: 'Custom tool' }),
+    result: null,
+    verb: 'Ran',
+    detail: '',
+    status,
+    statusLabel: statusLabel(status),
+    statusTone: statusTone(status),
+    toolCallId: 'tc-1',
+    toolKind: null,
+    rawInput: undefined,
+    rawOutput: undefined,
+    content: undefined,
+    locations: undefined,
+    ...overrides,
+  };
+}
+
+function statusLabel(status: ToolStatus): RichToolItem['statusLabel'] {
+  switch (status) {
+    case 'pending':
+      return 'Pending';
+    case 'in_progress':
+      return 'In progress';
+    case 'completed':
+      return 'Succeeded';
+    case 'failed':
+      return 'Failed';
+    case 'cancelled':
+      return 'Cancelled';
+  }
+}
+
+function statusTone(status: ToolStatus): RichToolItem['statusTone'] {
+  switch (status) {
+    case 'pending':
+      return 'muted';
+    case 'in_progress':
+      return 'running';
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'danger';
+    case 'cancelled':
+      return 'cancelled';
+  }
+}
+
+describe('buildToolCallViewModel classification', () => {
+  it('classifies from normalized toolKind before the visible verb', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        toolKind: 'Edit',
+        verb: 'Ran',
+        rawInput: { path: '/repo/src/App.svelte' },
+      }),
+      '/repo'
+    );
+
+    expect(model.category).toBe('edit');
+    expect(model.metadata.toolKind).toBe('edit');
+    expect(model.metadata.targetPath).toBe('src/App.svelte');
+  });
+
+  it('classifies from parsed tool titles and extracts parsed input', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        verb: 'Processed',
+        call: message({
+          id: 1,
+          role: 'tool_call',
+          content: JSON.stringify({
+            name: 'Read /repo/src/App.svelte',
+            input: { file_path: '/repo/src/App.svelte' },
+          }),
+        }),
+      }),
+      '/repo'
+    );
+
+    expect(model.category).toBe('read');
+    expect(model.metadata.toolName).toBe('Read /repo/src/App.svelte');
+    expect(model.metadata.targetPath).toBe('src/App.svelte');
+    expect(model.metadata.inputText).toContain('file_path');
+  });
+
+  it('classifies parsed_cmd metadata before falling back to display verbs', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        verb: 'Ran',
+        call: message({
+          id: 1,
+          role: 'tool_call',
+          content: JSON.stringify({
+            name: 'Custom wrapper',
+            input: {
+              parsed_cmd: [
+                {
+                  type: 'search',
+                  cmd: "rg -n 'needle' /repo/src",
+                  query: 'needle',
+                  path: '/repo/src',
+                },
+              ],
+            },
+          }),
+        }),
+      }),
+      '/repo'
+    );
+
+    expect(model.category).toBe('search');
+    expect(model.metadata.query).toBe('needle');
+    expect(model.metadata.targetPath).toBe('src');
+    expect(model.metadata.parsedCommands[0]).toMatchObject({
+      type: 'search',
+      cmd: "rg -n 'needle' /repo/src",
+    });
+  });
+
+  it('falls back to ACP content blocks when tool identity is missing', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        verb: 'Processed',
+        content: [
+          {
+            type: 'diff',
+            path: '/repo/src/a.ts',
+            oldText: 'old line\n',
+            newText: 'new line\n',
+          },
+        ],
+      }),
+      '/repo'
+    );
+
+    expect(model.category).toBe('edit');
+    expect(model.metadata.diffs).toEqual([
+      {
+        path: 'src/a.ts',
+        oldText: 'old line\n',
+        newText: 'new line\n',
+        kind: 'modified',
+      },
+    ]);
+    expect(model.sections.some((section) => section.kind === 'diff')).toBe(true);
+  });
+
+  it('detects network-style unknown tools from raw input metadata', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        verb: 'Processed',
+        rawInput: { method: 'post', url: 'https://example.test/api' },
+      })
+    );
+
+    expect(model.category).toBe('network');
+    expect(model.metadata.method).toBe('POST');
+    expect(model.metadata.url).toBe('https://example.test/api');
+  });
+
+  it('keeps unknown tools generic with raw JSON fallback sections', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        verb: 'Processed',
+        rawInput: { option: 'value' },
+        rawOutput: { payload: { ok: true } },
+      })
+    );
+
+    expect(model.category).toBe('generic');
+    expect(model.output.state).toBe('output');
+    expect(model.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'input', text: expect.stringContaining('option') }),
+        expect.objectContaining({ kind: 'raw_output', text: expect.stringContaining('payload') }),
+      ])
+    );
+  });
+});
+
+describe('buildToolCallViewModel output handling', () => {
+  it('promotes failed errors before raw output JSON', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        status: 'failed',
+        rawOutput: { error: 'permission denied', exitCode: 1 },
+      })
+    );
+
+    expect(model.output.state).toBe('output');
+    expect(model.output.errorText).toBe('permission denied');
+    expect(model.output.exitCode).toBe(1);
+
+    const errorIndex = model.sections.findIndex(
+      (section) => section.kind === 'output' && section.label === 'Error'
+    );
+    const rawIndex = model.sections.findIndex((section) => section.kind === 'raw_output');
+    expect(errorIndex).toBeGreaterThanOrEqual(0);
+    expect(rawIndex).toBeGreaterThan(errorIndex);
+  });
+
+  it('keeps structured stdout and stderr distinct for successful commands', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        rawOutput: { stdout: 'tests passed', stderr: 'warning only', exitCode: 0 },
+      })
+    );
+
+    expect(model.output.stdout).toBe('tests passed');
+    expect(model.output.stderr).toBe('warning only');
+    expect(model.output.errorText).toBe('');
+    const outputLabels = model.sections.flatMap((section) =>
+      section.kind === 'output' ? [section.label] : []
+    );
+    expect(outputLabels).toEqual(['Stdout', 'Stderr']);
+  });
+
+  it('falls back to legacy tool_result content when ACP output is absent', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        result: message({
+          id: 2,
+          role: 'tool_result',
+          content: '```text\nlegacy output\n```',
+        }),
+      })
+    );
+
+    expect(model.category).toBe('command');
+    expect(model.output.primaryText).toBe('legacy output');
+    expect(model.sections).toContainEqual({
+      kind: 'output',
+      label: 'Output',
+      text: 'legacy output',
+      tone: 'normal',
+    });
+  });
+
+  it('shows a waiting state for pending tools without output', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        status: 'pending',
+        statusTone: 'muted',
+        result: null,
+      })
+    );
+
+    expect(model.output.state).toBe('waiting');
+    expect(model.output.emptyLabel).toBe('Waiting for output');
+    expect(model.sections).toContainEqual({ kind: 'empty', label: 'Waiting for output' });
+  });
+
+  it('shows a no-output state for completed tools without output', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        status: 'completed',
+        result: null,
+      })
+    );
+
+    expect(model.output.state).toBe('empty');
+    expect(model.output.emptyLabel).toBe('No output');
+    expect(model.hasDetails).toBe(true);
+    expect(model.sections).toContainEqual({ kind: 'empty', label: 'No output' });
+  });
+});

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
@@ -202,7 +202,7 @@ describe('buildToolCallViewModel classification', () => {
 });
 
 describe('buildToolCallViewModel output handling', () => {
-  it('promotes failed errors before raw output JSON', () => {
+  it('suppresses raw output JSON when a structured error is shown', () => {
     const model = buildToolCallViewModel(
       richTool({
         status: 'failed',
@@ -217,9 +217,8 @@ describe('buildToolCallViewModel output handling', () => {
     const errorIndex = model.sections.findIndex(
       (section) => section.kind === 'output' && section.label === 'Error'
     );
-    const rawIndex = model.sections.findIndex((section) => section.kind === 'raw_output');
     expect(errorIndex).toBeGreaterThanOrEqual(0);
-    expect(rawIndex).toBeGreaterThan(errorIndex);
+    expect(model.sections.some((section) => section.kind === 'raw_output')).toBe(false);
   });
 
   it('keeps structured stdout and stderr distinct for successful commands', () => {
@@ -236,6 +235,7 @@ describe('buildToolCallViewModel output handling', () => {
       section.kind === 'output' ? [section.label] : []
     );
     expect(outputLabels).toEqual(['Stdout', 'Stderr']);
+    expect(model.sections.some((section) => section.kind === 'raw_output')).toBe(false);
   });
 
   it('falls back to legacy tool_result content when ACP output is absent', () => {

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
@@ -253,6 +253,7 @@ describe('buildToolCallViewModel output handling', () => {
     expect(model.output.primaryText).toBe('legacy output');
     expect(model.sections).toContainEqual({
       kind: 'output',
+      source: 'primary',
       label: 'Output',
       text: 'legacy output',
       tone: 'normal',
@@ -273,7 +274,7 @@ describe('buildToolCallViewModel output handling', () => {
     expect(model.sections).toContainEqual({ kind: 'empty', label: 'Waiting for output' });
   });
 
-  it('shows a no-output state for completed tools without output', () => {
+  it('is not expandable when only empty and status rows would show', () => {
     const model = buildToolCallViewModel(
       richTool({
         status: 'completed',
@@ -283,7 +284,13 @@ describe('buildToolCallViewModel output handling', () => {
 
     expect(model.output.state).toBe('empty');
     expect(model.output.emptyLabel).toBe('No output');
-    expect(model.hasDetails).toBe(true);
+    expect(model.hasDetails).toBe(false);
     expect(model.sections).toContainEqual({ kind: 'empty', label: 'No output' });
+  });
+
+  it('is expandable once any structured detail exists', () => {
+    const model = buildToolCallViewModel(richTool({ rawInput: { option: 'value' } }));
+
+    expect(model.hasDetails).toBe(true);
   });
 });

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { SessionMessage } from '../../types';
 import type { RichToolItem, ToolStatus } from './acpTranscript';
-import { buildToolCallViewModel } from './toolCallViewModel';
+import {
+  buildToolCallViewModel,
+  summarizeToolCallLocations,
+  type ToolCallLocation,
+} from './toolCallViewModel';
 
 function message(
   overrides: Partial<SessionMessage> & Pick<SessionMessage, 'id' | 'role'>
@@ -238,6 +242,22 @@ describe('buildToolCallViewModel output handling', () => {
     expect(model.sections.some((section) => section.kind === 'raw_output')).toBe(false);
   });
 
+  it('strips wrapping markdown fences from ACP content text', () => {
+    const model = buildToolCallViewModel(
+      richTool({
+        toolKind: 'read',
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: '```\n1952\tasync fn list()\n1953\t{}\n```' },
+          },
+        ],
+      })
+    );
+
+    expect(model.output.primaryText).toBe('1952\tasync fn list()\n1953\t{}');
+  });
+
   it('falls back to legacy tool_result content when ACP output is absent', () => {
     const model = buildToolCallViewModel(
       richTool({
@@ -292,5 +312,57 @@ describe('buildToolCallViewModel output handling', () => {
     const model = buildToolCallViewModel(richTool({ rawInput: { option: 'value' } }));
 
     expect(model.hasDetails).toBe(true);
+  });
+});
+
+describe('summarizeToolCallLocations', () => {
+  function location(overrides: Partial<ToolCallLocation> = {}): ToolCallLocation {
+    const path = overrides.path ?? 'src/a.ts';
+    const line = overrides.line ?? null;
+    const column = overrides.column ?? null;
+    return {
+      path,
+      display: `${path}${line !== null ? `:${line}` : ''}${column !== null ? `:${column}` : ''}`,
+      line,
+      column,
+      ...overrides,
+    };
+  }
+
+  it('folds the target path location into a line suffix instead of a chip', () => {
+    const summary = summarizeToolCallLocations([location({ line: 1952 })], 'src/a.ts');
+
+    expect(summary.pathSuffix).toBe(':1952');
+    expect(summary.chips).toEqual([]);
+  });
+
+  it('includes columns in the folded suffix', () => {
+    const summary = summarizeToolCallLocations([location({ line: 12, column: 4 })], 'src/a.ts');
+
+    expect(summary.pathSuffix).toBe(':12:4');
+  });
+
+  it('collapses extra covered-path locations to line labels and keeps other paths in full', () => {
+    const summary = summarizeToolCallLocations(
+      [location({ line: 12 }), location({ line: 40 }), location({ path: 'src/b.ts', line: 3 })],
+      'src/a.ts'
+    );
+
+    expect(summary.pathSuffix).toBe(':12');
+    expect(summary.chips).toEqual(['Line 40', 'src/b.ts:3']);
+  });
+
+  it('drops covered locations that add no line info', () => {
+    const summary = summarizeToolCallLocations([location()], 'src/a.ts');
+
+    expect(summary.pathSuffix).toBe('');
+    expect(summary.chips).toEqual([]);
+  });
+
+  it('keeps line labels for paths covered elsewhere when no path field is shown', () => {
+    const summary = summarizeToolCallLocations([location({ line: 12 })], null, ['src/a.ts']);
+
+    expect(summary.pathSuffix).toBe('');
+    expect(summary.chips).toEqual(['Line 12']);
   });
 });

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
@@ -35,7 +35,10 @@ export interface ToolCallMetadata {
   toolKind: string | null;
   toolName: string | null;
   input: Record<string, unknown> | null;
+  /** Pretty-printed input JSON. Lazily formatted — read only when expanded. */
   inputText: string;
+  /** Whether {@link inputText} would render anything, without formatting it. */
+  hasInputText: boolean;
   parsedCommands: ParsedToolCommand[];
   command: string | null;
   workingDirectory: string | null;
@@ -51,7 +54,10 @@ export interface ToolCallMetadata {
 export interface ToolCallOutput {
   state: ToolCallOutputState;
   primaryText: string;
+  /** Pretty-printed raw output JSON. Lazily formatted — read only when expanded. */
   rawText: string;
+  /** Whether {@link rawText} would render anything, without formatting it. */
+  hasRawText: boolean;
   errorText: string;
   stdout: string;
   stderr: string;
@@ -151,20 +157,12 @@ const COMMAND_KEYS = ['command', 'cmd', 'script'];
 const CWD_KEYS = ['cwd', 'workingDirectory', 'working_directory', 'workdir'];
 const URL_KEYS = ['url', 'uri', 'href'];
 const METHOD_KEYS = ['method', 'httpMethod', 'http_method'];
-const NETWORK_KEYS = new Set([
-  'body',
-  'headers',
-  'method',
-  'request',
-  'response',
-  'screenshot',
-  'selector',
-  'status',
-  'statusCode',
-  'status_code',
-  'title',
-  'url',
-]);
+// Only strong request/response evidence promotes an unknown tool to the
+// network renderer. Generic keys like `status` or `title` show up on plenty of
+// non-network payloads; classifying those as network routes the card through
+// NetworkToolDetails, which treats the status as a structured response and
+// hides the rest of the raw output.
+const NETWORK_KEYS = new Set([...URL_KEYS, ...METHOD_KEYS, 'request', 'response']);
 
 export function buildToolCallViewModel(
   item: RichToolItem,
@@ -200,12 +198,16 @@ export function extractToolCallMetadata(
   const parsedArgs = parsed ? recordOrNull(parsed.args) : null;
   const rawInput = recordOrNull(item.rawInput);
   const input = rawInput ?? parsedArgs;
-  const inputText =
+  // Formatting input to JSON is costly for large payloads and a collapsed card
+  // never shows it, so keep `inputText` behind a memoized getter and decide
+  // whether to render it from the cheap `hasInputText` flag instead.
+  const inputSource =
     item.rawInput !== undefined && item.rawInput !== null
-      ? formatJson(item.rawInput)
+      ? item.rawInput
       : parsedArgs && Object.keys(parsedArgs).length > 0
-        ? formatJson(parsedArgs)
-        : '';
+        ? parsedArgs
+        : null;
+  let inputTextCache: string | undefined;
   const parsedCommands = [...parsedCommandsFrom(input), ...parsedCommandsFrom(parsedArgs)].filter(
     uniqueParsedCommand
   );
@@ -216,7 +218,10 @@ export function extractToolCallMetadata(
     toolKind: normalizeToken(item.toolKind),
     toolName: parsed?.name ?? null,
     input,
-    inputText,
+    get inputText() {
+      return (inputTextCache ??= formatJson(inputSource));
+    },
+    hasInputText: hasFormattableJson(inputSource),
     parsedCommands,
     command: relativeValue(
       firstString(input, COMMAND_KEYS) ?? firstCommandValue(parsedCommands),
@@ -266,7 +271,12 @@ export function classifyToolCall(
 
 export function extractToolCallOutput(item: RichToolItem): ToolCallOutput {
   const rawRecord = recordOrNull(item.rawOutput);
-  const rawText = formatJson(item.rawOutput);
+  // Pretty-printing the whole raw output is the expensive path a collapsed card
+  // must not pay, and it's discarded outright when structured output exists, so
+  // keep it lazy and gate its section on the cheap `hasRawText` flag.
+  const rawOutput = item.rawOutput;
+  const hasRawText = hasFormattableJson(rawOutput);
+  let rawTextCache: string | undefined;
   // ACP content text is markdown-formatted for display; agents (e.g. goose)
   // wrap file/command output in code fences that a <pre> would show literally.
   const contentText = stripCodeFences(textFromAcpContent(item.content));
@@ -285,13 +295,16 @@ export function extractToolCallOutput(item: RichToolItem): ToolCallOutput {
     stdout ||
     stderr ||
     resultText;
-  const hasAnyOutput = !!(primaryText || rawText || errorText || stdout || stderr);
+  const hasAnyOutput = !!(primaryText || hasRawText || errorText || stdout || stderr);
   const isWaiting = item.status === 'pending' || item.status === 'in_progress';
 
   return {
     state: hasAnyOutput ? 'output' : isWaiting ? 'waiting' : 'empty',
     primaryText,
-    rawText,
+    get rawText() {
+      return (rawTextCache ??= formatJson(rawOutput));
+    },
+    hasRawText,
     errorText,
     stdout,
     stderr,
@@ -311,8 +324,16 @@ export function buildToolCallSections(
     sections.push({ kind: 'locations', locations: metadata.locations });
   }
 
-  if (metadata.inputText) {
-    sections.push({ kind: 'input', label: 'Input', text: metadata.inputText });
+  if (metadata.hasInputText) {
+    // `text` defers to the metadata's memoized getter so the caret-driven
+    // `hasDetails` check (which only reads `kind`) never triggers formatting.
+    sections.push({
+      kind: 'input',
+      label: 'Input',
+      get text() {
+        return metadata.inputText;
+      },
+    });
   }
 
   for (const diff of metadata.diffs) {
@@ -376,8 +397,14 @@ export function buildToolCallSections(
 
   // Raw JSON is a fallback for output we could not render structurally,
   // never a companion to structured output sections.
-  if (output.rawText && !hasStructuredOutput) {
-    sections.push({ kind: 'raw_output', label: 'Raw output', text: output.rawText });
+  if (output.hasRawText && !hasStructuredOutput) {
+    sections.push({
+      kind: 'raw_output',
+      label: 'Raw output',
+      get text() {
+        return output.rawText;
+      },
+    });
   }
 
   if (output.emptyLabel) {
@@ -640,6 +667,13 @@ function valueText(value: unknown): string {
   if (typeof value === 'string') return value;
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
   return formatJson(value);
+}
+
+/** Mirrors when {@link formatJson} yields a non-empty string, without formatting. */
+function hasFormattableJson(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.length > 0;
+  return true;
 }
 
 function extractErrorText(rawOutput: Record<string, unknown> | null, status: ToolStatus): string {

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
@@ -59,12 +59,20 @@ export interface ToolCallOutput {
   emptyLabel: 'Waiting for output' | 'No output' | null;
 }
 
+export type ToolCallOutputSource = 'error' | 'stdout' | 'stderr' | 'primary';
+
 export type ToolCallSection =
   | { kind: 'locations'; locations: ToolCallLocation[] }
   | { kind: 'input'; label: 'Input'; text: string }
   | { kind: 'diff'; diff: ToolCallDiff }
   | { kind: 'terminal_refs'; label: 'Terminal'; refs: string[] }
-  | { kind: 'output'; label: string; text: string; tone: 'normal' | 'danger' | 'cancelled' }
+  | {
+      kind: 'output';
+      source: ToolCallOutputSource;
+      label: string;
+      text: string;
+      tone: 'normal' | 'danger' | 'cancelled';
+    }
   | { kind: 'raw_output'; label: 'Raw output'; text: string }
   | { kind: 'empty'; label: 'Waiting for output' | 'No output' }
   | {
@@ -178,7 +186,9 @@ export function buildToolCallViewModel(
     metadata,
     output,
     sections,
-    hasDetails: sections.length > 0,
+    // Status and empty-state rows only echo what the collapsed header already
+    // shows, so they alone don't make a card worth expanding.
+    hasDetails: sections.some((section) => section.kind !== 'status' && section.kind !== 'empty'),
   };
 }
 
@@ -316,6 +326,7 @@ export function buildToolCallSections(
   if (output.errorText) {
     sections.push({
       kind: 'output',
+      source: 'error',
       label: 'Error',
       text: output.errorText,
       tone: 'danger',
@@ -326,6 +337,7 @@ export function buildToolCallSections(
   if (output.stdout) {
     sections.push({
       kind: 'output',
+      source: 'stdout',
       label: 'Stdout',
       text: output.stdout,
       tone: outputTone,
@@ -336,6 +348,7 @@ export function buildToolCallSections(
   if (output.stderr && output.stderr !== output.errorText) {
     sections.push({
       kind: 'output',
+      source: 'stderr',
       label: 'Stderr',
       text: output.stderr,
       tone: item.status === 'failed' ? 'danger' : outputTone,
@@ -351,6 +364,7 @@ export function buildToolCallSections(
   ) {
     sections.push({
       kind: 'output',
+      source: 'primary',
       label: 'Output',
       text: output.primaryText,
       tone: outputTone,

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
@@ -1,0 +1,607 @@
+import type { DisplayRootInput } from './pathDisplayRoots';
+import type { RichToolItem, ToolStatus } from './acpTranscript';
+import { formatJson, terminalRefsFromAcpContent, textFromAcpContent } from './acpTranscript';
+import { makePathsRelative, parseToolCall, stripCodeFences } from './sessionModalHelpers';
+
+export type ToolCallCategory = 'edit' | 'command' | 'read' | 'search' | 'network' | 'generic';
+
+export type ToolCallOutputState = 'output' | 'waiting' | 'empty';
+
+export type ToolCallDiffKind = 'created' | 'deleted' | 'modified' | 'unchanged';
+
+export interface ToolCallDiff {
+  path: string;
+  oldText: string | null;
+  newText: string | null;
+  kind: ToolCallDiffKind;
+}
+
+export interface ToolCallLocation {
+  path: string;
+  display: string;
+  line: number | null;
+  column: number | null;
+}
+
+export interface ParsedToolCommand {
+  type: string | null;
+  cmd: string | null;
+  path: string | null;
+  query: string | null;
+  name: string | null;
+}
+
+export interface ToolCallMetadata {
+  toolKind: string | null;
+  toolName: string | null;
+  input: Record<string, unknown> | null;
+  inputText: string;
+  parsedCommands: ParsedToolCommand[];
+  command: string | null;
+  workingDirectory: string | null;
+  targetPath: string | null;
+  query: string | null;
+  url: string | null;
+  method: string | null;
+  locations: ToolCallLocation[];
+  diffs: ToolCallDiff[];
+  terminalRefs: string[];
+}
+
+export interface ToolCallOutput {
+  state: ToolCallOutputState;
+  primaryText: string;
+  rawText: string;
+  errorText: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  emptyLabel: 'Waiting for output' | 'No output' | null;
+}
+
+export type ToolCallSection =
+  | { kind: 'locations'; locations: ToolCallLocation[] }
+  | { kind: 'input'; label: 'Input'; text: string }
+  | { kind: 'diff'; diff: ToolCallDiff }
+  | { kind: 'terminal_refs'; label: 'Terminal'; refs: string[] }
+  | { kind: 'output'; label: string; text: string; tone: 'normal' | 'danger' | 'cancelled' }
+  | { kind: 'raw_output'; label: 'Raw output'; text: string }
+  | { kind: 'empty'; label: 'Waiting for output' | 'No output' }
+  | {
+      kind: 'status';
+      label: string;
+      status: ToolStatus;
+      tone: RichToolItem['statusTone'];
+    };
+
+export interface ToolCallViewModel {
+  key: string;
+  category: ToolCallCategory;
+  verb: string;
+  detail: string;
+  status: ToolStatus;
+  statusLabel: string;
+  statusTone: RichToolItem['statusTone'];
+  metadata: ToolCallMetadata;
+  output: ToolCallOutput;
+  sections: ToolCallSection[];
+  hasDetails: boolean;
+}
+
+const EDIT_KINDS = new Set([
+  'applypatch',
+  'apply_patch',
+  'delete',
+  'edit',
+  'editfile',
+  'editnotebook',
+  'multi_edit',
+  'multiedit',
+  'patch',
+  'replace',
+  'strreplace',
+  'str_replace',
+  'update',
+  'write',
+  'writefile',
+]);
+
+const COMMAND_KINDS = new Set([
+  'bash',
+  'cmd',
+  'command',
+  'exec',
+  'execute',
+  'run',
+  'shell',
+  'terminal',
+]);
+
+const READ_KINDS = new Set(['cat', 'load', 'open', 'read', 'readfile', 'view']);
+
+const SEARCH_KINDS = new Set([
+  'find',
+  'glob',
+  'grep',
+  'list',
+  'ls',
+  'rg',
+  'search',
+  'semanticsearch',
+]);
+
+const NETWORK_KINDS = new Set(['browser', 'curl', 'fetch', 'http', 'network', 'request', 'web']);
+
+const READ_VERBS = new Set(['Read', 'Reading']);
+const SEARCH_VERBS = new Set(['Searched', 'Searching', 'Listed', 'Listing']);
+const EDIT_VERBS = new Set(['Deleted', 'Deleting', 'Edited', 'Editing', 'Wrote', 'Writing']);
+const COMMAND_VERBS = new Set(['Ran', 'Running']);
+
+const PATH_KEYS = ['file_path', 'filePath', 'path', 'filepath', 'filename', 'file'];
+const QUERY_KEYS = ['query', 'pattern', 'glob', 'selector'];
+const COMMAND_KEYS = ['command', 'cmd', 'script'];
+const CWD_KEYS = ['cwd', 'workingDirectory', 'working_directory', 'workdir'];
+const URL_KEYS = ['url', 'uri', 'href'];
+const METHOD_KEYS = ['method', 'httpMethod', 'http_method'];
+const NETWORK_KEYS = new Set([
+  'body',
+  'headers',
+  'method',
+  'request',
+  'response',
+  'screenshot',
+  'selector',
+  'status',
+  'statusCode',
+  'status_code',
+  'title',
+  'url',
+]);
+
+export function buildToolCallViewModel(
+  item: RichToolItem,
+  displayRoots?: DisplayRootInput
+): ToolCallViewModel {
+  const metadata = extractToolCallMetadata(item, displayRoots);
+  const category = classifyToolCall(item, metadata);
+  const output = extractToolCallOutput(item);
+  const sections = buildToolCallSections(item, metadata, output);
+
+  return {
+    key: item.key,
+    category,
+    verb: item.verb,
+    detail: item.detail,
+    status: item.status,
+    statusLabel: item.statusLabel,
+    statusTone: item.statusTone,
+    metadata,
+    output,
+    sections,
+    hasDetails: sections.length > 0,
+  };
+}
+
+export function extractToolCallMetadata(
+  item: RichToolItem,
+  displayRoots?: DisplayRootInput
+): ToolCallMetadata {
+  const parsed = parseToolCall(item.call.content);
+  const parsedArgs = parsed ? recordOrNull(parsed.args) : null;
+  const rawInput = recordOrNull(item.rawInput);
+  const input = rawInput ?? parsedArgs;
+  const inputText =
+    item.rawInput !== undefined && item.rawInput !== null
+      ? formatJson(item.rawInput)
+      : parsedArgs && Object.keys(parsedArgs).length > 0
+        ? formatJson(parsedArgs)
+        : '';
+  const parsedCommands = [...parsedCommandsFrom(input), ...parsedCommandsFrom(parsedArgs)].filter(
+    uniqueParsedCommand
+  );
+  const diffs = extractToolCallDiffs(item.content, displayRoots);
+  const locations = extractToolCallLocations(item.locations, displayRoots);
+
+  return {
+    toolKind: normalizeToken(item.toolKind),
+    toolName: parsed?.name ?? null,
+    input,
+    inputText,
+    parsedCommands,
+    command: relativeValue(
+      firstString(input, COMMAND_KEYS) ?? firstCommandValue(parsedCommands),
+      displayRoots
+    ),
+    workingDirectory: relativeValue(firstString(input, CWD_KEYS), displayRoots),
+    targetPath: relativeValue(
+      firstString(input, PATH_KEYS) ??
+        firstParsedCommandField(parsedCommands, 'path') ??
+        firstParsedCommandField(parsedCommands, 'name') ??
+        diffs[0]?.path ??
+        locations[0]?.path ??
+        null,
+      displayRoots
+    ),
+    query: firstString(input, QUERY_KEYS) ?? firstParsedCommandField(parsedCommands, 'query'),
+    url: firstString(input, URL_KEYS),
+    method: normalizeHttpMethod(firstString(input, METHOD_KEYS)),
+    locations,
+    diffs,
+    terminalRefs: terminalRefsFromAcpContent(item.content),
+  };
+}
+
+export function classifyToolCall(
+  item: RichToolItem,
+  metadata = extractToolCallMetadata(item)
+): ToolCallCategory {
+  const toolKindCategory = categoryFromToken(item.toolKind);
+  if (toolKindCategory) return toolKindCategory;
+
+  const parsedNameCategory = categoryFromTitle(metadata.toolName);
+  if (parsedNameCategory) return parsedNameCategory;
+
+  const parsedCommandCategory = categoryFromParsedCommands(metadata.parsedCommands);
+  if (parsedCommandCategory) return parsedCommandCategory;
+
+  const verbCategory = categoryFromVerb(item.verb);
+  if (verbCategory) return verbCategory;
+
+  if (metadata.diffs.length > 0) return 'edit';
+  if (metadata.terminalRefs.length > 0) return 'command';
+  if (hasNetworkMetadata(metadata.input) || hasNetworkMetadata(item.rawOutput)) return 'network';
+
+  return 'generic';
+}
+
+export function extractToolCallOutput(item: RichToolItem): ToolCallOutput {
+  const rawRecord = recordOrNull(item.rawOutput);
+  const rawText = formatJson(item.rawOutput);
+  const contentText = textFromAcpContent(item.content);
+  const errorText = extractErrorText(rawRecord, item.status);
+  const stdout = valueText(firstValue(rawRecord, ['stdout', 'standardOutput', 'standard_output']));
+  const stderr = valueText(firstValue(rawRecord, ['stderr', 'standardError', 'standard_error']));
+  const exitCode = firstNumber(rawRecord, ['exitCode', 'exit_code', 'code']);
+  const structuredOutput = valueText(
+    firstValue(rawRecord, ['output', 'text', 'body', 'response', 'content', 'result'])
+  );
+  const resultText = item.result?.content ? stripCodeFences(item.result.content) : '';
+  const primaryText =
+    contentText ||
+    (typeof item.rawOutput === 'string' ? item.rawOutput : '') ||
+    structuredOutput ||
+    stdout ||
+    stderr ||
+    resultText;
+  const hasAnyOutput = !!(primaryText || rawText || errorText || stdout || stderr);
+  const isWaiting = item.status === 'pending' || item.status === 'in_progress';
+
+  return {
+    state: hasAnyOutput ? 'output' : isWaiting ? 'waiting' : 'empty',
+    primaryText,
+    rawText,
+    errorText,
+    stdout,
+    stderr,
+    exitCode,
+    emptyLabel: hasAnyOutput ? null : isWaiting ? 'Waiting for output' : 'No output',
+  };
+}
+
+export function buildToolCallSections(
+  item: Pick<RichToolItem, 'status' | 'statusLabel' | 'statusTone'>,
+  metadata: ToolCallMetadata,
+  output: ToolCallOutput
+): ToolCallSection[] {
+  const sections: ToolCallSection[] = [];
+
+  if (metadata.locations.length > 0) {
+    sections.push({ kind: 'locations', locations: metadata.locations });
+  }
+
+  if (metadata.inputText) {
+    sections.push({ kind: 'input', label: 'Input', text: metadata.inputText });
+  }
+
+  for (const diff of metadata.diffs) {
+    sections.push({ kind: 'diff', diff });
+  }
+
+  if (metadata.terminalRefs.length > 0) {
+    sections.push({ kind: 'terminal_refs', label: 'Terminal', refs: metadata.terminalRefs });
+  }
+
+  const emittedOutputTexts = new Set<string>();
+  const outputTone = item.status === 'cancelled' ? 'cancelled' : 'normal';
+  if (output.errorText) {
+    sections.push({
+      kind: 'output',
+      label: 'Error',
+      text: output.errorText,
+      tone: 'danger',
+    });
+    emittedOutputTexts.add(output.errorText);
+  }
+
+  if (output.stdout) {
+    sections.push({
+      kind: 'output',
+      label: 'Stdout',
+      text: output.stdout,
+      tone: outputTone,
+    });
+    emittedOutputTexts.add(output.stdout);
+  }
+
+  if (output.stderr && output.stderr !== output.errorText) {
+    sections.push({
+      kind: 'output',
+      label: 'Stderr',
+      text: output.stderr,
+      tone: item.status === 'failed' ? 'danger' : outputTone,
+    });
+    emittedOutputTexts.add(output.stderr);
+  }
+
+  if (
+    output.primaryText &&
+    output.primaryText !== output.errorText &&
+    output.primaryText !== output.stdout &&
+    output.primaryText !== output.stderr
+  ) {
+    sections.push({
+      kind: 'output',
+      label: 'Output',
+      text: output.primaryText,
+      tone: outputTone,
+    });
+    emittedOutputTexts.add(output.primaryText);
+  }
+
+  if (output.rawText && !emittedOutputTexts.has(output.rawText)) {
+    sections.push({ kind: 'raw_output', label: 'Raw output', text: output.rawText });
+  }
+
+  if (output.emptyLabel) {
+    sections.push({ kind: 'empty', label: output.emptyLabel });
+  }
+
+  sections.push({
+    kind: 'status',
+    label: item.statusLabel,
+    status: item.status,
+    tone: item.statusTone,
+  });
+
+  return sections;
+}
+
+export function extractToolCallDiffs(
+  content: unknown,
+  displayRoots?: DisplayRootInput
+): ToolCallDiff[] {
+  if (!Array.isArray(content)) return [];
+
+  const diffs: ToolCallDiff[] = [];
+  for (const block of content) {
+    if (stringProp(block, 'type') !== 'diff') continue;
+    const path = stringProp(block, 'path');
+    if (!path) continue;
+
+    const oldText = nullableStringProp(block, 'oldText');
+    const newText = nullableStringProp(block, 'newText');
+    if (oldText === null && newText === null) continue;
+
+    diffs.push({
+      path: makePathsRelative(path, displayRoots),
+      oldText,
+      newText,
+      kind: diffKind(oldText, newText),
+    });
+  }
+
+  return diffs;
+}
+
+export function extractToolCallLocations(
+  locations: unknown,
+  displayRoots?: DisplayRootInput
+): ToolCallLocation[] {
+  if (!Array.isArray(locations)) return [];
+
+  return locations
+    .map((location) => {
+      const path = stringProp(location, 'path');
+      if (!path) return null;
+      const displayPath = makePathsRelative(path, displayRoots);
+      const line = numberProp(location, 'line');
+      const column = numberProp(location, 'column');
+      const suffix = `${line !== null ? `:${line}` : ''}${column !== null ? `:${column}` : ''}`;
+      return {
+        path: displayPath,
+        display: `${displayPath}${suffix}`,
+        line,
+        column,
+      };
+    })
+    .filter((location): location is ToolCallLocation => location !== null);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function stringProp(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null;
+  const prop = value[key];
+  return typeof prop === 'string' ? prop : null;
+}
+
+function nullableStringProp(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null;
+  const prop = value[key];
+  return typeof prop === 'string' ? prop : null;
+}
+
+function numberProp(value: unknown, key: string): number | null {
+  if (!isRecord(value)) return null;
+  const prop = value[key];
+  return typeof prop === 'number' && Number.isFinite(prop) ? prop : null;
+}
+
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+function normalizeToken(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return value.trim().toLowerCase();
+}
+
+function compactToken(value: string | null | undefined): string | null {
+  const normalized = normalizeToken(value);
+  return normalized ? normalized.replace(/[^a-z0-9]/g, '') : null;
+}
+
+function categoryFromToken(value: string | null | undefined): ToolCallCategory | null {
+  const normalized = normalizeToken(value);
+  const compact = compactToken(value);
+  if (!normalized || !compact) return null;
+
+  if (EDIT_KINDS.has(normalized) || EDIT_KINDS.has(compact)) return 'edit';
+  if (COMMAND_KINDS.has(normalized) || COMMAND_KINDS.has(compact)) return 'command';
+  if (READ_KINDS.has(normalized) || READ_KINDS.has(compact)) return 'read';
+  if (SEARCH_KINDS.has(normalized) || SEARCH_KINDS.has(compact)) return 'search';
+  if (NETWORK_KINDS.has(normalized) || NETWORK_KINDS.has(compact)) return 'network';
+
+  return null;
+}
+
+function categoryFromTitle(title: string | null): ToolCallCategory | null {
+  if (!title) return null;
+  const firstWord = title.trim().split(/\s+/, 1)[0];
+  return categoryFromToken(title) ?? categoryFromToken(firstWord);
+}
+
+function categoryFromParsedCommands(commands: ParsedToolCommand[]): ToolCallCategory | null {
+  for (const command of commands) {
+    const typeCategory = categoryFromToken(command.type);
+    if (typeCategory) return typeCategory;
+    if (command.cmd) return 'command';
+  }
+  return null;
+}
+
+function categoryFromVerb(verb: string): ToolCallCategory | null {
+  if (EDIT_VERBS.has(verb)) return 'edit';
+  if (COMMAND_VERBS.has(verb)) return 'command';
+  if (READ_VERBS.has(verb)) return 'read';
+  if (SEARCH_VERBS.has(verb)) return 'search';
+  return null;
+}
+
+function parsedCommandsFrom(input: Record<string, unknown> | null): ParsedToolCommand[] {
+  const parsedCmd = input?.parsed_cmd ?? input?.parsedCmd;
+  if (!Array.isArray(parsedCmd)) return [];
+
+  return parsedCmd.filter(isRecord).map((command) => ({
+    type: stringProp(command, 'type'),
+    cmd: stringProp(command, 'cmd') ?? stringProp(command, 'command'),
+    path: stringProp(command, 'path'),
+    query: stringProp(command, 'query'),
+    name: stringProp(command, 'name'),
+  }));
+}
+
+function uniqueParsedCommand(
+  command: ParsedToolCommand,
+  index: number,
+  commands: ParsedToolCommand[]
+): boolean {
+  return (
+    commands.findIndex(
+      (candidate) =>
+        candidate.type === command.type &&
+        candidate.cmd === command.cmd &&
+        candidate.path === command.path &&
+        candidate.query === command.query &&
+        candidate.name === command.name
+    ) === index
+  );
+}
+
+function firstString(input: Record<string, unknown> | null, keys: string[]): string | null {
+  if (!input) return null;
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function firstParsedCommandField(
+  commands: ParsedToolCommand[],
+  field: keyof ParsedToolCommand
+): string | null {
+  for (const command of commands) {
+    const value = command[field];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function firstCommandValue(commands: ParsedToolCommand[]): string | null {
+  return firstParsedCommandField(commands, 'cmd');
+}
+
+function firstValue(input: Record<string, unknown> | null, keys: string[]): unknown {
+  if (!input) return undefined;
+  for (const key of keys) {
+    if (input[key] !== undefined && input[key] !== null) return input[key];
+  }
+  return undefined;
+}
+
+function firstNumber(input: Record<string, unknown> | null, keys: string[]): number | null {
+  if (!input) return null;
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function valueText(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return formatJson(value);
+}
+
+function extractErrorText(rawOutput: Record<string, unknown> | null, status: ToolStatus): string {
+  const error = firstValue(rawOutput, ['error', 'errorMessage', 'error_message']);
+  if (error !== undefined && error !== null) return valueText(error);
+
+  if (status !== 'failed') return '';
+  const stderr = valueText(firstValue(rawOutput, ['stderr', 'standardError', 'standard_error']));
+  return stderr;
+}
+
+function normalizeHttpMethod(method: string | null): string | null {
+  return method ? method.toUpperCase() : null;
+}
+
+function relativeValue(value: string | null, displayRoots?: DisplayRootInput): string | null {
+  return value ? makePathsRelative(value, displayRoots) : null;
+}
+
+function hasNetworkMetadata(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return Object.keys(value).some((key) => NETWORK_KEYS.has(key));
+}
+
+function diffKind(oldText: string | null, newText: string | null): ToolCallDiffKind {
+  if (oldText === null) return 'created';
+  if (newText === null) return 'deleted';
+  return oldText === newText ? 'unchanged' : 'modified';
+}

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
@@ -311,7 +311,7 @@ export function buildToolCallSections(
     sections.push({ kind: 'terminal_refs', label: 'Terminal', refs: metadata.terminalRefs });
   }
 
-  const emittedOutputTexts = new Set<string>();
+  let hasStructuredOutput = false;
   const outputTone = item.status === 'cancelled' ? 'cancelled' : 'normal';
   if (output.errorText) {
     sections.push({
@@ -320,7 +320,7 @@ export function buildToolCallSections(
       text: output.errorText,
       tone: 'danger',
     });
-    emittedOutputTexts.add(output.errorText);
+    hasStructuredOutput = true;
   }
 
   if (output.stdout) {
@@ -330,7 +330,7 @@ export function buildToolCallSections(
       text: output.stdout,
       tone: outputTone,
     });
-    emittedOutputTexts.add(output.stdout);
+    hasStructuredOutput = true;
   }
 
   if (output.stderr && output.stderr !== output.errorText) {
@@ -340,7 +340,7 @@ export function buildToolCallSections(
       text: output.stderr,
       tone: item.status === 'failed' ? 'danger' : outputTone,
     });
-    emittedOutputTexts.add(output.stderr);
+    hasStructuredOutput = true;
   }
 
   if (
@@ -355,10 +355,12 @@ export function buildToolCallSections(
       text: output.primaryText,
       tone: outputTone,
     });
-    emittedOutputTexts.add(output.primaryText);
+    hasStructuredOutput = true;
   }
 
-  if (output.rawText && !emittedOutputTexts.has(output.rawText)) {
+  // Raw JSON is a fallback for output we could not render structurally,
+  // never a companion to structured output sections.
+  if (output.rawText && !hasStructuredOutput) {
     sections.push({ kind: 'raw_output', label: 'Raw output', text: output.rawText });
   }
 

--- a/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
+++ b/apps/staged/src/lib/features/sessions/toolCallViewModel.ts
@@ -267,7 +267,9 @@ export function classifyToolCall(
 export function extractToolCallOutput(item: RichToolItem): ToolCallOutput {
   const rawRecord = recordOrNull(item.rawOutput);
   const rawText = formatJson(item.rawOutput);
-  const contentText = textFromAcpContent(item.content);
+  // ACP content text is markdown-formatted for display; agents (e.g. goose)
+  // wrap file/command output in code fences that a <pre> would show literally.
+  const contentText = stripCodeFences(textFromAcpContent(item.content));
   const errorText = extractErrorText(rawRecord, item.status);
   const stdout = valueText(firstValue(rawRecord, ['stdout', 'standardOutput', 'standard_output']));
   const stderr = valueText(firstValue(rawRecord, ['stderr', 'standardError', 'standard_error']));
@@ -441,6 +443,52 @@ export function extractToolCallLocations(
       };
     })
     .filter((location): location is ToolCallLocation => location !== null);
+}
+
+export interface ToolCallLocationSummary {
+  /** ":line[:column]" from the first location matching the Path field's path. */
+  pathSuffix: string;
+  /** Labels for the remaining locations the card doesn't already name. */
+  chips: string[];
+}
+
+/**
+ * Fold locations into a card's Path field and chips without repeating paths
+ * the card already names. The first location matching `pathFieldPath` becomes
+ * a ":line" suffix on the Path field; the rest become chips — full
+ * "path:line" displays for new paths, bare "Line N" labels for covered paths,
+ * and dropped entirely when they add no line info.
+ */
+export function summarizeToolCallLocations(
+  locations: ToolCallLocation[],
+  pathFieldPath: string | null,
+  coveredPaths: Array<string | null> = []
+): ToolCallLocationSummary {
+  const covered = new Set<string>();
+  for (const path of [pathFieldPath, ...coveredPaths]) {
+    if (path) covered.add(path);
+  }
+
+  const suffixIndex = pathFieldPath
+    ? locations.findIndex((location) => location.path === pathFieldPath && location.line !== null)
+    : -1;
+
+  const chips = locations.flatMap((location, index) => {
+    if (index === suffixIndex) return [];
+    if (!covered.has(location.path)) return [location.display];
+    if (location.line === null) return [];
+    return [`Line ${location.line}${location.column !== null ? `:${location.column}` : ''}`];
+  });
+
+  return {
+    pathSuffix: suffixIndex >= 0 ? locationLineSuffix(locations[suffixIndex]) : '',
+    chips,
+  };
+}
+
+function locationLineSuffix(location: ToolCallLocation): string {
+  if (location.line === null) return '';
+  return `:${location.line}${location.column !== null ? `:${location.column}` : ''}`;
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

Replaces the generic expanded tool call rendering in the session chat pane with a typed view model and per-type detail components.

- **Tool call view model** (`toolCallViewModel.ts`): classifies ACP tool calls (edit, command, read/search, network, generic) and projects each into structured sections — fields, diffs, output blocks, locations, status — so rendering logic lives in one tested place instead of the chat pane template.
- **Per-type detail components** (`tool-calls/`): dedicated Svelte renderers dispatched from the view model — `EditToolDetails`, `CommandToolDetails`, `ReadSearchToolDetails`, `NetworkToolDetails`, and a `GenericToolDetails` fallback — plus shared `ToolCallCard`/`ToolCallHeader`/`ToolStatusDot`/`OutputSections` building blocks. `SessionChatPane.svelte` shrinks by ~370 lines.
- **Inline diffs** (`InlineToolDiff.svelte`, `inlineDiffRows.ts`): diff header with file path, created/deleted badge, and add/remove counts; long unchanged runs collapse behind an expandable "N unchanged lines" row; char-level highlights render from segments (no `{@html}`).
- **Raw output as fallback only**: raw JSON renders only when no structured blocks (error, stdout, stderr, output, network response) could be extracted.
- **Polish passes**: command output flows terminal-style beside the `$` gutter with a hanging indent; redundant labels dropped (no "Succeeded" footer, no "Output"/"Content" label on the primary block); paths no longer repeated across fields, location chips, and diff headers; markdown fences stripped from read content; search match paths made workspace-relative.
- **Cleanup**: dead `acpTranscript.ts` exports superseded by the view model are deleted.

## Testing

- New unit tests for the view model (`toolCallViewModel.test.ts`) and diff row building (`inlineDiffRows.test.ts`), including a regression test for modified pairs straddling an LCS anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)