### PR TITLE
fix(sessions): keep a space between hashtag badges and following text

### DIFF
--- a/apps/staged/src/lib/features/sessions/HashtagInput.svelte
+++ b/apps/staged/src/lib/features/sessions/HashtagInput.svelte
@@ -25,7 +25,12 @@
   import GitCommitVertical from '@lucide/svelte/icons/git-commit-vertical';
   import FileSearch from '@lucide/svelte/icons/file-search';
   import ImageLucide from '@lucide/svelte/icons/image';
-  import { HASHTAG_TOKEN_RE, hashtagTypeIconSvg, escapeHtml } from './hashtagItems';
+  import {
+    HASHTAG_TOKEN_RE,
+    createExtractedValueBuilder,
+    hashtagTypeIconSvg,
+    escapeHtml,
+  } from './hashtagItems';
   import { focusAtEndSync } from '../../shared/focusAtEnd';
   import { portal } from '../../shared/portal';
   import RepoLabel from '../../shared/RepoLabel.svelte';
@@ -304,28 +309,28 @@
   }
 
   function extractFromNode(node: Node): string {
-    let result = '';
+    const builder = createExtractedValueBuilder();
     for (const child of node.childNodes) {
       if (child.nodeType === Node.TEXT_NODE) {
-        result += (child.textContent ?? '').replace(/\u200B/g, '');
+        builder.appendText((child.textContent ?? '').replace(/\u200B/g, ''));
       } else if (child instanceof HTMLBRElement) {
-        result += '\n';
+        builder.appendText('\n');
       } else if (child instanceof HTMLElement) {
         if (child.dataset.token) {
-          result += child.dataset.token;
+          builder.appendToken(child.dataset.token);
         } else if (child.tagName === 'DIV') {
           // Browsers sometimes wrap lines in <div> elements on Enter
           const innerText = extractFromNode(child);
-          if (result.length > 0 && !result.endsWith('\n')) {
-            result += '\n';
+          if (builder.value.length > 0 && !builder.value.endsWith('\n')) {
+            builder.appendText('\n');
           }
-          result += innerText;
+          builder.appendText(innerText);
         } else {
-          result += extractFromNode(child);
+          builder.appendText(extractFromNode(child));
         }
       }
     }
-    return result;
+    return builder.value;
   }
 
   function handleInput(e: Event) {

--- a/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.test.ts
@@ -3,6 +3,7 @@ import type { Branch, BranchTimeline, HashtagItem, ProjectNote } from '../../typ
 import { getBranchTimeline, listProjectNotes } from '../../commands';
 import {
   buildProjectHashtagItems,
+  createExtractedValueBuilder,
   findHashtagItemForReference,
   projectNotesToHashtagItems,
   renderHashtagTokens,
@@ -330,6 +331,58 @@ describe('renderHashtagTokens', () => {
     expect(html).not.toContain('role="button"');
     expect(html).not.toContain('tabindex="0"');
     expect(html).not.toContain('data-hashtag-ref');
+  });
+});
+
+describe('createExtractedValueBuilder', () => {
+  it('inserts a space between a token and immediately following text', () => {
+    const builder = createExtractedValueBuilder();
+    builder.appendToken('#note:note-1');
+    builder.appendText('some words');
+
+    expect(builder.value).toBe('#note:note-1 some words');
+  });
+
+  it('does not add a space when the following text already starts with whitespace', () => {
+    const builder = createExtractedValueBuilder();
+    builder.appendText('Re: ');
+    builder.appendToken('#note:note-1');
+    builder.appendText(' already spaced');
+
+    expect(builder.value).toBe('Re: #note:note-1 already spaced');
+  });
+
+  it('does not add a space before a newline after a token', () => {
+    const builder = createExtractedValueBuilder();
+    builder.appendToken('#commit:abc123');
+    builder.appendText('\nnext line');
+
+    expect(builder.value).toBe('#commit:abc123\nnext line');
+  });
+
+  it('separates adjacent tokens even across empty text chunks', () => {
+    const builder = createExtractedValueBuilder();
+    builder.appendToken('#note:note-1');
+    builder.appendText('');
+    builder.appendToken('#commit:abc123');
+
+    expect(builder.value).toBe('#note:note-1 #commit:abc123');
+  });
+
+  it('does not add a trailing space after a token at the end', () => {
+    const builder = createExtractedValueBuilder();
+    builder.appendText('see ');
+    builder.appendToken('#note:note-1');
+
+    expect(builder.value).toBe('see #note:note-1');
+  });
+
+  it('joins plain text chunks without inserting spaces', () => {
+    const builder = createExtractedValueBuilder();
+    builder.appendText('hel');
+    builder.appendText('lo');
+
+    expect(builder.value).toBe('hello');
   });
 });
 

--- a/apps/staged/src/lib/features/sessions/hashtagItems.ts
+++ b/apps/staged/src/lib/features/sessions/hashtagItems.ts
@@ -6,6 +6,36 @@ import { branchTimelineReadyKey } from '../branches/branchTimelineReady';
 export const HASHTAG_TOKEN_RE = /#(note|commit|review|project-note|image):([^\s]+)/g;
 
 /**
+ * Incrementally joins editor content chunks into the raw `value` string,
+ * inserting a space between a `#type:id` badge token and immediately
+ * following non-whitespace text. Token ids match greedily up to whitespace
+ * (HASHTAG_TOKEN_RE), so `#note:1hello` would swallow the text into the id.
+ */
+export function createExtractedValueBuilder() {
+  let result = '';
+  let afterToken = false;
+
+  const push = (text: string, isToken: boolean) => {
+    if (!text) return;
+    if (afterToken && !/^\s/.test(text)) result += ' ';
+    result += text;
+    afterToken = isToken;
+  };
+
+  return {
+    appendText(text: string) {
+      push(text, false);
+    },
+    appendToken(token: string) {
+      push(token, true);
+    },
+    get value() {
+      return result;
+    },
+  };
+}
+
+/**
  * Inline SVG markup for each hashtag type icon (lucide icons at 12px).
  *
  * NOTE: These raw SVG strings intentionally duplicate the lucide icon paths


### PR DESCRIPTION
## Problem

Text typed immediately after a hashtag badge in the session composer was serialized flush against the `#type:id` token. Since token ids parse greedily up to whitespace (`HASHTAG_TOKEN_RE`), the following words got swallowed into the id — e.g. `#note:note-1some words` — corrupting the reference for both the timeline UI and agents.

## Change

- Add `createExtractedValueBuilder` in `hashtagItems.ts`: an incremental joiner that inserts a space between a badge token and any immediately following non-whitespace text (including an adjacent badge), while leaving already-spaced content, newlines, and trailing tokens untouched.
- Route `HashtagInput.svelte`'s `extractFromNode` through the builder instead of concatenating strings directly.
- Cover the builder with unit tests: token→text, already-spaced, newline-separated, adjacent tokens across empty chunks, trailing token, and plain-text-only cases.