### PR TITLE
feat(projects): share project filtering globally with a sidebar filter row

### DIFF
--- a/apps/staged/src/App.svelte
+++ b/apps/staged/src/App.svelte
@@ -47,6 +47,7 @@
   import { runSearchShortcut } from './lib/features/keyboard/searchTargets';
   import { projectStateStore } from './lib/stores/projectState.svelte';
   import { projectsDataStore } from './lib/stores/projectsData.svelte';
+  import { projectRunActionsStore } from './lib/stores/projectRunActions.svelte';
   import { initBloxEnv } from './lib/stores/bloxEnv.svelte';
   import { listenForSessionStatus } from './lib/listeners/sessionStatusListener';
   import { listenForCacheInvalidation } from './lib/listeners/cacheInvalidationListener';
@@ -309,6 +310,12 @@
     // Keep the shared project-list cache fresh for the app's lifetime — the
     // store dedupes, so starting before any view consumes it is safe.
     projectsDataStore.startListeners();
+    // Run-action state feeds the shared project filters (Running chip,
+    // filtered lists), which every route renders via the sidebar or the
+    // landing grid — so its listeners are app-lifetime too. A view-scoped
+    // lifecycle wiped the state on the repos route, where neither view that
+    // used to own it is mounted.
+    projectRunActionsStore.startListening();
 
     try {
       await initPreferences();
@@ -499,6 +506,7 @@
     unlistenPageLifecycle?.();
     unlistenAcpToolsReconciled?.();
     projectsDataStore.stopListeners();
+    projectRunActionsStore.stopListening();
     stopUpdaterLoop?.();
   });
 

--- a/apps/staged/src/lib/features/projects/ProjectFilterChips.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectFilterChips.svelte
@@ -6,6 +6,7 @@
   row can never drift. `compact` shrinks the chips for the narrow sidebar.
 -->
 <script lang="ts">
+  import X from '@lucide/svelte/icons/x';
   import RepoLabel from '../../shared/RepoLabel.svelte';
   import { badgeBg, badgeBgHover, badgeFg } from '../../shared/badgeColors';
   import { darkMode } from '../../stores/isDark.svelte';
@@ -57,6 +58,23 @@
       <span class="filter-count">{rf.count}</span>
     </button>
   {/each}
+  <!--
+    The filters outlive this bar's chips, so clearing has to be reachable from
+    the bar itself: repo chips only exist for repos computeRepoFilters still
+    sees (delete the last project using one and its filter stays active with
+    no chip to click), and both status chips go disabled when their counts hit
+    0. The sidebar's ✕ covers desktop, but the sidebar is hidden on mobile.
+  -->
+  {#if projectFiltersStore.hasActiveFilters}
+    <button
+      class="filter-chip clear-chip"
+      title="Clear filters"
+      onclick={() => projectFiltersStore.clearFilters()}
+    >
+      <X size={compact ? 11 : 12} />
+      Clear
+    </button>
+  {/if}
 </div>
 
 <style>
@@ -122,6 +140,15 @@
     background: var(--repo-bg, var(--ui-accent));
     color: var(--repo-fg, white);
     border-color: transparent;
+  }
+
+  .filter-chip.clear-chip {
+    gap: 4px;
+    color: var(--text-muted);
+  }
+
+  .filter-chip.clear-chip:hover {
+    color: var(--text-primary);
   }
 
   .filter-count {

--- a/apps/staged/src/lib/features/projects/ProjectFilterChips.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectFilterChips.svelte
@@ -1,0 +1,199 @@
+<!--
+  ProjectFilterChips.svelte - Shared project-filter chip bar.
+
+  Unread/running status chips plus one chip per repo, reading and toggling
+  projectFiltersStore directly so the landing page and the sidebar's filter
+  row can never drift. `compact` shrinks the chips for the narrow sidebar.
+-->
+<script lang="ts">
+  import RepoLabel from '../../shared/RepoLabel.svelte';
+  import { badgeBg, badgeBgHover, badgeFg } from '../../shared/badgeColors';
+  import { darkMode } from '../../stores/isDark.svelte';
+  import { repoBadgeStore } from '../../stores/repoBadges.svelte';
+  import { projectFiltersStore } from './projectFilters.svelte';
+
+  interface Props {
+    /** Smaller chips, tighter gaps for the narrow sidebar. */
+    compact?: boolean;
+  }
+
+  let { compact = false }: Props = $props();
+</script>
+
+<div class="filter-bar" class:compact>
+  <button
+    class="filter-chip"
+    class:active={projectFiltersStore.isFilterActive('unread')}
+    onclick={(e: MouseEvent) => projectFiltersStore.toggleFilter('unread', e)}
+    disabled={projectFiltersStore.unreadCount === 0 &&
+      !projectFiltersStore.isFilterActive('unread')}
+  >
+    Unread
+    <span class="filter-count">{projectFiltersStore.unreadCount}</span>
+  </button>
+  <button
+    class="filter-chip"
+    class:active={projectFiltersStore.isFilterActive('running')}
+    onclick={(e: MouseEvent) => projectFiltersStore.toggleFilter('running', e)}
+    disabled={projectFiltersStore.runningCount === 0 &&
+      !projectFiltersStore.isFilterActive('running')}
+  >
+    Running
+    <span class="filter-count">{projectFiltersStore.runningCount}</span>
+  </button>
+  {#each projectFiltersStore.repoFilters as rf}
+    {@const badge = repoBadgeStore.lookup(rf.repo, rf.subpath || undefined)}
+    {@const filter = { repo: rf.repo, subpath: rf.subpath }}
+    {@const active = projectFiltersStore.isFilterActive(filter)}
+    <button
+      class="filter-chip repo-filter"
+      class:active
+      onclick={(e: MouseEvent) => projectFiltersStore.toggleFilter(filter, e)}
+      style={badge
+        ? `--repo-bg: ${badgeBg(badge.hue, darkMode.value)}; --repo-fg: ${badgeFg(badge.hue, darkMode.value)}; --repo-bg-hover: ${badgeBgHover(badge.hue, darkMode.value)}`
+        : ''}
+    >
+      <RepoLabel githubRepo={rf.repo} subpath={rf.subpath || null} />
+      <span class="filter-count">{rf.count}</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 14px;
+  }
+
+  .filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border: 1px solid var(--border-muted);
+    border-radius: 999px;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-size: var(--size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .filter-chip:hover:not(:disabled) {
+    background: var(--bg-hover);
+    border-color: var(--border-emphasis);
+  }
+
+  .filter-chip.active:hover:not(:disabled) {
+    background: var(--ui-accent);
+    border-color: var(--ui-accent);
+  }
+
+  .filter-chip:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .filter-chip.active {
+    background: var(--ui-accent);
+    border-color: var(--ui-accent);
+    color: white;
+  }
+
+  .filter-chip.repo-filter {
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--repo-bg, var(--bg-elevated));
+    color: var(--repo-fg, var(--text-secondary));
+    border-color: transparent;
+  }
+
+  .filter-chip.repo-filter:hover:not(:disabled) {
+    background: var(--repo-bg-hover, var(--bg-hover));
+  }
+
+  .filter-chip.repo-filter.active {
+    box-shadow: 0 0 0 2px var(--repo-fg, var(--ui-accent));
+    background: var(--repo-bg, var(--ui-accent));
+    color: var(--repo-fg, white);
+    border-color: transparent;
+  }
+
+  .filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 999px;
+    background: rgba(128, 128, 128, 0.15);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .filter-chip.active .filter-count {
+    background: rgba(255, 255, 255, 0.25);
+  }
+
+  .filter-chip.repo-filter .filter-count {
+    background: rgba(128, 128, 128, 0.15);
+  }
+
+  .filter-chip.repo-filter.active .filter-count {
+    background: rgba(128, 128, 128, 0.2);
+  }
+
+  .filter-chip.repo-filter :global(.repo-label-prefix) {
+    color: inherit;
+    opacity: 0.6;
+  }
+
+  .filter-chip.repo-filter :global(.repo-label-emphasis) {
+    color: inherit;
+  }
+
+  .filter-bar.compact {
+    gap: 4px;
+    margin-bottom: 0;
+  }
+
+  .filter-bar.compact .filter-chip {
+    gap: 5px;
+    padding: 2px 8px;
+    font-size: var(--size-xs);
+  }
+
+  .filter-bar.compact .filter-chip.repo-filter {
+    font-size: 10px;
+  }
+
+  .filter-bar.compact .filter-count {
+    min-width: 15px;
+    height: 15px;
+    padding: 0 4px;
+    font-size: 10px;
+  }
+
+  /* The sidebar (compact) never renders on mobile, so only the landing-page
+     bar needs the swipeable single-row treatment. */
+  @media (max-width: 640px) {
+    .filter-bar:not(.compact) {
+      flex-wrap: nowrap;
+      gap: 8px;
+      overflow-x: auto;
+      margin: 0 -16px 14px;
+      padding: 0 16px 4px;
+    }
+
+    .filter-bar:not(.compact) .filter-chip {
+      min-height: 36px;
+    }
+  }
+</style>

--- a/apps/staged/src/lib/features/projects/ProjectHome.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectHome.svelte
@@ -128,14 +128,14 @@
   onMount(() => {
     // Backend/window listeners for the shared data (pr-status-changed,
     // session-status-changed, project-setup-progress, cache-stale) live in
-    // the projectsData store, started once from App.svelte.
+    // the projectsData and projectRunActions stores, started once from
+    // App.svelte.
     workspaceLifecycle.start({
       getBranchesByProject: () => projectsDataStore.branchesByProject,
       setBranchesByProject: (next) => projectsDataStore.setBranchesByProject(next),
       isProjectDeleting: (projectId) => projectsDataStore.isProjectDeleting(projectId),
     });
     checkStoreAndLoad();
-    void projectRunActionsStore.startListening();
 
     const onNewProject = (event: Event) => handleNewProject(repoSeedFromNewProjectEvent(event));
     window.addEventListener('staged:new-project', onNewProject);
@@ -165,7 +165,6 @@
       unlistenDetection();
       cancelQueuedSessionDrain();
       workspaceLifecycle.stop();
-      projectRunActionsStore.stopListening();
     };
   });
 

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -44,17 +44,18 @@
   } from './projectsListViewState.svelte';
   import { darkMode } from '../../stores/isDark.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
-  import { badgeBg, badgeFg, badgeBgHover } from '../../shared/badgeColors';
+  import { badgeBg, badgeFg } from '../../shared/badgeColors';
+  import { projectFiltersStore } from './projectFilters.svelte';
+  import ProjectFilterChips from './ProjectFilterChips.svelte';
   import { repoSeedFromNewProjectEvent } from './newProjectEvent';
   import type { RepoSelection } from '../../shared/githubUrl';
   import { viewport } from '../../shared/viewport.svelte';
   import TopBarPortal from '../layout/TopBarPortal.svelte';
 
-  type FilterKind = 'unread' | 'running' | { repo: string; subpath: string };
-
   // Data comes from the shared projectsData store — returning to the landing
   // page paints instantly from memory while the store revalidates in the
-  // background. Filters, scroll restore, and modal state stay view-local.
+  // background. Filters live in the shared projectFiltersStore so the sidebar
+  // sees the same selection; scroll restore and modal state stay view-local.
   let projects = $derived(projectsDataStore.projects);
   let projectBranches = $derived(projectsDataStore.branchesByProject);
   let reposByProject = $derived(projectsDataStore.reposByProject);
@@ -71,126 +72,11 @@
   let newProjectInitialRepo = $state<RepoSelection | null>(null);
   let isCommandKeyHeld = $state(false);
   let mainPanelEl = $state<HTMLDivElement | null>(null);
-  let activeFilters = $state<Set<string>>(new Set());
   let restoreInProgress = false;
   let restoreToken = 0;
   const projectCardElements = new Map<string, HTMLElement>();
 
-  /** Unique repo+subpath entries sorted alphabetically by full display string */
-  let repoFilters = $derived.by(() => {
-    const counts = new Map<string, { repo: string; subpath: string; count: number }>();
-    for (const project of projects) {
-      const repos = reposByProject.get(project.id) ?? [];
-      if (repos.length > 0) {
-        for (const r of repos) {
-          const displayRepo = r.headRepo ?? r.githubRepo;
-          const key = `${displayRepo}:${r.subpath ?? ''}`;
-          const entry = counts.get(key);
-          if (entry) {
-            entry.count++;
-          } else {
-            counts.set(key, { repo: displayRepo, subpath: r.subpath ?? '', count: 1 });
-          }
-        }
-      } else if (project.githubRepo) {
-        const key = `${project.githubRepo}:${project.subpath ?? ''}`;
-        const entry = counts.get(key);
-        if (entry) {
-          entry.count++;
-        } else {
-          counts.set(key, { repo: project.githubRepo, subpath: project.subpath ?? '', count: 1 });
-        }
-      }
-    }
-    return [...counts.values()].sort((a, b) => {
-      const aDisplay = a.subpath ? `${a.repo}/${a.subpath}` : a.repo;
-      const bDisplay = b.subpath ? `${b.repo}/${b.subpath}` : b.repo;
-      return aDisplay.localeCompare(bDisplay);
-    });
-  });
-
-  function filterKey(filter: FilterKind): string {
-    if (typeof filter === 'string') return filter;
-    return `repo:${filter.repo}:${filter.subpath}`;
-  }
-
-  let allFilters = $derived.by(() => {
-    const filters: FilterKind[] = ['unread', 'running'];
-    for (const rf of repoFilters) {
-      filters.push({ repo: rf.repo, subpath: rf.subpath });
-    }
-    return filters;
-  });
-
-  let unreadCount = $derived(projects.filter((p) => projectStateStore.isUnread(p.id)).length);
-
-  let runningCount = $derived(
-    projects.filter((p) => {
-      const status = getProjectStatus(p.id, deletingProjectNames, projectBranches.get(p.id) || []);
-      return status.kind === 'running' || status.kind === 'runAction';
-    }).length
-  );
-
-  let hasRepoFilters = $derived(
-    [...activeFilters].some((key) => key !== 'unread' && key !== 'running')
-  );
-
-  let filteredProjects = $derived.by(() => {
-    if (activeFilters.size === 0) return projects;
-    return projects.filter((p) => {
-      // Status filters are AND'd with each other and with repo filters
-      if (activeFilters.has('unread') && !projectStateStore.isUnread(p.id)) return false;
-      if (activeFilters.has('running')) {
-        const status = getProjectStatus(
-          p.id,
-          deletingProjectNames,
-          projectBranches.get(p.id) || []
-        );
-        if (status.kind !== 'running' && status.kind !== 'runAction') return false;
-      }
-      // Repo filters are OR'd with each other
-      if (!hasRepoFilters) return true;
-      const repos = reposByProject.get(p.id) ?? [];
-      if (repos.length > 0) {
-        return repos.some((r) =>
-          activeFilters.has(
-            filterKey({ repo: r.headRepo ?? r.githubRepo, subpath: r.subpath ?? '' })
-          )
-        );
-      }
-      if (p.githubRepo) {
-        return activeFilters.has(filterKey({ repo: p.githubRepo, subpath: p.subpath ?? '' }));
-      }
-      return false;
-    });
-  });
-
-  function toggleFilter(filter: FilterKind, event?: MouseEvent) {
-    const key = filterKey(filter);
-
-    if (event?.shiftKey) {
-      // Shift+click: toggle individual filter
-      const next = new Set(activeFilters);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      activeFilters = next;
-    } else {
-      // Plain click: switch to this filter exclusively
-      if (activeFilters.size === 1 && activeFilters.has(key)) {
-        // Clicking the only active filter deselects it (back to showing all)
-        activeFilters = new Set();
-      } else {
-        activeFilters = new Set([key]);
-      }
-    }
-  }
-
-  function isFilterActive(filter: FilterKind): boolean {
-    return activeFilters.has(filterKey(filter));
-  }
+  let filteredProjects = $derived(projectFiltersStore.filteredProjects);
 
   function trackProjectCard(node: HTMLElement, projectId: string) {
     let currentProjectId = projectId;
@@ -462,44 +348,7 @@
           </div>
         {/if}
 
-        {#if projects.length > 0}
-          <div class="filter-bar">
-            <button
-              class="filter-chip"
-              class:active={isFilterActive('unread')}
-              onclick={(e: MouseEvent) => toggleFilter('unread', e)}
-              disabled={unreadCount === 0 && !isFilterActive('unread')}
-            >
-              Unread
-              <span class="filter-count">{unreadCount}</span>
-            </button>
-            <button
-              class="filter-chip"
-              class:active={isFilterActive('running')}
-              onclick={(e: MouseEvent) => toggleFilter('running', e)}
-              disabled={runningCount === 0 && !isFilterActive('running')}
-            >
-              Running
-              <span class="filter-count">{runningCount}</span>
-            </button>
-            {#each repoFilters as rf}
-              {@const badge = repoBadgeStore.lookup(rf.repo, rf.subpath || undefined)}
-              {@const filter = { repo: rf.repo, subpath: rf.subpath }}
-              {@const active = isFilterActive(filter)}
-              <button
-                class="filter-chip repo-filter"
-                class:active
-                onclick={(e: MouseEvent) => toggleFilter(filter, e)}
-                style={badge
-                  ? `--repo-bg: ${badgeBg(badge.hue, darkMode.value)}; --repo-fg: ${badgeFg(badge.hue, darkMode.value)}; --repo-bg-hover: ${badgeBgHover(badge.hue, darkMode.value)}`
-                  : ''}
-              >
-                <RepoLabel githubRepo={rf.repo} subpath={rf.subpath || null} />
-                <span class="filter-count">{rf.count}</span>
-              </button>
-            {/each}
-          </div>
-        {/if}
+        <ProjectFilterChips />
         <div class="projects-grid">
           {#each filteredProjects as project, index (project.id)}
             {@const status = getProjectStatus(
@@ -714,105 +563,6 @@
 
   .state.error {
     color: var(--ui-danger);
-  }
-
-  .filter-bar {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin-bottom: 14px;
-  }
-
-  .filter-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    border: 1px solid var(--border-muted);
-    border-radius: 999px;
-    background: var(--bg-elevated);
-    color: var(--text-secondary);
-    font-size: var(--size-sm);
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    white-space: nowrap;
-  }
-
-  .filter-chip:hover:not(:disabled) {
-    background: var(--bg-hover);
-    border-color: var(--border-emphasis);
-  }
-
-  .filter-chip.active:hover:not(:disabled) {
-    background: var(--ui-accent);
-    border-color: var(--ui-accent);
-  }
-
-  .filter-chip:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-
-  .filter-chip.active {
-    background: var(--ui-accent);
-    border-color: var(--ui-accent);
-    color: white;
-  }
-
-  .filter-chip.repo-filter {
-    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
-    font-size: 11px;
-    font-weight: 600;
-    background: var(--repo-bg, var(--bg-elevated));
-    color: var(--repo-fg, var(--text-secondary));
-    border-color: transparent;
-  }
-
-  .filter-chip.repo-filter:hover:not(:disabled) {
-    background: var(--repo-bg-hover, var(--bg-hover));
-  }
-
-  .filter-chip.repo-filter.active {
-    box-shadow: 0 0 0 2px var(--repo-fg, var(--ui-accent));
-    background: var(--repo-bg, var(--ui-accent));
-    color: var(--repo-fg, white);
-    border-color: transparent;
-  }
-
-  .filter-count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 18px;
-    height: 18px;
-    padding: 0 5px;
-    border-radius: 999px;
-    background: rgba(128, 128, 128, 0.15);
-    font-size: 11px;
-    font-weight: 600;
-    line-height: 1;
-  }
-
-  .filter-chip.active .filter-count {
-    background: rgba(255, 255, 255, 0.25);
-  }
-
-  .filter-chip.repo-filter .filter-count {
-    background: rgba(128, 128, 128, 0.15);
-  }
-
-  .filter-chip.repo-filter.active .filter-count {
-    background: rgba(128, 128, 128, 0.2);
-  }
-
-  .filter-chip.repo-filter :global(.repo-label-prefix) {
-    color: inherit;
-    opacity: 0.6;
-  }
-
-  .filter-chip.repo-filter :global(.repo-label-emphasis) {
-    color: inherit;
   }
 
   .repos-section {
@@ -1082,18 +832,6 @@
   @media (max-width: 640px) {
     .content {
       padding: 16px;
-    }
-
-    .filter-bar {
-      flex-wrap: nowrap;
-      gap: 8px;
-      overflow-x: auto;
-      margin: 0 -16px 14px;
-      padding: 0 16px 4px;
-    }
-
-    .filter-chip {
-      min-height: 36px;
     }
 
     .projects-grid {

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -182,10 +182,9 @@
 
   onMount(() => {
     // Backend/window listeners for the shared data live in the projectsData
-    // store, started once from App.svelte.
+    // and projectRunActions stores, started once from App.svelte.
     void projectsDataStore.ensureLoaded();
     void projectsDataStore.ensureHomeReposLoaded();
-    void projectRunActionsStore.startListening();
 
     const onNewProject = (event: Event) => {
       newProjectInitialRepo = repoSeedFromNewProjectEvent(event);
@@ -194,7 +193,6 @@
     window.addEventListener('staged:new-project', onNewProject);
 
     return () => {
-      projectRunActionsStore.stopListening();
       window.removeEventListener('staged:new-project', onNewProject);
     };
   });

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -286,8 +286,8 @@
     if ((e.metaKey || e.ctrlKey) && /^[1-9]$/.test(e.key)) {
       e.preventDefault();
       const index = parseInt(e.key) - 1;
-      if (index < projects.length) {
-        openProject(projects[index].id);
+      if (index < filteredProjects.length) {
+        openProject(filteredProjects[index].id);
       }
     }
   }

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -81,25 +81,29 @@
   // Unread active the card returnTargetProjectId points at — the one the
   // scroll restore is aiming for — would otherwise be gone on arrival. Same
   // exception the sidebar makes for the selected project. Captured at mount
-  // (this component is created fresh on every return to the landing page) and
-  // dropped on the first filter change, so a deliberate re-filter hides it.
-  let stickyProjectId = $state<string | null>(projectsListViewState.returnTargetProjectId);
-  let lastSeenFilters: Set<string> | null = null;
-  $effect(() => {
-    const active = projectFiltersStore.activeFilters;
-    if (lastSeenFilters && lastSeenFilters !== active) {
-      stickyProjectId = null;
-    }
-    lastSeenFilters = active;
-  });
+  // (this component is created fresh on every return to the landing page),
+  // but only while a restore is actually pending: returnTargetProjectId is
+  // never cleared, so an ordinary mount — landing → settings → back, where
+  // requestProjectsListRestore(null) early-returns — would otherwise pin a
+  // project from a previous visit. restorePending is still true here; the
+  // effect that finishes the restore runs after mount.
+  const stickyProjectId = projectsListViewState.restorePending
+    ? projectsListViewState.returnTargetProjectId
+    : null;
+  // The exception lasts only until the first filter change, so a deliberate
+  // re-filter hides the card. The store replaces the Set on every change, so
+  // identity is the signal — derived rather than tracked in an effect, which
+  // would paint the stale card once under the new filters before removing it.
+  const filtersAtMount = projectFiltersStore.activeFilters;
 
   let filteredProjects = $derived.by(() => {
     const filtered = projectFiltersStore.filteredProjects;
-    if (!stickyProjectId || filtered.some((p) => p.id === stickyProjectId)) return filtered;
+    const sticky = projectFiltersStore.activeFilters === filtersAtMount ? stickyProjectId : null;
+    if (!sticky || filtered.some((p) => p.id === sticky)) return filtered;
     // Rebuilt from the full list rather than appended so the sticky card keeps
     // its place in the grid — the position the scroll restore captured.
     const matched = new Set(filtered.map((p) => p.id));
-    return projects.filter((p) => matched.has(p.id) || p.id === stickyProjectId);
+    return projects.filter((p) => matched.has(p.id) || p.id === sticky);
   });
 
   function trackProjectCard(node: HTMLElement, projectId: string) {

--- a/apps/staged/src/lib/features/projects/ProjectsList.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsList.svelte
@@ -76,7 +76,31 @@
   let restoreToken = 0;
   const projectCardElements = new Map<string, HTMLElement>();
 
-  let filteredProjects = $derived(projectFiltersStore.filteredProjects);
+  // The card you just came back from stays in the grid even when the active
+  // filters no longer match it: visiting a project marks it read, so with
+  // Unread active the card returnTargetProjectId points at — the one the
+  // scroll restore is aiming for — would otherwise be gone on arrival. Same
+  // exception the sidebar makes for the selected project. Captured at mount
+  // (this component is created fresh on every return to the landing page) and
+  // dropped on the first filter change, so a deliberate re-filter hides it.
+  let stickyProjectId = $state<string | null>(projectsListViewState.returnTargetProjectId);
+  let lastSeenFilters: Set<string> | null = null;
+  $effect(() => {
+    const active = projectFiltersStore.activeFilters;
+    if (lastSeenFilters && lastSeenFilters !== active) {
+      stickyProjectId = null;
+    }
+    lastSeenFilters = active;
+  });
+
+  let filteredProjects = $derived.by(() => {
+    const filtered = projectFiltersStore.filteredProjects;
+    if (!stickyProjectId || filtered.some((p) => p.id === stickyProjectId)) return filtered;
+    // Rebuilt from the full list rather than appended so the sticky card keeps
+    // its place in the grid — the position the scroll restore captured.
+    const matched = new Set(filtered.map((p) => p.id));
+    return projects.filter((p) => matched.has(p.id) || p.id === stickyProjectId);
+  });
 
   function trackProjectCard(node: HTMLElement, projectId: string) {
     let currentProjectId = projectId;
@@ -131,15 +155,24 @@
   }
 
   $effect(() => {
-    const readyToRestore =
+    const readyToDecide =
       projectsListViewState.restorePending &&
       !restoreInProgress &&
       !loading &&
       !error &&
-      filteredProjects.length > 0 &&
       mainPanelEl;
 
-    if (!readyToRestore) return;
+    if (!readyToDecide) return;
+
+    // Nothing to restore to — the shared filters can outlive this view and
+    // match no project at all. Drop the request rather than leaving it armed:
+    // it would otherwise fire whenever the list next became non-empty, jumping
+    // scroll to a position captured for a different list.
+    if (filteredProjects.length === 0) {
+      finishProjectsListRestore();
+      return;
+    }
+
     void restoreProjectsListPosition();
   });
 
@@ -349,6 +382,9 @@
         {/if}
 
         <ProjectFilterChips />
+        {#if filteredProjects.length === 0}
+          <div class="state">No projects match filters</div>
+        {/if}
         <div class="projects-grid">
           {#each filteredProjects as project, index (project.id)}
             {@const status = getProjectStatus(

--- a/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
@@ -25,6 +25,7 @@
   import RepoBadge from '../../shared/RepoBadge.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { projectsDataStore } from '../../stores/projectsData.svelte';
+  import { projectRunActionsStore } from '../../stores/projectRunActions.svelte';
   import { projectStateStore } from '../../stores/projectState.svelte';
   import Spinner from '../../shared/Spinner.svelte';
   import SineWave from '../../shared/SineWave.svelte';
@@ -100,6 +101,17 @@
     if (!selectedId || filtered.some((p) => p.id === selectedId)) return filtered;
     const selected = projects.find((p) => p.id === selectedId);
     return selected ? [...filtered, selected] : filtered;
+  });
+
+  // Keep run-action state hydrated for the row status dots and the Running
+  // filter — on the repos route this is the only mounted surface that can
+  // feed branch data to the store (ProjectsList and ProjectHome run the same
+  // sweep on their routes). The store dedupes branches it has already
+  // queried, so overlapping with ProjectHome on the project route is cheap.
+  $effect(() => {
+    projectRunActionsStore
+      .hydrateFromProjectBranches(projectsDataStore.branchesByProject)
+      .catch(console.error);
   });
 
   function handleDragStart(index: number) {

--- a/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
+++ b/apps/staged/src/lib/features/projects/ProjectsSidebar.svelte
@@ -41,6 +41,8 @@
   } from './projectsSidebarState.svelte';
   import { viewport, watchViewport } from '../../shared/viewport.svelte';
   import RepoCard from './RepoCard.svelte';
+  import SidebarFilterRow from './SidebarFilterRow.svelte';
+  import { projectFiltersStore } from './projectFilters.svelte';
   import * as commands from '../../api/commands';
   import { projectActions } from './projectActions.svelte';
   import * as ContextMenu from '$lib/components/ui/context-menu';
@@ -87,6 +89,18 @@
   let showAllReposRow = $derived(
     projectsDataStore.homeRepos.length > 0 || navigation.showReposList
   );
+
+  // Project rows follow the shared filter state, with one exception: the
+  // selected project stays visible (appended if filtered out) so the row
+  // highlighting the active view can't vanish out from under it — the same
+  // rule that keeps the All Repos row above.
+  let sidebarProjects = $derived.by(() => {
+    const filtered = projectFiltersStore.filteredProjects;
+    const selectedId = navigation.selectedProjectId;
+    if (!selectedId || filtered.some((p) => p.id === selectedId)) return filtered;
+    const selected = projects.find((p) => p.id === selectedId);
+    return selected ? [...filtered, selected] : filtered;
+  });
 
   function handleDragStart(index: number) {
     return (e: DragEvent) => {
@@ -473,7 +487,17 @@
           {#if projects.length === 0}
             <div class="state">No projects yet.</div>
           {:else}
-            {#each projects as project (project.id)}
+            <SidebarFilterRow />
+            {#if sidebarProjects.length === 0}
+              <div class="state no-matches">
+                <span>No projects match filters</span>
+                <button
+                  class="clear-filters-link"
+                  onclick={() => projectFiltersStore.clearFilters()}>Clear filters</button
+                >
+              </div>
+            {/if}
+            {#each sidebarProjects as project (project.id)}
               {@const status = getProjectStatus(
                 project.id,
                 deletingProjectNames,
@@ -925,6 +949,28 @@
 
   .state.error {
     color: var(--ui-danger);
+  }
+
+  .state.no-matches {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 8px 2px;
+  }
+
+  .clear-filters-link {
+    border: none;
+    background: transparent;
+    padding: 0;
+    color: var(--ui-accent);
+    font-size: var(--size-xs);
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .clear-filters-link:hover {
+    text-decoration: underline;
   }
 
   .resize-handle {

--- a/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
+++ b/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
@@ -9,6 +9,10 @@
   in an elevated dropdown under the row (so the two surfaces can't drift),
   dismissed by clicking anywhere outside. Only the open/closed state is
   local — the selection itself lives in projectFiltersStore.
+
+  The row is sticky: once the sidebar scrolls past its natural position it
+  pins to the top of the scroll area, so the filter summary (and the way out
+  of a filtered-down list) stays reachable from anywhere in a long list.
 -->
 <script lang="ts">
   import ChevronDown from '@lucide/svelte/icons/chevron-down';
@@ -24,6 +28,35 @@
   import ProjectFilterChips from './ProjectFilterChips.svelte';
 
   let open = $state(false);
+  let stuck = $state(false);
+
+  // The hairline under the row should only exist while it's pinned, and CSS
+  // has no pinned-state selector for sticky elements. With the scroll
+  // container's top edge inset by 1px, being clipped at the *top* is unique
+  // to the pinned state — clipped at the bottom just means the row scrolled
+  // below the fold — and an observer also catches pinning caused by content
+  // above the row changing height, which fires no scroll event.
+  function observeStuck(node: HTMLElement) {
+    let scrollParent = node.parentElement;
+    while (scrollParent && !/auto|scroll/.test(getComputedStyle(scrollParent).overflowY)) {
+      scrollParent = scrollParent.parentElement;
+    }
+    if (!scrollParent) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        stuck =
+          entry.intersectionRatio < 1 &&
+          entry.boundingClientRect.top <= (entry.rootBounds?.top ?? Number.NEGATIVE_INFINITY);
+      },
+      { root: scrollParent, threshold: 1, rootMargin: '-1px 0px 0px 0px' }
+    );
+    observer.observe(node);
+    return {
+      destroy() {
+        observer.disconnect();
+      },
+    };
+  }
 
   let statusLabels = $derived.by(() => {
     const labels: string[] = [];
@@ -59,7 +92,12 @@
 </script>
 
 <Popover.Root bind:open>
-  <div class="filter-row" class:filtering={projectFiltersStore.hasActiveFilters}>
+  <div
+    class="filter-row"
+    class:filtering={projectFiltersStore.hasActiveFilters}
+    class:stuck
+    use:observeStuck
+  >
     <Popover.Trigger
       class="sidebar-filter-trigger"
       title={open ? 'Hide filter options' : 'Filter projects'}
@@ -120,11 +158,21 @@
 
 <style>
   .filter-row {
+    position: sticky;
+    top: 0;
+    z-index: 2;
     display: flex;
     align-items: center;
     gap: 2px;
     width: calc(100% + (2 * var(--project-row-bleed)));
     margin: 0 calc(-1 * var(--project-row-bleed));
+    /* Opaque so rows scrolling under the pinned row are masked, invisible at
+       rest since it matches the sidebar. */
+    background: var(--bg-app-bar);
+  }
+
+  .filter-row.stuck {
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--border-subtle) 50%, transparent);
   }
 
   /* Popover.Trigger renders in a child component, so its class escapes this

--- a/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
+++ b/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
@@ -15,9 +15,10 @@
   import ListFilter from '@lucide/svelte/icons/list-filter';
   import X from '@lucide/svelte/icons/x';
   import RepoBadge from '../../shared/RepoBadge.svelte';
+  import RepoLabel from '../../shared/RepoLabel.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
   import { projectsDataStore } from '../../stores/projectsData.svelte';
-  import { projectFiltersStore } from './projectFilters.svelte';
+  import { filterKey, projectFiltersStore } from './projectFilters.svelte';
   import ProjectFilterChips from './ProjectFilterChips.svelte';
 
   let expanded = $state(false);
@@ -29,11 +30,19 @@
     return labels;
   });
 
-  let activeBadges = $derived(
+  // A badge lookup can miss — badges are only ensured for a repo's
+  // githubRepo, while filter keys use headRepo ?? githubRepo, so a
+  // fork-backed repo has no badge under its head name. Fall back to the repo
+  // path instead of dropping the entry: a filter that names nothing leaves
+  // this row showing a funnel and a bare count, which is the one thing it
+  // exists to explain.
+  let activeRepos = $derived(
     projectFiltersStore.activeRepoFilters
-      .map((f) => repoBadgeStore.lookup(f.repo, f.subpath || undefined))
-      .filter((b): b is NonNullable<typeof b> => Boolean(b))
-      .sort((a, b) => a.shortName.localeCompare(b.shortName))
+      .map((filter) => {
+        const badge = repoBadgeStore.lookup(filter.repo, filter.subpath || undefined);
+        return { filter, badge, sortKey: badge?.shortName ?? filter.repo };
+      })
+      .sort((a, b) => a.sortKey.localeCompare(b.sortKey))
   );
 
   // The repo chips and their counts derive from reposByProject, which
@@ -60,10 +69,16 @@
         {#if statusLabels.length > 0}
           <span class="status-labels">{statusLabels.join(', ')}</span>
         {/if}
-        {#if activeBadges.length > 0}
+        {#if activeRepos.length > 0}
           <span class="badge-row">
-            {#each activeBadges as badge}
-              <RepoBadge shortName={badge.shortName} hue={badge.hue} small />
+            {#each activeRepos as { filter, badge } (filterKey(filter))}
+              {#if badge}
+                <RepoBadge shortName={badge.shortName} hue={badge.hue} small />
+              {:else}
+                <span class="repo-fallback">
+                  <RepoLabel githubRepo={filter.repo} subpath={filter.subpath || null} />
+                </span>
+              {/if}
             {/each}
           </span>
         {/if}
@@ -172,6 +187,15 @@
     min-width: 0;
     min-height: 14px;
     overflow: hidden;
+  }
+
+  .repo-fallback {
+    display: inline-flex;
+    align-items: center;
+    max-width: 96px;
+    overflow: hidden;
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+    font-size: 9.5px;
   }
 
   .match-count {

--- a/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
+++ b/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
@@ -4,16 +4,18 @@
   Collapsed: one line summarizing the shared filter state — muted "Filter
   projects" when nothing is active; otherwise the active status filters as
   text, the active repo filters as badges, and a matched/total count, plus a
-  ✕ that clears everything without expanding. Expanded: the same
-  ProjectFilterChips bar the landing page renders, so the two surfaces can't
-  drift. Only the open/closed state is local — the selection itself lives in
-  projectFiltersStore.
+  ✕ that clears everything without expanding. The row is a Popover trigger:
+  opening it floats the same ProjectFilterChips bar the landing page renders
+  in an elevated dropdown under the row (so the two surfaces can't drift),
+  dismissed by clicking anywhere outside. Only the open/closed state is
+  local — the selection itself lives in projectFiltersStore.
 -->
 <script lang="ts">
   import ChevronDown from '@lucide/svelte/icons/chevron-down';
   import ChevronRight from '@lucide/svelte/icons/chevron-right';
   import ListFilter from '@lucide/svelte/icons/list-filter';
   import X from '@lucide/svelte/icons/x';
+  import * as Popover from '$lib/components/ui/popover';
   import RepoBadge from '../../shared/RepoBadge.svelte';
   import RepoLabel from '../../shared/RepoLabel.svelte';
   import { repoBadgeStore } from '../../stores/repoBadges.svelte';
@@ -21,7 +23,7 @@
   import { filterKey, projectFiltersStore } from './projectFilters.svelte';
   import ProjectFilterChips from './ProjectFilterChips.svelte';
 
-  let expanded = $state(false);
+  let open = $state(false);
 
   let statusLabels = $derived.by(() => {
     const labels: string[] = [];
@@ -49,71 +51,72 @@
   // otherwise only fills via the store's idle drip — the landing page forces
   // hydration but the sidebar never did, so kick it when the chips become
   // visible or they could render missing or undercounted when the app opens
-  // straight into a project. Re-runs when a reload lands while expanded.
+  // straight into a project. Re-runs when a reload lands while open.
   $effect(() => {
-    if (!expanded || !projectsDataStore.loaded) return;
+    if (!open || !projectsDataStore.loaded) return;
     void projectsDataStore.ensureProjectsHydrated();
   });
 </script>
 
-<div class="filter-row" class:filtering={projectFiltersStore.hasActiveFilters}>
-  <button
-    class="summary-button"
-    aria-expanded={expanded}
-    title={expanded ? 'Hide filter options' : 'Filter projects'}
-    onclick={() => (expanded = !expanded)}
-  >
-    <span class="filter-icon"><ListFilter size={13} /></span>
-    {#if projectFiltersStore.hasActiveFilters}
-      <span class="summary">
-        {#if statusLabels.length > 0}
-          <span class="status-labels">{statusLabels.join(', ')}</span>
-        {/if}
-        {#if activeRepos.length > 0}
-          <span class="badge-row">
-            {#each activeRepos as { filter, badge } (filterKey(filter))}
-              {#if badge}
-                <RepoBadge shortName={badge.shortName} hue={badge.hue} small />
-              {:else}
-                <span class="repo-fallback">
-                  <RepoLabel githubRepo={filter.repo} subpath={filter.subpath || null} />
-                </span>
-              {/if}
-            {/each}
-          </span>
-        {/if}
-      </span>
-      <span class="match-count">
-        {projectFiltersStore.filteredProjects.length}/{projectsDataStore.projects.length}
-      </span>
-    {:else}
-      <span class="summary placeholder">Filter projects</span>
-    {/if}
-    <span class="chevron">
-      {#if expanded}
-        <ChevronDown size={12} />
-      {:else}
-        <ChevronRight size={12} />
-      {/if}
-    </span>
-  </button>
-  {#if projectFiltersStore.hasActiveFilters}
-    <button
-      class="clear-button"
-      aria-label="Clear filters"
-      title="Clear filters"
-      onclick={() => projectFiltersStore.clearFilters()}
+<Popover.Root bind:open>
+  <div class="filter-row" class:filtering={projectFiltersStore.hasActiveFilters}>
+    <Popover.Trigger
+      class="sidebar-filter-trigger"
+      title={open ? 'Hide filter options' : 'Filter projects'}
     >
-      <X size={12} />
-    </button>
-  {/if}
-</div>
-
-{#if expanded}
-  <div class="chips-container">
-    <ProjectFilterChips compact />
+      <span class="filter-icon"><ListFilter size={13} /></span>
+      {#if projectFiltersStore.hasActiveFilters}
+        <span class="summary">
+          {#if statusLabels.length > 0}
+            <span class="status-labels">{statusLabels.join(', ')}</span>
+          {/if}
+          {#if activeRepos.length > 0}
+            <span class="badge-row">
+              {#each activeRepos as { filter, badge } (filterKey(filter))}
+                {#if badge}
+                  <RepoBadge shortName={badge.shortName} hue={badge.hue} small />
+                {:else}
+                  <span class="repo-fallback">
+                    <RepoLabel githubRepo={filter.repo} subpath={filter.subpath || null} />
+                  </span>
+                {/if}
+              {/each}
+            </span>
+          {/if}
+        </span>
+        <span class="match-count">
+          {projectFiltersStore.filteredProjects.length}/{projectsDataStore.projects.length}
+        </span>
+      {:else}
+        <span class="summary placeholder">Filter projects</span>
+      {/if}
+      <span class="chevron">
+        {#if open}
+          <ChevronDown size={12} />
+        {:else}
+          <ChevronRight size={12} />
+        {/if}
+      </span>
+    </Popover.Trigger>
+    {#if projectFiltersStore.hasActiveFilters}
+      <button
+        class="clear-button"
+        aria-label="Clear filters"
+        title="Clear filters"
+        onclick={() => projectFiltersStore.clearFilters()}
+      >
+        <X size={12} />
+      </button>
+    {/if}
   </div>
-{/if}
+  <Popover.Content
+    align="start"
+    sideOffset={4}
+    class="sidebar-filter-panel w-[var(--bits-popover-anchor-width)] ring-0"
+  >
+    <ProjectFilterChips compact />
+  </Popover.Content>
+</Popover.Root>
 
 <style>
   .filter-row {
@@ -124,7 +127,10 @@
     margin: 0 calc(-1 * var(--project-row-bleed));
   }
 
-  .summary-button {
+  /* Popover.Trigger renders in a child component, so its class escapes this
+     component's scoping; the descendants below are authored here and stay
+     scoped. */
+  :global(.sidebar-filter-trigger) {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -144,7 +150,7 @@
       color 0.15s ease;
   }
 
-  .summary-button:hover {
+  :global(.sidebar-filter-trigger:hover) {
     background-color: var(--projects-sidebar-hover-bg);
     color: var(--text-primary);
   }
@@ -235,7 +241,15 @@
     color: var(--text-primary);
   }
 
-  .chips-container {
-    padding: 2px 2px 6px;
+  /* Unlayered, so it wins over the Tailwind utility defaults (p-4, gap-4,
+     bg-popover) baked into Popover.Content — same pattern as the settings
+     panel's theme dropdown. */
+  :global(.sidebar-filter-panel) {
+    gap: 0;
+    padding: 8px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    box-shadow: var(--shadow-elevated);
   }
 </style>

--- a/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
+++ b/apps/staged/src/lib/features/projects/SidebarFilterRow.svelte
@@ -1,0 +1,217 @@
+<!--
+  SidebarFilterRow.svelte - Compact project-filter row for the projects sidebar.
+
+  Collapsed: one line summarizing the shared filter state — muted "Filter
+  projects" when nothing is active; otherwise the active status filters as
+  text, the active repo filters as badges, and a matched/total count, plus a
+  ✕ that clears everything without expanding. Expanded: the same
+  ProjectFilterChips bar the landing page renders, so the two surfaces can't
+  drift. Only the open/closed state is local — the selection itself lives in
+  projectFiltersStore.
+-->
+<script lang="ts">
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
+  import ChevronRight from '@lucide/svelte/icons/chevron-right';
+  import ListFilter from '@lucide/svelte/icons/list-filter';
+  import X from '@lucide/svelte/icons/x';
+  import RepoBadge from '../../shared/RepoBadge.svelte';
+  import { repoBadgeStore } from '../../stores/repoBadges.svelte';
+  import { projectsDataStore } from '../../stores/projectsData.svelte';
+  import { projectFiltersStore } from './projectFilters.svelte';
+  import ProjectFilterChips from './ProjectFilterChips.svelte';
+
+  let expanded = $state(false);
+
+  let statusLabels = $derived.by(() => {
+    const labels: string[] = [];
+    if (projectFiltersStore.isFilterActive('unread')) labels.push('Unread');
+    if (projectFiltersStore.isFilterActive('running')) labels.push('Running');
+    return labels;
+  });
+
+  let activeBadges = $derived(
+    projectFiltersStore.activeRepoFilters
+      .map((f) => repoBadgeStore.lookup(f.repo, f.subpath || undefined))
+      .filter((b): b is NonNullable<typeof b> => Boolean(b))
+      .sort((a, b) => a.shortName.localeCompare(b.shortName))
+  );
+
+  // The repo chips and their counts derive from reposByProject, which
+  // otherwise only fills via the store's idle drip — the landing page forces
+  // hydration but the sidebar never did, so kick it when the chips become
+  // visible or they could render missing or undercounted when the app opens
+  // straight into a project. Re-runs when a reload lands while expanded.
+  $effect(() => {
+    if (!expanded || !projectsDataStore.loaded) return;
+    void projectsDataStore.ensureProjectsHydrated();
+  });
+</script>
+
+<div class="filter-row" class:filtering={projectFiltersStore.hasActiveFilters}>
+  <button
+    class="summary-button"
+    aria-expanded={expanded}
+    title={expanded ? 'Hide filter options' : 'Filter projects'}
+    onclick={() => (expanded = !expanded)}
+  >
+    <span class="filter-icon"><ListFilter size={13} /></span>
+    {#if projectFiltersStore.hasActiveFilters}
+      <span class="summary">
+        {#if statusLabels.length > 0}
+          <span class="status-labels">{statusLabels.join(', ')}</span>
+        {/if}
+        {#if activeBadges.length > 0}
+          <span class="badge-row">
+            {#each activeBadges as badge}
+              <RepoBadge shortName={badge.shortName} hue={badge.hue} small />
+            {/each}
+          </span>
+        {/if}
+      </span>
+      <span class="match-count">
+        {projectFiltersStore.filteredProjects.length}/{projectsDataStore.projects.length}
+      </span>
+    {:else}
+      <span class="summary placeholder">Filter projects</span>
+    {/if}
+    <span class="chevron">
+      {#if expanded}
+        <ChevronDown size={12} />
+      {:else}
+        <ChevronRight size={12} />
+      {/if}
+    </span>
+  </button>
+  {#if projectFiltersStore.hasActiveFilters}
+    <button
+      class="clear-button"
+      aria-label="Clear filters"
+      title="Clear filters"
+      onclick={() => projectFiltersStore.clearFilters()}
+    >
+      <X size={12} />
+    </button>
+  {/if}
+</div>
+
+{#if expanded}
+  <div class="chips-container">
+    <ProjectFilterChips compact />
+  </div>
+{/if}
+
+<style>
+  .filter-row {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    width: calc(100% + (2 * var(--project-row-bleed)));
+    margin: 0 calc(-1 * var(--project-row-bleed));
+  }
+
+  .summary-button {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: calc(var(--size-xs) - 1px);
+    font-weight: 500;
+    cursor: pointer;
+    padding: 5px 10px;
+    text-align: left;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .summary-button:hover {
+    background-color: var(--projects-sidebar-hover-bg);
+    color: var(--text-primary);
+  }
+
+  .filter-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .filter-row.filtering .filter-icon {
+    color: var(--ui-accent);
+  }
+
+  .summary {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .summary.placeholder {
+    color: inherit;
+  }
+
+  .status-labels {
+    flex-shrink: 0;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .badge-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    min-width: 0;
+    min-height: 14px;
+    overflow: hidden;
+  }
+
+  .match-count {
+    flex-shrink: 0;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .chevron {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    color: var(--text-faint);
+  }
+
+  .clear-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    margin-right: 4px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 0;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .clear-button:hover {
+    background-color: var(--projects-sidebar-hover-bg);
+    color: var(--text-primary);
+  }
+
+  .chips-container {
+    padding: 2px 2px 6px;
+  }
+</style>

--- a/apps/staged/src/lib/features/projects/projectFilters.svelte.ts
+++ b/apps/staged/src/lib/features/projects/projectFilters.svelte.ts
@@ -170,9 +170,6 @@ class ProjectFiltersStore {
 
   hasActiveFilters = $derived(this._activeFilters.size > 0);
 
-  /** True when any repo (non-status) filter is active. */
-  hasRepoFilters = $derived(hasRepoFilterKeys(this._activeFilters));
-
   repoFilters: RepoFilter[] = $derived.by(() =>
     computeRepoFilters(projectsDataStore.projects, projectsDataStore.reposByProject)
   );

--- a/apps/staged/src/lib/features/projects/projectFilters.svelte.ts
+++ b/apps/staged/src/lib/features/projects/projectFilters.svelte.ts
@@ -7,7 +7,7 @@
  * into a project and back for the app session — deliberately not persisted
  * to disk, matching how nothing about the filter UI persisted before.
  *
- * The derived getters read the global data stores directly; the underlying
+ * The $derived fields read the global data stores directly; the underlying
  * computations are exported as plain functions taking data as arguments so
  * the repo-fallback rules (repos list vs. legacy project.githubRepo,
  * headRepo ?? githubRepo) stay unit-testable without store plumbing.
@@ -83,8 +83,18 @@ export function computeRepoFilters(
   });
 }
 
+/**
+ * True when the set holds any repo filter. Classifies through
+ * parseRepoFilterKey so this and the repo matching in filterProjects agree by
+ * construction — classifying by exclusion instead ("anything that isn't
+ * unread or running") would silently promote a future third status filter to
+ * a repo filter that no project's repos can match, filtering everything out.
+ */
 export function hasRepoFilterKeys(activeFilters: Set<string>): boolean {
-  return [...activeFilters].some((key) => key !== 'unread' && key !== 'running');
+  for (const key of activeFilters) {
+    if (parseRepoFilterKey(key) !== null) return true;
+  }
+  return false;
 }
 
 /**
@@ -147,49 +157,49 @@ class ProjectFiltersStore {
   private _activeFilters = $state<Set<string>>(new Set());
 
   // ── Reactive reads ──
+  //
+  // $derived fields rather than getters so every consumer shares one
+  // computation instead of recomputing per read: filteredProjects is read by
+  // the landing grid, the sidebar's project list and the sidebar row's match
+  // count, and each pass would otherwise call getProjectStatus for every
+  // project when `running` is active. The counts are read twice per chip.
 
   get activeFilters(): Set<string> {
     return this._activeFilters;
   }
 
-  get hasActiveFilters(): boolean {
-    return this._activeFilters.size > 0;
-  }
+  hasActiveFilters = $derived(this._activeFilters.size > 0);
 
   /** True when any repo (non-status) filter is active. */
-  get hasRepoFilters(): boolean {
-    return hasRepoFilterKeys(this._activeFilters);
-  }
+  hasRepoFilters = $derived(hasRepoFilterKeys(this._activeFilters));
 
-  get repoFilters(): RepoFilter[] {
-    return computeRepoFilters(projectsDataStore.projects, projectsDataStore.reposByProject);
-  }
+  repoFilters: RepoFilter[] = $derived.by(() =>
+    computeRepoFilters(projectsDataStore.projects, projectsDataStore.reposByProject)
+  );
 
   /** The active repo filters, parsed from their keys. Kept independent of
    *  repoFilters so a stale-but-active selection still renders a summary. */
-  get activeRepoFilters(): RepoFilterRef[] {
-    return [...this._activeFilters]
-      .map(parseRepoFilterKey)
-      .filter((f): f is RepoFilterRef => f !== null);
-  }
+  activeRepoFilters: RepoFilterRef[] = $derived.by(() =>
+    [...this._activeFilters].map(parseRepoFilterKey).filter((f): f is RepoFilterRef => f !== null)
+  );
 
-  get unreadCount(): number {
-    return projectsDataStore.projects.filter((p) => projectStateStore.isUnread(p.id)).length;
-  }
+  unreadCount = $derived.by(
+    () => projectsDataStore.projects.filter((p) => projectStateStore.isUnread(p.id)).length
+  );
 
-  get runningCount(): number {
-    return projectsDataStore.projects.filter((p) => this.isProjectRunning(p.id)).length;
-  }
+  runningCount = $derived.by(
+    () => projectsDataStore.projects.filter((p) => this.isProjectRunning(p.id)).length
+  );
 
-  get filteredProjects(): Project[] {
-    return filterProjects(
+  filteredProjects: Project[] = $derived.by(() =>
+    filterProjects(
       projectsDataStore.projects,
       this._activeFilters,
       projectsDataStore.reposByProject,
       (projectId) => projectStateStore.isUnread(projectId),
       (projectId) => this.isProjectRunning(projectId)
-    );
-  }
+    )
+  );
 
   // ── Mutations ──
 

--- a/apps/staged/src/lib/features/projects/projectFilters.svelte.ts
+++ b/apps/staged/src/lib/features/projects/projectFilters.svelte.ts
@@ -1,0 +1,223 @@
+/**
+ * Shared project-filter state.
+ *
+ * Module-scoped runes store (following the projectsData store pattern) that
+ * owns the filter selection ProjectsList and ProjectsSidebar both render.
+ * Because it lives at module scope, the active filters survive navigating
+ * into a project and back for the app session — deliberately not persisted
+ * to disk, matching how nothing about the filter UI persisted before.
+ *
+ * The derived getters read the global data stores directly; the underlying
+ * computations are exported as plain functions taking data as arguments so
+ * the repo-fallback rules (repos list vs. legacy project.githubRepo,
+ * headRepo ?? githubRepo) stay unit-testable without store plumbing.
+ */
+
+import type { Project, ProjectRepo } from '../../types';
+import { projectsDataStore } from '../../stores/projectsData.svelte';
+import { projectStateStore } from '../../stores/projectState.svelte';
+import { getProjectStatus } from './projectStatus';
+
+/** A repo+subpath a filter chip can target. */
+export interface RepoFilterRef {
+  repo: string;
+  subpath: string;
+}
+
+export type FilterKind = 'unread' | 'running' | RepoFilterRef;
+
+/** A repo chip entry: the target plus how many projects show that repo. */
+export interface RepoFilter extends RepoFilterRef {
+  count: number;
+}
+
+export function filterKey(filter: FilterKind): string {
+  if (typeof filter === 'string') return filter;
+  return `repo:${filter.repo}:${filter.subpath}`;
+}
+
+/** Inverse of filterKey for repo filters; null for status keys. GitHub repo
+ *  names can't contain a colon, so the first one ends the repo segment. */
+export function parseRepoFilterKey(key: string): RepoFilterRef | null {
+  if (!key.startsWith('repo:')) return null;
+  const rest = key.slice('repo:'.length);
+  const separator = rest.indexOf(':');
+  if (separator === -1) return null;
+  return { repo: rest.slice(0, separator), subpath: rest.slice(separator + 1) };
+}
+
+/**
+ * Unique repo+subpath entries with project counts, sorted alphabetically by
+ * full display string. Projects with a hydrated repos list contribute every
+ * repo (displayed as headRepo ?? githubRepo); projects without one fall back
+ * to the legacy project.githubRepo field.
+ */
+export function computeRepoFilters(
+  projects: Project[],
+  reposByProject: Map<string, ProjectRepo[]>
+): RepoFilter[] {
+  const counts = new Map<string, RepoFilter>();
+  const add = (repo: string, subpath: string) => {
+    const key = `${repo}:${subpath}`;
+    const entry = counts.get(key);
+    if (entry) {
+      entry.count++;
+    } else {
+      counts.set(key, { repo, subpath, count: 1 });
+    }
+  };
+  for (const project of projects) {
+    const repos = reposByProject.get(project.id) ?? [];
+    if (repos.length > 0) {
+      for (const r of repos) {
+        add(r.headRepo ?? r.githubRepo, r.subpath ?? '');
+      }
+    } else if (project.githubRepo) {
+      add(project.githubRepo, project.subpath ?? '');
+    }
+  }
+  return [...counts.values()].sort((a, b) => {
+    const aDisplay = a.subpath ? `${a.repo}/${a.subpath}` : a.repo;
+    const bDisplay = b.subpath ? `${b.repo}/${b.subpath}` : b.repo;
+    return aDisplay.localeCompare(bDisplay);
+  });
+}
+
+export function hasRepoFilterKeys(activeFilters: Set<string>): boolean {
+  return [...activeFilters].some((key) => key !== 'unread' && key !== 'running');
+}
+
+/**
+ * Apply the active filter set: status filters AND with each other and with
+ * repo filters; repo filters OR with each other. The unread/running checks
+ * are injected so this stays pure.
+ */
+export function filterProjects(
+  projects: Project[],
+  activeFilters: Set<string>,
+  reposByProject: Map<string, ProjectRepo[]>,
+  isUnread: (projectId: string) => boolean,
+  isRunning: (projectId: string) => boolean
+): Project[] {
+  if (activeFilters.size === 0) return projects;
+  const hasRepoFilters = hasRepoFilterKeys(activeFilters);
+  return projects.filter((p) => {
+    if (activeFilters.has('unread') && !isUnread(p.id)) return false;
+    if (activeFilters.has('running') && !isRunning(p.id)) return false;
+    if (!hasRepoFilters) return true;
+    const repos = reposByProject.get(p.id) ?? [];
+    if (repos.length > 0) {
+      return repos.some((r) =>
+        activeFilters.has(filterKey({ repo: r.headRepo ?? r.githubRepo, subpath: r.subpath ?? '' }))
+      );
+    }
+    if (p.githubRepo) {
+      return activeFilters.has(filterKey({ repo: p.githubRepo, subpath: p.subpath ?? '' }));
+    }
+    return false;
+  });
+}
+
+/**
+ * Chip click semantics: a plain click selects the filter exclusively, and
+ * clicking the only active filter deselects it (back to showing all);
+ * shift-click toggles the filter within the current set.
+ */
+export function toggleFilterKey(
+  activeFilters: Set<string>,
+  key: string,
+  additive: boolean
+): Set<string> {
+  if (additive) {
+    const next = new Set(activeFilters);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    return next;
+  }
+  if (activeFilters.size === 1 && activeFilters.has(key)) {
+    return new Set();
+  }
+  return new Set([key]);
+}
+
+class ProjectFiltersStore {
+  private _activeFilters = $state<Set<string>>(new Set());
+
+  // ── Reactive reads ──
+
+  get activeFilters(): Set<string> {
+    return this._activeFilters;
+  }
+
+  get hasActiveFilters(): boolean {
+    return this._activeFilters.size > 0;
+  }
+
+  /** True when any repo (non-status) filter is active. */
+  get hasRepoFilters(): boolean {
+    return hasRepoFilterKeys(this._activeFilters);
+  }
+
+  get repoFilters(): RepoFilter[] {
+    return computeRepoFilters(projectsDataStore.projects, projectsDataStore.reposByProject);
+  }
+
+  /** The active repo filters, parsed from their keys. Kept independent of
+   *  repoFilters so a stale-but-active selection still renders a summary. */
+  get activeRepoFilters(): RepoFilterRef[] {
+    return [...this._activeFilters]
+      .map(parseRepoFilterKey)
+      .filter((f): f is RepoFilterRef => f !== null);
+  }
+
+  get unreadCount(): number {
+    return projectsDataStore.projects.filter((p) => projectStateStore.isUnread(p.id)).length;
+  }
+
+  get runningCount(): number {
+    return projectsDataStore.projects.filter((p) => this.isProjectRunning(p.id)).length;
+  }
+
+  get filteredProjects(): Project[] {
+    return filterProjects(
+      projectsDataStore.projects,
+      this._activeFilters,
+      projectsDataStore.reposByProject,
+      (projectId) => projectStateStore.isUnread(projectId),
+      (projectId) => this.isProjectRunning(projectId)
+    );
+  }
+
+  // ── Mutations ──
+
+  isFilterActive(filter: FilterKind): boolean {
+    return this._activeFilters.has(filterKey(filter));
+  }
+
+  toggleFilter(filter: FilterKind, event?: MouseEvent): void {
+    this._activeFilters = toggleFilterKey(
+      this._activeFilters,
+      filterKey(filter),
+      event?.shiftKey ?? false
+    );
+  }
+
+  clearFilters(): void {
+    if (this._activeFilters.size === 0) return;
+    this._activeFilters = new Set();
+  }
+
+  private isProjectRunning(projectId: string): boolean {
+    const status = getProjectStatus(
+      projectId,
+      projectsDataStore.deletingProjectNames,
+      projectsDataStore.branchesByProject.get(projectId) || []
+    );
+    return status.kind === 'running' || status.kind === 'runAction';
+  }
+}
+
+export const projectFiltersStore = new ProjectFiltersStore();

--- a/apps/staged/src/lib/features/projects/projectFilters.test.ts
+++ b/apps/staged/src/lib/features/projects/projectFilters.test.ts
@@ -48,10 +48,19 @@ beforeEach(() => {
   vi.resetModules();
   // The store's runes compile away in the app build; under vitest they stay
   // plain global calls, so stub $state as identity (projectsData.test.ts
-  // precedent).
+  // precedent). $derived needs the same treatment for the store's derived
+  // fields, and since the stub evaluates them eagerly at construction the
+  // mocked data stores have to carry the shape those fields read.
   vi.stubGlobal('$state', (initial: unknown) => initial);
-  vi.doMock('../../stores/projectsData.svelte', () => ({ projectsDataStore: {} }));
-  vi.doMock('../../stores/projectState.svelte', () => ({ projectStateStore: {} }));
+  const derived = (value: unknown) => value;
+  derived.by = (compute: () => unknown) => compute();
+  vi.stubGlobal('$derived', derived);
+  vi.doMock('../../stores/projectsData.svelte', () => ({
+    projectsDataStore: { projects: [], reposByProject: new Map() },
+  }));
+  vi.doMock('../../stores/projectState.svelte', () => ({
+    projectStateStore: { isUnread: () => false },
+  }));
   vi.doMock('./projectStatus', () => ({ getProjectStatus: vi.fn() }));
 });
 
@@ -282,10 +291,20 @@ describe('toggleFilterKey', () => {
 });
 
 describe('hasRepoFilterKeys', () => {
-  it('is true only when a non-status key is active', async () => {
+  it('is true only when a repo key is active', async () => {
     const { hasRepoFilterKeys } = await importHelpers();
     expect(hasRepoFilterKeys(new Set())).toBe(false);
     expect(hasRepoFilterKeys(new Set(['unread', 'running']))).toBe(false);
     expect(hasRepoFilterKeys(new Set(['unread', 'repo:org/alpha:']))).toBe(true);
+  });
+
+  it('does not treat an unrecognized status key as a repo filter', async () => {
+    const { hasRepoFilterKeys, filterProjects } = await importHelpers();
+    // A third status filter must not make every project fail the repo check.
+    expect(hasRepoFilterKeys(new Set(['archived']))).toBe(false);
+    const projects = [project({ id: 'p1' })];
+    expect(filterProjects(projects, new Set(['archived']), new Map(), never, never)).toHaveLength(
+      1
+    );
   });
 });

--- a/apps/staged/src/lib/features/projects/projectFilters.test.ts
+++ b/apps/staged/src/lib/features/projects/projectFilters.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Project, ProjectRepo } from '../../types';
+
+// ── Fixtures ──
+
+function project(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'p1',
+    name: 'Alpha',
+    githubRepo: 'org/alpha',
+    location: 'local',
+    subpath: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function projectRepo(overrides: Partial<ProjectRepo> = {}): ProjectRepo {
+  return {
+    id: 'r1',
+    projectId: 'p1',
+    githubRepo: 'org/alpha',
+    branchName: 'feature',
+    subpath: null,
+    isPrimary: true,
+    reason: null,
+    headRepo: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+const never = () => false;
+
+// ── Mock plumbing ──
+//
+// Only the pure helpers are under test, but importing the module also
+// instantiates the store singleton, which pulls in the global data stores —
+// mock those out and stub $state the way projectsData.test.ts does.
+
+async function importHelpers() {
+  return await import('./projectFilters.svelte');
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  // The store's runes compile away in the app build; under vitest they stay
+  // plain global calls, so stub $state as identity (projectsData.test.ts
+  // precedent).
+  vi.stubGlobal('$state', (initial: unknown) => initial);
+  vi.doMock('../../stores/projectsData.svelte', () => ({ projectsDataStore: {} }));
+  vi.doMock('../../stores/projectState.svelte', () => ({ projectStateStore: {} }));
+  vi.doMock('./projectStatus', () => ({ getProjectStatus: vi.fn() }));
+});
+
+afterEach(() => {
+  vi.doUnmock('../../stores/projectsData.svelte');
+  vi.doUnmock('../../stores/projectState.svelte');
+  vi.doUnmock('./projectStatus');
+  vi.unstubAllGlobals();
+});
+
+// ── Tests ──
+
+describe('filterKey / parseRepoFilterKey', () => {
+  it('passes status filters through and formats repo filters', async () => {
+    const { filterKey } = await importHelpers();
+    expect(filterKey('unread')).toBe('unread');
+    expect(filterKey('running')).toBe('running');
+    expect(filterKey({ repo: 'org/alpha', subpath: '' })).toBe('repo:org/alpha:');
+    expect(filterKey({ repo: 'org/alpha', subpath: 'apps/web' })).toBe('repo:org/alpha:apps/web');
+  });
+
+  it('parses repo keys back into their parts and rejects status keys', async () => {
+    const { parseRepoFilterKey } = await importHelpers();
+    expect(parseRepoFilterKey('repo:org/alpha:apps/web')).toEqual({
+      repo: 'org/alpha',
+      subpath: 'apps/web',
+    });
+    expect(parseRepoFilterKey('repo:org/alpha:')).toEqual({ repo: 'org/alpha', subpath: '' });
+    expect(parseRepoFilterKey('unread')).toBeNull();
+    expect(parseRepoFilterKey('running')).toBeNull();
+  });
+
+  it('round-trips repo filters, including subpaths containing a colon', async () => {
+    const { filterKey, parseRepoFilterKey } = await importHelpers();
+    const filter = { repo: 'org/alpha', subpath: 'apps:odd' };
+    expect(parseRepoFilterKey(filterKey(filter))).toEqual(filter);
+  });
+});
+
+describe('computeRepoFilters', () => {
+  it('counts unique repo+subpath entries across hydrated projects', async () => {
+    const { computeRepoFilters } = await importHelpers();
+    const projects = [project({ id: 'p1' }), project({ id: 'p2' }), project({ id: 'p3' })];
+    const repos = new Map([
+      ['p1', [projectRepo({ githubRepo: 'org/alpha' })]],
+      ['p2', [projectRepo({ githubRepo: 'org/alpha' }), projectRepo({ githubRepo: 'org/beta' })]],
+      ['p3', [projectRepo({ githubRepo: 'org/alpha', subpath: 'apps/web' })]],
+    ]);
+
+    expect(computeRepoFilters(projects, repos)).toEqual([
+      { repo: 'org/alpha', subpath: '', count: 2 },
+      { repo: 'org/alpha', subpath: 'apps/web', count: 1 },
+      { repo: 'org/beta', subpath: '', count: 1 },
+    ]);
+  });
+
+  it('prefers headRepo over githubRepo for display', async () => {
+    const { computeRepoFilters } = await importHelpers();
+    const repos = new Map([
+      ['p1', [projectRepo({ githubRepo: 'org/alpha', headRepo: 'fork/alpha' })]],
+    ]);
+
+    expect(computeRepoFilters([project()], repos)).toEqual([
+      { repo: 'fork/alpha', subpath: '', count: 1 },
+    ]);
+  });
+
+  it('falls back to the legacy project.githubRepo only when the repos list is empty', async () => {
+    const { computeRepoFilters } = await importHelpers();
+    const projects = [
+      project({ id: 'p1', githubRepo: 'org/legacy', subpath: 'sub' }),
+      project({ id: 'p2', githubRepo: 'org/ignored' }),
+    ];
+    const repos = new Map([['p2', [projectRepo({ githubRepo: 'org/hydrated' })]]]);
+
+    expect(computeRepoFilters(projects, repos)).toEqual([
+      { repo: 'org/hydrated', subpath: '', count: 1 },
+      { repo: 'org/legacy', subpath: 'sub', count: 1 },
+    ]);
+  });
+
+  it('skips projects with no repos and no githubRepo', async () => {
+    const { computeRepoFilters } = await importHelpers();
+    expect(computeRepoFilters([project({ githubRepo: null })], new Map())).toEqual([]);
+  });
+
+  it('sorts by full display string including subpath', async () => {
+    const { computeRepoFilters } = await importHelpers();
+    const projects = [project({ id: 'p1' }), project({ id: 'p2' }), project({ id: 'p3' })];
+    const repos = new Map([
+      ['p1', [projectRepo({ githubRepo: 'org/b' })]],
+      ['p2', [projectRepo({ githubRepo: 'org/a', subpath: 'z' })]],
+      ['p3', [projectRepo({ githubRepo: 'org/a', subpath: 'm' })]],
+    ]);
+
+    expect(computeRepoFilters(projects, repos).map((rf) => `${rf.repo}:${rf.subpath}`)).toEqual([
+      'org/a:m',
+      'org/a:z',
+      'org/b:',
+    ]);
+  });
+});
+
+describe('filterProjects', () => {
+  it('returns every project when no filters are active', async () => {
+    const { filterProjects } = await importHelpers();
+    const projects = [project({ id: 'p1' }), project({ id: 'p2' })];
+    expect(filterProjects(projects, new Set(), new Map(), never, never)).toBe(projects);
+  });
+
+  it('ANDs status filters with each other', async () => {
+    const { filterProjects } = await importHelpers();
+    const projects = [project({ id: 'p1' }), project({ id: 'p2' }), project({ id: 'p3' })];
+    const isUnread = (id: string) => id !== 'p3';
+    const isRunning = (id: string) => id !== 'p1';
+
+    expect(
+      filterProjects(projects, new Set(['unread']), new Map(), isUnread, isRunning).map((p) => p.id)
+    ).toEqual(['p1', 'p2']);
+    expect(
+      filterProjects(projects, new Set(['unread', 'running']), new Map(), isUnread, isRunning).map(
+        (p) => p.id
+      )
+    ).toEqual(['p2']);
+  });
+
+  it('ORs repo filters with each other and ANDs them with status filters', async () => {
+    const { filterProjects } = await importHelpers();
+    const projects = [project({ id: 'p1' }), project({ id: 'p2' }), project({ id: 'p3' })];
+    const repos = new Map([
+      ['p1', [projectRepo({ githubRepo: 'org/alpha' })]],
+      ['p2', [projectRepo({ githubRepo: 'org/beta' })]],
+      ['p3', [projectRepo({ githubRepo: 'org/gamma' })]],
+    ]);
+    const bothRepos = new Set(['repo:org/alpha:', 'repo:org/beta:']);
+
+    expect(filterProjects(projects, bothRepos, repos, never, never).map((p) => p.id)).toEqual([
+      'p1',
+      'p2',
+    ]);
+    expect(
+      filterProjects(
+        projects,
+        new Set(['unread', 'repo:org/alpha:', 'repo:org/beta:']),
+        repos,
+        (id) => id === 'p2',
+        never
+      ).map((p) => p.id)
+    ).toEqual(['p2']);
+  });
+
+  it('matches repo filters against headRepo when present', async () => {
+    const { filterProjects } = await importHelpers();
+    const projects = [project({ id: 'p1' })];
+    const repos = new Map([
+      ['p1', [projectRepo({ githubRepo: 'org/alpha', headRepo: 'fork/alpha' })]],
+    ]);
+
+    expect(
+      filterProjects(projects, new Set(['repo:fork/alpha:']), repos, never, never)
+    ).toHaveLength(1);
+    expect(
+      filterProjects(projects, new Set(['repo:org/alpha:']), repos, never, never)
+    ).toHaveLength(0);
+  });
+
+  it('falls back to the legacy project.githubRepo when the repos list is empty', async () => {
+    const { filterProjects } = await importHelpers();
+    const projects = [
+      project({ id: 'p1', githubRepo: 'org/legacy', subpath: 'sub' }),
+      project({ id: 'p2', githubRepo: null }),
+    ];
+
+    expect(
+      filterProjects(projects, new Set(['repo:org/legacy:sub']), new Map(), never, never).map(
+        (p) => p.id
+      )
+    ).toEqual(['p1']);
+  });
+
+  it('excludes repo-less projects when a repo filter is active', async () => {
+    const { filterProjects } = await importHelpers();
+    const projects = [project({ id: 'p1', githubRepo: null })];
+    expect(filterProjects(projects, new Set(['repo:org/alpha:']), new Map(), never, never)).toEqual(
+      []
+    );
+  });
+});
+
+describe('toggleFilterKey', () => {
+  it('plain click selects the filter exclusively', async () => {
+    const { toggleFilterKey } = await importHelpers();
+    expect(toggleFilterKey(new Set(), 'unread', false)).toEqual(new Set(['unread']));
+    expect(toggleFilterKey(new Set(['running', 'repo:org/alpha:']), 'unread', false)).toEqual(
+      new Set(['unread'])
+    );
+  });
+
+  it('plain click on an active filter among others collapses to just it', async () => {
+    const { toggleFilterKey } = await importHelpers();
+    expect(toggleFilterKey(new Set(['unread', 'running']), 'unread', false)).toEqual(
+      new Set(['unread'])
+    );
+  });
+
+  it('plain click on the only active filter deselects it', async () => {
+    const { toggleFilterKey } = await importHelpers();
+    expect(toggleFilterKey(new Set(['unread']), 'unread', false)).toEqual(new Set());
+  });
+
+  it('shift-click toggles the filter within the current set', async () => {
+    const { toggleFilterKey } = await importHelpers();
+    expect(toggleFilterKey(new Set(['unread']), 'running', true)).toEqual(
+      new Set(['unread', 'running'])
+    );
+    expect(toggleFilterKey(new Set(['unread', 'running']), 'running', true)).toEqual(
+      new Set(['unread'])
+    );
+  });
+
+  it('returns a new Set rather than mutating the input', async () => {
+    const { toggleFilterKey } = await importHelpers();
+    const input = new Set(['unread']);
+    const next = toggleFilterKey(input, 'running', true);
+    expect(next).not.toBe(input);
+    expect(input).toEqual(new Set(['unread']));
+  });
+});
+
+describe('hasRepoFilterKeys', () => {
+  it('is true only when a non-status key is active', async () => {
+    const { hasRepoFilterKeys } = await importHelpers();
+    expect(hasRepoFilterKeys(new Set())).toBe(false);
+    expect(hasRepoFilterKeys(new Set(['unread', 'running']))).toBe(false);
+    expect(hasRepoFilterKeys(new Set(['unread', 'repo:org/alpha:']))).toBe(true);
+  });
+});

--- a/apps/staged/src/lib/stores/projectRunActions.svelte.ts
+++ b/apps/staged/src/lib/stores/projectRunActions.svelte.ts
@@ -44,7 +44,8 @@ class ProjectRunActionsStore {
 
   /**
    * Start listening to global Tauri events.
-   * Called when ProjectsList or ProjectHome mounts.
+   * Called once from App.svelte — the state feeds the shared project filters,
+   * which every route renders via the sidebar or the landing grid.
    */
   startListening(): void {
     if (this.initialized) return;
@@ -76,7 +77,7 @@ class ProjectRunActionsStore {
   }
 
   /**
-   * Stop listening and reset state. Call on cleanup.
+   * Stop listening and reset state. Called on app teardown.
    */
   stopListening(): void {
     for (const unlisten of this.unlisteners) {
@@ -106,8 +107,9 @@ class ProjectRunActionsStore {
 
   /**
    * Update the branch→project map and hydrate run-action state from a
-   * project→branches map. Convenience wrapper used by both ProjectsList
-   * and ProjectHome after loading branch data.
+   * project→branches map. Convenience wrapper the project surfaces
+   * (ProjectsList, ProjectHome, ProjectsSidebar) run against the shared
+   * branch data; already-queried branches are skipped unless forced.
    */
   async hydrateFromProjectBranches(
     branchesByProject: Map<string, Branch[]>,


### PR DESCRIPTION
Project filtering was view-local to the landing page: pick a filter, open a project, come back, and the selection was gone. This branch lifts that state into a shared store and gives the sidebar its own filter surface, so a filtered view of the project list follows you around the app session.

## What changed

**Shared filter state.** A module-scoped `projectFiltersStore` (`projectFilters.svelte.ts`) owns the selection that `ProjectsList` and `ProjectsSidebar` both render. It survives navigating into a project and back — session-only, not persisted to disk. The pure computations (`computeRepoFilters`, `filterProjects`, `toggleFilterKey`, `filterKey`/`parseRepoFilterKey`) are exported as plain functions with vitest coverage of the repo-fallback rules (`headRepo ?? githubRepo`, hydrated repos list vs. legacy `project.githubRepo`). Reactive reads are `$derived` fields, so `filteredProjects` is computed once for the grid, the sidebar list and the match count.

**Shared chip bar.** The landing page's chips move into `ProjectFilterChips` (with a compact mode) rendered by both surfaces so they can't drift, plus a Clear chip — the chips that produced a selection can all disappear, so the bar needs its own way out.

**Sidebar filter row.** `SidebarFilterRow` is a collapsed summary — funnel icon, active-filter summary with repo badges, matched/total count, ✕ to clear — that opens the compact chip bar in a bits-ui Popover (elevated, closes on outside click or Escape) and kicks `ensureProjectsHydrated()` so repo counts aren't undercounted when the app opens straight into a project. The row is `position: sticky` at the top of the sidebar scroll area, with a hairline that appears only while pinned (an IntersectionObserver detects the stuck state, which CSS can't select).

**Sidebar list follows the filters,** keeping the selected project's row visible when it doesn't match (mirroring the All Repos row rule) and showing a "No projects match filters" state with a clear affordance. The grid picks up the same empty state.

## Fixes along the way

- ⌘1–9 indexed the unfiltered project list while the numbered overlays are painted on the filtered grid — with filters active, ⌘2 could open a project other than the one labeled ⌘2. Now indexes the same derivation the overlays iterate.
- The scroll-restore "return target" card was captured on every mount and never cleared, so landing → settings → back pinned a stale project into the grid. Capture is now gated on `restorePending`, and the first-filter-change drop moved from an `$effect` into the derivation so the grid never paints the stale card.
- A pending restore against an empty filtered list now drops instead of staying armed until something refilled the list and jumped scroll to a position captured for a different list.
- `SidebarFilterRow` falls back to a `RepoLabel` when a badge lookup misses, so a fork-backed repo no longer renders a funnel and a bare count naming nothing.