### PR TITLE
feat(staged): use ACP session titles for interim and fallback session names

### DIFF
--- a/apps/staged/src-tauri/src/agent/writer.rs
+++ b/apps/staged/src-tauri/src/agent/writer.rs
@@ -22,6 +22,7 @@ use acp_client::{
     autoapprove_permission_decision, strip_code_fences, AcpEventMetadata, AcpInitializeMetadata,
     AcpPermissionDecision, AcpPermissionRequest, AcpToolCallMetadata,
 };
+use agent_client_protocol::schema::MaybeUndefined;
 
 /// Minimum interval between DB flushes for streaming text. Chunks accumulate
 /// in memory and are written at most this often, reducing mutex contention
@@ -317,6 +318,31 @@ impl acp_client::MessageWriter for MessageWriter {
         {
             log::error!("Failed to persist ACP session info update: {e}");
         }
+
+        // Mirror the agent-provided title onto the session row so it can be
+        // shown as an interim session name while the session runs.
+        match &info.title {
+            MaybeUndefined::Value(title) => {
+                let title = sanitize_title(title);
+                let title = title.trim();
+                if !title.is_empty() {
+                    if let Err(e) = self
+                        .store
+                        .update_session_acp_title(&self.session_id, Some(title))
+                    {
+                        log::error!("Failed to persist ACP session title: {e}");
+                    }
+                }
+            }
+            // The agent explicitly retracted the title.
+            MaybeUndefined::Null => {
+                if let Err(e) = self.store.update_session_acp_title(&self.session_id, None) {
+                    log::error!("Failed to clear ACP session title: {e}");
+                }
+            }
+            // Update was about `updated_at`/meta only — leave the title alone.
+            MaybeUndefined::Undefined => {}
+        }
     }
 
     async fn on_model_state_update(&self, state: &acp_client::SessionModelState) {
@@ -425,6 +451,7 @@ mod tests {
     use acp_client::{
         AcpPermissionDecision, AcpPermissionOption, AcpPermissionOptionKind, AcpPermissionRequest,
     };
+    use agent_client_protocol::schema::MaybeUndefined;
     use tokio_util::sync::CancellationToken;
 
     fn setup_writer() -> (Arc<Store>, String, MessageWriter) {
@@ -754,5 +781,68 @@ mod tests {
             metadata_rows[0].acp.acp_usage.as_ref().unwrap()["outputTokens"],
             7
         );
+    }
+
+    #[tokio::test]
+    async fn session_info_update_title_value_sets_session_acp_title() {
+        let (store, session_id, writer) = setup_writer();
+
+        let info = acp_client::SessionInfoUpdate::new().title("  `Fix the login flow`  ");
+        <MessageWriter as acp_client::MessageWriter>::on_session_info_update(&writer, &info).await;
+
+        let session = store.get_session(&session_id).unwrap().unwrap();
+        assert_eq!(session.acp_title.as_deref(), Some("Fix the login flow"));
+
+        // The metadata-row archive of the raw update is unchanged behavior.
+        let metadata_rows = store
+            .get_session_acp_metadata_messages(&session_id)
+            .unwrap();
+        assert_eq!(metadata_rows.len(), 1);
+        assert_eq!(
+            metadata_rows[0].acp.acp_event_kind.as_deref(),
+            Some("session_info_update")
+        );
+    }
+
+    #[tokio::test]
+    async fn session_info_update_null_title_clears_session_acp_title() {
+        let (store, session_id, writer) = setup_writer();
+        store
+            .update_session_acp_title(&session_id, Some("Earlier title"))
+            .unwrap();
+
+        let info = acp_client::SessionInfoUpdate::new().title(MaybeUndefined::Null);
+        <MessageWriter as acp_client::MessageWriter>::on_session_info_update(&writer, &info).await;
+
+        let session = store.get_session(&session_id).unwrap().unwrap();
+        assert_eq!(session.acp_title, None);
+    }
+
+    #[tokio::test]
+    async fn session_info_update_undefined_title_preserves_session_acp_title() {
+        let (store, session_id, writer) = setup_writer();
+        store
+            .update_session_acp_title(&session_id, Some("Earlier title"))
+            .unwrap();
+
+        let info = acp_client::SessionInfoUpdate::new().updated_at("2026-08-04T00:00:00Z");
+        <MessageWriter as acp_client::MessageWriter>::on_session_info_update(&writer, &info).await;
+
+        let session = store.get_session(&session_id).unwrap().unwrap();
+        assert_eq!(session.acp_title.as_deref(), Some("Earlier title"));
+    }
+
+    #[tokio::test]
+    async fn session_info_update_blank_title_value_preserves_session_acp_title() {
+        let (store, session_id, writer) = setup_writer();
+        store
+            .update_session_acp_title(&session_id, Some("Earlier title"))
+            .unwrap();
+
+        let info = acp_client::SessionInfoUpdate::new().title("  ``  ");
+        <MessageWriter as acp_client::MessageWriter>::on_session_info_update(&writer, &info).await;
+
+        let session = store.get_session(&session_id).unwrap().unwrap();
+        assert_eq!(session.acp_title.as_deref(), Some("Earlier title"));
     }
 }

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -2527,16 +2527,25 @@ fn run_post_completion_hooks(
             if review.title.is_none() {
                 // Fall back to the ACP-provided session title when no
                 // review-title block is found.
-                let title = extract_review_title(&full_text).or_else(|| {
-                    store
-                        .get_session(session_id)
-                        .ok()
-                        .flatten()
-                        .as_ref()
-                        .and_then(non_empty_acp_title)
-                });
+                let title = match extract_review_title(&full_text) {
+                    Some(title) => {
+                        log::info!("Session {session_id}: extracted review title: {title}");
+                        Some(title)
+                    }
+                    None => {
+                        let acp_title = store
+                            .get_session(session_id)
+                            .ok()
+                            .flatten()
+                            .as_ref()
+                            .and_then(non_empty_acp_title);
+                        if let Some(title) = &acp_title {
+                            log::info!("Session {session_id}: no review-title block found; using ACP session title as review title: {title}");
+                        }
+                        acp_title
+                    }
+                };
                 if let Some(title) = title {
-                    log::info!("Session {session_id}: extracted review title: {title}");
                     if let Err(e) = store.update_review_title(&review.id, &title) {
                         log::error!("Failed to update review title: {e}");
                     }

--- a/apps/staged/src-tauri/src/session_runner.rs
+++ b/apps/staged/src-tauri/src/session_runner.rs
@@ -2525,7 +2525,17 @@ fn run_post_completion_hooks(
 
             // Extract and save review title (always attempt, even if comments exist)
             if review.title.is_none() {
-                if let Some(title) = extract_review_title(&full_text) {
+                // Fall back to the ACP-provided session title when no
+                // review-title block is found.
+                let title = extract_review_title(&full_text).or_else(|| {
+                    store
+                        .get_session(session_id)
+                        .ok()
+                        .flatten()
+                        .as_ref()
+                        .and_then(non_empty_acp_title)
+                });
+                if let Some(title) = title {
                     log::info!("Session {session_id}: extracted review title: {title}");
                     if let Err(e) = store.update_review_title(&review.id, &title) {
                         log::error!("Failed to update review title: {e}");
@@ -2797,8 +2807,22 @@ fn extract_note_title(content: &str) -> (String, String) {
     }
 }
 
-/// Parse note content into a final `(title, body)` pair, using the session
-/// prompt as a fallback title when the note has no H1 heading.
+/// The session's ACP-provided title, trimmed, when set and non-empty.
+///
+/// Used as an end-of-session fallback name when the session produced no
+/// better title (note without an H1, review without a review-title block).
+fn non_empty_acp_title(session: &crate::store::Session) -> Option<String> {
+    session
+        .acp_title
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+}
+
+/// Parse note content into a final `(title, body)` pair. When the note has
+/// no H1 heading, fall back to the ACP-provided session title, then the
+/// session prompt.
 ///
 /// Shared by both repo-note and project-note extraction paths.
 fn resolve_note_title_and_body(
@@ -2807,12 +2831,15 @@ fn resolve_note_title_and_body(
     session_id: &str,
 ) -> (String, String) {
     let (title, body) = extract_note_title(note_content);
-    let final_title = if title.is_empty() {
-        store
-            .get_session(session_id)
-            .ok()
-            .flatten()
-            .map(|s| {
+    if !title.is_empty() {
+        return (title, body);
+    }
+    let session = store.get_session(session_id).ok().flatten();
+    let final_title = session
+        .as_ref()
+        .and_then(non_empty_acp_title)
+        .or_else(|| {
+            session.as_ref().map(|s| {
                 let prompt = strip_action_wrapper(&s.prompt);
                 let t: String = prompt.chars().take(80).collect();
                 if prompt.len() > 80 {
@@ -2821,10 +2848,8 @@ fn resolve_note_title_and_body(
                     t
                 }
             })
-            .unwrap_or_else(|| "Untitled Note".to_string())
-    } else {
-        title
-    };
+        })
+        .unwrap_or_else(|| "Untitled Note".to_string());
     (final_title, body)
 }
 
@@ -3764,6 +3789,135 @@ Solid changes with minor nit
             extract_review_title(text),
             Some("Solid changes with minor nit".to_string())
         );
+    }
+
+    // ── end-of-session ACP title fallbacks ──────────────────────────────
+
+    fn store_with_session(prompt: &str, acp_title: Option<&str>) -> (Arc<Store>, String) {
+        let store = Arc::new(Store::in_memory().unwrap());
+        let mut session = crate::store::Session::new_running(prompt, std::path::Path::new("/tmp"));
+        session.acp_title = acp_title.map(str::to_string);
+        store.create_session(&session).unwrap();
+        (store, session.id)
+    }
+
+    #[test]
+    fn note_title_prefers_h1_over_acp_title() {
+        let (store, session_id) = store_with_session("Write a note", Some("ACP session title"));
+        let (title, body) =
+            resolve_note_title_and_body("# Heading From Note\n\nBody text", &store, &session_id);
+        assert_eq!(title, "Heading From Note");
+        assert_eq!(body, "Body text");
+    }
+
+    #[test]
+    fn note_title_falls_back_to_acp_title_when_no_h1() {
+        let (store, session_id) =
+            store_with_session("Write a note", Some("Investigate flaky login test"));
+        let (title, body) =
+            resolve_note_title_and_body("Body without a heading", &store, &session_id);
+        assert_eq!(title, "Investigate flaky login test");
+        assert_eq!(body, "Body without a heading");
+    }
+
+    #[test]
+    fn note_title_falls_back_to_prompt_without_h1_or_acp_title() {
+        let (store, session_id) = store_with_session("Write a note", None);
+        let (title, _) = resolve_note_title_and_body("Body without a heading", &store, &session_id);
+        assert_eq!(title, "Write a note");
+    }
+
+    #[test]
+    fn note_title_skips_blank_acp_title() {
+        let (store, session_id) = store_with_session("Write a note", Some("   "));
+        let (title, _) = resolve_note_title_and_body("Body without a heading", &store, &session_id);
+        assert_eq!(title, "Write a note");
+    }
+
+    fn create_review_for_session(store: &Store, session_id: &str) -> String {
+        let project = crate::store::Project::new("test-owner/test-repo");
+        store.create_project(&project).unwrap();
+        let branch = crate::store::Branch::new(&project.id, "feature", "main");
+        store.create_branch(&branch).unwrap();
+        let review =
+            crate::store::Review::new(&branch.id, "abc123", crate::store::ReviewScope::Branch)
+                .with_session(session_id);
+        store.create_review(&review).unwrap();
+        review.id
+    }
+
+    #[test]
+    fn review_title_falls_back_to_acp_title_when_no_title_block() {
+        let (store, session_id) =
+            store_with_session("Review this", Some("Solid refactor of the parser"));
+        let review_id = create_review_for_session(&store, &session_id);
+        store
+            .add_session_message(
+                &session_id,
+                MessageRole::Assistant,
+                "Looked at everything; no fenced blocks here.",
+            )
+            .unwrap();
+
+        run_post_completion_hooks(
+            &session_id,
+            std::path::Path::new("/tmp"),
+            None,
+            None,
+            &store,
+        );
+
+        let review = store.get_review(&review_id).unwrap().unwrap();
+        assert_eq!(
+            review.title.as_deref(),
+            Some("Solid refactor of the parser")
+        );
+        assert!(review.completed_at.is_some());
+    }
+
+    #[test]
+    fn review_title_block_wins_over_acp_title() {
+        let (store, session_id) = store_with_session("Review this", Some("ACP session title"));
+        let review_id = create_review_for_session(&store, &session_id);
+        store
+            .add_session_message(
+                &session_id,
+                MessageRole::Assistant,
+                "```review-title\nExtracted block title\n```\n",
+            )
+            .unwrap();
+
+        run_post_completion_hooks(
+            &session_id,
+            std::path::Path::new("/tmp"),
+            None,
+            None,
+            &store,
+        );
+
+        let review = store.get_review(&review_id).unwrap().unwrap();
+        assert_eq!(review.title.as_deref(), Some("Extracted block title"));
+    }
+
+    #[test]
+    fn review_without_title_block_or_acp_title_stays_untitled_but_completes() {
+        let (store, session_id) = store_with_session("Review this", None);
+        let review_id = create_review_for_session(&store, &session_id);
+        store
+            .add_session_message(&session_id, MessageRole::Assistant, "No blocks at all.")
+            .unwrap();
+
+        run_post_completion_hooks(
+            &session_id,
+            std::path::Path::new("/tmp"),
+            None,
+            None,
+            &store,
+        );
+
+        let review = store.get_review(&review_id).unwrap().unwrap();
+        assert_eq!(review.title, None);
+        assert!(review.completed_at.is_some());
     }
 
     // ── extract_review_comments ─────────────────────────────────────────

--- a/apps/staged/src-tauri/src/store/migration_tests.rs
+++ b/apps/staged/src-tauri/src/store/migration_tests.rs
@@ -145,7 +145,7 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         )
         .unwrap();
 
-    assert_eq!(version, 20);
+    assert_eq!(version, 21);
     assert_eq!(app_version, super::APP_VERSION);
     assert!(table_exists(&conn, "projects"));
     assert!(table_exists(&conn, "project_notes"));
@@ -159,6 +159,7 @@ fn test_store_bootstraps_fresh_database_with_baseline_migration() {
         "acp_agent_capabilities"
     ));
     assert!(column_exists(&conn, "sessions", "acp_config_selection"));
+    assert!(column_exists(&conn, "sessions", "acp_title"));
 
     let trigger_count: i64 = conn
         .query_row(
@@ -222,9 +223,10 @@ fn test_store_repairs_github_comment_tracking_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 20);
+    assert_eq!(version, 21);
     assert!(column_exists(&conn, "sessions", "pipeline"));
     assert!(column_exists(&conn, "sessions", "acp_config_selection"));
+    assert!(column_exists(&conn, "sessions", "acp_title"));
     assert!(column_exists(
         &conn,
         "session_messages",
@@ -280,7 +282,7 @@ fn test_store_repairs_pipeline_user_version() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 20);
+    assert_eq!(version, 21);
     assert!(column_exists(&conn, "comments", "github_comment_id"));
     assert!(column_exists(&conn, "comments", "github_comment_type"));
     assert!(column_exists(&conn, "comments", "github_comment_stale"));
@@ -291,6 +293,7 @@ fn test_store_repairs_pipeline_user_version() {
     ));
     assert!(table_exists(&conn, "queued_session_messages"));
     assert!(column_exists(&conn, "sessions", "acp_config_selection"));
+    assert!(column_exists(&conn, "sessions", "acp_title"));
 
     cleanup_db(&path);
 }

--- a/apps/staged/src-tauri/src/store/migrations/0021-add-session-acp-title/up.sql
+++ b/apps/staged/src-tauri/src/store/migrations/0021-add-session-acp-title/up.sql
@@ -1,0 +1,2 @@
+-- Persist the latest ACP-provided session title (session_info_update) for display while running.
+ALTER TABLE sessions ADD COLUMN acp_title TEXT DEFAULT NULL;

--- a/apps/staged/src-tauri/src/store/mod.rs
+++ b/apps/staged/src-tauri/src/store/mod.rs
@@ -194,6 +194,8 @@ pub struct ResolvedSession {
     pub status: Option<String>,
     pub completion_reason: Option<String>,
     pub provider: Option<String>,
+    /// Latest ACP-provided session title, if the agent pushed one.
+    pub acp_title: Option<String>,
 }
 
 // =============================================================================
@@ -246,6 +248,7 @@ impl Store {
                         .as_ref()
                         .and_then(|s| s.completion_reason.as_ref().map(|r| r.as_str().to_string())),
                     provider: session.as_ref().and_then(|s| s.provider.clone()),
+                    acp_title: session.as_ref().and_then(|s| s.acp_title.clone()),
                 }
             }
             None => ResolvedSession::default(),

--- a/apps/staged/src-tauri/src/store/models.rs
+++ b/apps/staged/src-tauri/src/store/models.rs
@@ -527,6 +527,10 @@ pub struct Session {
     /// Selected ACP config values to apply before prompting the agent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acp_config_selection: Option<AcpConfigSelection>,
+    /// Latest session title pushed by the agent via ACP `session_info_update`.
+    /// Used as an interim display name while the session is running.
+    #[serde(default)]
+    pub acp_title: Option<String>,
 }
 
 /// Persistent follow-up message waiting to be sent to an existing session.
@@ -616,6 +620,7 @@ impl Session {
             owner_pid: Some(std::process::id()),
             pipeline: None,
             acp_config_selection: None,
+            acp_title: None,
         }
     }
 
@@ -638,6 +643,7 @@ impl Session {
             owner_pid: None,
             pipeline: None,
             acp_config_selection: None,
+            acp_title: None,
         }
     }
 

--- a/apps/staged/src-tauri/src/store/sessions.rs
+++ b/apps/staged/src-tauri/src/store/sessions.rs
@@ -19,8 +19,8 @@ impl Store {
         let acp_config_selection_json =
             serialize_acp_config_selection(session.acp_config_selection.as_ref())?;
         conn.execute(
-            "INSERT INTO sessions (id, prompt, status, working_dir, provider, agent_id, error_message, completion_reason, created_at, updated_at, owner_pid, pipeline, acp_config_selection)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            "INSERT INTO sessions (id, prompt, status, working_dir, provider, agent_id, error_message, completion_reason, created_at, updated_at, owner_pid, pipeline, acp_config_selection, acp_title)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             params![
                 session.id,
                 session.prompt,
@@ -35,6 +35,7 @@ impl Store {
                 session.owner_pid,
                 pipeline_json,
                 acp_config_selection_json,
+                session.acp_title,
             ],
         )?;
         Ok(())
@@ -43,7 +44,7 @@ impl Store {
     pub fn get_session(&self, id: &str) -> Result<Option<Session>, StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, prompt, status, working_dir, provider, agent_id, error_message, completion_reason, created_at, updated_at, owner_pid, pipeline, acp_config_selection
+            "SELECT id, prompt, status, working_dir, provider, agent_id, error_message, completion_reason, created_at, updated_at, owner_pid, pipeline, acp_config_selection, acp_title
              FROM sessions WHERE id = ?1",
             params![id],
             Self::row_to_session,
@@ -222,7 +223,7 @@ impl Store {
     pub fn get_running_sessions(&self) -> Result<Vec<Session>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, prompt, status, working_dir, provider, agent_id, error_message, completion_reason, created_at, updated_at, owner_pid, pipeline, acp_config_selection
+            "SELECT id, prompt, status, working_dir, provider, agent_id, error_message, completion_reason, created_at, updated_at, owner_pid, pipeline, acp_config_selection, acp_title
              FROM sessions WHERE status = 'running'",
         )?;
         let sessions = stmt
@@ -295,7 +296,7 @@ impl Store {
     ) -> Result<Vec<Session>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT s.id, s.prompt, s.status, s.working_dir, s.provider, s.agent_id, s.error_message, s.completion_reason, s.created_at, s.updated_at, s.owner_pid, s.pipeline, s.acp_config_selection
+            "SELECT s.id, s.prompt, s.status, s.working_dir, s.provider, s.agent_id, s.error_message, s.completion_reason, s.created_at, s.updated_at, s.owner_pid, s.pipeline, s.acp_config_selection, s.acp_title
              FROM sessions s
              WHERE s.status = 'queued'
                AND (
@@ -416,6 +417,22 @@ impl Store {
         Ok(())
     }
 
+    /// Update the ACP-provided session title.
+    ///
+    /// `None` clears the column (the agent explicitly retracted the title).
+    pub fn update_session_acp_title(
+        &self,
+        id: &str,
+        title: Option<&str>,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE sessions SET acp_title = ?1, updated_at = ?2 WHERE id = ?3",
+            params![title, now_timestamp(), id],
+        )?;
+        Ok(())
+    }
+
     /// Update the pipeline execution state for a session.
     pub fn update_session_pipeline(
         &self,
@@ -461,6 +478,7 @@ impl Store {
             owner_pid: row.get(10)?,
             pipeline,
             acp_config_selection,
+            acp_title: row.get(13)?,
         })
     }
 }

--- a/apps/staged/src-tauri/src/store/tests.rs
+++ b/apps/staged/src-tauri/src/store/tests.rs
@@ -640,6 +640,59 @@ fn test_session_acp_config_selection_round_trips() {
 }
 
 #[test]
+fn test_session_acp_title_round_trips() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+
+    let fetched = store.get_session(&session.id).unwrap().unwrap();
+    assert_eq!(fetched.acp_title, None);
+
+    store
+        .update_session_acp_title(&session.id, Some("Refactor the widget pipeline"))
+        .unwrap();
+    let updated = store.get_session(&session.id).unwrap().unwrap();
+    assert_eq!(
+        updated.acp_title.as_deref(),
+        Some("Refactor the widget pipeline")
+    );
+
+    store
+        .update_session_acp_title(&session.id, Some("Refactor and test the widget pipeline"))
+        .unwrap();
+    let replaced = store.get_session(&session.id).unwrap().unwrap();
+    assert_eq!(
+        replaced.acp_title.as_deref(),
+        Some("Refactor and test the widget pipeline")
+    );
+
+    store.update_session_acp_title(&session.id, None).unwrap();
+    let cleared = store.get_session(&session.id).unwrap().unwrap();
+    assert_eq!(cleared.acp_title, None);
+}
+
+#[test]
+fn test_resolve_session_status_exposes_acp_title() {
+    let store = Store::in_memory().unwrap();
+    let session = Session::new_running("work", Path::new("/tmp"));
+    store.create_session(&session).unwrap();
+
+    let resolved = store.resolve_session_status(Some(&session.id));
+    assert_eq!(resolved.acp_title, None);
+
+    store
+        .update_session_acp_title(&session.id, Some("Fix the login flow"))
+        .unwrap();
+    let resolved = store.resolve_session_status(Some(&session.id));
+    assert_eq!(resolved.session_id.as_deref(), Some(session.id.as_str()));
+    assert_eq!(resolved.status.as_deref(), Some("running"));
+    assert_eq!(resolved.acp_title.as_deref(), Some("Fix the login flow"));
+
+    let unresolved = store.resolve_session_status(None);
+    assert_eq!(unresolved.acp_title, None);
+}
+
+#[test]
 fn test_queued_session_acp_config_selection_round_trips() {
     let store = Store::in_memory().unwrap();
     let project = Project::new("test-owner/test-repo");

--- a/apps/staged/src-tauri/src/timeline.rs
+++ b/apps/staged/src-tauri/src/timeline.rs
@@ -10,7 +10,7 @@
 
 use crate::git;
 use crate::session_runner;
-use crate::store::{CommentAuthor, Review, Store};
+use crate::store::{CommentAuthor, ResolvedSession, Review, Store};
 use crate::{
     blox, branches, BranchTimeline, CommitTimelineItem, ImageTimelineItem, NoteTimelineItem,
     ReviewTimelineItem,
@@ -271,6 +271,20 @@ fn map_local_commits(
         .collect()
 }
 
+/// The agent-pushed ACP session title, when set and non-empty.
+///
+/// Applied at read time only, as an interim display name for in-progress
+/// timeline rows — stored artifact names (commit subject, note H1, review
+/// title) always win once the session ends.
+fn non_empty_acp_title(resolved: &ResolvedSession) -> Option<String> {
+    resolved
+        .acp_title
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+}
+
 /// Public wrapper for `build_branch_timeline` for use by the web server.
 pub fn build_branch_timeline_public(
     store: &Arc<Store>,
@@ -419,15 +433,15 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
                 id: Some(dc.id.clone()),
                 sha: String::new(),
                 short_sha: String::new(),
-                subject: resolved
-                    .session_id
-                    .as_deref()
-                    .and_then(|sid| {
-                        store
-                            .get_session(sid)
-                            .ok()
-                            .flatten()
-                            .map(|s| s.prompt.clone())
+                subject: non_empty_acp_title(&resolved)
+                    .or_else(|| {
+                        resolved.session_id.as_deref().and_then(|sid| {
+                            store
+                                .get_session(sid)
+                                .ok()
+                                .flatten()
+                                .map(|s| s.prompt.clone())
+                        })
                     })
                     .unwrap_or_else(|| "Pending commit".to_string()),
                 author: String::new(),
@@ -456,9 +470,18 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         .into_iter()
         .map(|n| {
             let resolved = store.resolve_session_status(n.session_id.as_deref());
+            // While the session runs, the stored title is just the prompt
+            // stub — an agent-pushed ACP title is a better interim name.
+            // Once the session ends the stored title is final (note H1 or
+            // prompt fallback) and always wins.
+            let title = if resolved.status.as_deref() == Some("running") {
+                non_empty_acp_title(&resolved).unwrap_or(n.title)
+            } else {
+                n.title
+            };
             NoteTimelineItem {
                 id: n.id,
-                title: n.title,
+                title,
                 content: n.content,
                 session_id: resolved.session_id,
                 session_status: resolved.status,
@@ -481,6 +504,15 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
         .map(|r| {
             let resolved = store.resolve_session_status(r.session_id.as_deref());
             let comment_count = r.comments.len();
+            // Untitled running reviews would otherwise render a static
+            // placeholder; surface the agent-pushed ACP title instead. A
+            // stored title always wins.
+            let title = match r.title {
+                None if resolved.status.as_deref() == Some("running") => {
+                    non_empty_acp_title(&resolved)
+                }
+                title => title,
+            };
             ReviewTimelineItem {
                 id: r.id,
                 commit_sha: r.commit_sha,
@@ -489,7 +521,7 @@ fn build_branch_timeline(store: &Arc<Store>, branch_id: &str) -> Result<BranchTi
                 session_status: resolved.status,
                 session_provider: resolved.provider,
                 completion_reason: resolved.completion_reason,
-                title: r.title,
+                title,
                 comment_count,
                 is_auto: r.is_auto,
                 created_at: r.created_at,
@@ -1377,7 +1409,9 @@ pub(crate) async fn delete_commit_impl(
 mod tests {
     use super::*;
     use crate::git::Span;
-    use crate::store::models::{Branch, Comment, Project, ReviewScope, Workdir};
+    use crate::store::models::{
+        Branch, Comment, Commit, Note, Project, ReviewScope, Session, SessionStatus, Workdir,
+    };
     use crate::test_utils::TempGitRepo;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -1648,5 +1682,138 @@ mod tests {
 
         assert_eq!(timeline.commits.len(), 1);
         assert!(timeline.reviews.is_empty());
+    }
+
+    fn running_session(store: &Arc<Store>, prompt: &str, acp_title: Option<&str>) -> Session {
+        let session = Session::new_running(prompt, Path::new("/tmp"));
+        store.create_session(&session).unwrap();
+        if let Some(title) = acp_title {
+            store
+                .update_session_acp_title(&session.id, Some(title))
+                .unwrap();
+        }
+        session
+    }
+
+    #[test]
+    fn build_branch_timeline_pending_commit_prefers_acp_title_over_prompt() {
+        let (repo, _visible_sha, _stale_sha) = repo_with_visible_and_stale_commit();
+        let (store, branch) = store_with_branch(&repo);
+
+        let titled = running_session(&store, "fix the login bug", Some("Fix login token refresh"));
+        let untitled = running_session(&store, "add more tests", None);
+        let titled_commit = Commit::new_pending(&branch.id).with_session(&titled.id);
+        let untitled_commit = Commit::new_pending(&branch.id).with_session(&untitled.id);
+        store.create_commit(&titled_commit).unwrap();
+        store.create_commit(&untitled_commit).unwrap();
+
+        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+
+        let subject_of = |commit_id: &str| {
+            timeline
+                .commits
+                .iter()
+                .find(|c| c.id.as_deref() == Some(commit_id))
+                .unwrap()
+                .subject
+                .clone()
+        };
+        assert_eq!(subject_of(&titled_commit.id), "Fix login token refresh");
+        assert_eq!(subject_of(&untitled_commit.id), "add more tests");
+    }
+
+    #[test]
+    fn build_branch_timeline_running_note_shows_acp_title() {
+        let (repo, _visible_sha, _stale_sha) = repo_with_visible_and_stale_commit();
+        let (store, branch) = store_with_branch(&repo);
+
+        let titled = running_session(&store, "write up the plan", Some("Plan: staged rollout"));
+        let untitled = running_session(&store, "summarize findings", None);
+        let titled_note = Note::new(&branch.id, "write up the plan", "").with_session(&titled.id);
+        let untitled_note =
+            Note::new(&branch.id, "summarize findings", "").with_session(&untitled.id);
+        store.create_note(&titled_note).unwrap();
+        store.create_note(&untitled_note).unwrap();
+
+        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+
+        let title_of = |note_id: &str| {
+            timeline
+                .notes
+                .iter()
+                .find(|n| n.id == note_id)
+                .unwrap()
+                .title
+                .clone()
+        };
+        assert_eq!(title_of(&titled_note.id), "Plan: staged rollout");
+        assert_eq!(title_of(&untitled_note.id), "summarize findings");
+    }
+
+    #[test]
+    fn build_branch_timeline_running_review_shows_acp_title() {
+        let (repo, visible_sha, _stale_sha) = repo_with_visible_and_stale_commit();
+        let (store, branch) = store_with_branch(&repo);
+
+        let session = running_session(&store, "review the change", Some("Review: token refresh"));
+        let untitled_review =
+            Review::new(&branch.id, &visible_sha, ReviewScope::Commit).with_session(&session.id);
+        store.create_review(&untitled_review).unwrap();
+
+        let stored_session = running_session(&store, "another review", Some("Should not display"));
+        let mut stored_review = Review::new(&branch.id, &visible_sha, ReviewScope::Commit)
+            .with_session(&stored_session.id);
+        stored_review.title = Some("Stored review title".to_string());
+        store.create_review(&stored_review).unwrap();
+
+        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+
+        let title_of = |review_id: &str| {
+            timeline
+                .reviews
+                .iter()
+                .find(|r| r.id == review_id)
+                .unwrap()
+                .title
+                .clone()
+        };
+        assert_eq!(
+            title_of(&untitled_review.id),
+            Some("Review: token refresh".to_string())
+        );
+        assert_eq!(
+            title_of(&stored_review.id),
+            Some("Stored review title".to_string())
+        );
+    }
+
+    #[test]
+    fn build_branch_timeline_completed_artifacts_ignore_acp_title() {
+        let (repo, visible_sha, _stale_sha) = repo_with_visible_and_stale_commit();
+        let (store, branch) = store_with_branch(&repo);
+
+        let session = running_session(&store, "the prompt", Some("Interim ACP title"));
+        store
+            .update_session_status(&session.id, SessionStatus::Completed, None, None)
+            .unwrap();
+
+        let commit = Commit::new_with_sha(&branch.id, &visible_sha).with_session(&session.id);
+        store.create_commit(&commit).unwrap();
+        let note = Note::new(&branch.id, "Final note title", "note body").with_session(&session.id);
+        store.create_note(&note).unwrap();
+        let review =
+            Review::new(&branch.id, &visible_sha, ReviewScope::Commit).with_session(&session.id);
+        store.create_review(&review).unwrap();
+
+        let timeline = build_branch_timeline(&store, &branch.id).unwrap();
+
+        let landed = timeline
+            .commits
+            .iter()
+            .find(|c| c.sha == visible_sha)
+            .unwrap();
+        assert_eq!(landed.subject, "visible change");
+        assert_eq!(timeline.notes[0].title, "Final note title");
+        assert_eq!(timeline.reviews[0].title, None);
     }
 }

--- a/apps/staged/src/lib/features/projects/ProjectSection.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectSection.svelte
@@ -106,13 +106,17 @@
   /** Session IDs for running project sessions (all produce notes). */
   let activeSessionIds = $state<Set<string>>(new Set());
 
-  // ── Live session hints (show latest agent message for running notes) ──
+  // ── Live session hints/titles (latest agent message + ACP title for running notes) ──
   let liveSessionHints = $state<Record<string, string>>({});
+  let liveSessionTitles = $state<Record<string, string>>({});
   const liveSessionHintPoller = createLiveSessionHints(
     (nextHints) => {
       liveSessionHints = nextHints;
     },
-    () => projectDisplayRootCandidates
+    () => projectDisplayRootCandidates,
+    (nextTitles) => {
+      liveSessionTitles = nextTitles;
+    }
   );
 
   /** Collect session IDs from running project notes + activeSessionIds. */
@@ -466,10 +470,12 @@
             {@const noteType = isRunning ? 'generating-note' : isFailed ? 'failed-note' : 'note'}
             {@const liveHint =
               isRunning && note.sessionId ? liveSessionHints[note.sessionId] : undefined}
+            {@const liveTitle =
+              isRunning && note.sessionId ? liveSessionTitles[note.sessionId] : undefined}
             <TimelineRow
               type={noteType}
               title={isRunning
-                ? 'Generating note…'
+                ? (liveTitle ?? 'Generating note…')
                 : isFailed
                   ? 'Session finished — no note created'
                   : note.title || 'Untitled note'}

--- a/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
+++ b/apps/staged/src/lib/features/sessions/noteFreshness.test.ts
@@ -25,6 +25,7 @@ function session(
     completionReason,
     createdAt: 1000,
     updatedAt: 2000,
+    acpTitle: null,
   };
 }
 

--- a/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
+++ b/apps/staged/src/lib/features/timeline/BranchTimeline.svelte
@@ -195,11 +195,15 @@
   }
 
   let liveSessionHints = $state<Record<string, string>>({});
+  let liveSessionTitles = $state<Record<string, string>>({});
   const liveSessionHintPoller = createLiveSessionHints(
     (nextHints) => {
       liveSessionHints = nextHints;
     },
-    () => repoDir
+    () => repoDir,
+    (nextTitles) => {
+      liveSessionTitles = nextTitles;
+    }
   );
 
   // Unified timeline item for display
@@ -535,11 +539,15 @@
       }
 
       const showAuthor = type === 'commit' && !isDeleting && !!commit.author && !commit.isOwnCommit;
+      const liveTitle =
+        type === 'pending-commit' && commit.sessionId
+          ? liveSessionTitles[commit.sessionId]
+          : undefined;
 
       all.push({
         key: commit.sha || `pending-${commit.sessionId || commit.timestamp}`,
         type,
-        title: stripXmlTags(commit.subject),
+        title: stripXmlTags(liveTitle ?? commit.subject),
         meta: isDeleting ? 'Deleting...' : secondaryMeta,
         secondaryMeta: isDeleting || isRunning ? undefined : commit.shortSha || undefined,
         tertiaryMeta: showAuthor ? commit.author : undefined,
@@ -591,10 +599,15 @@
         secondaryMeta = formatRelativeTime(note.completedAt ?? note.createdAt, nowMs);
       }
 
+      const liveTitle =
+        type === 'generating-note' && note.sessionId
+          ? liveSessionTitles[note.sessionId]
+          : undefined;
+
       all.push({
         key: `note-${note.id}`,
         type,
-        title: stripXmlTags(note.title),
+        title: stripXmlTags(liveTitle ?? note.title),
         secondaryMeta: isDeleting ? 'Deleting...' : secondaryMeta,
         deleting: isDeleting,
         // Use completedAt so completed notes sort by completion time, not queue time
@@ -657,10 +670,15 @@
         meta = formatRelativeTime(review.completedAt ?? review.createdAt, nowMs);
       }
 
+      const liveTitle =
+        type === 'generating-review' && review.sessionId
+          ? liveSessionTitles[review.sessionId]
+          : undefined;
+
       all.push({
         key: `review-${review.id}`,
         type,
-        title: review.title || 'Code Review',
+        title: liveTitle ?? (review.title || 'Code Review'),
         meta: isDeleting ? 'Deleting...' : meta,
         badges: badges.length > 0 ? badges : undefined,
         deleting: isDeleting,

--- a/apps/staged/src/lib/features/timeline/liveSessionHints.test.ts
+++ b/apps/staged/src/lib/features/timeline/liveSessionHints.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '../../types';
+
+type LiveSessionHintsModule = typeof import('./liveSessionHints');
+type LiveSessionHintPoller = ReturnType<LiveSessionHintsModule['createLiveSessionHints']>;
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 's1',
+    prompt: 'do the thing',
+    status: 'running',
+    workingDir: '',
+    provider: null,
+    agentId: null,
+    errorMessage: null,
+    completionReason: null,
+    createdAt: 1000,
+    updatedAt: 2000,
+    acpTitle: null,
+    ...overrides,
+  };
+}
+
+/** Flush the poller's promise chains (all mocked commands resolve in microtasks). */
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('createLiveSessionHints titles', () => {
+  let getSession: ReturnType<typeof vi.fn>;
+  let createLiveSessionHints: LiveSessionHintsModule['createLiveSessionHints'];
+  let poller: LiveSessionHintPoller | null;
+  let latestTitles: Record<string, string>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    getSession = vi.fn();
+    vi.doMock('../../api/commands', () => ({
+      getSession,
+      getSessionMessages: vi.fn().mockResolvedValue({ data: [] }),
+      getSessionMessagesSince: vi.fn().mockResolvedValue([]),
+      resolvePathAliases: vi.fn().mockResolvedValue([]),
+    }));
+    ({ createLiveSessionHints } = await import('./liveSessionHints'));
+    poller = null;
+    latestTitles = {};
+  });
+
+  afterEach(() => {
+    poller?.destroy();
+    vi.doUnmock('../../api/commands');
+  });
+
+  function createPoller(): LiveSessionHintPoller {
+    poller = createLiveSessionHints(
+      () => {},
+      undefined,
+      (titles) => {
+        latestTitles = titles;
+      }
+    );
+    return poller;
+  }
+
+  it('surfaces the ACP title of a running session', async () => {
+    getSession.mockResolvedValue(session({ acpTitle: 'Fix login flow' }));
+
+    createPoller().syncRunningSessionIds(['s1']);
+    await flushAsync();
+
+    expect(getSession).toHaveBeenCalledWith('s1');
+    expect(latestTitles).toEqual({ s1: 'Fix login flow' });
+  });
+
+  it('replaces the title when the agent pushes a new one', async () => {
+    getSession.mockResolvedValue(session({ acpTitle: 'First pass' }));
+
+    const p = createPoller();
+    p.syncRunningSessionIds(['s1']);
+    await flushAsync();
+    expect(latestTitles).toEqual({ s1: 'First pass' });
+
+    getSession.mockResolvedValue(session({ acpTitle: 'Refined title' }));
+    p.syncRunningSessionIds(['s1']);
+    await flushAsync();
+
+    expect(latestTitles).toEqual({ s1: 'Refined title' });
+  });
+
+  it('strips XML context blocks and collapses whitespace in titles', async () => {
+    getSession.mockResolvedValue(
+      session({ acpTitle: '  Fix   login <action>injected</action> flow  ' })
+    );
+
+    createPoller().syncRunningSessionIds(['s1']);
+    await flushAsync();
+
+    expect(latestTitles).toEqual({ s1: 'Fix login flow' });
+  });
+
+  it('does not surface blank titles', async () => {
+    getSession.mockResolvedValue(session({ acpTitle: '   ' }));
+
+    createPoller().syncRunningSessionIds(['s1']);
+    await flushAsync();
+
+    expect(latestTitles).toEqual({});
+  });
+
+  it('clears the title when the agent retracts it', async () => {
+    getSession.mockResolvedValue(session({ acpTitle: 'Fix login flow' }));
+
+    const p = createPoller();
+    p.syncRunningSessionIds(['s1']);
+    await flushAsync();
+    expect(latestTitles).toEqual({ s1: 'Fix login flow' });
+
+    getSession.mockResolvedValue(session({ acpTitle: null }));
+    p.syncRunningSessionIds(['s1']);
+    await flushAsync();
+
+    expect(latestTitles).toEqual({});
+  });
+
+  it('clears the title when the session stops running', async () => {
+    getSession.mockResolvedValue(session({ acpTitle: 'Fix login flow' }));
+
+    const p = createPoller();
+    p.syncRunningSessionIds(['s1']);
+    await flushAsync();
+    expect(latestTitles).toEqual({ s1: 'Fix login flow' });
+
+    getSession.mockResolvedValue(session({ status: 'completed', acpTitle: 'Fix login flow' }));
+    p.syncRunningSessionIds(['s1']);
+    await flushAsync();
+
+    expect(latestTitles).toEqual({});
+  });
+
+  it('clears the title when the session leaves the running set', async () => {
+    getSession.mockResolvedValue(session({ acpTitle: 'Fix login flow' }));
+
+    const p = createPoller();
+    p.syncRunningSessionIds(['s1']);
+    await flushAsync();
+    expect(latestTitles).toEqual({ s1: 'Fix login flow' });
+
+    p.syncRunningSessionIds([]);
+
+    expect(latestTitles).toEqual({});
+  });
+
+  it('tracks titles per session', async () => {
+    getSession.mockImplementation((sessionId: string) =>
+      Promise.resolve(
+        session({
+          id: sessionId,
+          acpTitle: sessionId === 's1' ? 'Fix login flow' : 'Update docs',
+        })
+      )
+    );
+
+    const p = createPoller();
+    p.syncRunningSessionIds(['s1', 's2']);
+    await flushAsync();
+    expect(latestTitles).toEqual({ s1: 'Fix login flow', s2: 'Update docs' });
+
+    p.syncRunningSessionIds(['s2']);
+
+    expect(latestTitles).toEqual({ s2: 'Update docs' });
+  });
+});

--- a/apps/staged/src/lib/features/timeline/liveSessionHints.ts
+++ b/apps/staged/src/lib/features/timeline/liveSessionHints.ts
@@ -26,6 +26,12 @@ export type PendingHintItem = {
   sessionId?: string;
 };
 
+function normalizeTitleText(title: string | null | undefined): string | undefined {
+  if (!title) return undefined;
+  const cleaned = stripXmlTags(title).replace(/\s+/g, ' ').trim();
+  return cleaned || undefined;
+}
+
 function normalizeHintText(text: string): string | undefined {
   const cleaned = stripXmlTags(text)
     .replace(/```[\s\S]*?```/g, ' ')
@@ -182,10 +188,12 @@ export function collectRunningSessionIds(
 
 export function createLiveSessionHints(
   onHintsChange: (hints: Record<string, string>) => void,
-  getDisplayRootCandidates?: () => DisplayRootInput
+  getDisplayRootCandidates?: () => DisplayRootInput,
+  onTitlesChange?: (titles: Record<string, string>) => void
 ) {
   const hintTrackers = new Map<string, HintTracker>();
   let hints: Record<string, string> = {};
+  let titles: Record<string, string> = {};
   let hintPollTimer: ReturnType<typeof setInterval> | null = null;
   let hintPollInFlight = false;
   let destroyed = false;
@@ -206,6 +214,22 @@ export function createLiveSessionHints(
     onHintsChange(hints);
   }
 
+  function setTitle(sessionId: string, title: string) {
+    if (destroyed || !onTitlesChange) return;
+    if (titles[sessionId] === title) return;
+    titles = { ...titles, [sessionId]: title };
+    onTitlesChange(titles);
+  }
+
+  function clearTitle(sessionId: string) {
+    if (destroyed || !onTitlesChange) return;
+    if (!(sessionId in titles)) return;
+    const next = { ...titles };
+    delete next[sessionId];
+    titles = next;
+    onTitlesChange(titles);
+  }
+
   async function refreshHint(sessionId: string, tracker: HintTracker) {
     if (destroyed) return;
     try {
@@ -214,7 +238,15 @@ export function createLiveSessionHints(
       if (!session || session.status !== 'running') {
         hintTrackers.delete(sessionId);
         clearHint(sessionId);
+        clearTitle(sessionId);
         return;
+      }
+
+      const acpTitle = normalizeTitleText(session.acpTitle);
+      if (acpTitle) {
+        setTitle(sessionId, acpTitle);
+      } else {
+        clearTitle(sessionId);
       }
 
       const rootCandidates: DisplayRootInput = [getDisplayRootCandidates?.(), session.workingDir];
@@ -310,6 +342,7 @@ export function createLiveSessionHints(
         if (!activeIds.has(sessionId)) {
           hintTrackers.delete(sessionId);
           clearHint(sessionId);
+          clearTitle(sessionId);
         }
       }
 
@@ -328,6 +361,10 @@ export function createLiveSessionHints(
       if (Object.keys(hints).length > 0) {
         hints = {};
         onHintsChange(hints);
+      }
+      if (Object.keys(titles).length > 0) {
+        titles = {};
+        onTitlesChange?.(titles);
       }
     },
   };

--- a/apps/staged/src/lib/types.ts
+++ b/apps/staged/src/lib/types.ts
@@ -382,6 +382,8 @@ export interface Session {
   pipeline?: PipelineExecution | null;
   /** Selected ACP config values to apply before prompting the agent. */
   acpConfigSelection?: AcpConfigSelection | null;
+  /** Latest session title pushed by the agent via ACP `session_info_update`. */
+  acpTitle: string | null;
 }
 
 export type QueuedSessionMessageStatus = 'queued' | 'sending' | 'sent';


### PR DESCRIPTION
ACP agents can push a session title mid-run via `session_info_update`. Staged archived that update but never used it, so running rows showed the raw prompt (or a static placeholder like `Generating note…` / `Code Review`), and sessions that finished without producing a title stayed `Untitled Note` or untitled.

This branch persists that title and uses it in two ways: as an interim display name while the session runs, and as an end-of-session fallback when nothing better exists.

## Changes

**Persistence** — migration `0021-add-session-acp-title` adds a nullable `acp_title` column to `sessions`. `Session` gains `acp_title` (serialized as `acpTitle`), wired through the INSERT and every session SELECT; `ResolvedSession` carries it so timeline consumers get it from `resolve_session_status`. New `Store::update_session_acp_title(id, Option<&str>)` sets or clears the column.

**Writer** — `MessageWriter::on_session_info_update` maps the three `MaybeUndefined` states of `info.title`: `Value(t)` sanitizes (strip backticks, trim) and stores when non-empty, `Null` clears the column (the agent retracted the title), `Undefined` leaves it unchanged. The existing metadata-row archive of the raw update is untouched.

**Timeline (read time)** — `build_branch_timeline` prefers a non-empty `acp_title` for in-progress rows, so stored artifact names never carry a stale interim value. Pending/failed commits prefer it over the prompt; running notes override the stored stub title; running untitled reviews surface it instead of the UI's static `Code Review`. Stored titles always win once a session ends. Both the desktop UI and the web server's `get_branch_timeline` go through this path.

**Frontend (live)** — `createLiveSessionHints` rides its existing 750 ms `getSession` poll to report `titles` alongside hints, so mid-session titles appear with zero extra requests and no whole-timeline refetch. Titles are sanitized at the source and clear on the same paths as hints (session leaves running, leaves the tracked set, `destroy()`). `BranchTimeline.svelte` applies them to running rows only; `ProjectSection.svelte` shows them in place of the `Generating note…` placeholder.

**End-of-session fallbacks** — in `session_runner.rs`, the note fallback order becomes H1 → ACP session title → truncated prompt → `Untitled Note`. On review completion, when no `review-title` block is found, the ACP title is persisted as the review title (`update_review_title` also coalesces `completed_at`, so the review is still marked completed). Only when neither source yields a title does the row stay untitled. Post-completion hooks log which source the title came from.

## Testing

Rust tests cover the migration (`user_version` now 21), the store round-trip (set/replace/clear) and `resolve_session_status` exposure, all four writer variants including the blank-`Value` guard, the timeline read-time overrides and stored-title precedence, and the runner note/review fallback ordering. TS tests cover the new `liveSessionHints` title flow — surfacing, replacing, sanitizing, blank/retracted titles, clearing, and per-session tracking. Full CI (`crates-fmt`, `crates-test`, `crates-lint`, `differ-ci`, `staged-ci`) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)