### PR TITLE
fix(sessions): drop the redundant In progress footer row from tool call details

### DIFF
--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -131,10 +131,10 @@
   <div class="tool-empty-row">{viewModel.output.emptyLabel}</div>
 {/if}
 
-<!-- A success row only echoes the green check already in the card header, so
-     the footer status shows only when it adds something (failed, cancelled,
-     still running). -->
-{#if includeStatus && viewModel.statusTone !== 'success'}
+<!-- Success and in-progress rows only echo the check and clock icons already
+     in the card header, so the footer status shows only when it adds something
+     (failed, cancelled, pending). -->
+{#if includeStatus && viewModel.statusTone !== 'success' && viewModel.statusTone !== 'running'}
   <div
     class="tool-code-status"
     class:status-danger={viewModel.statusTone === 'danger'}

--- a/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
+++ b/apps/staged/src/lib/features/sessions/tool-calls/OutputSections.svelte
@@ -134,7 +134,7 @@
 <!-- Success and in-progress rows only echo the check and clock icons already
      in the card header, so the footer status shows only when it adds something
      (failed, cancelled, pending). -->
-{#if includeStatus && viewModel.statusTone !== 'success' && viewModel.statusTone !== 'running'}
+{#if includeStatus && ['danger', 'cancelled', 'muted'].includes(viewModel.statusTone)}
   <div
     class="tool-code-status"
     class:status-danger={viewModel.statusTone === 'danger'}


### PR DESCRIPTION
The expanded tool call card ended its output with an "In progress" status row, but the header's status dot already shows a clock icon for running calls — so the row repeated information without adding any.

`OutputSections.svelte` already suppressed the footer row for the `success` tone for the same reason (it echoed the header's green check). Rather than growing that into a two-tone exclusion list, the condition is now an explicit allow-list of the tones that actually add information: `danger`, `cancelled`, and `muted` (pending). Any future tone has to consciously opt in to rendering the row instead of defaulting to shown.

Net effect: failed, cancelled, and pending rows still render; success and in-progress rows do not.