### PR TITLE
fix(branches): keep the behind-count and Rebase button visible during git refresh

### DIFF
--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -1702,7 +1702,7 @@
         baseBranch={isRemote
           ? (branch.workspaceName ?? formatBaseBranch(branch.baseBranch))
           : formatBaseBranch(branch.baseBranch)}
-        parentAheadCount={refreshingGitState ? 0 : (timeline?.gitState?.base.commitsSinceFork ?? 0)}
+        parentAheadCount={timeline?.gitState?.base.commitsSinceFork ?? 0}
         onRebase={branchCommandDisabledReason
           ? undefined
           : () => startBranchCommandPipeline('rebase')}

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -567,9 +567,14 @@
 
     // Kick off a background git-state refresh (TTL-gated fetch).
     refreshingGitState = true;
-    commands.refreshBranchGitState(branch.id).catch(() => {
-      refreshingGitState = false;
-    });
+    commands
+      .refreshBranchGitState(branch.id)
+      .catch(() => {})
+      .finally(() => {
+        // Clear on settle, not just on the `git-state-updated` event: branches
+        // with no workdir (or a deleted worktree) resolve Ok without emitting.
+        refreshingGitState = false;
+      });
   }
 
   // Synchronously hydrate timeline from cache so isSettingUp is never true
@@ -802,9 +807,14 @@
     // Kick off a background git-state refresh (TTL-gated fetch).
     // The result arrives via the `git-state-updated` event listener above.
     refreshingGitState = true;
-    commands.refreshBranchGitState(branch.id).catch(() => {
-      refreshingGitState = false;
-    });
+    commands
+      .refreshBranchGitState(branch.id)
+      .catch(() => {})
+      .finally(() => {
+        // Clear on settle, not just on the `git-state-updated` event: branches
+        // with no workdir (or a deleted worktree) resolve Ok without emitting.
+        refreshingGitState = false;
+      });
   }
 
   function getTimelineReviewDetails(fullReview: TimelineFullReview): TimelineReviewDetails {

--- a/apps/staged/src/lib/features/branches/BranchCard.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCard.svelte
@@ -520,6 +520,30 @@
   let requestedTimelineKey: string | null = null;
   let timelineLoadVersion = 0;
   let revalidationVersion = 0;
+  let gitRefreshVersion = 0;
+
+  /**
+   * Kick off a background git-state refresh (TTL-gated fetch). Fresh state
+   * arrives via the `git-state-updated` event listener below.
+   *
+   * Clear the flag on settle, not just on the event: branches with no workdir
+   * (or a deleted worktree) resolve Ok without emitting. Version-gated so an
+   * older refresh settling can't end the spinner while a newer one — e.g. a
+   * `loadTimeline` re-run overlapping the mount-time hydration refresh — is
+   * still in flight.
+   */
+  function startGitStateRefresh() {
+    const version = ++gitRefreshVersion;
+    refreshingGitState = true;
+    commands
+      .refreshBranchGitState(branch.id)
+      .catch(() => {})
+      .finally(() => {
+        if (version === gitRefreshVersion) {
+          refreshingGitState = false;
+        }
+      });
+  }
 
   function isCurrentTimelineLoad(loadVersion: number, timelineKey: string): boolean {
     return loadVersion === timelineLoadVersion && branchTimelineReadyKey(branch) === timelineKey;
@@ -565,16 +589,7 @@
       void loadTimelineReviewDetails(cached.reviews);
     }
 
-    // Kick off a background git-state refresh (TTL-gated fetch).
-    refreshingGitState = true;
-    commands
-      .refreshBranchGitState(branch.id)
-      .catch(() => {})
-      .finally(() => {
-        // Clear on settle, not just on the `git-state-updated` event: branches
-        // with no workdir (or a deleted worktree) resolve Ok without emitting.
-        refreshingGitState = false;
-      });
+    startGitStateRefresh();
   }
 
   // Synchronously hydrate timeline from cache so isSettingUp is never true
@@ -702,7 +717,10 @@
       if (timeline) {
         timeline = { ...timeline, gitState: payload.gitState };
       }
-      refreshingGitState = false;
+      // `refreshingGitState` is cleared by startGitStateRefresh's settle
+      // handler, not here: an event from an external refresh (e.g. the bulk
+      // refresh on project open) must not end the spinner while this card's
+      // own refresh is still in flight.
     });
 
     return () => {
@@ -804,17 +822,7 @@
       }
     }
 
-    // Kick off a background git-state refresh (TTL-gated fetch).
-    // The result arrives via the `git-state-updated` event listener above.
-    refreshingGitState = true;
-    commands
-      .refreshBranchGitState(branch.id)
-      .catch(() => {})
-      .finally(() => {
-        // Clear on settle, not just on the `git-state-updated` event: branches
-        // with no workdir (or a deleted worktree) resolve Ok without emitting.
-        refreshingGitState = false;
-      });
+    startGitStateRefresh();
   }
 
   function getTimelineReviewDetails(fullReview: TimelineFullReview): TimelineReviewDetails {

--- a/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
+++ b/apps/staged/src/lib/features/branches/BranchCardHeaderInfo.svelte
@@ -33,12 +33,21 @@
     refreshingGitState = false,
     fetchError = null,
   }: Props = $props();
+
+  const capsuleTitle = $derived.by(() => {
+    if (!baseBranch || parentAheadCount <= 0) return baseBranch ?? undefined;
+    const behind = `${parentAheadCount} commit${parentAheadCount === 1 ? '' : 's'} behind`;
+    return refreshingGitState
+      ? `${baseBranch} · ${behind} (checking for updates…)`
+      : `${baseBranch} · ${behind}`;
+  });
 </script>
 
 {#snippet capsule()}
-  <span class="branch-capsule" title={baseBranch ?? undefined}>
+  <span class="branch-capsule" title={capsuleTitle}>
     {baseBranch}{#if parentAheadCount > 0}<span
         class="ahead-count"
+        class:provisional={refreshingGitState}
         transition:fade={{ duration: 150 }}
       >
         +{parentAheadCount}</span
@@ -173,6 +182,10 @@
   .ahead-count {
     font-weight: 600;
     color: var(--ui-accent);
+  }
+
+  .ahead-count.provisional {
+    opacity: 0.6;
   }
 
   .branch-warning {


### PR DESCRIPTION
## Problem

`BranchCard` zeroed `parentAheadCount` while a background git-state refresh was in flight, so the `+N` behind-count — and with it the **Rebase** button, which is gated on `parentAheadCount > 0` — vanished from the card header and then popped back once the refresh landed. Every branch-card refresh flickered the primary action out from under the user.

A second, related bug made this worse: `refreshBranchGitState` resolves `Ok` *without* emitting `git-state-updated` when a branch has no workdir or its worktree path no longer exists. Since `refreshingGitState` was only cleared on the event (or on rejection), those branches kept the flag set forever — a perpetual spinner, and after the first fix, a permanently dimmed count.

## Changes

- **Show the real count during refresh.** Pass `timeline?.gitState?.base.commitsSinceFork` straight through instead of substituting `0`. The count and Rebase button stay put; the refresh updates them in place.
- **Signal staleness without hiding it.** The `+N` capsule dims to 60% opacity (`.ahead-count.provisional`) while refreshing, and its tooltip becomes `<base> · N commits behind (checking for updates…)`.
- **Clear the flag on settle, not on the event.** Both refresh call sites now use `.catch(() => {}).finally(...)`, so the spinner and dimming stop even on the no-workdir arms. The command resolves only after the impl (including the emit, when there is one) completes, so the happy path still merges fresh state. The `git-state-updated` listener stays for refreshes triggered outside the card — bulk refresh on project open, post-push force refresh.