### PR TITLE
feat(repos): jump from a repo card's more menu to its repo settings

### DIFF
--- a/apps/staged/src/lib/features/projects/RepoCard.svelte
+++ b/apps/staged/src/lib/features/projects/RepoCard.svelte
@@ -7,8 +7,9 @@
   as many lines as it needs) above a row of actions: a labelled "Add project"
   button on the left, then — right-aligned — the action-runner surfaces (running
   pills and the primary run button) or a clone button, the pin toggle, and a
-  more menu carrying every repo action, an Actions submenu, and the local-clone
-  openers. Card tint, border and accent all come from the repo's badge hue.
+  more menu carrying every repo action, an Actions submenu, the local-clone
+  openers, and a Repo Settings jump to this repo's entry in Settings → Repos.
+  Card tint, border and accent all come from the repo's badge hue.
 
   Action runs go through the shared ActionRunner, scoped to the synthetic
   repoActionScopeId and executed by run_repo_action against the repo's main
@@ -31,6 +32,7 @@
   import PinOff from '@lucide/svelte/icons/pin-off';
   import Copy from '@lucide/svelte/icons/copy';
   import FolderOpen from '@lucide/svelte/icons/folder-open';
+  import Settings2 from '@lucide/svelte/icons/settings-2';
   import Zap from '@lucide/svelte/icons/zap';
   import type { RepoHomeItem } from '../../types';
   import type { UnlistenFn } from '../../transport';
@@ -64,6 +66,7 @@
   import { bulkRepoActions, bulkRunningForScope } from '../actions/repoActionsBulk';
   import { detectRepoActions, listenToRepoActionsDetection } from '../actions/actions';
   import { getPreferredAgent } from '../settings/preferences.svelte';
+  import { openRepoSettings } from '../settings/repoSettingsTarget';
   import { agentState } from '../agents/agent.svelte';
 
   interface Props {
@@ -494,6 +497,10 @@
               <DropdownMenu.Item disabled>Loading…</DropdownMenu.Item>
             {/if}
           {/if}
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item onSelect={() => openRepoSettings(repo.githubRepo, repo.subpath)}>
+            <Settings2 size={14} /> Repo Settings
+          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Root>
     </div>

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy, untrack } from 'svelte';
+  import { onMount, onDestroy, tick, untrack } from 'svelte';
   import { cubicInOut } from 'svelte/easing';
   import FolderGit2 from '@lucide/svelte/icons/folder-git-2';
   import Play from '@lucide/svelte/icons/play';
@@ -38,6 +38,7 @@
   import { getPreferredAgent } from './preferences.svelte';
   import { agentState } from '../agents/agent.svelte';
   import { navigation } from '../layout/navigation.svelte';
+  import { consumeRepoSettingsTarget } from './repoSettingsTarget';
 
   type RepoAttachment = {
     projectId: string;
@@ -61,6 +62,7 @@
   let repoAttachmentsByContext = $state<Record<string, RepoAttachment[]>>({});
   let repoAttachmentLoadGeneration = 0;
   let repoSearch = $state('');
+  let sidebarEl: HTMLElement | null = null;
 
   let actions = $state<ProjectAction[]>([]);
   let loadingActions = $state(false);
@@ -248,7 +250,14 @@
       const nextContexts = await commands.listActionContexts();
       contexts = nextContexts;
       await loadRepoAttachments(nextContexts);
-      if (!selectedRepoKey && mergedEntries.length > 0) {
+      // A repo card's "Repo Settings" action parks the repo it wants selected;
+      // honor it now that the entry list is resolved.
+      const requested = consumeRepoSettingsTarget();
+      const requestedKey = requested ? repoKey(requested.githubRepo, requested.subpath) : null;
+      if (requestedKey && mergedEntries.some((e) => e.key === requestedKey)) {
+        selectedRepoKey = requestedKey;
+        void revealSelectedRepo();
+      } else if (!selectedRepoKey && mergedEntries.length > 0) {
         selectedRepoKey = mergedEntries[0].key;
       } else if (selectedRepoKey && !mergedEntries.some((e) => e.key === selectedRepoKey)) {
         selectedRepoKey = mergedEntries.length > 0 ? mergedEntries[0].key : null;
@@ -259,6 +268,12 @@
     } finally {
       loadingContexts = false;
     }
+  }
+
+  /** Scroll the selected repo's sidebar row into view once it has rendered. */
+  async function revealSelectedRepo() {
+    await tick();
+    sidebarEl?.querySelector('.context-item.selected')?.scrollIntoView({ block: 'nearest' });
   }
 
   async function loadActions() {
@@ -546,7 +561,7 @@
 
 <div class="actions-settings-panel">
   <div class="panel-body">
-    <aside class="sidebar" transition:sidebarSlide|global>
+    <aside class="sidebar" bind:this={sidebarEl} transition:sidebarSlide|global>
       <div class="sidebar-header">
         <h2>
           <FolderGit2 size={16} />

--- a/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
+++ b/apps/staged/src/lib/features/settings/ActionsSettingsPanel.svelte
@@ -245,18 +245,22 @@
   }
 
   async function loadContexts() {
+    // A repo card's "Repo Settings" action parks the repo it wants selected.
+    // Take it up front so a failed load drops the request rather than leaving
+    // it parked for some later, unrelated visit to Settings → Repos.
+    const requested = consumeRepoSettingsTarget();
+    const requestedKey = requested ? repoKey(requested.githubRepo, requested.subpath) : null;
+    let revealRequested = false;
+
     loadingContexts = true;
     try {
       const nextContexts = await commands.listActionContexts();
       contexts = nextContexts;
       await loadRepoAttachments(nextContexts);
-      // A repo card's "Repo Settings" action parks the repo it wants selected;
-      // honor it now that the entry list is resolved.
-      const requested = consumeRepoSettingsTarget();
-      const requestedKey = requested ? repoKey(requested.githubRepo, requested.subpath) : null;
+      // Honor the parked target now that the entry list is resolved.
       if (requestedKey && mergedEntries.some((e) => e.key === requestedKey)) {
         selectedRepoKey = requestedKey;
-        void revealSelectedRepo();
+        revealRequested = true;
       } else if (!selectedRepoKey && mergedEntries.length > 0) {
         selectedRepoKey = mergedEntries[0].key;
       } else if (selectedRepoKey && !mergedEntries.some((e) => e.key === selectedRepoKey)) {
@@ -267,6 +271,9 @@
       console.error('Failed to load action contexts:', e);
     } finally {
       loadingContexts = false;
+      // The sidebar renders a spinner until this flag clears, so the selected
+      // row only exists to scroll to after it does.
+      if (revealRequested) void revealSelectedRepo();
     }
   }
 

--- a/apps/staged/src/lib/features/settings/repoSettingsTarget.ts
+++ b/apps/staged/src/lib/features/settings/repoSettingsTarget.ts
@@ -1,0 +1,30 @@
+/**
+ * Deep link into Settings → Repos with a specific repo selected.
+ *
+ * Repo cards request this from their more menu, but the repos panel owns its
+ * selection state and only resolves its entry list after an async load — so
+ * the target is parked here and consumed by ActionsSettingsPanel once its
+ * entries are ready.
+ */
+
+import { openSettings } from '../layout/navigation.svelte';
+
+export interface RepoSettingsTarget {
+  githubRepo: string;
+  subpath: string;
+}
+
+let pendingTarget: RepoSettingsTarget | null = null;
+
+/** Navigate to Settings → Repos and select the given repo once loaded. */
+export function openRepoSettings(githubRepo: string, subpath: string | null | undefined): void {
+  pendingTarget = { githubRepo, subpath: subpath ?? '' };
+  openSettings('repo');
+}
+
+/** One-shot read of the most recently requested repo selection. */
+export function consumeRepoSettingsTarget(): RepoSettingsTarget | null {
+  const target = pendingTarget;
+  pendingTarget = null;
+  return target;
+}


### PR DESCRIPTION
Adds a **Repo Settings** item at the end of every repo card's more menu (home repos row, All Repos grid, sidebar pinned list). Selecting it opens Settings → Repos with that repo already selected and scrolled into view.

## How it works

The repos panel owns its selection state and only resolves its entry list after an async load, so the navigation can't just pass a selection along:

- New `repoSettingsTarget.ts` parks the requested repo (`openRepoSettings`) and hands it out once (`consumeRepoSettingsTarget`) before navigating to Settings → Repos.
- `ActionsSettingsPanel` consumes the parked target after its merged entries resolve, selects the matching row, and scrolls it into view via a new `revealSelectedRepo` helper.

Cards always resolve to an entry: `RepoHomeItem` extends `RepoBadge`, and the panel's merged entries include every badge.